### PR TITLE
TypeValidator: Add flatter broken format, and generateOnly mode

### DIFF
--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -20,7 +20,10 @@ export interface BrokenCompatSettings{
     forwardCompat?: false;
 }
 
-export type BrokenCompatTypes = Partial<Record<string,Record<string, BrokenCompatSettings>>>;
+// back compat for the previous back compat setting the nested under the version number
+export type BackCompatBrokenCompatSettings = BrokenCompatSettings & Partial<Record<string, BrokenCompatSettings>>
+
+export type BrokenCompatTypes = Partial<Record<string, BackCompatBrokenCompatSettings>>;
 
 
 interface PackageJson{

--- a/tools/build-tools/src/typeValidator/testGeneration.ts
+++ b/tools/build-tools/src/typeValidator/testGeneration.ts
@@ -59,11 +59,13 @@ export async function generateTests(packageDetails: PackageDetails) {
                 ... currentTypeData,
                 removed: false
             };
-            const brokenData = currentProjectData.packageDetails.broken?.[oldProjectData.packageDetails.version]?.[getFullTypeName(currentType)];
+            const broken = currentProjectData.packageDetails.broken;
+            // look for settings not under version, then fall back to version for back compat
+            const brokenData = broken?.[getFullTypeName(currentType)] ?? broken?.[oldProjectData.packageDetails.version]?.[getFullTypeName(currentType)];
 
             testString.push(`/*`)
             testString.push(`* Validate forward compat by using old type in place of current type`);
-            testString.push(`* If breaking change required, add in package.json under typeValidation.broken.${oldProjectData.packageDetails.version}:`);
+            testString.push(`* If breaking change required, add in package.json under typeValidation.broken:`);
             testString.push(`* "${getFullTypeName(currentType)}": {"forwardCompat": false}`);
             testString.push("*/");
             testString.push(...  buildTestCase(oldType, currentType, brokenData?.forwardCompat ?? true));
@@ -72,7 +74,7 @@ export async function generateTests(packageDetails: PackageDetails) {
 
             testString.push(`/*`)
             testString.push(`* Validate back compat by using current type in place of old type`);
-            testString.push(`* If breaking change required, add in package.json under typeValidation.broken.${oldProjectData.packageDetails.version}:`);
+            testString.push(`* If breaking change required, add in package.json under typeValidation.broken:`);
             testString.push(`* "${getFullTypeName(currentType)}": {"backCompat": false}`);
             testString.push("*/");
             testString.push(... buildTestCase(currentType, oldType, brokenData?.backCompat ?? true));

--- a/tools/build-tools/src/typeValidator/typeValidator.ts
+++ b/tools/build-tools/src/typeValidator/typeValidator.ts
@@ -41,7 +41,7 @@ async function run(): Promise<boolean>{
     writeOutLine(`preinstallOnly: ${program.preinstallOnly}`)
     writeOutLine(`generateOnly: ${program.generateOnly}`)
 
-    const concurrency = 1;
+    const concurrency = 10;
     const runningGenerates: Promise<boolean>[]=[];
     // this loop incrementally builds up the runningGenerates promise list
     // each dir with an index greater than concurrency looks back the concurrency value

--- a/tools/build-tools/src/typeValidator/typeValidator.ts
+++ b/tools/build-tools/src/typeValidator/typeValidator.ts
@@ -41,7 +41,7 @@ async function run(): Promise<boolean>{
     writeOutLine(`preinstallOnly: ${program.preinstallOnly}`)
     writeOutLine(`generateOnly: ${program.generateOnly}`)
 
-    const concurrency = 10;
+    const concurrency = 25;
     const runningGenerates: Promise<boolean>[]=[];
     // this loop incrementally builds up the runningGenerates promise list
     // each dir with an index greater than concurrency looks back the concurrency value


### PR DESCRIPTION
Previously the type validation tool would compare against multiple previous versions. This didn't provide value and increased overhead, so we moved it to a single version. However, we still kept the broken data nested under the previous version number, this makes the merges between main and next harder, as they don't have matching versions, so this change support a new default format that does not nest the broken data under version numbers.

Additionally, i've added a generateOnly mode that only generates the test, and does not update the package.json. I want to experiment with the performance of this mode, as it may be fast enough to integrate in the build, as the need to generate independently is causing confusion.