### PR TITLE
Fix to e2e test (#9923)

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -6053,37 +6053,53 @@
 			}
 		},
 		"@fluidframework/server-local-server": {
-			"version": "0.1036.1000-58953",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.1000-58953.tgz",
-			"integrity": "sha512-YigI9+VEIrKJLBeyOmA3Duq/iiczr8LATSBBdQ63OS6D/UQ/aR2w4VwYjwlGiHOtb37muDpMUg7HpTVNJ7ZH4A==",
+			"version": "0.1036.1000-61474",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.1000-61474.tgz",
+			"integrity": "sha512-D2URJJTZg5+/t0t/Brwsl5tOIaovqomPCMFf34cBTKK/BKZSqgJE06fanQ/qACoOA0kIHJgyBEv3xAwaaG4kHQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/protocol-definitions": "^0.1028.1000-0",
-				"@fluidframework/server-lambdas": "0.1036.1000-58953",
-				"@fluidframework/server-memory-orderer": "0.1036.1000-58953",
-				"@fluidframework/server-services-client": "0.1036.1000-58953",
-				"@fluidframework/server-services-core": "0.1036.1000-58953",
-				"@fluidframework/server-services-telemetry": "0.1036.1000-58953",
-				"@fluidframework/server-test-utils": "0.1036.1000-58953",
+				"@fluidframework/server-lambdas": "0.1036.1000-61474",
+				"@fluidframework/server-memory-orderer": "0.1036.1000-61474",
+				"@fluidframework/server-services-client": "0.1036.1000-61474",
+				"@fluidframework/server-services-core": "0.1036.1000-61474",
+				"@fluidframework/server-services-telemetry": "0.1036.1000-61474",
+				"@fluidframework/server-test-utils": "0.1036.1000-61474",
 				"debug": "^4.1.1",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/gitresources": {
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000-61474.tgz",
+					"integrity": "sha512-ZQ90F+04/UwDa/TMLetdnirAfzM5Sou7VU3f9aNTvZHnngEPkU/STCj88+nUujd6aHvQ+mF6xIpe1IcaLuFqfQ=="
+				},
+				"@fluidframework/protocol-base": {
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000-61474.tgz",
+					"integrity": "sha512-oV0Kj4nrHoU61lAYRkk7K2y+hJZb4F2hG0ZGoE65tAhikxHWjqvH82wklohRK7YJxrzyy5L9da4XghrBbcib6A==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "0.1036.1000-61474",
+						"@fluidframework/protocol-definitions": "^0.1028.1000-0",
+						"lodash": "^4.17.21"
+					}
+				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1036.1000-58953",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.1000-58953.tgz",
-					"integrity": "sha512-PuYPsSPJB7823IO3C18PyrbdXCjv4qXhyEjfu9/DOG7u3lkge9xevtHDe5WM33rQVbWlilzasFJ6ejFPfMSFXw==",
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.1000-61474.tgz",
+					"integrity": "sha512-s8wHznC//mV617krMUYxbcEdzE1EO7kSaAosZ4egDjylnXfBgHdAK+y8IJfw44ah6t8ImTKPz/D9Cln6JX7Vxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "0.1036.1000-58953",
-						"@fluidframework/protocol-base": "0.1036.1000-58953",
+						"@fluidframework/gitresources": "0.1036.1000-61474",
+						"@fluidframework/protocol-base": "0.1036.1000-61474",
 						"@fluidframework/protocol-definitions": "^0.1028.1000-0",
-						"@fluidframework/server-lambdas-driver": "0.1036.1000-58953",
-						"@fluidframework/server-services-client": "0.1036.1000-58953",
-						"@fluidframework/server-services-core": "0.1036.1000-58953",
-						"@fluidframework/server-services-telemetry": "0.1036.1000-58953",
+						"@fluidframework/server-lambdas-driver": "0.1036.1000-61474",
+						"@fluidframework/server-services-client": "0.1036.1000-61474",
+						"@fluidframework/server-services-core": "0.1036.1000-61474",
+						"@fluidframework/server-services-telemetry": "0.1036.1000-61474",
 						"@types/semver": "^6.0.1",
 						"async": "^3.2.0",
 						"axios": "^0.26.0",
@@ -6097,30 +6113,30 @@
 					}
 				},
 				"@fluidframework/server-lambdas-driver": {
-					"version": "0.1036.1000-58953",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.1000-58953.tgz",
-					"integrity": "sha512-p2MfDgWA+VuBI4GdnrjaaqFNtPKOmjkXb5QXHn0DF7t+eEHZh8GY5F4px3OkekE+iXonb7AwGzeP1DED+rkv3g==",
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.1000-61474.tgz",
+					"integrity": "sha512-0boYYKqbzBJ5CJMvUkfN8Hv0NqId64RTFgdepJMGJNNRXluNmEG+zZBNXarFrK2FNTx+lfxUHs1oDf1vYA0kxA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/server-services-client": "0.1036.1000-58953",
-						"@fluidframework/server-services-core": "0.1036.1000-58953",
-						"@fluidframework/server-services-telemetry": "0.1036.1000-58953",
+						"@fluidframework/server-services-client": "0.1036.1000-61474",
+						"@fluidframework/server-services-core": "0.1036.1000-61474",
+						"@fluidframework/server-services-telemetry": "0.1036.1000-61474",
 						"async": "^3.2.0",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1036.1000-58953",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.1000-58953.tgz",
-					"integrity": "sha512-FEbPiiso1O4eN++vLbleEkJZ3xwhclA88kY+kfBgRQrFekBhLRD/EFwj4W0n+Zo2+CcOgDsTIbU/DLWL9eMahg==",
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.1000-61474.tgz",
+					"integrity": "sha512-KX/aFPGiihCQhDCRz174qbFdDvfTQGT978da9PVC8X9eD/DaA2J4kEzh1seMFD07B/02m/OrS8eRVWFbiAqtbA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-base": "0.1036.1000-58953",
+						"@fluidframework/protocol-base": "0.1036.1000-61474",
 						"@fluidframework/protocol-definitions": "^0.1028.1000-0",
-						"@fluidframework/server-lambdas": "0.1036.1000-58953",
-						"@fluidframework/server-services-client": "0.1036.1000-58953",
-						"@fluidframework/server-services-core": "0.1036.1000-58953",
-						"@fluidframework/server-services-telemetry": "0.1036.1000-58953",
+						"@fluidframework/server-lambdas": "0.1036.1000-61474",
+						"@fluidframework/server-services-client": "0.1036.1000-61474",
+						"@fluidframework/server-services-core": "0.1036.1000-61474",
+						"@fluidframework/server-services-telemetry": "0.1036.1000-61474",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -6134,10 +6150,45 @@
 						"ws": "^7.4.6"
 					}
 				},
+				"@fluidframework/server-services-client": {
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000-61474.tgz",
+					"integrity": "sha512-Qvot2pRfpgPjKywoIaT6XUJ6oH2e/Oe7uLSXz6q4aUdtSgrwiAHxLP42qsN1LEP2DCxclOOt3Dt8QDaU6+ayRw==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "0.1036.1000-61474",
+						"@fluidframework/protocol-base": "0.1036.1000-61474",
+						"@fluidframework/protocol-definitions": "^0.1028.1000-0",
+						"axios": "^0.26.0",
+						"crc-32": "1.2.0",
+						"debug": "^4.1.1",
+						"json-stringify-safe": "^5.0.1",
+						"jsrsasign": "^10.2.0",
+						"jwt-decode": "^3.0.0",
+						"sillyname": "^0.1.0",
+						"uuid": "^8.3.1"
+					}
+				},
+				"@fluidframework/server-services-core": {
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.1000-61474.tgz",
+					"integrity": "sha512-35Jd4ltMDhSbotsULqXx+9Jt57gWbDuqI6VJUyQkjoaBSviOB3p8+ZskWwX28c7Rj2t47nsMTbrPqtYdj8sS2g==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "0.1036.1000-61474",
+						"@fluidframework/protocol-definitions": "^0.1028.1000-0",
+						"@fluidframework/server-services-client": "0.1036.1000-61474",
+						"@fluidframework/server-services-telemetry": "0.1036.1000-61474",
+						"@types/nconf": "^0.10.0",
+						"@types/node": "^14.18.0",
+						"debug": "^4.1.1",
+						"nconf": "^0.11.0"
+					}
+				},
 				"@fluidframework/server-services-telemetry": {
-					"version": "0.1036.1000-58953",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.1000-58953.tgz",
-					"integrity": "sha512-iIFNLROqFbYVht7NKyDhLz1q/DeAyzbenfx8AxaiaPIsDX5z4cG8WtI5ZoJkag3C95j7tBYNt63DG48Hsds3vQ==",
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.1000-61474.tgz",
+					"integrity": "sha512-ip06zdkGh/njtgapR0k3O+2icurD0vdexZVj2+Ghth0WYf8kbmx854/ip1aWr5HoObexTnY17ft3YjxJSc505A==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"json-stringify-safe": "^5.0.1",
@@ -6146,10 +6197,33 @@
 						"uuid": "^8.3.1"
 					}
 				},
+				"@fluidframework/server-test-utils": {
+					"version": "0.1036.1000-61474",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.1000-61474.tgz",
+					"integrity": "sha512-WjMamUMvS3Jzdz6oNbBPCwxWQHEqB8GX1jX/hJ1DVLbGdN1RrtWgt0dNuPbaOyB34J1NKRaUQE0W4et59nUCig==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "0.1036.1000-61474",
+						"@fluidframework/protocol-base": "0.1036.1000-61474",
+						"@fluidframework/protocol-definitions": "^0.1028.1000-0",
+						"@fluidframework/server-services-client": "0.1036.1000-61474",
+						"@fluidframework/server-services-core": "0.1036.1000-61474",
+						"@fluidframework/server-services-telemetry": "0.1036.1000-61474",
+						"debug": "^4.1.1",
+						"lodash": "^4.17.21",
+						"string-hash": "^1.1.3",
+						"uuid": "^8.3.1"
+					}
+				},
 				"@types/semver": {
 					"version": "6.2.3",
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
+				},
+				"jwt-decode": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+					"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
 				},
 				"semver": {
 					"version": "6.3.0",

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -73,6 +73,8 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
             sequenceNumber,
             documentAttributes.term ?? 1,
             defaultHash,
+            resolvedUrl.endpoints.ordererUrl ?? "",
+            resolvedUrl.endpoints.storageUrl ?? "",
             quorumValues,
         );
         return this.createDocumentService(resolvedUrl, logger, clientIsSummarizer);


### PR DESCRIPTION
Cherry-pick the changes from this PR: https://github.com/microsoft/FluidFramework/pull/9923

The end-to-end tests were failing as they had pulled in the new change which updated the lerna-package-lock.json. This is the fix for that issue as it pulls in the right version and provides the fix for the build.