### PR TITLE
[r11s] Allowing kafka producer's maxBatchSize to be configurable

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -122,6 +122,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
         const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
         const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
         const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
+        const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
         const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
 
         const producer = services.createProducer(
@@ -133,6 +134,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
             kafkaProducerPollIntervalMs,
             kafkaNumberOfPartitions,
             kafkaReplicationFactor,
+            kafkaMaxBatchSize,
             kafkaSslCACertFilePath);
 
         const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -21,6 +21,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
     const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
+    const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
     const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
 
     const kafkaForwardClientId = config.get("deli:kafkaClientId");
@@ -62,6 +63,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
+        kafkaMaxBatchSize,
         kafkaSslCACertFilePath);
     const reverseProducer = services.createProducer(
         kafkaLibrary,
@@ -72,6 +74,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
+        kafkaMaxBatchSize,
         kafkaSslCACertFilePath);
 
     const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -29,6 +29,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
     const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
+    const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
     const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
     const sendTopic = config.get("lambdas:deli:topic");
     const kafkaClientId = config.get("scribe:kafkaClientId");
@@ -94,6 +95,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
+        kafkaMaxBatchSize,
         kafkaSslCACertFilePath);
 
     return new ScribeLambdaFactory(

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -20,6 +20,7 @@ import { IKafkaBaseOptions, IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
 export interface IKafkaProducerOptions extends Partial<IKafkaBaseOptions> {
 	enableIdempotence: boolean;
 	pollIntervalMs: number;
+	maxBatchSize: number;
 	additionalOptions?: kafkaTypes.ProducerGlobalConfig;
 	topicConfig?: kafkaTypes.ProducerTopicConfig;
 }
@@ -62,6 +63,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			...options,
 			enableIdempotence: options?.enableIdempotence ?? false,
 			pollIntervalMs: options?.pollIntervalMs ?? 10,
+			maxBatchSize: options?.maxBatchSize ?? MaxBatchSize,
 		};
 	}
 
@@ -190,7 +192,8 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			boxcar = boxcars[boxcars.length - 1];
 
 			// Create a new boxcar if necessary
-			if (boxcar.partitionId !== partitionId || boxcar.messages.length + messages.length >= MaxBatchSize) {
+			if (boxcar.partitionId !== partitionId ||
+				boxcar.messages.length + messages.length >= this.producerOptions.maxBatchSize) {
 				boxcar = new PendingBoxcar(tenantId, documentId);
 				boxcars.push(boxcar);
 			}
@@ -210,7 +213,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 
 		// If adding a new message to the boxcar filled it up, and we are connected, then send immediately. Otherwise
 		// request a send
-		if (this.connected && boxcar.messages.length >= MaxBatchSize) {
+		if (this.connected && boxcar.messages.length >= this.producerOptions.maxBatchSize) {
 			// Send all the boxcars
 			this.sendBoxcars(boxcars);
 			this.messages.delete(key);

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -19,6 +19,7 @@ export function createProducer(
     pollIntervalMs?: number,
     numberOfPartitions?: number,
     replicationFactor?: number,
+    maxBatchSize?: number,
     sslCACertFilePath?: string): IProducer {
     let producer: IProducer;
 
@@ -27,7 +28,14 @@ export function createProducer(
             { kafka: [kafkaEndPoint] },
             clientId,
             topic,
-            { enableIdempotence, pollIntervalMs, numberOfPartitions, replicationFactor, sslCACertFilePath });
+            {
+                enableIdempotence,
+                pollIntervalMs,
+                numberOfPartitions,
+                replicationFactor,
+                maxBatchSize,
+                sslCACertFilePath,
+            });
 
         producer.on("error", (error, errorData: IContextErrorData) => {
             if (errorData?.restart) {
@@ -47,7 +55,8 @@ export function createProducer(
             clientId,
             topic,
             numberOfPartitions,
-            replicationFactor);
+            replicationFactor,
+            maxBatchSize);
         producer.on("error", (error) => {
             winston.error(error);
             Lumberjack.error(error);


### PR DESCRIPTION
We recently had an incident in our production cluster where Kafka Producers were failing with the following error:
`Error: Broker: Message size too large`

While the appropriate long-term fix for this involves improving how we compute the Kafka producers' batch sizer, as well as adding checks in Alfred to prevent large ops from being accepted, changing the maxBatchSize was the mitigation approach we used, as it was a simple and quick change. There is value in making that value configurable, and this PR does that.