### PR TITLE
Improve logging in DeltaScheduler

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -198,9 +198,9 @@ export interface ContainerRuntimeMessage {
 export class DeltaScheduler {
     constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, logger: ITelemetryLogger);
     // (undocumented)
-    batchBegin(): void;
+    batchBegin(message: ISequencedDocumentMessage): void;
     // (undocumented)
-    batchEnd(): void;
+    batchEnd(message: ISequencedDocumentMessage): void;
     // (undocumented)
     static readonly processingTime = 50;
     }

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -202,7 +202,7 @@ export class DeltaScheduler {
     // (undocumented)
     batchEnd(): void;
     // (undocumented)
-    static readonly processingTime = 20;
+    static readonly processingTime = 50;
     }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -632,7 +632,7 @@ export class ScheduleManager {
 
             // This could be the beginning of a new batch or an individual message.
             this.emitter.emit("batchBegin", message);
-            this.deltaScheduler.batchBegin();
+            this.deltaScheduler.batchBegin(message);
 
             const batch = (message?.metadata as IRuntimeMessageMetadata)?.batch;
             if (batch) {
@@ -653,7 +653,7 @@ export class ScheduleManager {
             this.hitError = true;
             this.batchClientId = undefined;
             this.emitter.emit("batchEnd", error, message);
-            this.deltaScheduler.batchEnd();
+            this.deltaScheduler.batchEnd(message);
             return;
         }
 
@@ -663,7 +663,7 @@ export class ScheduleManager {
         if (this.batchClientId === undefined || batch === false) {
             this.batchClientId = undefined;
             this.emitter.emit("batchEnd", undefined, message);
-            this.deltaScheduler.batchEnd();
+            this.deltaScheduler.batchEnd(message);
             return;
         }
     }

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -146,7 +146,7 @@ export class DeltaScheduler {
                 processingTime: TelemetryLogger.formatTick(this.schedulingLog.totalProcessingTime),
                 opsProcessed: this.schedulingLog.lastSequenceNumber - this.schedulingLog.firstSequenceNumber,
                 batchesProcessed: this.schedulingLog.numberOfBatchesProcessed,
-                totalTime: TelemetryLogger.formatTick(currentTime - this.schedulingLog.startTime),
+                duration: TelemetryLogger.formatTick(currentTime - this.schedulingLog.startTime),
 
             });
 

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -48,6 +48,7 @@ export class DeltaScheduler {
         numberOfBatchesProcessed: number;
         lastSequenceNumber: number;
         firstSequenceNumber: number;
+        startTime: number;
     } | undefined;
 
     constructor(
@@ -72,6 +73,7 @@ export class DeltaScheduler {
                 numberOfBatchesProcessed: 0,
                 firstSequenceNumber: message.sequenceNumber,
                 lastSequenceNumber: message.sequenceNumber,
+                startTime: performance.now(),
             };
         }
         if (this.schedulingLog) {
@@ -133,8 +135,9 @@ export class DeltaScheduler {
         if (this.schedulingLog) {
             // Add the time taken for processing the final ops to the total processing time in the
             // telemetry log object.
+            const currentTime = performance.now();
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this.schedulingLog.totalProcessingTime += performance.now() - this.processingStartTime!;
+            this.schedulingLog.totalProcessingTime += currentTime - this.processingStartTime!;
 
             this.logger.sendTelemetryEvent({
                 eventName: "InboundOpsProcessingTime",
@@ -143,6 +146,7 @@ export class DeltaScheduler {
                 processingTime: TelemetryLogger.formatTick(this.schedulingLog.totalProcessingTime),
                 opsProcessed: this.schedulingLog.lastSequenceNumber - this.schedulingLog.firstSequenceNumber,
                 batchesProcessed: this.schedulingLog.numberOfBatchesProcessed,
+                totalTime: TelemetryLogger.formatTick(currentTime - this.schedulingLog.startTime),
 
             });
 

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -61,18 +61,18 @@ export class DeltaScheduler {
     public batchBegin(message: ISequencedDocumentMessage) {
         if (!this.processingStartTime) {
             this.processingStartTime = performance.now();
-            if (this.schedulingLog === undefined && this.schedulingCount % 2000 === 0) {
-                // Every 2000th time we are scheduling the inbound queue, we log telemetry for the
-                // number of ops processed, the time and number of turns it took to process the ops.
-                this.schedulingLog = {
-                    opsRemainingToProcess: 0,
-                    numberOfTurns: 1,
-                    totalProcessingTime: 0,
-                    numberOfBatchesProcessed: 0,
-                    firstSequenceNumber: message.sequenceNumber,
-                    lastSequenceNumber: message.sequenceNumber,
-                };
-            }
+        }
+        if (this.schedulingLog === undefined && this.schedulingCount % 2000 === 0) {
+            // Every 2000th time we are scheduling the inbound queue, we log telemetry for the
+            // number of ops processed, the time and number of turns it took to process the ops.
+            this.schedulingLog = {
+                opsRemainingToProcess: 0,
+                numberOfTurns: 1,
+                totalProcessingTime: 0,
+                numberOfBatchesProcessed: 0,
+                firstSequenceNumber: message.sequenceNumber,
+                lastSequenceNumber: message.sequenceNumber,
+            };
         }
         if (this.schedulingLog) {
             this.schedulingLog.numberOfBatchesProcessed++;

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -82,9 +82,7 @@ export class DeltaScheduler {
     public batchEnd(message: ISequencedDocumentMessage) {
         if (this.schedulingLog) {
             this.schedulingLog.lastSequenceNumber = message.sequenceNumber;
-            if (this.schedulingCount % 2000 === 0) {
-                this.schedulingLog.opsRemainingToProcess = this.deltaManager.inbound.length;
-            }
+            this.schedulingLog.opsRemainingToProcess = this.deltaManager.inbound.length;
         }
 
         if (this.shouldRunScheduler()) {


### PR DESCRIPTION
Fix for #8909  - Adding additional logging to the DeltaScheduler before invoking the inboundqueue.resume() inside batchEnd call 


Information Added to the new event **DeltaManagerPaused**
a) how many ops we already processed till that moment?
b) how many ops are remained in queue?
c) current numberOfTurns 
d) processing and elapsed times

Added to the existing one (InboundOpsProcessingTime): 
a)Once done (reached idle), how many ops actually were processed (will be different from # 2, as ops are coming in).

@vladsud - it seems we do need the isScheduling  as we can call batchEnd() multiple times in case we have multiple batches ? 
