### PR TITLE
Patch bump 1650075263535

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -218,9 +218,9 @@
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.43.1000-60265",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000-60265.tgz",
-      "integrity": "sha512-JWv+tivT53q0xbPh/wgjfQoHNU1OftF4wC8ZDh5njm4t130m9txPnNVng7QfN5hYgAlWLsjRZ8KZm5lIx3yD1Q=="
+      "version": "0.43.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
+      "integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
     },
     "@fluidframework/driver-definitions": {
       "version": "0.46.1000-58535",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0"
   },

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/core-interfaces",
-  "version": "0.43.1000",
+  "version": "0.43.1001",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -173,9 +173,9 @@
       }
     },
     "@fluidframework/core-interfaces-previous": {
-      "version": "npm:@fluidframework/core-interfaces@0.42.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0.tgz",
-      "integrity": "sha512-++hCu5X6e2CL2swrhXoGaJanGjvaHZNmTT/cSYI8tfnX4cW7eRJuIy8Kcg6K3nMn4thxbVPW7+QG4VPRNuGlMQ==",
+      "version": "npm:@fluidframework/core-interfaces@0.43.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
+      "integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA==",
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/core-interfaces",
-  "version": "0.43.1000",
+  "version": "0.43.1001",
   "description": "Fluid object interfaces",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.61288",
-    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@^0.42.0",
+    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@0.43.1000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
@@ -63,22 +63,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.43.1000",
-    "broken": {
-      "0.42.0": {
-        "RemovedVariableDeclaration_IFluidConfiguration": {
-          "backCompat": false,
-          "forwardCompat": false
-        },
-        "RemovedInterfaceDeclaration_IFluidConfiguration": {
-          "backCompat": false,
-          "forwardCompat": false
-        },
-        "RemovedInterfaceDeclaration_IProvideFluidConfiguration": {
-          "backCompat": false,
-          "forwardCompat": false
-        }
-      }
-    }
+    "version": "0.43.1001",
+    "broken": {}
   }
 }

--- a/common/lib/core-interfaces/src/test/types/validateCoreInterfacesPrevious.ts
+++ b/common/lib/core-interfaces/src/test/types/validateCoreInterfacesPrevious.ts
@@ -16,7 +16,7 @@ type TypeOnly<T> = {
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "TypeAliasDeclaration_FluidObject": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_FluidObject():
@@ -28,7 +28,7 @@ use_current_TypeAliasDeclaration_FluidObject(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "TypeAliasDeclaration_FluidObject": {"backCompat": false}
 */
 declare function get_current_TypeAliasDeclaration_FluidObject():
@@ -40,7 +40,7 @@ use_old_TypeAliasDeclaration_FluidObject(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "TypeAliasDeclaration_FluidObjectKeys": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_FluidObjectKeys():
@@ -52,7 +52,7 @@ use_current_TypeAliasDeclaration_FluidObjectKeys(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "TypeAliasDeclaration_FluidObjectKeys": {"backCompat": false}
 */
 declare function get_current_TypeAliasDeclaration_FluidObjectKeys():
@@ -64,7 +64,7 @@ use_old_TypeAliasDeclaration_FluidObjectKeys(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "TypeAliasDeclaration_FluidObjectProviderKeys": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_FluidObjectProviderKeys():
@@ -76,7 +76,7 @@ use_current_TypeAliasDeclaration_FluidObjectProviderKeys(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "TypeAliasDeclaration_FluidObjectProviderKeys": {"backCompat": false}
 */
 declare function get_current_TypeAliasDeclaration_FluidObjectProviderKeys():
@@ -88,7 +88,7 @@ use_old_TypeAliasDeclaration_FluidObjectProviderKeys(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidCodeDetails": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidCodeDetails():
@@ -100,7 +100,7 @@ use_current_InterfaceDeclaration_IFluidCodeDetails(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidCodeDetails": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidCodeDetails():
@@ -112,7 +112,7 @@ use_old_InterfaceDeclaration_IFluidCodeDetails(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidCodeDetailsComparer": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidCodeDetailsComparer():
@@ -124,7 +124,7 @@ use_current_VariableDeclaration_IFluidCodeDetailsComparer(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidCodeDetailsComparer": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_IFluidCodeDetailsComparer():
@@ -136,7 +136,7 @@ use_old_VariableDeclaration_IFluidCodeDetailsComparer(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidCodeDetailsComparer": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidCodeDetailsComparer():
@@ -148,7 +148,7 @@ use_current_InterfaceDeclaration_IFluidCodeDetailsComparer(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidCodeDetailsComparer": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidCodeDetailsComparer():
@@ -160,7 +160,7 @@ use_old_InterfaceDeclaration_IFluidCodeDetailsComparer(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidCodeDetailsConfig": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidCodeDetailsConfig():
@@ -172,7 +172,7 @@ use_current_InterfaceDeclaration_IFluidCodeDetailsConfig(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidCodeDetailsConfig": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidCodeDetailsConfig():
@@ -184,59 +184,7 @@ use_old_InterfaceDeclaration_IFluidCodeDetailsConfig(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
-* "RemovedVariableDeclaration_IFluidConfiguration": {"forwardCompat": false}
-*/
-declare function get_old_VariableDeclaration_IFluidConfiguration():
-    TypeOnly<typeof old.IFluidConfiguration>;
-declare function use_current_RemovedVariableDeclaration_IFluidConfiguration(
-    // @ts-expect-error compatibility expected to be broken
-    use: TypeOnly<typeof current.IFluidConfiguration>);
-use_current_RemovedVariableDeclaration_IFluidConfiguration(
-    get_old_VariableDeclaration_IFluidConfiguration());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
-* "RemovedVariableDeclaration_IFluidConfiguration": {"backCompat": false}
-*/
-declare function get_current_RemovedVariableDeclaration_IFluidConfiguration():
-    // @ts-expect-error compatibility expected to be broken
-    TypeOnly<typeof current.IFluidConfiguration>;
-declare function use_old_VariableDeclaration_IFluidConfiguration(
-    use: TypeOnly<typeof old.IFluidConfiguration>);
-use_old_VariableDeclaration_IFluidConfiguration(
-    get_current_RemovedVariableDeclaration_IFluidConfiguration());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
-* "RemovedInterfaceDeclaration_IFluidConfiguration": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_IFluidConfiguration():
-    TypeOnly<old.IFluidConfiguration>;
-declare function use_current_RemovedInterfaceDeclaration_IFluidConfiguration(
-    // @ts-expect-error compatibility expected to be broken
-    use: TypeOnly<current.IFluidConfiguration>);
-use_current_RemovedInterfaceDeclaration_IFluidConfiguration(
-    get_old_InterfaceDeclaration_IFluidConfiguration());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
-* "RemovedInterfaceDeclaration_IFluidConfiguration": {"backCompat": false}
-*/
-declare function get_current_RemovedInterfaceDeclaration_IFluidConfiguration():
-    // @ts-expect-error compatibility expected to be broken
-    TypeOnly<current.IFluidConfiguration>;
-declare function use_old_InterfaceDeclaration_IFluidConfiguration(
-    use: TypeOnly<old.IFluidConfiguration>);
-use_old_InterfaceDeclaration_IFluidConfiguration(
-    get_current_RemovedInterfaceDeclaration_IFluidConfiguration());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidHandle": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidHandle():
@@ -248,7 +196,7 @@ use_current_VariableDeclaration_IFluidHandle(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidHandle": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_IFluidHandle():
@@ -260,7 +208,7 @@ use_old_VariableDeclaration_IFluidHandle(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidHandle": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidHandle():
@@ -272,7 +220,7 @@ use_current_InterfaceDeclaration_IFluidHandle(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidHandle": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidHandle():
@@ -284,7 +232,7 @@ use_old_InterfaceDeclaration_IFluidHandle(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidHandleContext": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidHandleContext():
@@ -296,7 +244,7 @@ use_current_VariableDeclaration_IFluidHandleContext(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidHandleContext": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_IFluidHandleContext():
@@ -308,7 +256,7 @@ use_old_VariableDeclaration_IFluidHandleContext(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidHandleContext": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidHandleContext():
@@ -320,7 +268,7 @@ use_current_InterfaceDeclaration_IFluidHandleContext(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidHandleContext": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidHandleContext():
@@ -332,7 +280,7 @@ use_old_InterfaceDeclaration_IFluidHandleContext(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidLoadable": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidLoadable():
@@ -344,7 +292,7 @@ use_current_VariableDeclaration_IFluidLoadable(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidLoadable": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_IFluidLoadable():
@@ -356,7 +304,7 @@ use_old_VariableDeclaration_IFluidLoadable(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidLoadable": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidLoadable():
@@ -368,7 +316,7 @@ use_current_InterfaceDeclaration_IFluidLoadable(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidLoadable": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidLoadable():
@@ -380,7 +328,7 @@ use_old_InterfaceDeclaration_IFluidLoadable(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidObject": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidObject():
@@ -392,7 +340,7 @@ use_current_InterfaceDeclaration_IFluidObject(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidObject": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidObject():
@@ -404,7 +352,7 @@ use_old_InterfaceDeclaration_IFluidObject(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidPackage": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidPackage():
@@ -416,7 +364,7 @@ use_current_InterfaceDeclaration_IFluidPackage(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidPackage": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidPackage():
@@ -428,7 +376,7 @@ use_old_InterfaceDeclaration_IFluidPackage(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidPackageEnvironment": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidPackageEnvironment():
@@ -440,7 +388,7 @@ use_current_InterfaceDeclaration_IFluidPackageEnvironment(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidPackageEnvironment": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidPackageEnvironment():
@@ -452,7 +400,7 @@ use_old_InterfaceDeclaration_IFluidPackageEnvironment(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidRouter": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidRouter():
@@ -464,7 +412,7 @@ use_current_VariableDeclaration_IFluidRouter(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidRouter": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_IFluidRouter():
@@ -476,7 +424,7 @@ use_old_VariableDeclaration_IFluidRouter(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidRouter": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidRouter():
@@ -488,7 +436,7 @@ use_current_InterfaceDeclaration_IFluidRouter(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidRouter": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidRouter():
@@ -500,7 +448,7 @@ use_old_InterfaceDeclaration_IFluidRouter(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidRunnable": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidRunnable():
@@ -512,7 +460,7 @@ use_current_VariableDeclaration_IFluidRunnable(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidRunnable": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_IFluidRunnable():
@@ -524,7 +472,7 @@ use_old_VariableDeclaration_IFluidRunnable(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidRunnable": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidRunnable():
@@ -536,7 +484,7 @@ use_current_InterfaceDeclaration_IFluidRunnable(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidRunnable": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidRunnable():
@@ -548,7 +496,7 @@ use_old_InterfaceDeclaration_IFluidRunnable(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidSerializer": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidSerializer():
@@ -560,7 +508,7 @@ use_current_VariableDeclaration_IFluidSerializer(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_IFluidSerializer": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_IFluidSerializer():
@@ -572,7 +520,7 @@ use_old_VariableDeclaration_IFluidSerializer(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidSerializer": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidSerializer():
@@ -584,7 +532,7 @@ use_current_InterfaceDeclaration_IFluidSerializer(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IFluidSerializer": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IFluidSerializer():
@@ -596,7 +544,7 @@ use_old_InterfaceDeclaration_IFluidSerializer(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidCodeDetailsComparer": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidCodeDetailsComparer():
@@ -608,7 +556,7 @@ use_current_InterfaceDeclaration_IProvideFluidCodeDetailsComparer(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidCodeDetailsComparer": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IProvideFluidCodeDetailsComparer():
@@ -620,33 +568,7 @@ use_old_InterfaceDeclaration_IProvideFluidCodeDetailsComparer(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
-* "RemovedInterfaceDeclaration_IProvideFluidConfiguration": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_IProvideFluidConfiguration():
-    TypeOnly<old.IProvideFluidConfiguration>;
-declare function use_current_RemovedInterfaceDeclaration_IProvideFluidConfiguration(
-    // @ts-expect-error compatibility expected to be broken
-    use: TypeOnly<current.IProvideFluidConfiguration>);
-use_current_RemovedInterfaceDeclaration_IProvideFluidConfiguration(
-    get_old_InterfaceDeclaration_IProvideFluidConfiguration());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
-* "RemovedInterfaceDeclaration_IProvideFluidConfiguration": {"backCompat": false}
-*/
-declare function get_current_RemovedInterfaceDeclaration_IProvideFluidConfiguration():
-    // @ts-expect-error compatibility expected to be broken
-    TypeOnly<current.IProvideFluidConfiguration>;
-declare function use_old_InterfaceDeclaration_IProvideFluidConfiguration(
-    use: TypeOnly<old.IProvideFluidConfiguration>);
-use_old_InterfaceDeclaration_IProvideFluidConfiguration(
-    get_current_RemovedInterfaceDeclaration_IProvideFluidConfiguration());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidHandle": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidHandle():
@@ -658,7 +580,7 @@ use_current_InterfaceDeclaration_IProvideFluidHandle(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidHandle": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IProvideFluidHandle():
@@ -670,7 +592,7 @@ use_old_InterfaceDeclaration_IProvideFluidHandle(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidHandleContext": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidHandleContext():
@@ -682,7 +604,7 @@ use_current_InterfaceDeclaration_IProvideFluidHandleContext(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidHandleContext": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IProvideFluidHandleContext():
@@ -694,7 +616,7 @@ use_old_InterfaceDeclaration_IProvideFluidHandleContext(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidLoadable": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidLoadable():
@@ -706,7 +628,7 @@ use_current_InterfaceDeclaration_IProvideFluidLoadable(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidLoadable": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IProvideFluidLoadable():
@@ -718,7 +640,7 @@ use_old_InterfaceDeclaration_IProvideFluidLoadable(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidRouter": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidRouter():
@@ -730,7 +652,7 @@ use_current_InterfaceDeclaration_IProvideFluidRouter(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidRouter": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IProvideFluidRouter():
@@ -742,7 +664,7 @@ use_old_InterfaceDeclaration_IProvideFluidRouter(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidRunnable": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidRunnable():
@@ -754,7 +676,7 @@ use_current_InterfaceDeclaration_IProvideFluidRunnable(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidRunnable": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IProvideFluidRunnable():
@@ -766,7 +688,7 @@ use_old_InterfaceDeclaration_IProvideFluidRunnable(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidSerializer": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidSerializer():
@@ -778,7 +700,7 @@ use_current_InterfaceDeclaration_IProvideFluidSerializer(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IProvideFluidSerializer": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IProvideFluidSerializer():
@@ -790,7 +712,7 @@ use_old_InterfaceDeclaration_IProvideFluidSerializer(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IRequest": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IRequest():
@@ -802,7 +724,7 @@ use_current_InterfaceDeclaration_IRequest(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IRequest": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IRequest():
@@ -814,7 +736,7 @@ use_old_InterfaceDeclaration_IRequest(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IRequestHeader": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IRequestHeader():
@@ -826,7 +748,7 @@ use_current_InterfaceDeclaration_IRequestHeader(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IRequestHeader": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IRequestHeader():
@@ -838,7 +760,7 @@ use_old_InterfaceDeclaration_IRequestHeader(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IResponse": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IResponse():
@@ -850,7 +772,7 @@ use_current_InterfaceDeclaration_IResponse(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_IResponse": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_IResponse():
@@ -862,7 +784,7 @@ use_old_InterfaceDeclaration_IResponse(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_ISerializedHandle": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISerializedHandle():
@@ -874,7 +796,7 @@ use_current_InterfaceDeclaration_ISerializedHandle(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "InterfaceDeclaration_ISerializedHandle": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_ISerializedHandle():
@@ -886,7 +808,7 @@ use_old_InterfaceDeclaration_ISerializedHandle(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_isFluidCodeDetails": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_isFluidCodeDetails():
@@ -898,7 +820,7 @@ use_current_VariableDeclaration_isFluidCodeDetails(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_isFluidCodeDetails": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_isFluidCodeDetails():
@@ -910,7 +832,7 @@ use_old_VariableDeclaration_isFluidCodeDetails(
 
 /*
 * Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_isFluidPackage": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_isFluidPackage():
@@ -922,7 +844,7 @@ use_current_VariableDeclaration_isFluidPackage(
 
 /*
 * Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken.0.42.0:
+* If breaking change required, add in package.json under typeValidation.broken.0.43.1000:
 * "VariableDeclaration_isFluidPackage": {"backCompat": false}
 */
 declare function get_current_VariableDeclaration_isFluidPackage():

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -178,9 +178,9 @@
       "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.43.1000-60265",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000-60265.tgz",
-      "integrity": "sha512-JWv+tivT53q0xbPh/wgjfQoHNU1OftF4wC8ZDh5njm4t130m9txPnNVng7QfN5hYgAlWLsjRZ8KZm5lIx3yD1Q=="
+      "version": "0.43.1000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
+      "integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
     },
     "@fluidframework/driver-definitions-previous": {
       "version": "npm:@fluidframework/driver-definitions@0.45.1000",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0"
   },
   "devDependencies": {

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/react-inputs": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/sequence": "^0.59.1000",
     "@fluidframework/view-interfaces": "^0.59.1000",
     "css-loader": "^1.0.0",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "css-loader": "^1.0.0",
     "react": "^16.10.2",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -48,7 +48,7 @@
     "@fluid-experimental/get-container": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/runtime-definitions": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/cell": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "@uifabric/fluent-theme": "^7.1.3",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -44,7 +44,7 @@
     "@fluid-example/example-utils": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/ink": "^0.59.1000",
     "react": "^16.10.2"
   },

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -45,7 +45,7 @@
     "@fluid-experimental/task-manager": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/runtime-definitions": "^0.59.1000",
     "react": "^16.10.2"

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/ink": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -42,7 +42,7 @@
     "@fluid-example/example-utils": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/merge-tree": "^0.59.1000",
     "@fluidframework/runtime-definitions": "^0.59.1000",
     "@fluidframework/sequence": "^0.59.1000",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -44,7 +44,7 @@
     "@fluid-example/multiview-coordinate-model": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/map": "^0.59.1000"
   },
   "devDependencies": {

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -41,7 +41,7 @@
     "@fluid-example/example-utils": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/map": "^0.59.1000",
     "react": "^16.10.2"
   },

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/ink": "^0.59.1000",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/merge-tree": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/matrix": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "@fluidframework/sequence": "^0.59.1000",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/request-handler": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "css-loader": "^1.0.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/cell": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/map": "^0.59.1000",
     "@fluidframework/runtime-definitions": "^0.59.1000",
     "@fluidframework/sequence": "^0.59.1000",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/data-object-base": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "@fluidframework/merge-tree": "^0.59.1000",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/map": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "@fluidframework/view-adapters": "^0.59.1000",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/register-collection": "^0.59.1000",
     "@fluidframework/request-handler": "^0.59.1000",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0"
+    "@fluidframework/core-interfaces": "^0.43.1000"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/routerlicious-driver": "^0.59.1000",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/iframe-driver": "^0.59.1000",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -30,7 +30,7 @@
     "@fluid-example/key-value-cache": "^0.59.1000",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/routerlicious-driver": "^0.59.1000",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/data-object-base": "^0.59.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/data-object-base": "^0.59.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -39,7 +39,7 @@
     "@fluid-experimental/property-properties": "^0.59.1000",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-definitions": "^0.59.1000",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-definitions": "^0.59.1000",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluid-experimental/ot": "^0.59.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/shared-object-base": "^0.59.1000",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-definitions": "^0.59.1000",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-base": "^0.1036.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "react": "^16.10.2"

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -56,7 +56,7 @@
     "@fluid-experimental/tree": "^0.59.1000",
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "@fluidframework/view-interfaces": "^0.59.1000",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "ot-json1": "^1.0.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",
     "react": "^16.10.2"

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/local-driver": "^0.59.1000",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-utils": "^0.59.1000",
     "@fluidframework/shared-summary-block": "^0.59.1000"

--- a/experimental/framework/react/package.json
+++ b/experimental/framework/react/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.59.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3168,9 +3168,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.43.1000-60792",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000-60792.tgz",
-			"integrity": "sha512-uaC3z6O3Vf469TnHzIPGY57xMtwEmRkaRjORLlE1SBIiufV0qbS0ybtHMJ4M82M1kdBdunrPs0ft0DC4MBVpIQ=="
+			"version": "0.43.1000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
+			"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
 		},
 		"@fluidframework/counter": {
 			"version": "0.58.2002",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-utils": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/merge-tree": "^0.59.1000",
     "@fluidframework/protocol-base": "^0.1036.1000-0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-definitions": "^0.59.1000",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-definitions": "^0.59.1000",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-base": "^0.1036.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/merge-tree": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-utils": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/odsp-driver": "^0.59.1000",
     "@fluidframework/odsp-driver-definitions": "^0.59.1000"

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-base": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-base": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -36,7 +36,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/odsp-driver": "^0.59.1000",
     "@fluidframework/odsp-driver-definitions": "^0.59.1000"

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "axios": "^0.26.0"
   },

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "nconf": "^0.11.0"

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -31,7 +31,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/fluid-static": "^0.59.1000",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/request-handler": "^0.59.1000",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/request-handler": "^0.59.1000",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/runtime-definitions": "^0.59.1000",
     "@fluidframework/runtime-utils": "^0.59.1000"
   },

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.1000",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/view-interfaces": "^0.59.1000",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.43.1000-0"
+    "@fluidframework/core-interfaces": "^0.43.1000"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-utils": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/protocol-base": "^0.1036.1000-0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/gitresources": "^0.1036.1000-0",
     "@fluidframework/protocol-base": "^0.1036.1000-0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/map": "^0.59.1000",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-definitions": "^0.59.1000",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
     "@fluidframework/container-utils": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@fluidframework/runtime-definitions": "^0.59.1000",
     "@types/node": "^14.18.0"

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-utils": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "@types/node": "^14.18.0"

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/garbage-collector": "^0.59.1000",
     "@fluidframework/protocol-base": "^0.1036.1000-0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
     "@fluidframework/container-utils": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000-0",
     "uuid": "^8.3.1"

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/local-driver": "^0.59.1000",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
     "@fluidframework/container-utils": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/container-loader": "^0.59.1000",
     "@fluidframework/container-runtime": "^0.59.1000",
     "@fluidframework/container-runtime-definitions": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.1000",
     "@fluidframework/datastore-definitions": "^0.59.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.1000-0",
     "@fluidframework/container-loader": "^0.59.1000",
-    "@fluidframework/core-interfaces": "^0.43.1000-0",
+    "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.1000-0",
     "@fluidframework/driver-utils": "^0.59.1000",
     "@fluidframework/local-driver": "^0.59.1000",


### PR DESCRIPTION
 @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:  0.28.1001 (unchanged)
      @fluidframework/common-definitions:  0.21.1000 (unchanged)
            @fluidframework/common-utils:  0.33.1000 (unchanged)
         @fluidframework/core-interfaces:  0.43.1000 -> 0.43.1001
    @fluidframework/protocol-definitions: 0.1028.1000 (unchanged)
      @fluidframework/driver-definitions:  0.46.1000 (unchanged)
   @fluidframework/container-definitions:  0.48.1000 (unchanged)
                                  Server: 0.1036.1000 (unchanged)
                                  Client:  0.59.1000 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)

Also remove pre-release dependencies for core-interfaces
         @fluidframework/core-interfaces -> ^0.43.1000