### PR TITLE
Add opaque handle type for internalized SharedTree edits

### DIFF
--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -66,6 +66,7 @@ import {
 	ghostSessionId,
 	WriteFormat,
 	TreeNodeSequence,
+	InternalizedChange,
 } from './persisted-types';
 import { serialize, SummaryContents } from './Summary';
 import {
@@ -558,8 +559,8 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * @returns the edit history of the tree.
 	 * @public
 	 */
-	public get edits(): OrderedEditSet {
-		return this.editLog;
+	public get edits(): OrderedEditSet<InternalizedChange> {
+		return this.editLog as unknown as OrderedEditSet<InternalizedChange>;
 	}
 
 	/**
@@ -1174,9 +1175,9 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * should be used instead.
 	 * @public
 	 */
-	public applyEdit(...changes: Change[]): Edit<unknown>;
-	public applyEdit(changes: Change[]): Edit<unknown>;
-	public applyEdit(headOrChanges: Change | Change[], ...tail: Change[]): Edit<unknown> {
+	public applyEdit(...changes: Change[]): Edit<InternalizedChange>;
+	public applyEdit(changes: Change[]): Edit<InternalizedChange>;
+	public applyEdit(headOrChanges: Change | Change[], ...tail: Change[]): Edit<InternalizedChange> {
 		const changes = Array.isArray(headOrChanges) ? headOrChanges : [headOrChanges, ...tail];
 		const id = newEditId();
 		const internalEdit: Edit<ChangeInternal> = {
@@ -1185,7 +1186,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 		};
 		this.submitEditOp(internalEdit);
 		this.applyEditLocally(internalEdit, undefined);
-		return internalEdit;
+		return internalEdit as unknown as Edit<InternalizedChange>;
 	}
 
 	/**

--- a/experimental/dds/tree/src/SummaryTestUtilities.ts
+++ b/experimental/dds/tree/src/SummaryTestUtilities.ts
@@ -29,7 +29,7 @@ export interface UploadedEditChunkContents {
  */
 export async function getUploadedEditChunkContents(sharedTree: SharedTree): Promise<UploadedEditChunkContents[]> {
 	const editChunks: UploadedEditChunkContents[] = [];
-	const { editChunks: editsOrHandles } = (sharedTree.edits as EditLog<ChangeInternal>).getEditLogSummary();
+	const { editChunks: editsOrHandles } = (sharedTree.editsInternal as EditLog<ChangeInternal>).getEditLogSummary();
 	for (const { chunk } of editsOrHandles) {
 		if (!Array.isArray(chunk)) {
 			const handle = chunk as FluidEditHandle;

--- a/experimental/dds/tree/src/persisted-types/0.1.1.ts
+++ b/experimental/dds/tree/src/persisted-types/0.1.1.ts
@@ -204,6 +204,17 @@ export interface CompressedBuildInternal<TId extends OpSpaceNodeId> {
  */
 export type CompressedBuildNode<TId extends OpSpaceNodeId> = CompressedPlaceholderTree<TId, DetachedSequenceId>;
 
+// TODO: `ChangeInternal`s should be assignable to this type without casting; this will require some test refactoring.
+/**
+ * This type should be used as an opaque handle in the public API for `ChangeInternal` objects.
+ * This is useful for supporting public APIs which involve working with a tree's edit history,
+ * which will involve changes that have already been internalized.
+ * @public
+ */
+export interface InternalizedChange {
+	InternalChangeBrand: '2cae1045-61cf-4ef7-a6a3-8ad920cb7ab3';
+}
+
 /**
  * {@inheritdoc (Change:type)}
  * @public

--- a/experimental/dds/tree/src/test/utilities/PendingLocalStateTests.ts
+++ b/experimental/dds/tree/src/test/utilities/PendingLocalStateTests.ts
@@ -67,9 +67,7 @@ export function runPendingLocalStateTests(
 						testObjectProvider,
 						container,
 						() =>
-							tree.applyEdit(
-								...Change.insertTree(testTree.buildLeaf(), StablePlace.after(testTree.left))
-							) as Edit<ChangeInternal>
+							tree.applyEdit(...Change.insertTree(testTree.buildLeaf(), StablePlace.after(testTree.left)))
 					);
 					await testObjectProvider.ensureSynchronized();
 					const leftTraitAfterOfflineClose = tree2.currentView.getTrait(
@@ -99,7 +97,7 @@ export function runPendingLocalStateTests(
 						'Tree collaborating with a client that applies stashed pending edits should see them.'
 					);
 
-					const stableEdit = stabilizeEdit(tree, edit);
+					const stableEdit = stabilizeEdit(tree, edit as unknown as Edit<ChangeInternal>);
 					expect(
 						stabilizeEdit(tree2, (await tree2.editsInternal.tryGetEdit(edit.id)) ?? fail())
 					).to.deep.equal(stableEdit);

--- a/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
@@ -14,7 +14,7 @@ import {
 	MockFluidDataStoreRuntime,
 } from '@fluidframework/test-runtime-utils';
 import { assertArrayOfOne, assertNotUndefined, fail, isSharedTreeEvent } from '../../Common';
-import { EditId, OpSpaceNodeId, TraitLabel } from '../../Identifiers';
+import { EditId, NodeId, OpSpaceNodeId, TraitLabel } from '../../Identifiers';
 import { CachingLogViewer } from '../../LogViewer';
 import { EditLog, OrderedEditSet } from '../../EditLog';
 import { initialTree } from '../../InitialTree';
@@ -1413,7 +1413,7 @@ export function runSharedTreeOperationsTests(
 
 					const uncompressedEdits: EditWithoutId<ChangeInternal>[] = [
 						{
-							changes: tree.edits.getEditInSessionAtIndex(0).changes as ChangeInternal[],
+							changes: tree.editsInternal.getEditInSessionAtIndex(0).changes,
 						},
 					];
 

--- a/experimental/dds/tree/src/test/utilities/SummarySizeTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SummarySizeTests.ts
@@ -142,7 +142,7 @@ export function runSummarySizeTests(
 			if (revertEdits) {
 				for (let i = changes.length - 1; i >= 0; i--) {
 					const editIndex = tree.edits.getIndexOfId(edits[i].id);
-					const edit = tree.edits.getEditInSessionAtIndex(editIndex) as Edit<ChangeInternal>;
+					const edit = tree.edits.getEditInSessionAtIndex(editIndex) as unknown as Edit<ChangeInternal>;
 					const reverted = revert(edit.changes, tree.logViewer.getRevisionViewInSession(editIndex));
 					if (reverted !== undefined) {
 						tree.applyEditInternal(reverted);


### PR DESCRIPTION
The intent of this change is to allow shared-tree public APIs exposing `ChangeInternal` to instead cast to `InternalizedChange` before return. Then, APIs which accept changes that have already been internalized (e.g. one could imagine us exposing `revert` or other history methods this way) can accept types in terms of this opaque handle type.

This is slightly more typesafe than the `unknown` approach we take now.