### PR TITLE
Allow FluidObject to be used as object builder

### DIFF
--- a/common/lib/core-interfaces/api-report/core-interfaces.api.md
+++ b/common/lib/core-interfaces/api-report/core-interfaces.api.md
@@ -8,7 +8,7 @@
 //
 // @public
 export type FluidObject<T = unknown> = {
-    readonly [P in FluidObjectProviderKeys<T>]?: T[P];
+    [P in FluidObjectProviderKeys<T>]?: T[P];
 };
 
 // @public

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/core-interfaces",
-  "version": "0.43.0",
+  "version": "0.43.1000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/core-interfaces/src/provider.ts
+++ b/common/lib/core-interfaces/src/provider.ts
@@ -61,7 +61,7 @@
  *
  */
  export type FluidObject<T = unknown> = {
-    readonly [P in FluidObjectProviderKeys<T>]?: T[P];
+    [P in FluidObjectProviderKeys<T>]?: T[P];
 };
 
 /**

--- a/common/lib/core-interfaces/src/test/types/fluidObjectTypes.ts
+++ b/common/lib/core-interfaces/src/test/types/fluidObjectTypes.ts
@@ -148,3 +148,10 @@ declare function getIFluidObject(): IFluidObject;
     const builder: FluidObject<IFluidLoadable> = {};
     builder.IFluidLoadable = getLoadable();
 }
+
+// validate readonly prevents modification
+{
+    const builder: Readonly<FluidObject<IFluidLoadable>> = {};
+    // @ts-expect-error Cannot assign to 'IFluidLoadable' because it is a read-only property.
+    builder.IFluidLoadable = getLoadable();
+}

--- a/common/lib/core-interfaces/src/test/types/fluidObjectTypes.ts
+++ b/common/lib/core-interfaces/src/test/types/fluidObjectTypes.ts
@@ -13,6 +13,7 @@ declare function useProvider<T extends FluidObject>(params: FluidObject<T> | und
 declare function useProviderKey<T,TKey extends FluidObjectKeys<T> = FluidObjectKeys<T>>(key: TKey): void;
 
 declare function useLoadable(params: FluidObject<IFluidLoadable> | undefined): void;
+declare function getLoadable(): IFluidLoadable;
 
 declare function use(obj: any);
 // test implicit conversions between FluidObject and a FluidObject with a provides interface
@@ -140,4 +141,10 @@ declare function getIFluidObject(): IFluidObject;
     useProvider(c.IFooChild?.child());
     useProvider(c.IFooChild?.parent());
     useProvider(c.IFooChild?.IFooParent?.parent());
+}
+
+// validate usage as builder
+{
+    const builder: FluidObject<IFluidLoadable> = {};
+    builder.IFluidLoadable = getLoadable();
 }


### PR DESCRIPTION
In the fix for #8294 I made the properties of FluidObject readonly. This makes building and composition scenarios harder, and was an unintended breaking change. This removes the readonly on property and adds test. If someone wishes to have a readonly FluidObject, they can use the Readonly helper type