### PR TITLE
Fix inconsistent TreeView iteration

### DIFF
--- a/experimental/dds/tree/src/TreeView.ts
+++ b/experimental/dds/tree/src/TreeView.ts
@@ -291,8 +291,9 @@ export abstract class TreeView {
 
 	private *iterateNodeDescendants(node: TreeViewNode): IterableIterator<TreeViewNode> {
 		yield node;
-		for (const trait of Array.from(node.traits.values()).sort()) {
-			for (const childId of trait) {
+		for (const label of [...node.traits.keys()].sort()) {
+			const trait = node.traits.get(label);
+			for (const childId of trait ?? fail('Expected trait with label')) {
 				const child = this.getViewNode(childId);
 				yield* this.iterateNodeDescendants(child);
 			}

--- a/experimental/dds/tree/src/test/fuzz/SharedTreeFuzzTests.ts
+++ b/experimental/dds/tree/src/test/fuzz/SharedTreeFuzzTests.ts
@@ -8,8 +8,10 @@ import { join } from 'path';
 import Prando from 'prando';
 import { expect } from 'chai';
 import { setUpLocalServerTestSharedTree, testDocumentsPathBase } from '../utilities/TestUtilities';
-import { WriteFormat } from '../../persisted-types';
+import { ChangeInternal, WriteFormat } from '../../persisted-types';
 import { fail } from '../../Common';
+import { areRevisionViewsSemanticallyEqual } from '../../EditUtilities';
+import { EditLog } from '../../EditLog';
 import { FuzzTestState, done, EditGenerationConfig, AsyncGenerator, Operation } from './Types';
 import { chain, makeOpGenerator, take } from './Generators';
 
@@ -102,7 +104,23 @@ export async function performFuzzActions(
 						fail('Attempted to synchronize with undefined testObjectProvider');
 					}
 					await testObjectProvider.ensureSynchronized();
-					// May want to validate state here
+					const trees = [...state.activeCollaborators, ...state.passiveCollaborators];
+					if (trees.length > 1) {
+						const first = trees[0].tree;
+						for (let i = 1; i < trees.length; i++) {
+							const tree = trees[i].tree;
+							const editLogA = first.editsInternal as EditLog<ChangeInternal>;
+							const editLogB = tree.editsInternal as EditLog<ChangeInternal>;
+							const minEdits = Math.min(editLogA.length, editLogB.length);
+							for (let j = 0; j < minEdits - 1; j++) {
+								const editA = await editLogA.getEditAtIndex(editLogA.length - j - 1);
+								const editB = await editLogB.getEditAtIndex(editLogB.length - j - 1);
+								expect(editA.id).to.equal(editB.id);
+							}
+							expect(areRevisionViewsSemanticallyEqual(tree.currentView, tree, first.currentView, first))
+								.to.be.true;
+						}
+					}
 					break;
 				}
 				default:


### PR DESCRIPTION
This resolves an issue in which we sorted the values of a node's traits, which yields an inconsistent sort order (it sorts arrays of non-normalized ids). Instead we should be sorting by the keys.

This issue was caught by adding additional validation to the fuzz tests which is bundled here; we still need to add an explicit regression test for the problem.