### PR TITLE
Identify when the legacy `_createDataStoreWithProps` API is used to create root datastores

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1900,6 +1900,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
         if (isRoot) {
             fluidDataStore.bindToContext();
+            this.logger.sendTelemetryEvent({
+                eventName: "Root datastore with props",
+                hasProps: props !== undefined,
+            });
         }
         return channelToDataStore(fluidDataStore, id, this, this.dataStores, this.mc.logger);
     }


### PR DESCRIPTION
This would help better identify the targets for migrating away from the legacy API.

Related to https://github.com/microsoft/FluidFramework/issues/9660