### PR TITLE
[bump] package version for eslint-config-fluid (patch)

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.28.1000",
+  "version": "0.28.1001",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.28.1000",
+  "version": "0.28.1001",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -179,9 +179,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
     "@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -584,9 +584,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -88,7 +88,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
     "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@^0.32.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/base64-js": "^1.3.0",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -240,9 +240,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
     "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@0.47.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -179,9 +179,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
     "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@^0.42.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -211,9 +211,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
     "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@0.45.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -178,9 +178,9 @@
       "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@0.1027.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -51,7 +51,7 @@
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/babel__core": "^7",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/orderedmap": "^1",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/marked": "^2.0.2",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "@fluidframework/test-utils": "^0.59.1000",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/fluid-static": "^0.59.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
     "@types/semver": "^7.3.6",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -55,7 +55,7 @@
     "@fluid-experimental/property-common": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/local-driver": "^0.59.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/sequence": "^0.59.1000",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "@fluidframework/test-driver-definitions": "^0.59.1000",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/experimental/framework/react/package.json
+++ b/experimental/framework/react/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3805,9 +3805,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.28.1000-61189",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-			"integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+			"version": "0.28.1000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+			"integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -71,7 +71,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell-previous": "npm:@fluidframework/cell@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/counter-previous": "npm:@fluidframework/counter@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/ink-previous": "npm:@fluidframework/ink@^0.58.0",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/map-previous": "npm:@fluidframework/map@^0.58.0",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
@@ -104,7 +104,9 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "ClassDeclaration_SharedDirectory": {"forwardCompat": false}
+        "ClassDeclaration_SharedDirectory": {
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@^0.58.0",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@^0.58.0",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@^0.58.0",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@^0.58.0",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/gitresources": "^0.1036.1000-0",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@^0.58.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@^0.58.0",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -74,7 +74,7 @@
     "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@^0.58.0",
     "@fluid-internal/test-dds-utils": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jest": "22.2.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@^0.58.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@^0.58.0",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@^0.58.0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
@@ -70,7 +70,9 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "InterfaceDeclaration_IFileSnapshot": {"forwardCompat": false}
+        "InterfaceDeclaration_IFileSnapshot": {
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@^0.58.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
@@ -111,7 +111,9 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "InterfaceDeclaration_IDataObjectProps": {"backCompat": false}
+        "InterfaceDeclaration_IDataObjectProps": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@^0.58.0",
     "@fluidframework/azure-local-service": "^0.1.38773",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-client-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/azure-service-utils/package.json
+++ b/packages/framework/azure-service-utils/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@^0.58.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.59.1000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
@@ -75,8 +75,12 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "ClassDeclaration_FluidContainer": {"forwardCompat": false},
-        "InterfaceDeclaration_IFluidContainer": {"forwardCompat": false}
+        "ClassDeclaration_FluidContainer": {
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidContainer": {
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@^0.58.0",
     "@fluidframework/test-runtime-utils": "^0.59.1000",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/core-interfaces": "^0.43.1000-0",
     "@fluidframework/datastore": "^0.59.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.59.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@^0.58.0",
@@ -100,7 +100,9 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "ClassDeclaration_SharedSegmentSequenceRevertible": {"forwardCompat": false}
+        "ClassDeclaration_SharedSegmentSequenceRevertible": {
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -78,7 +78,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-loader-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",
@@ -111,7 +111,10 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "ClassDeclaration_Container": {"forwardCompat": false, "backCompat": false}
+        "ClassDeclaration_Container": {
+          "forwardCompat": false,
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@^0.58.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
     "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@^0.58.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@^0.58.0",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
@@ -104,7 +104,9 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "TypeAliasDeclaration_RefreshSummaryResult": {"backCompat": false}
+        "TypeAliasDeclaration_RefreshSummaryResult": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
@@ -105,7 +105,9 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "ClassDeclaration_MockFluidDataStoreContext": {"backCompat": false}
+        "ClassDeclaration_MockFluidDataStoreContext": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/sequence": "^0.59.1000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/driver-base": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/ink": "^0.59.1000",
     "@fluidframework/local-driver": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -116,7 +116,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -93,7 +93,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
@@ -112,9 +112,15 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "InterfaceDeclaration_IProvideTestFluidObject": {"backCompat": false},
-        "InterfaceDeclaration_ITestFluidObject": {"backCompat": false},
-        "ClassDeclaration_TestFluidObject": {"backCompat": false}
+        "InterfaceDeclaration_IProvideTestFluidObject": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_ITestFluidObject": {
+          "backCompat": false
+        },
+        "ClassDeclaration_TestFluidObject": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -114,9 +114,17 @@
     "version": "0.59.1000",
     "broken": {
       "0.58.2002": {
-        "InterfaceDeclaration_ITestDataObject": {"backCompat": false},
-        "RemovedVariableDeclaration_pkgName": {"backCompat": false, "forwardCompat": false},
-        "RemovedVariableDeclaration_pkgVersion": {"backCompat": false, "forwardCompat": false}
+        "InterfaceDeclaration_ITestDataObject": {
+          "backCompat": false
+        },
+        "RemovedVariableDeclaration_pkgName": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "RemovedVariableDeclaration_pkgVersion": {
+          "backCompat": false,
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/json-stable-stringify": "^1.0.32",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -93,7 +93,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@^0.58.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@^0.58.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",
     "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@^0.58.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/server/azure-local-service/package-lock.json
+++ b/server/azure-local-service/package-lock.json
@@ -95,9 +95,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/server/azure-local-service/package.json
+++ b/server/azure-local-service/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -449,9 +449,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.28.1000-61189",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-			"integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+			"version": "0.28.1000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+			"integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/async": "^3.2.6",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/async": "^3.2.6",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^8.2.2",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/uuid": "^8.3.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-local-server": "^0.1036.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-local-server": "^0.1036.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
     "@types/formidable": "1.2.3",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/server-test-utils": "^0.1036.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^8.2.2",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -97,9 +97,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -412,9 +412,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.1000-61189",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000-61189.tgz",
-      "integrity": "sha512-S+yCZCASSCoeOaCT9+VlScLraCE6YFN9m919by+AdgSWEXPJjczl1AA8/gMi8vGk6rlfbEWofEHHnq6WNJV22A==",
+      "version": "0.28.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.1000.tgz",
+      "integrity": "sha512-JZMMmOBLKxlNd4Bj61BPrOUKTX+JYWSQE/r1tjk1VBFw7AT9iKnjvjTlUq1zpWVNxYk9ubguh3HzBe13b/zLVA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
+    "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.41.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:  0.28.1000 -> 0.28.1001
      @fluidframework/common-definitions:  0.21.1000 (unchanged)
            @fluidframework/common-utils:  0.33.1000 (unchanged)
         @fluidframework/core-interfaces:  0.43.1000 (unchanged)
    @fluidframework/protocol-definitions: 0.1028.1000 (unchanged)
      @fluidframework/driver-definitions:  0.46.1000 (unchanged)
   @fluidframework/container-definitions:  0.48.1000 (unchanged)
                                  Server: 0.1036.1000 (unchanged)
                                  Client:  0.59.1000 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)

Also remove pre-release dependencies for eslint-config-fluid
     @fluidframework/eslint-config-fluid -> ^0.28.1000