### PR TITLE
Remove Remaining IFluidObject References

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -30,6 +30,7 @@ ICodeLoader interface was deprecated a while ago and will be removed in the next
 - [Replace ICodeLoader with ICodeDetailsLoader interface](#Replace-ICodeLoader-with-ICodeDetailsLoader-interface)
 - [IFluidModule.fluidExport is no longer an IFluidObject](#IFluidModule.fluidExport-is-no-longer-an-IFluidObject)
 - [IContainerContext.scope is no longer an IFluidObject](#IContainerContext.scope-is-no-longer-an-IFluidObject)
+- [IFluidHandle and requestFluidObject generic's default no longer includes IFluidObject](#IFluidHandle-and-requestFluidObject-generics-default-no-longer-includes-IFluidObject)
 
 ### Removing Commit from TreeEntry and commits from SnapShotTree
 Cleaning up properties that are not being used in the codebase: `TreeEntry.Commit` and `ISnapshotTree.commits`.
@@ -101,16 +102,24 @@ IFluidObject is no longer part of the type of IFluidModule.fluidExport. IFluidMo
 ### IContainerContext.scope is no longer an IFluidObject
 IFluidObject is no longer part of the type of IContainerContext.scope. IContainerContext.scope is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
 
-### IFluidHandle generic's default no longer includes IFluidObject
-IFluidObject is no longer part of the type of IFluidHandle generic's default.
+### IFluidHandle and requestFluidObject generic's default no longer includes IFluidObject
+IFluidObject is no longer part of the type of IFluidHandle and requestFluidObject generic's default.
 
 ``` diff
 - IFluidHandle<T = IFluidObject & FluidObject & IFluidLoadable>
 + IFluidHandle<T = FluidObject & IFluidLoadable>
+
+- export function requestFluidObject<T = IFluidObject & FluidObject>(router: IFluidRouter, url: string | IRequest): Promise<T>;
++ export function requestFluidObject<T = FluidObject>(router: IFluidRouter, url: string | IRequest): Promise<T>;
 ```
 
-This will affect the result of all `get()` calls on IFluidHandle's, and the default return will no longer be and IFluidObject by default. IFluidHandle generic's default is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
+This will affect the result of all `get()` calls on IFluidHandle's, and the default return will no longer be and IFluidObject by default.
 
+Similarly `requestFluidObject` default generic which is also its return type no longer contains IFluidObject.
+
+In both cases the generic's default is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
+
+As a short term fix in both these cases IFluidObject can be passed at the generic type. However, IFluidObject is deprecated and will be removed in an upcoming release so this can only be a temporary workaround before moving to [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject).
 
 # 0.58
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -31,6 +31,7 @@ ICodeLoader interface was deprecated a while ago and will be removed in the next
 - [IFluidModule.fluidExport is no longer an IFluidObject](#IFluidModule.fluidExport-is-no-longer-an-IFluidObject)
 - [IContainerContext.scope is no longer an IFluidObject](#IContainerContext.scope-is-no-longer-an-IFluidObject)
 - [IFluidHandle and requestFluidObject generic's default no longer includes IFluidObject](#IFluidHandle-and-requestFluidObject-generics-default-no-longer-includes-IFluidObject)
+- [LazyLoadedDataObjectFactory.create no longer returns an IFluidObject](#LazyLoadedDataObjectFactory.create-no-longer-returns-an-IFluidObject)
 
 ### Removing Commit from TreeEntry and commits from SnapShotTree
 Cleaning up properties that are not being used in the codebase: `TreeEntry.Commit` and `ISnapshotTree.commits`.
@@ -120,6 +121,11 @@ Similarly `requestFluidObject` default generic which is also its return type no 
 In both cases the generic's default is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
 
 As a short term fix in both these cases IFluidObject can be passed at the generic type. However, IFluidObject is deprecated and will be removed in an upcoming release so this can only be a temporary workaround before moving to [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject).
+
+### LazyLoadedDataObjectFactory.create no longer returns an IFluidObject
+LazyLoadedDataObjectFactory.create no longer returns an IFluidObject, it now only returns a [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject).
+
+As a short term fix the return type of this method can be safely casted to an IFluidObject. However, IFluidObject is deprecated and will be removed in an upcoming release so this can only be a temporary workaround before moving to [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject).
 
 # 0.58
 

--- a/api-report/data-object-base.api.md
+++ b/api-report/data-object-base.api.md
@@ -17,7 +17,6 @@ import { IFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IProvideFluidHandle } from '@fluidframework/core-interfaces';
 import { IRequest } from '@fluidframework/core-interfaces';
@@ -58,7 +57,7 @@ export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = IShared
 export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> implements IFluidDataStoreFactory {
     constructor(type: string, ctor: new (context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, root: ISharedObject) => T, root: IChannelFactory, sharedObjects?: readonly IChannelFactory[], storeFactories?: readonly IFluidDataStoreFactory[]);
     // (undocumented)
-    create(parentContext: IFluidDataStoreContext, props?: any): Promise<IFluidObject & FluidObject>;
+    create(parentContext: IFluidDataStoreContext, props?: any): Promise<FluidObject>;
     // (undocumented)
     get IFluidDataStoreFactory(): this;
     // (undocumented)

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -11,7 +11,6 @@ import { IContainerRuntime } from '@fluidframework/container-runtime-definitions
 import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IGarbageCollectionDetailsBase } from '@fluidframework/runtime-definitions';
@@ -140,7 +139,7 @@ export type RefreshSummaryResult = {
 };
 
 // @public (undocumented)
-export function requestFluidObject<T = IFluidObject & FluidObject>(router: IFluidRouter, url: string | IRequest): Promise<T>;
+export function requestFluidObject<T = FluidObject>(router: IFluidRouter, url: string | IRequest): Promise<T>;
 
 // @public
 export class RequestParser implements IRequest {

--- a/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { FluidObject, IFluidObject, IRequest } from "@fluidframework/core-interfaces";
+import { FluidObject, IRequest } from "@fluidframework/core-interfaces";
 import { FluidDataStoreRuntime, ISharedObjectRegistry, mixinRequestHandler } from "@fluidframework/datastore";
 import { FluidDataStoreRegistry } from "@fluidframework/container-runtime";
 import {
@@ -67,7 +67,7 @@ export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> impleme
         return runtime;
     }
 
-    public async create(parentContext: IFluidDataStoreContext, props?: any): Promise<IFluidObject & FluidObject> {
+    public async create(parentContext: IFluidDataStoreContext, props?: any): Promise<FluidObject> {
         const { containerRuntime, packagePath } = parentContext;
 
         const router = await containerRuntime.createDataStore(packagePath.concat(this.type));

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -83,7 +83,7 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
      */
     private getProvider(provider: string & keyof TMap) {
         // this was removed, but some partners have trouble with back compat where they
-        // use invalid patterns with IFluidObject and IFluidDependencySynthesizer
+        // use invalid patterns with FluidObject and IFluidDependencySynthesizer
         // this is just for back compat until those are removed
         if(this.has(provider)) {
             if(this.providers.has(provider)) {

--- a/packages/framework/synthesize/src/types.ts
+++ b/packages/framework/synthesize/src/types.ts
@@ -5,7 +5,7 @@
 import { IFluidDependencySynthesizer } from ".";
 /**
  * This is a condensed version of Record that requires the object has all
- * the IFluidObject properties as its type mapped to a string representation
+ * the FluidObject properties as its type mapped to a string representation
  * of that property.
  *
  * @example - \{ IFoo: "IFoo" \}
@@ -16,7 +16,7 @@ export type FluidObjectSymbolProvider<T> = {
 
 /**
  * This is a condensed version of Record that requires the object has all
- * the IFluidObject properties as its type mapped to an object that implements
+ * the FluidObject properties as its type mapped to an object that implements
  * the property.
  */
 export type AsyncRequiredFluidObjectProvider<T> = T extends undefined ? Record<string, never> : {
@@ -25,7 +25,7 @@ export type AsyncRequiredFluidObjectProvider<T> = T extends undefined ? Record<s
 
 /**
  * This is a condensed version of Record that requires the object has all
- * the IFluidObject properties as its type, mapped to an object that implements
+ * the FluidObject properties as its type, mapped to an object that implements
  * the property or undefined.
  */
 export type AsyncOptionalFluidObjectProvider<T> = T extends undefined

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -6,7 +6,6 @@
 import { assert } from "@fluidframework/common-utils";
 import {
     FluidObject,
-    IFluidObject,
     IFluidRouter,
     IRequest,
     IResponse,
@@ -62,7 +61,7 @@ export function responseToException(response: IResponse, request: IRequest): Err
     return responseErr;
 }
 
-export async function requestFluidObject<T = IFluidObject & FluidObject>(
+export async function requestFluidObject<T = FluidObject>(
     router: IFluidRouter, url: string | IRequest): Promise<T> {
     const request = typeof url === "string" ? { url } : url;
     const response = await router.request(request);


### PR DESCRIPTION
### IFluidHandle and requestFluidObject generic's default no longer includes IFluidObject
IFluidObject is no longer part of the type of IFluidHandle and requestFluidObject generic's default.

``` diff
- IFluidHandle<T = IFluidObject & FluidObject & IFluidLoadable>
+ IFluidHandle<T = FluidObject & IFluidLoadable>

- export function requestFluidObject<T = IFluidObject & FluidObject>(router: IFluidRouter, url: string | IRequest): Promise<T>;
+ export function requestFluidObject<T = FluidObject>(router: IFluidRouter, url: string | IRequest): Promise<T>;
```

This will affect the result of all `get()` calls on IFluidHandle's, and the default return will no longer be and IFluidObject by default.

Similarly `requestFluidObject` default generic which is also its return type no longer contains IFluidObject.

In both cases the generic's default is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.

As a short term fix in both these cases IFluidObject can be passed at the generic type. However, IFluidObject is deprecated and will be removed in an upcoming release so this can only be a temporary workaround before moving to [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject).

### LazyLoadedDataObjectFactory.create no longer returns an IFluidObject
LazyLoadedDataObjectFactory.create no longer returns an IFluidObject, it now only returns a [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject).

As a short term fix the return type of this method can be safely casted to an IFluidObject. However, IFluidObject is deprecated and will be removed in an upcoming release so this can only be a temporary workaround before moving to [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject).

related #8077 