### PR TITLE
Add Support for generating type test in fluid-build

### DIFF
--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -277,10 +277,17 @@ export class FluidPackageCheck {
             }
 
             if(pkg.getScript("typetests:gen")){
-                if (pkg.getScript("build:commonjs")) {
-                    buildCommonJs.push("typetests:gen");
-                } else {
-                    buildCompile.push("typetests:gen");
+                // typetests:gen should be in build:commonjs if it exists, otherwise, it should be in build:compile
+                const buildTargetScripts =
+                    pkg.getScript("build:commonjs") ? buildCommonJs : buildCompile;
+                if(pkg.getScript("build:test")){
+                    // if there is a test target put test type gen after tsc
+                    // as the type test will build with the tests
+                    buildTargetScripts.push("typetests:gen");
+                }else{
+                    // if there is no test target put it before tsc
+                    // so type test build with tsc
+                    buildTargetScripts.unshift("typetests:gen");
                 }
             }
 

--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -276,11 +276,20 @@ export class FluidPackageCheck {
                 }
             }
 
+            if(pkg.getScript("typetests:gen")){
+                if (pkg.getScript("build:commonjs")) {
+                    buildCommonJs.push("typetests:gen");
+                } else {
+                    buildCompile.push("typetests:gen");
+                }
+            }
+
             const splitTestBuild = this.splitTestBuild(pkg, true);
             // build:test should be in build:commonjs if it exists, otherwise, it should be in build:compile
             if (pkg.getScript("build:test") || splitTestBuild) {
                 if (pkg.getScript("build:commonjs")) {
                     buildCommonJs.push("build:test");
+
                     // build common js is not concurrent by default
                 } else {
                     buildCompile.push("build:test");
@@ -288,6 +297,8 @@ export class FluidPackageCheck {
                     concurrentBuildCompile = !splitTestBuild;
                 }
             }
+
+
 
             if (pkg.getScript("build:realsvctest")) {
                 buildCompile.push("build:realsvctest");

--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -289,7 +289,6 @@ export class FluidPackageCheck {
             if (pkg.getScript("build:test") || splitTestBuild) {
                 if (pkg.getScript("build:commonjs")) {
                     buildCommonJs.push("build:test");
-
                     // build common js is not concurrent by default
                 } else {
                     buildCompile.push("build:test");
@@ -297,8 +296,6 @@ export class FluidPackageCheck {
                     concurrentBuildCompile = !splitTestBuild;
                 }
             }
-
-
 
             if (pkg.getScript("build:realsvctest")) {
                 buildCompile.push("build:realsvctest");

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { LeafTask } from "./leafTask";
+import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
 import { toPosixPath, globFn, unquote, statAsync, readFileAsync } from "../../../common/utils";
 import { logVerbose } from "../../../common/logging";
 import * as path from "path";
@@ -137,7 +137,17 @@ export class CopyfilesTask extends LeafTask {
     }
 }
 
-export class GenVerTask extends LeafTask {
+export abstract class PackageJsonChangedTask extends LeafWithDoneFileTask {
+    protected get doneFile(): string {
+        return "package.json.done.build.log"
+    }
+    protected async getDoneFileContent(): Promise<string | undefined> {
+        return JSON.stringify(this.package.packageJson);
+    }
+}
+
+
+export class GenVerTask extends PackageJsonChangedTask {
     protected addDependentTasks(dependentTasks: LeafTask[]) { }
     protected async checkLeafIsUpToDate() {
         try {
@@ -151,13 +161,9 @@ export class GenVerTask extends LeafTask {
     }
 };
 
-export class TypeValidationTask extends LeafTask {
+export class TypeValidationTask extends PackageJsonChangedTask {
+
     protected addDependentTasks(dependentTasks: LeafTask[]): void {
     }
-    protected async checkLeafIsUpToDate(): Promise<boolean> {
-        // look for the tsc task, and only regen if tsc needs to run as
-        // well, as it there are not code changes, there is no reason
-        // to regen
-        return this.node.findTask("tsc")?.isUpToDate() ?? false;
-    }
+
 }

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -150,3 +150,14 @@ export class GenVerTask extends LeafTask {
         return false;
     }
 };
+
+export class TypeValidationTask extends LeafTask {
+    protected addDependentTasks(dependentTasks: LeafTask[]): void {
+    }
+    protected async checkLeafIsUpToDate(): Promise<boolean> {
+        // look for the tsc task, and only regen if tsc needs to run as
+        // well, as it there are not code changes, there is no reason
+        // to regen
+        return this.node.findTask("tsc")?.isUpToDate() ?? false;
+    }
+}

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -137,17 +137,7 @@ export class CopyfilesTask extends LeafTask {
     }
 }
 
-export abstract class PackageJsonChangedTask extends LeafWithDoneFileTask {
-    protected get doneFile(): string {
-        return "package.json.done.build.log"
-    }
-    protected async getDoneFileContent(): Promise<string | undefined> {
-        return JSON.stringify(this.package.packageJson);
-    }
-}
-
-
-export class GenVerTask extends PackageJsonChangedTask {
+export class GenVerTask extends LeafTask {
     protected addDependentTasks(dependentTasks: LeafTask[]) { }
     protected async checkLeafIsUpToDate() {
         try {
@@ -161,9 +151,16 @@ export class GenVerTask extends PackageJsonChangedTask {
     }
 };
 
-export class TypeValidationTask extends PackageJsonChangedTask {
+export abstract class PackageJsonChangedTask extends LeafWithDoneFileTask {
+    protected get doneFile(): string {
+        return "package.json.done.build.log"
+    }
+    protected async getDoneFileContent(): Promise<string | undefined> {
+        return JSON.stringify(this.package.packageJson);
+    }
+}
 
+export class TypeValidationTask extends PackageJsonChangedTask {
     protected addDependentTasks(dependentTasks: LeafTask[]): void {
     }
-
 }

--- a/tools/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -13,7 +13,7 @@ import { getExecutableFromCommand } from "../../common/utils";
 import { EsLintTask, TsFormatTask, TsLintTask } from "./leaf/lintTasks";
 import { ApiExtractorTask } from "./leaf/apiExtractorTask";
 import { WebpackTask } from "./leaf/webpackTask";
-import { LesscTask, CopyfilesTask, EchoTask, GenVerTask } from "./leaf/miscTasks";
+import { LesscTask, CopyfilesTask, EchoTask, GenVerTask, TypeValidationTask } from "./leaf/miscTasks";
 import { PrettierTask } from "./leaf/prettierTask";
 
 // Map of executable name to LeafTasks
@@ -30,6 +30,7 @@ const executableToLeafTask: { [key: string]: new (node: BuildPackage, command: s
     prettier: PrettierTask,
     "gen-version": GenVerTask,
     "api-extractor": ApiExtractorTask,
+    "fluid-type-validator": TypeValidationTask,
 };
 
 export class TaskFactory {


### PR DESCRIPTION
This change adds knowledge of fluid-type-validation to both fuild-build and the package checker. The fluid-build integration ensures we only generate the test types when the package json has changed as we only need to generate type test when either the version of the package changes, or new entries are added to the broken list.
