### PR TITLE
Add feature gate to test odsp binary wire snapshot

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -20,6 +20,7 @@ export interface HostStoragePolicy {
     // (undocumented)
     enableRedeemFallback?: boolean;
     enableShareLinkWithCreate?: boolean;
+    // @deprecated (undocumented)
     fetchBinarySnapshotFormat?: boolean;
     isolateSocketCache?: boolean;
     // (undocumented)

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -139,8 +139,10 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     fileVersion?: string;
 }
 
-// @public
-export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, forceAccessTokenViaAuthorizationHeader: boolean, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, fetchBinarySnapshotFormat?: boolean): Promise<boolean>;
+// Warning: (ae-forgotten-export) The symbol "SnapshotFormatSupportType" needs to be exported by the entry point index.d.ts
+//
+// @public @deprecated
+export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, forceAccessTokenViaAuthorizationHeader: boolean, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, fetchBinarySnapshotFormat?: boolean, snapshotFormatFetchType?: SnapshotFormatSupportType): Promise<boolean>;
 
 // @public
 export interface ShareLinkFetcherProps {

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -106,6 +106,7 @@ export interface HostStoragePolicy {
     cacheCreateNewSummary?: boolean;
 
     /**
+     * @deprecated - This will be replaced with feature gate snapshotFormatFetchType.
      * Policy controlling if we want to fetch binary format snapshot.
      */
     fetchBinarySnapshotFormat?: boolean;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -37,9 +37,9 @@ import { EpochTracker } from "./epochTracker";
  * Enum to support different types of snapshot formats.
  */
 export enum SnapshotFormatSupportType {
-    Json,
-    Binary,
-    JsonAndBinary,
+    Json = 0,
+    Binary = 1,
+    JsonAndBinary = 2,
 }
 
 /**
@@ -473,13 +473,17 @@ export async function downloadSnapshot(
         method: "POST",
     };
     // Decide what snapshot format to fetch as per the feature gate.
-    if (snapshotFormatFetchType?.valueOf() === SnapshotFormatSupportType.JsonAndBinary) {
-        headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
-    } else if (snapshotFormatFetchType?.valueOf() === SnapshotFormatSupportType.Binary) {
-        headers.accept = `application/ms-fluid; v=${currentReadVersion}`;
-    } else {
-        headers.accept = "application/json";
+    switch (snapshotFormatFetchType) {
+        case SnapshotFormatSupportType.JsonAndBinary:
+            headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
+            break;
+        case SnapshotFormatSupportType.Binary:
+            headers.accept = `application/ms-fluid; v=${currentReadVersion}`;
+            break;
+        default:
+            headers.accept = "application/json";
     }
+
     const response = await (epochTracker?.fetch(url, fetchOptions, "treesLatest", true) ??
         fetchHelper(url, fetchOptions));
 

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -34,6 +34,15 @@ import { ReadBuffer } from "./ReadBufferUtils";
 import { EpochTracker } from "./epochTracker";
 
 /**
+ * Enum to support different types of snapshot formats.
+ */
+export enum SnapshotFormatSupportType {
+    Json,
+    Binary,
+    JsonAndBinary,
+}
+
+/**
  * Fetches a snapshot from the server with a given version id.
  * @param snapshotUrl - snapshot url from where the odsp snapshot will be fetched
  * @param token - token used for authorization in the request
@@ -428,7 +437,7 @@ function countTreesInSnapshotTree(snapshotTree: ISnapshotTree): number {
  * @param storageToken - token to do the auth for network request.
  * @param snapshotOptions - Options used to specify how and what to fetch in the snapshot.
  * @param logger - logger
- * @param fetchBinarySnapshotFormat - whether to fetch binary snapshot or not.
+ * @param snapshotFormatFetchType - Snapshot format to fetch.
  * @param controller - abort controller if caller needs to abort the network call.
  * @param epochTracker - epoch tracker used to add/validate epoch in the network call.
  * @returns fetched snapshot.
@@ -438,7 +447,7 @@ export async function downloadSnapshot(
     storageToken: string,
     logger: ITelemetryLogger,
     snapshotOptions: ISnapshotOptions | undefined,
-    fetchBinarySnapshotFormat?: boolean,
+    snapshotFormatFetchType?: SnapshotFormatSupportType,
     controller?: AbortController,
     epochTracker?: EpochTracker,
 ): Promise<ISnapshotRequestAndResponseOptions> {
@@ -463,10 +472,11 @@ export async function downloadSnapshot(
         signal: controller?.signal,
         method: "POST",
     };
-    // For now we are keeping both json and ms-fluid values in accept header while fetching as we want to let
-    // the server decide what format it wants to send to the client as we roll it out slowly.
-    if (fetchBinarySnapshotFormat) {
+    // Decide what snapshot format to fetch as per the feature gate.
+    if (snapshotFormatFetchType?.valueOf() === SnapshotFormatSupportType.JsonAndBinary) {
         headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
+    } else if (snapshotFormatFetchType?.valueOf() === SnapshotFormatSupportType.Binary) {
+        headers.accept = `application/ms-fluid; v=${currentReadVersion}`;
     } else {
         headers.accept = "application/json";
     }

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -151,8 +151,6 @@ export class OdspDocumentService implements IDocumentService {
             }));
 
         this.hostPolicy = hostPolicy;
-        this.hostPolicy.fetchBinarySnapshotFormat ??=
-            this.mc.config.getBoolean("Fluid.Driver.Odsp.binaryFormatSnapshot");
         if (this.clientIsSummarizer) {
             this.hostPolicy = { ...this.hostPolicy, summarizerClient: true };
         }
@@ -187,6 +185,7 @@ export class OdspDocumentService implements IDocumentService {
                     }
                     throw new Error("Disconnected while uploading summary (attempt to perform flush())");
                 },
+                this.mc.config.getNumber("Fluid.Driver.Odsp.snapshotFormatFetchType"),
             );
         }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -32,7 +32,7 @@ import {
     IVersionedValueWithEpoch,
     ISnapshotCachedEntry,
 } from "./contracts";
-import { downloadSnapshot, fetchSnapshot, fetchSnapshotWithRedeem } from "./fetchSnapshot";
+import { downloadSnapshot, fetchSnapshot, fetchSnapshotWithRedeem, SnapshotFormatSupportType } from "./fetchSnapshot";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { IOdspCache } from "./odspCache";
 import {
@@ -221,6 +221,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         private readonly hostPolicy: HostStoragePolicyInternal,
         private readonly epochTracker: EpochTracker,
         private readonly flushCallback: () => Promise<FlushResult>,
+        private readonly snapshotFormatFetchType?: SnapshotFormatSupportType,
     ) {
         this.documentId = this.odspResolvedUrl.hashedDocumentId;
         this.snapshotUrl = this.odspResolvedUrl.endpoints.snapshotStorageUrl;
@@ -596,7 +597,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 storageToken,
                 this.logger,
                 options,
-                this.hostPolicy.fetchBinarySnapshotFormat,
+                this.snapshotFormatFetchType,
                 controller,
                 this.epochTracker,
             );

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -22,7 +22,7 @@ import {
     getOdspResolvedUrl,
     toInstrumentedOdspTokenFetcher,
 } from "./odspUtils";
-import { downloadSnapshot, fetchSnapshotWithRedeem } from "./fetchSnapshot";
+import { downloadSnapshot, fetchSnapshotWithRedeem, SnapshotFormatSupportType } from "./fetchSnapshot";
 import { IVersionedValueWithEpoch } from "./contracts";
 
 /**
@@ -38,6 +38,9 @@ import { IVersionedValueWithEpoch } from "./contracts";
  * @param enableRedeemFallback - True to have the sharing link redeem fallback in case the Trees Latest/Redeem
  *  1RT call fails with redeem error. During fallback it will first redeem the sharing link and then make
  *  the Trees latest call.
+ *  @deprecated - This will be replaced with snapshotFormatFetchType.
+ * @param fetchBinarySnapshotFormat - Control if we want to fetch binary format snapshot.
+ * @param snapshotFormatFetchType - Snapshot format to fetch.
  * @returns - True if the snapshot is cached, false otherwise.
  */
 export async function prefetchLatestSnapshot(
@@ -49,6 +52,7 @@ export async function prefetchLatestSnapshot(
     hostSnapshotFetchOptions: ISnapshotOptions | undefined,
     enableRedeemFallback?: boolean,
     fetchBinarySnapshotFormat?: boolean,
+    snapshotFormatFetchType?: SnapshotFormatSupportType,
 ): Promise<boolean> {
     const odspLogger = createOdspLogger(ChildLogger.create(logger, "PrefetchSnapshot"));
     const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
@@ -72,7 +76,7 @@ export async function prefetchLatestSnapshot(
         controller?: AbortController,
     ) => {
         return downloadSnapshot(
-            finalOdspResolvedUrl, storageToken, odspLogger, snapshotOptions, fetchBinarySnapshotFormat, controller);
+            finalOdspResolvedUrl, storageToken, odspLogger, snapshotOptions, snapshotFormatFetchType, controller);
     };
     const snapshotKey = createCacheSnapshotKey(odspResolvedUrl);
     let cacheP: Promise<void> | undefined;

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -164,7 +164,9 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
         await Promise.all([...Array(testConfig.detachedBlobCount).keys()].map(async (i) => dsm.writeBlob(i)));
     }
 
-    const testId = Date.now().toString();
+    // Currently odsp binary snapshot format only works for special file names. This won't affect any other test
+    // since we have a unique dateId as prefix. So we can just add the required suffix.
+    const testId = `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`;
     const request = testDriver.createCreateNewRequest(testId);
     await container.attach(request);
     assert(container.resolvedUrl !== undefined, "Container missing resolved URL after attach");

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -14,9 +14,6 @@
                 "odsp":{
                     "loader":{
                         "summarizeProtocolTree": [true,false]
-                    },
-                    "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1, 2]
                     }
                 }
             }

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -14,6 +14,9 @@
                 "odsp":{
                     "loader":{
                         "summarizeProtocolTree": [true,false]
+                    },
+                    "configurations":{
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1, 2]
                     }
                 }
             }
@@ -96,7 +99,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.binaryFormatSnapshot": [true]
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [1]
                     }
                 }
             }


### PR DESCRIPTION
1.) Add code to handle new feature gate to fetch snapshot format type in odsp driver.
2.) Make corresponding changes in stress test config.