### PR TITLE
Adding conversion options for summary transformation

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -45,7 +45,7 @@ export const choose: () => string;
 export function convertSummaryTreeToWholeSummaryTree(parentHandle: string | undefined, tree: ISummaryTree, path?: string, rootNodeName?: string): IWholeSummaryTree;
 
 // @public
-export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(flatSummary: IWholeFlatSummary, options?: ISnapshotConversionOptions): INormalizedWholeSummary;
+export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(flatSummary: IWholeFlatSummary, treePrefixToRemove?: string): INormalizedWholeSummary;
 
 // @public
 export function createFluidServiceNetworkError(statusCode: number, errorData?: INetworkErrorDetails | string): NetworkError;
@@ -341,11 +341,6 @@ export interface ISession {
     isSessionAlive: boolean;
     // (undocumented)
     ordererUrl: string;
-}
-
-// @public
-export interface ISnapshotConversionOptions {
-    stripAppPath: boolean;
 }
 
 // @public (undocumented)

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -45,7 +45,7 @@ export const choose: () => string;
 export function convertSummaryTreeToWholeSummaryTree(parentHandle: string | undefined, tree: ISummaryTree, path?: string, rootNodeName?: string): IWholeSummaryTree;
 
 // @public
-export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(flatSummary: IWholeFlatSummary): INormalizedWholeSummary;
+export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(flatSummary: IWholeFlatSummary, options?: ISnapshotConversionOptions): INormalizedWholeSummary;
 
 // @public
 export function createFluidServiceNetworkError(statusCode: number, errorData?: INetworkErrorDetails | string): NetworkError;
@@ -341,6 +341,11 @@ export interface ISession {
     isSessionAlive: boolean;
     // (undocumented)
     ordererUrl: string;
+}
+
+// @public
+export interface ISnapshotConversionOptions {
+    stripAppPath: boolean;
 }
 
 // @public (undocumented)

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -181,7 +181,7 @@ export function convertSummaryTreeToWholeSummaryTree(
  * Converts existing IWholeFlatSummary to snapshot tree, blob array, and sequence number.
  *
  * @param flatSummary - flat summary
- * @param treePrefixToRemove - tree prefix to strip
+ * @param treePrefixToRemove - tree prefix to strip. By default we are stripping ".app" prefix
  * @returns snapshot tree, blob array, and sequence number
  */
 export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -140,7 +140,7 @@ export function convertSummaryTreeToWholeSummaryTree(
  * Build a tree heirarchy from a flat tree.
  *
  * @param flatTree - a flat tree
- * @param options - conversion options
+ * @param treePrefixToRemove - tree prefix to strip
  * @returns the heirarchical tree
  */
  function buildHierarchy(
@@ -181,7 +181,7 @@ export function convertSummaryTreeToWholeSummaryTree(
  * Converts existing IWholeFlatSummary to snapshot tree, blob array, and sequence number.
  *
  * @param flatSummary - flat summary
- * @param options - conversion options
+ * @param treePrefixToRemove - tree prefix to strip
  * @returns snapshot tree, blob array, and sequence number
  */
 export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(

--- a/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
@@ -4,7 +4,153 @@
  */
 
 import assert from "assert";
-import { buildTreePath } from "../storageUtils";
+import { stringToBuffer } from "@fluidframework/common-utils";
+import { buildTreePath, convertWholeFlatSummaryToSnapshotTreeAndBlobs } from "../storageUtils";
+
+import {
+    IWholeFlatSummaryBlob,
+    IWholeFlatSummary,
+    IWholeFlatSummaryTree,
+    IWholeFlatSummaryTreeEntry,
+} from "../storageContracts";
+
+const summaryBlobs: IWholeFlatSummaryBlob[] = [
+    {
+        id: "bARCTBK4PQiMLVK2gR5hPRkId",
+        content: "[]",
+        encoding: "utf-8",
+        size: 2
+    },
+    {
+        id: "bARCfbIYtOyFwf1+nY75C4UFc",
+        content: "[]",
+        encoding: "utf-8",
+        size: 2
+    },
+    {
+        id: "bARAL2CXvHYOch_aQtJAJOker",
+        content: "[]",
+        encoding: "utf-8",
+        size: 2
+    },
+]
+
+const treeEntries: IWholeFlatSummaryTreeEntry[] = [
+    {
+        path: ".protocol",
+        type: "tree",
+        unreferenced: null
+    },
+    {
+        id: "bARCTBK4PQiMLVK2gR5hPRkId",
+        path: ".protocol/attributes",
+        type: "blob",
+    },
+    {
+        id: "bARAL2CXvHYOch_aQtJAJOker",
+        path: ".protocol/quorumValues",
+        type: "blob",
+    },
+    {
+        path: ".app",
+        type: "tree",
+        unreferenced: null
+    },
+    {
+        path: ".app/.channels",
+        type: "tree",
+        unreferenced: null
+    },
+    {
+        path: ".app/.channels/rootDOId",
+        type: "tree",
+        unreferenced: null
+    },
+    {
+        id: "bARCfbIYtOyFwf1+nY75C4UFc",
+        path: ".app/.metadata",
+        type: "blob",
+    },
+]
+
+const flatSummary: IWholeFlatSummary = {
+    id: "bBwAAAAAHAAAA",
+    trees: [
+        {
+            id: "bBwAAAAAHAAAA",
+            sequenceNumber: 0,
+            entries: treeEntries
+        }
+    ],
+    blobs: summaryBlobs,
+}
+
+const snapshotTree = {
+    blobs: {
+        ".metadata": "bARCfbIYtOyFwf1+nY75C4UFc",
+    },
+    id: "bBwAAAAAHAAAA",
+    trees: {
+        ".app": {
+            blobs: {},
+            trees: {},
+            unreferenced: null
+        },
+        ".channels": {
+            blobs: {},
+            trees: {
+                rootDOId: {
+                    blobs: {},
+                    trees: {},
+                    unreferenced: null,
+                }
+            },
+            unreferenced: null,
+        },
+        ".protocol": {
+            blobs: {
+                attributes: "bARCTBK4PQiMLVK2gR5hPRkId",
+                quorumValues: "bARAL2CXvHYOch_aQtJAJOker",
+            },
+            trees: {},
+            unreferenced: null,
+        }
+    }
+}
+
+const snapshotTreeWithoutPrefixStrip ={
+    blobs: {},
+    id: "bBwAAAAAHAAAA",
+    trees: {
+        ".app": {
+            blobs: {
+                ".metadata": "bARCfbIYtOyFwf1+nY75C4UFc",
+            },
+            trees: {
+                ".channels": {
+                    blobs: {},
+                    trees: {
+                        rootDOId: {
+                            blobs: {},
+                            trees: {},
+                            unreferenced: null,
+                        }
+                    },
+                    unreferenced: null,
+                },
+            },
+            unreferenced: null
+        },
+        ".protocol": {
+            blobs: {
+                attributes: "bARCTBK4PQiMLVK2gR5hPRkId",
+                quorumValues: "bARAL2CXvHYOch_aQtJAJOker",
+            },
+            trees: {},
+            unreferenced: null,
+        }
+    }
+}
 
 describe("Storage Utils", () => {
     describe("buildTreePath()", () => {
@@ -33,6 +179,42 @@ describe("Storage Utils", () => {
             assert.strictEqual(
                 buildTreePath("ABC", ".app/", ".handle/component/"),
                 "ABC/.app/.handle/component",
+            );
+        });
+    });
+
+    describe("convertWholeFlatSummaryToSnapshotTreeAndBlobs()", () => {
+        const blobs = new Map<string, ArrayBuffer>();
+        let flatSummaryTree: IWholeFlatSummaryTree;
+        let sequenceNumber: number;
+
+        beforeEach(() => {
+            for (const b of summaryBlobs) {
+                blobs.set(b.id, stringToBuffer(b.content, b.encoding ?? "utf-8"));
+            }
+            flatSummaryTree = flatSummary.trees && flatSummary.trees[0];
+            sequenceNumber = flatSummaryTree?.sequenceNumber;
+        });
+
+        it("converts while stripping .app prefix", () => {
+            assert.deepStrictEqual(
+                convertWholeFlatSummaryToSnapshotTreeAndBlobs(flatSummary),
+                {
+                    blobs,
+                    snapshotTree,
+                    sequenceNumber,
+                },
+            );
+        });
+
+        it("converts without stripping .app prefix", () => {
+            assert.deepStrictEqual(
+                convertWholeFlatSummaryToSnapshotTreeAndBlobs(flatSummary, ""),
+                {
+                    blobs,
+                    snapshotTree: snapshotTreeWithoutPrefixStrip,
+                    sequenceNumber,
+                },
             );
         });
     });


### PR DESCRIPTION
This PR supplements https://github.com/microsoft/FluidFramework/pull/9650. We want to be able to transform WholeFlatSummary in a more generic way, without stripping app path. Exposing transformation options as interface so we can extend it in future, as needed. The existing callers of this function will not see difference in api behavior since by default, app path is still being stripped.