### PR TITLE
r11s: socket connection auth error recognition

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -66,7 +66,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
         // Note: we suspect the incoming error object is either:
         // - a socketError: add it to the R11sError object for driver to be able to parse it and reason over it.
         // - anything else: let base class handle it
-        if (canRetry && Number.isInteger(error?.code) && typeof error?.message === "string") {
+        if (canRetry && Number.isInteger(error?.code) && ["string", "object"].includes(typeof error?.message)) {
             return errorObjectFromSocketError(error as IR11sSocketError, handler);
         } else {
             return super.createErrorObject(handler, error, canRetry);

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -64,7 +64,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
      */
     protected createErrorObject(handler: string, error?: any, canRetry = true): IAnyDriverError {
         // Note: we suspect the incoming error object is either:
-        // - a socketError: add it to the OdspError object for driver to be able to parse it and reason over it.
+        // - a socketError: add it to the R11sError object for driver to be able to parse it and reason over it.
         // - anything else: let base class handle it
         if (canRetry && Number.isInteger(error?.code) && typeof error?.message === "string") {
             return errorObjectFromSocketError(error as IR11sSocketError, handler);

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -66,7 +66,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
         // Note: we suspect the incoming error object is either:
         // - a socketError: add it to the R11sError object for driver to be able to parse it and reason over it.
         // - anything else: let base class handle it
-        if (canRetry && Number.isInteger(error?.code) && ["string", "object"].includes(typeof error?.message)) {
+        if (canRetry && Number.isInteger(error?.code) && typeof error?.message === "string") {
             return errorObjectFromSocketError(error as IR11sSocketError, handler);
         } else {
             return super.createErrorObject(handler, error, canRetry);

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -18,6 +18,7 @@ export enum R11sErrorType {
 
 /**
  * Interface for error responses for the WebSocket connection
+ * Intended to be compatible with output from {@link NetworkError.toJSON}
  */
 export interface IR11sSocketError {
     /**

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -36,6 +36,12 @@ export interface IR11sSocketError {
      * Optional Retry-After time in seconds.
      * The client should wait this many seconds before retrying its request.
      */
+    retryAfter?: number;
+
+    /**
+     * Optional Retry-After time in milliseconds.
+     * The client should wait this many milliseconds before retrying its request.
+     */
     retryAfterMs?: number;
 }
 
@@ -61,6 +67,8 @@ export function createR11sNetworkError(
             return new GenericNetworkError(
                 errorMessage, errorMessage.startsWith("NetworkError"), props);
         case 401:
+            // The first 401 is manually retried in RouterliciousRestWrapper with a refreshed token,
+            // so we treat repeat 401s the same as 403.
         case 403:
             return new AuthorizationError(
                 errorMessage, undefined, undefined, props);

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -321,6 +321,7 @@ export interface INetworkErrorDetails {
     isFatal?: boolean;
     message?: string;
     retryAfter?: number;
+    retryAfterMs?: number;
 }
 
 // @public
@@ -490,6 +491,7 @@ export class NetworkError extends Error {
     readonly code: number;
     get details(): INetworkErrorDetails | string;
     readonly isFatal?: boolean;
+    readonly retryAfter: number;
     readonly retryAfterMs?: number;
 }
 

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -351,6 +351,9 @@ export interface ISession {
 }
 
 // @public (undocumented)
+export function isNetworkError(error: unknown): error is NetworkError;
+
+// @public (undocumented)
 export interface ISummaryTree extends ISummaryTree_2 {
     // (undocumented)
     tree: {

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -493,6 +493,9 @@ export class NetworkError extends Error {
     readonly isFatal?: boolean;
     readonly retryAfter: number;
     readonly retryAfterMs?: number;
+    toJSON(): INetworkErrorDetails & {
+        code: number;
+    };
 }
 
 // @public (undocumented)

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -287,7 +287,7 @@ export function configureWebSocketServices(
                 throw new NetworkError(
                     400,
                     // eslint-disable-next-line max-len
-                    `Unsupported client protocol. Server: ${protocolVersions}. Client: ${JSON.stringify(connectVersions)}`
+                    `Unsupported client protocol. Server: ${protocolVersions}. Client: ${JSON.stringify(connectVersions)}`,
                 );
             }
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -18,6 +18,7 @@ import {
 import {
     canSummarize,
     canWrite,
+    NetworkError,
     validateTokenClaims,
     validateTokenClaimsExpiration,
 } from "@fluidframework/server-services-client";
@@ -241,8 +242,8 @@ export function configureWebSocketServices(
                 // eslint-disable-next-line prefer-promise-reject-errors
                 return Promise.reject({
                     // if we don't understand the error, be lenient and allow retry
-                    code: err?.response?.status ?? 401,
-                    message: err?.response?.data ?? "Invalid token",
+                    code: (err as NetworkError | undefined)?.code ?? 401,
+                    message: (err as NetworkError | undefined)?.message ?? "Invalid token",
                 });
             }
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -286,11 +286,8 @@ export function configureWebSocketServices(
             if (!version) {
                 throw new NetworkError(
                     400,
-                    [
-                        `Unsupported client protocol.`,
-                        `Server: ${protocolVersions}.`,
-                        `Client: ${JSON.stringify(connectVersions)}`,
-                    ].join(" "),
+                    // eslint-disable-next-line max-len
+                    `Unsupported client protocol. Server: ${protocolVersions}. Client: ${JSON.stringify(connectVersions)}`
                 );
             }
 
@@ -304,9 +301,9 @@ export function configureWebSocketServices(
                 throw new NetworkError(
                     429,
                     "Too Many Clients Connected to Document",
-                    true,
-                    false,
-                    5 * 60 * 1000 /* 5 min */,
+                    true, /* canRetry */
+                    false, /* isFatal */
+                    5 * 60 * 1000 /* retryAfterMs (5 min) */,
                 );
             }
 

--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -22,10 +22,16 @@ export interface INetworkErrorDetails {
      */
     message?: string;
     /**
-     * Represents the time in milliseconds that should be waited before retrying.
-     * Refer to {@link NetworkError.retryAfterMs}.
+     * Represents the time in seconds that should be waited before retrying.
+     * TODO: remove in favor of retryAfterMs.
+     * Refer to {@link NetworkError.retryAfter}.
      */
     retryAfter?: number;
+    /**
+     * Represents the time in seconds that should be waited before retrying.
+     * Refer to {@link NetworkError.retryAfterMs}.
+     */
+    retryAfterMs?: number;
 }
 
 /**
@@ -38,6 +44,13 @@ export interface INetworkErrorDetails {
  * network error and making those services more prepared to react to such kinds of errors.
  */
 export class NetworkError extends Error {
+    /**
+     * Value representing the time in seconds that should be waited before retrying.
+     * TODO: remove in favor of retryAfterMs once driver supports retryAfterMs.
+     * @public
+     */
+    public readonly retryAfter: number;
+
     constructor(
         /**
          * HTTP status code that describes the error.
@@ -69,6 +82,7 @@ export class NetworkError extends Error {
     ) {
         super(message);
         this.name = "NetworkError";
+        this.retryAfter = retryAfterMs !== undefined ? retryAfterMs / 1000 : undefined;
     }
 
     /**
@@ -86,7 +100,8 @@ export class NetworkError extends Error {
             message: this.message,
             canRetry: this.canRetry,
             isFatal: this.isFatal,
-            retryAfter: this.retryAfterMs,
+            retryAfter: this.retryAfterMs !== undefined ? this.retryAfterMs / 1000 : undefined,
+            retryAfterMs: this.retryAfterMs,
         };
     }
 }

--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -100,7 +100,7 @@ export class NetworkError extends Error {
             message: this.message,
             canRetry: this.canRetry,
             isFatal: this.isFatal,
-            retryAfter: this.retryAfterMs !== undefined ? this.retryAfterMs / 1000 : undefined,
+            retryAfter: this.retryAfter,
             retryAfterMs: this.retryAfterMs,
         };
     }
@@ -119,6 +119,12 @@ export class NetworkError extends Error {
             retryAfter: this.retryAfter,
         };
     }
+}
+
+export function isNetworkError(error: unknown): error is NetworkError {
+    return (error as NetworkError).name === "NetworkError" &&
+        typeof (error as NetworkError).code === "number" &&
+        typeof (error as NetworkError).message === "string";
 }
 
 /**

--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -104,6 +104,21 @@ export class NetworkError extends Error {
             retryAfterMs: this.retryAfterMs,
         };
     }
+
+    /**
+     * Explicitly define how to serialize as JSON so that socket.io can emit relevant info.
+     * @public
+     */
+    public toJSON(): INetworkErrorDetails & { code: number } {
+        return {
+            code: this.code,
+            message: this.message,
+            canRetry: this.canRetry,
+            isFatal: this.isFatal,
+            retryAfterMs: this.retryAfterMs,
+            retryAfter: this.retryAfter,
+        };
+    }
 }
 
 /**

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -141,7 +141,6 @@ export class BasicRestWrapper extends RestWrapper {
                         debug(`request to ${options.url} failed ${error ? error.message : ""}`);
                     }
 
-                    // TODO: replace retryAfter with retryAfterMs
                     if (error?.response?.status === 429 && error?.response?.data?.retryAfter > 0 && canRetry) {
                         setTimeout(() => {
                             this.request<T>(options, statusCode)

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -141,6 +141,7 @@ export class BasicRestWrapper extends RestWrapper {
                         debug(`request to ${options.url} failed ${error ? error.message : ""}`);
                     }
 
+                    // TODO: replace retryAfter with retryAfterMs
                     if (error?.response?.status === 429 && error?.response?.data?.retryAfter > 0 && canRetry) {
                         setTimeout(() => {
                             this.request<T>(options, statusCode)

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -135,6 +135,7 @@ export async function runWithRetry<T>(
                 return Promise.reject(error);
             }
 
+            // TODO: if error is a NetworkError, we should respect NetworkError.retryAfter or NetworkError.retryAfterMs
             const intervalMs = calculateIntervalMs(error, retryCount, retryAfterMs);
             await delay(intervalMs);
             retryCount++;

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -9,10 +9,15 @@ import { Params } from "express-serve-static-core";
 import { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";
 import * as jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
-import { NetworkError, validateTokenClaimsExpiration } from "@fluidframework/server-services-client";
+import {
+    NetworkError,
+    isNetworkError,
+    validateTokenClaimsExpiration,
+} from "@fluidframework/server-services-client";
 import type { ICache, ITenantManager } from "@fluidframework/server-services-core";
-import type { RequestHandler } from "express";
+import type { RequestHandler, Response } from "express";
 import type { Provider } from "nconf";
+import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 
 /**
  * Validates a JWT token to authorize routerlicious.
@@ -106,6 +111,13 @@ interface IVerifyTokenOptions {
     singleUseTokenCache: ICache | undefined;
 }
 
+export function respondWithNetworkError(
+    response: Response,
+    error: NetworkError,
+): Response {
+    return response.status(error.code).json(error.details);
+}
+
 /**
  * Verifies the storage token claims and calls riddler to validate the token.
  */
@@ -122,57 +134,70 @@ export function verifyStorageToken(
         const isTokenExpiryEnabled = config.get("auth:enableTokenExpiration") as boolean;
         const authorizationHeader = request.header("Authorization");
         if (!authorizationHeader) {
-            return res.status(403).send("Missing Authorization header.");
+            return respondWithNetworkError(res, new NetworkError(403, "Missing Authorization header."));
         }
         const tokenRegex = /Basic (.+)/;
         const tokenMatch = tokenRegex.exec(authorizationHeader);
         if (!tokenMatch || !tokenMatch[1]) {
-            return res.status(403).send("Missing access token.");
+            return respondWithNetworkError(res, new NetworkError(403, "Missing access token."));
         }
         const token = tokenMatch[1];
         const tenantId = getParam(request.params, "tenantId");
         if (!tenantId) {
-            return res.status(403).send("Missing tenantId in request.");
+            return respondWithNetworkError(res, new NetworkError(403, "Missing tenantId in request."));
         }
         const documentId = getParam(request.params, "id") || request.body.id;
         if (options.requireDocumentId && !documentId) {
-            return res.status(403).send("Missing documentId in request");
+            return respondWithNetworkError(res, new NetworkError(403, "Missing documentId in request"));
         }
-        let claims: ITokenClaims;
+        let claims: ITokenClaims | undefined;
         let tokenLifetimeMs: number | undefined;
         try {
             claims = validateTokenClaims(token, documentId, tenantId, options.requireDocumentId);
             if (isTokenExpiryEnabled) {
                 tokenLifetimeMs = validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
             }
-        } catch (error) {
-            if (error instanceof NetworkError) {
-                return res.status(error.code).send(error.message);
-            }
-            throw error;
-        }
-        try {
             await tenantManager.verifyToken(claims.tenantId, token);
         } catch (error) {
-            if (error instanceof NetworkError) {
-                return res.status(error.code).send(error.message);
+            if (isNetworkError(error)) {
+                return respondWithNetworkError(res, error);
             }
-            return res.status(403).json(error);
+            // We don't understand the error, so it is likely an internal service error.
+            Lumberjack.error(
+                "Unrecognized error when validating/verifying request token",
+                claims ? getLumberBaseProperties(claims.documentId, claims.tenantId) : undefined,
+                error,
+            );
+            return respondWithNetworkError(res, new NetworkError(500, "Internal server error."));
         }
 
         if (options.ensureSingleUseToken) {
-            // TODO: remove `as any` after #7065 is merged and released
-            const singleUseKey = (claims as any).jti ?? token;
+            // Use token as key for minimum chance of collision.
+            const singleUseKey = token;
             // TODO: monitor uptime of services and switch to errors blocking
             // flow if needed to prevent malicious activity
-            if (await options.singleUseTokenCache?.get(singleUseKey).catch(() => false)) {
+            const cachedSingleUseToken = await options.singleUseTokenCache?.get(singleUseKey).catch((error) => {
+                Lumberjack.error(
+                    "Unable to retrieve cached single-use JWT",
+                    claims ? getLumberBaseProperties(claims.documentId, claims.tenantId) : undefined,
+                    error,
+                );
+                return false;
+            });
+            if (cachedSingleUseToken) {
                 return res.status(403).send("Access token has already been used.");
             }
             options.singleUseTokenCache?.set(
                 singleUseKey,
                 "used",
                 tokenLifetimeMs !== undefined ? Math.floor(tokenLifetimeMs / 1000) : undefined,
-            ).catch((error) => {});
+            ).catch((error) => {
+                Lumberjack.error(
+                    "Unable to cache single-use JWT",
+                    claims ? getLumberBaseProperties(claims.documentId, claims.tenantId) : undefined,
+                    error,
+                );
+            });
         }
         next();
     };

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -154,6 +154,9 @@ export function verifyStorageToken(
         try {
             await tenantManager.verifyToken(claims.tenantId, token);
         } catch (error) {
+            if (error instanceof NetworkError) {
+                return res.status(error.code).send(error.message);
+            }
             return res.status(403).json(error);
         }
 

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -49,12 +49,12 @@ export function validateTokenClaims(
  * But it can be used by other services to validate the document creator identity upon creating a document.
  */
 export function getCreationToken(token: string, key: string, documentId: string, lifetime = 5 * 60) {
- // Current time in seconds
- const tokenClaims = jwt.decode(token) as ITokenClaims;
+    // Current time in seconds
+    const tokenClaims = jwt.decode(token) as ITokenClaims;
 
- const { tenantId, user } = tokenClaims;
+    const { tenantId, user } = tokenClaims;
 
- return generateToken(tenantId, documentId, key, [], user, lifetime);
+    return generateToken(tenantId, documentId, key, [], user, lifetime);
 }
 
 /**

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -12,7 +12,6 @@ import {
 } from "@fluidframework/server-services-client";
 import { generateToken, getCorrelationId } from "@fluidframework/server-services-utils";
 import * as core from "@fluidframework/server-services-core";
-import Axios from "axios";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 
 export class Tenant implements core.ITenant {
@@ -44,14 +43,18 @@ export class TenantManager implements core.ITenantManager {
     }
 
     public async createTenant(tenantId?: string): Promise<core.ITenantConfig & { key: string }> {
-        const result = await Axios.post<core.ITenantConfig & { key: string }>(
-            `${this.endpoint}/api/tenants/${encodeURIComponent(tenantId || "")}`);
-        return result.data;
+        const restWrapper = new BasicRestWrapper();
+        const result = await restWrapper.post<core.ITenantConfig & { key: string }>(
+            `${this.endpoint}/api/tenants/${encodeURIComponent(tenantId || "")}`,
+            undefined,
+        );
+        return result;
     }
 
     public async getTenant(tenantId: string, documentId: string, includeDisabledTenant = false): Promise<core.ITenant> {
+        const restWrapper = new BasicRestWrapper();
         const [details, key] = await Promise.all([
-            Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`,
+            restWrapper.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`,
             { params: { includeDisabledTenant }}),
             this.getKey(tenantId, includeDisabledTenant)]);
 
@@ -68,8 +71,8 @@ export class TenantManager implements core.ITenantManager {
             });
         };
         const defaultHeaders = getDefaultHeaders();
-        const baseUrl = `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`;
-        const restWrapper = new BasicRestWrapper(
+        const baseUrl = `${details.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`;
+        const tenantRestWrapper = new BasicRestWrapper(
             baseUrl,
             defaultQueryString,
             undefined,
@@ -80,27 +83,29 @@ export class TenantManager implements core.ITenantManager {
             getDefaultHeaders,
             getCorrelationId);
         const historian = new Historian(
-            `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`,
+            `${details.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`,
             true,
             false,
-            restWrapper);
+            tenantRestWrapper);
         const gitManager = new GitManager(historian);
-        const tenant = new Tenant(details.data, gitManager);
+        const tenant = new Tenant(details, gitManager);
 
         return tenant;
     }
 
     public async verifyToken(tenantId: string, token: string): Promise<void> {
-        await Axios.post(
+        const restWrapper = new BasicRestWrapper();
+        await restWrapper.post(
             `${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/validate`,
             { token });
     }
 
     public async getKey(tenantId: string, includeDisabledTenant = false): Promise<string> {
-        const result = await Axios.get<core.ITenantKeys>(
+        const restWrapper = new BasicRestWrapper();
+        const result = await restWrapper.get<core.ITenantKeys>(
             `${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/keys`,
-            { params: { includeDisabledTenant }});
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return result.data.key1;
+            { params: { includeDisabledTenant }},
+        );
+        return result.key1;
     }
 }


### PR DESCRIPTION
#8537 changed R11s server's `NetworkError` class so that internal service calls would contain additional information for internal error handling. This meant that the `Promise.reject` following `tenantManager.verifyToken()` in Alfred Lambda can send an object as the error message. Also, NetworkError.toJSON() was not explicitly defined, and for whatever reason caused `socket.emit("connect_document_error", new NetworkError(403, "some message"))` to only emit an object like `{ code: 403, name: "NetworkError" }`. A bit earlier, #7670 made R11s Driver's error type check stricter, which meant that it no longer recognized errors with `typeof message === "object"` as valid. An example error object in this case would be `{ code: 403, message: { canRetry: false, isFatal: false, message: "Invalid token validated with key1" } }`

This combo can cause R11sDriver to "silently fail" with a vague, retriable "(connect_document_error): [object omitted]" error from driver-base's DocumentDeltaConnection default error handler.

A few things are addressed in this PR:
1. Small comment fix in r11s driver
2. Wrap more internal R11s HTTP requests with BasicRestWrapper to properly parse errors for better consistency
3. #8537 changed the unit of `error.retryAfter` in R11s to be in milliseconds, which differs from the r11s-driver's contract, so I've added both retryAfter and retryAfterMs with the intention of switching everything to retryAfterMs in the future
4. Explicitly define NetworkError.toJSON()

Follow-ups:
- Add UTs to prevent future regressions. Will have a separate PR soon