### PR TITLE
Remove IFluidObject from IContainerRuntime.scope type

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -29,7 +29,7 @@ ICodeLoader interface was deprecated a while ago and will be removed in the next
 - [getAbsoluteUrl() argument type changed](#getAbsoluteUrl-argument-type-changed)
 - [Replace ICodeLoader with ICodeDetailsLoader interface](#Replace-ICodeLoader-with-ICodeDetailsLoader-interface)
 - [IFluidModule.fluidExport is no longer an IFluidObject](#IFluidModule.fluidExport-is-no-longer-an-IFluidObject)
-- [IContainerContext.scope is no longer an IFluidObject](#IContainerContext.scope-is-no-longer-an-IFluidObject)
+- [Scope is no longer an IFluidObject](#scope-is-no-longer-an-IFluidObject)
 
 ### Removing Commit from TreeEntry and commits from SnapShotTree
 Cleaning up properties that are not being used in the codebase: `TreeEntry.Commit` and `ISnapshotTree.commits`.
@@ -98,8 +98,9 @@ You can start by returning default code details that were passed into the code l
 ### IFluidModule.fluidExport is no longer an IFluidObject
 IFluidObject is no longer part of the type of IFluidModule.fluidExport. IFluidModule.fluidExport is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
 
-### IContainerContext.scope is no longer an IFluidObject
-IFluidObject is no longer part of the type of IContainerContext.scope. IContainerContext.scope is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
+### Scope is no longer an IFluidObject
+IFluidObject is no longer part of the type of IContainerContext.scope or IContainerRuntime.scope.
+Scope is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
 
 ### IFluidHandle generic's default no longer includes IFluidObject
 IFluidObject is no longer part of the type of IFluidHandle generic's default.

--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -16,7 +16,6 @@ import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidDataStoreContextDetached } from '@fluidframework/runtime-definitions';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IHelpMessage } from '@fluidframework/protocol-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
@@ -51,7 +50,7 @@ export interface IContainerRuntime extends IProvideContainerRuntime, IProvideFlu
     readonly options: ILoaderOptions;
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
-    readonly scope: IFluidObject & FluidObject;
+    readonly scope: FluidObject;
     // (undocumented)
     readonly storage: IDocumentStorageService;
 }

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -28,7 +28,6 @@ import { IFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IFluidTokenProvider } from '@fluidframework/container-definitions';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
@@ -152,7 +151,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     get reSubmitFn(): (type: ContainerMessageType, content: any, localOpMetadata: unknown, opMetadata: Record<string, unknown> | undefined) => void;
     // (undocumented)
-    get scope(): IFluidObject & FluidObject;
+    get scope(): FluidObject;
     // (undocumented)
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
     // (undocumented)

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -12,7 +12,6 @@ import {
 import {
     IRequest,
     IResponse,
-    IFluidObject,
     IFluidRouter,
     FluidObject,
 } from "@fluidframework/core-interfaces";
@@ -80,7 +79,7 @@ export interface IContainerRuntime extends
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly storage: IDocumentStorageService;
     readonly flushMode: FlushMode;
-    readonly scope: IFluidObject & FluidObject;
+    readonly scope: FluidObject;
     /**
      * Indicates the attachment state of the container to a host service.
      */

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -10,7 +10,6 @@ import {
     FluidObject,
     IFluidHandle,
     IFluidHandleContext,
-    IFluidObject,
     IFluidRouter,
     IRequest,
     IResponse,
@@ -902,7 +901,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this._flushMode;
     }
 
-    public get scope(): IFluidObject & FluidObject {
+    public get scope(): FluidObject {
         return this.containerScope;
     }
 


### PR DESCRIPTION
### Scope is no longer an IFluidObject
IFluidObject is no longer part of the type of IContainerContext.scope or IContainerRuntime.scope.
Scope is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.

fixes #8941 