### PR TITLE
don't regenerate annotate op on removed segment

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -707,7 +707,7 @@ export class Client {
                     assert(segment.propertyManager?.hasPendingProperties() === true,
                         0x036 /* "Segment has no pending properties" */);
                     // if the segment has been removed, there's no need to send the annotate op
-                    if (segment.removedSeq === undefined && segment.localRemovedSeq === undefined) {
+                    if (segment.removedSeq === undefined || segment.localRemovedSeq !== undefined) {
                         newOp = createAnnotateRangeOp(
                             segmentPosition,
                             segmentPosition + segment.cachedLength,

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -707,6 +707,8 @@ export class Client {
                     assert(segment.propertyManager?.hasPendingProperties() === true,
                         0x036 /* "Segment has no pending properties" */);
                     // if the segment has been removed, there's no need to send the annotate op
+                    // unless the remove was local, in which case the annotate must have come
+                    // before the remove
                     if (segment.removedSeq === undefined || segment.localRemovedSeq !== undefined) {
                         newOp = createAnnotateRangeOp(
                             segmentPosition,

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -706,11 +706,14 @@ export class Client {
                 case MergeTreeDeltaType.ANNOTATE:
                     assert(segment.propertyManager?.hasPendingProperties() === true,
                         0x036 /* "Segment has no pending properties" */);
-                    newOp = createAnnotateRangeOp(
-                        segmentPosition,
-                        segmentPosition + segment.cachedLength,
-                        resetOp.props,
-                        resetOp.combiningOp);
+                    // if the segment has been removed, there's no need to send the annotate op
+                    if (segment.removedSeq === undefined && segment.localRemovedSeq === undefined) {
+                        newOp = createAnnotateRangeOp(
+                            segmentPosition,
+                            segmentPosition + segment.cachedLength,
+                            resetOp.props,
+                            resetOp.combiningOp);
+                    }
                     break;
 
                 case MergeTreeDeltaType.INSERT:


### PR DESCRIPTION
Related to #9927
Don't regenerate annotate ops for segments that have been removed by remote clients since the change was initially made.

Client checks that an annotate op is valid when the changes are initially made, but not when the ops are regenerated. On remote clients, the ops are not checked and are applied to no effect. However, they cause issues for applyStashedOp() implementation, since the regenerated ops need to be applied, but in this case are not valid.