### PR TITLE
Classify 'Runtime is closed' error as UsageError

### DIFF
--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -8,6 +8,7 @@ import {
     IGenericError,
     IErrorBase,
     IThrottlingWarning,
+    IUsageError,
 } from "@fluidframework/container-definitions";
 import {
     LoggingError,
@@ -72,9 +73,8 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
 }
 
 /** Error indicating an API is being used improperly resulting in an invalid operation. */
-export class UsageError extends LoggingError implements IFluidErrorBase {
-    // TODO: implement IUsageError once available
-    readonly errorType = "usageError";
+export class UsageError extends LoggingError implements IFluidErrorBase, IUsageError {
+    readonly errorType: ContainerErrorType.usageError = ContainerErrorType.usageError;
 
     constructor(
         message: string,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2606,7 +2606,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     private verifyNotClosed() {
         if (this._disposed) {
-            throw new Error("Runtime is closed");
+            throw new UsageError("Runtime is closed");
         }
     }
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -17,7 +17,7 @@ import {
     AttachState,
     ILoaderOptions,
 } from "@fluidframework/container-definitions";
-import { DataProcessingError } from "@fluidframework/container-utils";
+import { DataProcessingError, UsageError } from "@fluidframework/container-utils";
 import {
     assert,
     Deferred,
@@ -868,7 +868,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
     private verifyNotClosed() {
         if (this._disposed) {
-            throw new Error("Runtime is closed");
+            throw new UsageError("Runtime is closed");
         }
     }
 }


### PR DESCRIPTION
This error means that the containerRuntime/dataStoreRuntime is being used after it's already been closed/disposed.  If this error is encountered, the caller should consider checking the state of the runtime object before proceeding.

This will preclude this error from being classified as a DataProcessingError, which is typically what is happening today based on how it is propagating.  This is fine though - UsageError more directly gets to the point - the runtime closes but the caller isn't checking/aware.