### PR TITLE
Restore additional validation

### DIFF
--- a/experimental/dds/tree/src/test/fuzz/SharedTreeFuzzTests.ts
+++ b/experimental/dds/tree/src/test/fuzz/SharedTreeFuzzTests.ts
@@ -165,7 +165,7 @@ export function runSharedTreeFuzzTests(title: string): void {
 					mkdirSync(directory);
 				}
 				await performFuzzActions(generatorFactory(), seed + adjustSeed, true, saveInfo);
-			}).timeout(5000);
+			}).timeout(10000);
 		}
 
 		function runMixedVersionTests(summarizeHistory: boolean, testsPerSuite: number): void {


### PR DESCRIPTION
The issue was just this test suite hitting a timeout. All logs from CI show that the failures happened near the end of the suite, and only when coverage was enabled. Doubling the timeout should safely avoid future issues.