### PR TITLE
Bump core-interfaces and container-definitions in client

### DIFF
--- a/experimental/framework/react/src/helpers/getFluidState.ts
+++ b/experimental/framework/react/src/helpers/getFluidState.ts
@@ -51,8 +51,8 @@ export function getFluidState<
             ?.sharedObjectCreate;
         let value = fluidObjectState.get(fluidKey);
         if (value !== undefined && createCallback !== undefined) {
-            const possibleFluidObjectId = (value as FluidObject<IFluidHandle>)
-                ?.IFluidHandle?.absolutePath;
+            const handle: FluidObject<IFluidHandle> = value;
+            const possibleFluidObjectId = handle?.IFluidHandle?.absolutePath;
             if (possibleFluidObjectId !== undefined) {
                 value = (fluidObjectMap.get(possibleFluidObjectId)) as IFluidObjectMapItem;
                 fluidState[fluidKey] = value?.fluidObject;

--- a/experimental/framework/react/src/helpers/getViewFromFluid.ts
+++ b/experimental/framework/react/src/helpers/getViewFromFluid.ts
@@ -58,9 +58,9 @@ export function getViewFromFluid<
         return viewConverter(viewState, partialFluidState, fluidObjectMap);
     } else {
         const partialViewState: Partial<SV> = {};
-        const valueAsIFluidHandle = (value as FluidObject<IFluidHandle>).IFluidHandle;
-        const convertedValue = valueAsIFluidHandle !== undefined
-            ? fluidObjectMap.get(valueAsIFluidHandle.absolutePath)
+        const valueAsIFluidHandle: FluidObject<IFluidHandle> = value;
+        const convertedValue = valueAsIFluidHandle.IFluidHandle !== undefined
+            ? fluidObjectMap.get(valueAsIFluidHandle.IFluidHandle.absolutePath)
             : value;
         partialViewState[fluidKey as string] = convertedValue;
         return partialViewState;

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2600,21 +2600,14 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.48.1000-59255",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000-59255.tgz",
-			"integrity": "sha512-kP3Xt2lJxWPdgIXEvKj7urZFmXjKcfmdqurQW/JQV04Brjf0Kol5FUMvhmYeWHDnxnzEwXkYu/D6hbUcgWaskA==",
+			"version": "0.48.1000-60762",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000-60762.tgz",
+			"integrity": "sha512-ezCjHa3pLLZa2zP9U8dOQ5tGNywiVs+qhMGFiiafyhCGeR1vXe6kQNiwwTy4Xe5cXPO7uQDDPr+GIkuf4Q+Z5A==",
 			"requires": {
-				"@fluidframework/common-definitions": "^0.20.0",
-				"@fluidframework/core-interfaces": "^0.42.0",
+				"@fluidframework/common-definitions": "^0.20.1",
+				"@fluidframework/core-interfaces": "^0.43.1000-0",
 				"@fluidframework/driver-definitions": "^0.46.1000-0",
 				"@fluidframework/protocol-definitions": "^0.1028.1000-0"
-			},
-			"dependencies": {
-				"@fluidframework/core-interfaces": {
-					"version": "0.42.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0.tgz",
-					"integrity": "sha512-++hCu5X6e2CL2swrhXoGaJanGjvaHZNmTT/cSYI8tfnX4cW7eRJuIy8Kcg6K3nMn4thxbVPW7+QG4VPRNuGlMQ=="
-				}
 			}
 		},
 		"@fluidframework/container-loader": {
@@ -3112,9 +3105,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.43.1000-60265",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000-60265.tgz",
-			"integrity": "sha512-JWv+tivT53q0xbPh/wgjfQoHNU1OftF4wC8ZDh5njm4t130m9txPnNVng7QfN5hYgAlWLsjRZ8KZm5lIx3yD1Q=="
+			"version": "0.43.1000-60792",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000-60792.tgz",
+			"integrity": "sha512-uaC3z6O3Vf469TnHzIPGY57xMtwEmRkaRjORLlE1SBIiufV0qbS0ybtHMJ4M82M1kdBdunrPs0ft0DC4MBVpIQ=="
 		},
 		"@fluidframework/counter": {
 			"version": "0.58.2002",

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -69,7 +69,7 @@ export class BaseContainerRuntimeFactory
         context: IContainerContext,
         existing: boolean,
     ): Promise<ContainerRuntime> {
-        const scope = context.scope as FluidObject<IProvideFluidDependencySynthesizer>;
+        const scope: Partial<IProvideFluidDependencySynthesizer> = context.scope;
         const dc = new DependencyContainer<FluidObject<IContainerRuntime>>(
             this.dependencyContainer, scope.IFluidDependencySynthesizer);
         scope.IFluidDependencySynthesizer = dc;

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -77,7 +77,7 @@ async function createDataObject<TObj extends PureDataObject,I extends DataObject
     // becomes globally available. But it's not full initialization - constructor can't
     // access DDSs or other services of runtime as objects are not fully initialized.
     // In order to use object, we need to go through full initialization by calling finishInitialization().
-    const scope = context.scope as FluidObject<IFluidDependencySynthesizer>;
+    const scope: FluidObject<IFluidDependencySynthesizer> = context.scope;
     const dependencyContainer = new DependencyContainer(scope.IFluidDependencySynthesizer);
     const providers = dependencyContainer.synthesize<I["OptionalProviders"]>(optionalProviders, {});
     const instance = new ctor({ runtime, context, providers, initProps });

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -294,7 +294,7 @@ export class Loader implements IHostLoader {
     private readonly mc: MonitoringContext;
 
     constructor(loaderProps: ILoaderProps) {
-        const scope = { ...loaderProps.scope as FluidObject<ILoader> };
+        const scope: FluidObject<ILoader> = { ...loaderProps.scope };
         if (loaderProps.options?.provideScopeLoader !== false) {
             scope.ILoader = this;
         }


### PR DESCRIPTION
This change brings in the latest version of core-interface and container-definitions, and does a bit of cleanup around some FluidObject type usages now that we have the latest types.