### PR TITLE
Add missing uuid dependency to azure-service-utils

### DIFF
--- a/api-report/azure-service-utils.api.md
+++ b/api-report/azure-service-utils.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { IUser } from '@fluidframework/protocol-definitions';
+import type { IUser } from '@fluidframework/protocol-definitions';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 
 // @public

--- a/packages/framework/azure-service-utils/.eslintrc.js
+++ b/packages/framework/azure-service-utils/.eslintrc.js
@@ -11,7 +11,5 @@ module.exports = {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
     },
     "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off",
-        "import/no-extraneous-dependencies": "off"
     }
 }

--- a/packages/framework/azure-service-utils/package.json
+++ b/packages/framework/azure-service-utils/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
-    "jsrsasign": "^10.2.0"
+    "jsrsasign": "^10.2.0",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@^0.58.0",

--- a/packages/framework/azure-service-utils/src/generateToken.ts
+++ b/packages/framework/azure-service-utils/src/generateToken.ts
@@ -29,9 +29,10 @@ export function generateToken(
 
     // Current time in seconds
     const now = Math.round(Date.now() / 1000);
+    const docId = documentId ?? "";
 
     const claims: ITokenClaims & { jti: string } = {
-        documentId,
+        documentId: docId,
         scopes,
         tenantId,
         user: userClaim,
@@ -42,7 +43,7 @@ export function generateToken(
     };
 
     const utf8Key = { utf8: key };
-    return jsrsasign.jws.JWS.sign(undefined, JSON.stringify({ alg: "HS256", typ: "JWT" }), claims, utf8Key);
+    return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg: "HS256", typ: "JWT" }), claims, utf8Key);
 }
 
 export function generateUser(): IUser {

--- a/packages/framework/azure-service-utils/src/generateToken.ts
+++ b/packages/framework/azure-service-utils/src/generateToken.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";
+import type { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";
 import { KJUR as jsrsasign } from "jsrsasign";
 import { v4 as uuid } from "uuid";
 
@@ -28,7 +28,7 @@ export function generateToken(
     }
 
     // Current time in seconds
-    const now = Math.round((new Date()).getTime() / 1000);
+    const now = Math.round(Date.now() / 1000);
 
     const claims: ITokenClaims & { jti: string } = {
         documentId,
@@ -42,7 +42,7 @@ export function generateToken(
     };
 
     const utf8Key = { utf8: key };
-    return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, utf8Key);
+    return jsrsasign.jws.JWS.sign(undefined, JSON.stringify({ alg: "HS256", typ: "JWT" }), claims, utf8Key);
 }
 
 export function generateUser(): IUser {

--- a/packages/framework/azure-service-utils/tsconfig.json
+++ b/packages/framework/azure-service-utils/tsconfig.json
@@ -4,7 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [


### PR DESCRIPTION
I discovered this while investigating lint config stuff. The `import/no-extraneous-dependencies` was disabled, which was hiding a missing dependency! I also fixed up some other lint issues I found using a more aggressive config.