### PR TITLE
Enable strict null in Merge Tree Tests

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -100,7 +100,7 @@ export class Client {
     addLocalReference(lref: LocalReference): void;
     // (undocumented)
     addLongClientId(longClientId: string): void;
-    annotateMarker(marker: Marker, props: PropertySet, combiningOp: ICombiningOp): IMergeTreeAnnotateMsg | undefined;
+    annotateMarker(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): IMergeTreeAnnotateMsg | undefined;
     annotateMarkerNotifyConsensus(marker: Marker, props: PropertySet, consensusCallback: (m: Marker) => void): IMergeTreeAnnotateMsg | undefined;
     annotateRangeLocal(start: number, end: number, props: PropertySet, combiningOp: ICombiningOp | undefined): IMergeTreeAnnotateMsg | undefined;
     // (undocumented)
@@ -253,7 +253,7 @@ export const compareStrings: (a: string, b: string) => number;
 export type ConflictAction<TKey, TData> = (key: TKey, currentKey: TKey, data: TData, currentData: TData) => QProperty<TKey, TData>;
 
 // @public
-export function createAnnotateMarkerOp(marker: Marker, props: PropertySet, combiningOp: ICombiningOp): IMergeTreeAnnotateMsg | undefined;
+export function createAnnotateMarkerOp(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): IMergeTreeAnnotateMsg | undefined;
 
 // @public
 export function createAnnotateRangeOp(start: number, end: number, props: PropertySet, combiningOp: ICombiningOp | undefined): IMergeTreeAnnotateMsg;

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -163,7 +163,7 @@ export class Client {
     public annotateMarker(
         marker: Marker,
         props: PropertySet,
-        combiningOp: ICombiningOp): IMergeTreeAnnotateMsg | undefined {
+        combiningOp?: ICombiningOp): IMergeTreeAnnotateMsg | undefined {
         const annotateOp =
             createAnnotateMarkerOp(marker, props, combiningOp)!;
 

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -153,7 +153,7 @@ export class LocalReferenceCollection {
         private readonly segment: ISegment,
         initialRefsByfOffset = new Array<IRefsAtOffset | undefined>(segment.cachedLength)) {
         // Since javascript arrays are sparse the above won't populate any of the
-        // indicies, but it will ensure the length property of the array matches
+        // indices, but it will ensure the length property of the array matches
         // the length of the segment.
         this.refsByOffset = initialRefsByfOffset;
     }

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-/* eslint-disable max-lines */
+
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 

--- a/packages/dds/merge-tree/src/opBuilder.ts
+++ b/packages/dds/merge-tree/src/opBuilder.ts
@@ -23,7 +23,7 @@ import { PropertySet } from "./properties";
  * @returns The annotate op
  */
 export function createAnnotateMarkerOp(
-    marker: Marker, props: PropertySet, combiningOp: ICombiningOp): IMergeTreeAnnotateMsg | undefined {
+    marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): IMergeTreeAnnotateMsg | undefined {
     const id = marker.getId();
     if (!id) {
         return undefined;

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -1,11 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions, max-len, no-bitwise */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import fs from "fs";

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -63,11 +65,9 @@ function LinearDictionary<TKey, TData>(compareKeys: KeyComparer<TKey>): SortedDi
         if (props.length !== 0) { return; }
 
         if (_start === undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             _start = min()!.key;
         }
         if (_end === undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             _end = max()!.key;
         }
         for (let i = 0, len = props.length; i < len; i++) {
@@ -151,8 +151,8 @@ const compareStrings = (a: string, b: string) => a.localeCompare(b);
 
 const compareNumbers = (a: number, b: number) => a - b;
 
-function printStringProperty(p: Property<string, string>) {
-    log(`[${p.key}, ${p.data}]`);
+function printStringProperty(p?: Property<string, string>) {
+    log(`[${p?.key}, ${p?.data}]`);
     return true;
 }
 
@@ -327,7 +327,7 @@ function checkMarkRemoveMergeTree(mergeTree: MergeTree, start: number, end: numb
     const origText = helper.getText(UniversalSequenceNumber, LocalClientId);
     const checkText = editFlat(origText, start, end - start);
     const clockStart = clock();
-    mergeTree.markRangeRemoved(start, end, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, false, undefined);
+    mergeTree.markRangeRemoved(start, end, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, false, {op: createRemoveRangeOp(start, end)});
     accumTime += elapsedMicroseconds(clockStart);
     const updatedText = helper.getText(UniversalSequenceNumber, LocalClientId);
     const result = (checkText === updatedText);
@@ -352,7 +352,7 @@ export function mergeTreeTest1() {
     checkInsertMergeTree(mergeTree, 4, makeCollabTextSegment("fi"));
     mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId, undefined);
     const segoff = mergeTree.getContainingSegment(4, UniversalSequenceNumber, LocalClientId);
-    log(mergeTree.getPosition(segoff.segment, UniversalSequenceNumber, LocalClientId));
+    log(mergeTree.getPosition(segoff.segment!, UniversalSequenceNumber, LocalClientId));
     log(new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId));
     log(mergeTree.toString());
     TestPack().firstTest();
@@ -406,7 +406,7 @@ export function mergeTreeLargeTest() {
         const pos = random.integer(0, preLen)(mt);
         // Log(itree.toString());
         const clockStart = clock();
-        mergeTree.markRangeRemoved(pos, pos + dlen, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, false, undefined);
+        mergeTree.markRangeRemoved(pos, pos + dlen, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, false, undefined as any);
         accumTime += elapsedMicroseconds(clockStart);
 
         if ((i > 0) && (0 === (i % 50000))) {
@@ -625,7 +625,7 @@ export function TestPack(verbose = true) {
         const aveTime = (client.accumTime / client.accumOps).toFixed(1);
         const aveLocalTime = (client.localTime / client.localOps).toFixed(1);
         const stats = client.mergeTree.getStats();
-        const windowTime = stats.windowTime;
+        const windowTime = stats.windowTime!;
         const packTime = stats.packTime;
         const aveWindowTime = ((windowTime || 0) / (client.accumOps)).toFixed(1);
         const avePackTime = ((packTime || 0) / (client.accumOps)).toFixed(1);
@@ -765,10 +765,10 @@ export function TestPack(verbose = true) {
             if (includeMarkers) {
                 const insertMarkerOp = client.insertMarkerLocal(pos, ReferenceType.Tile,
                     { [reservedTileLabelsKey]: "test" });
-                server.enqueueMsg(client.makeOpMessage(insertMarkerOp, UnassignedSequenceNumber));
+                server.enqueueMsg(client.makeOpMessage(insertMarkerOp!, UnassignedSequenceNumber));
             }
             const insertTextOp = client.insertTextLocal(pos, text);
-            server.enqueueMsg(client.makeOpMessage(insertTextOp, UnassignedSequenceNumber));
+            server.enqueueMsg(client.makeOpMessage(insertTextOp!, UnassignedSequenceNumber));
 
             if (TestClient.useCheckQ) {
                 client.enqueueTestString();
@@ -780,7 +780,7 @@ export function TestPack(verbose = true) {
             const preLen = client.getLength();
             const pos = random.integer(0, preLen)(mt);
             const op = client.removeRangeLocal(pos, pos + dlen);
-            server.enqueueMsg(client.makeOpMessage(op));
+            server.enqueueMsg(client.makeOpMessage(op!));
             if (TestClient.useCheckQ) {
                 client.enqueueTestString();
             }
@@ -792,7 +792,7 @@ export function TestPack(verbose = true) {
                 const removeStart = word1.pos;
                 const removeEnd = removeStart + word1.text.length;
                 const removeOp = client.removeRangeLocal(removeStart, removeEnd);
-                server.enqueueMsg(client.makeOpMessage(removeOp, UnassignedSequenceNumber));
+                server.enqueueMsg(client.makeOpMessage(removeOp!, UnassignedSequenceNumber));
                 if (TestClient.useCheckQ) {
                     client.enqueueTestString();
                 }
@@ -802,7 +802,7 @@ export function TestPack(verbose = true) {
                 }
                 const pos = word2.pos + word2.text.length;
                 const insertOp = client.insertTextLocal(pos, word1.text);
-                server.enqueueMsg(client.makeOpMessage(insertOp, UnassignedSequenceNumber));
+                server.enqueueMsg(client.makeOpMessage(insertOp!, UnassignedSequenceNumber));
 
                 if (TestClient.useCheckQ) {
                     client.enqueueTestString();
@@ -1065,13 +1065,13 @@ export function TestPack(verbose = true) {
                     const preLen = cliA.getLength();
                     const pos = random.integer(0, preLen)(mt);
 
-                    const msg = cliA.makeOpMessage(cliA.insertTextLocal(pos, text), sequenceNumber++);
+                    const msg = cliA.makeOpMessage(cliA.insertTextLocal(pos, text)!, sequenceNumber++);
                     msg.minimumSequenceNumber = min;
                     cliAMsgs.push(msg);
                     cliB.applyMsg(msg);
                 }
                 for (let k = firstSeq; k < sequenceNumber; k++) {
-                    cliA.applyMsg(cliAMsgs.shift());
+                    cliA.applyMsg(cliAMsgs.shift()!);
                 }
                 if (checkTextMatch(sequenceNumber - 1)) {
                     return true;
@@ -1088,13 +1088,13 @@ export function TestPack(verbose = true) {
                     const text = randomString(textLen, String.fromCharCode(zedCode + (sequenceNumber % 50)));
                     const preLen = cliB.getLength();
                     const pos = random.integer(0, preLen)(mt);
-                    const msg = cliB.makeOpMessage(cliB.insertTextLocal(pos, text), sequenceNumber++);
+                    const msg = cliB.makeOpMessage(cliB.insertTextLocal(pos, text)!, sequenceNumber++);
                     msg.minimumSequenceNumber = min;
                     cliBMsgs.push(msg);
                     cliA.applyMsg(msg);
                 }
                 for (let k = firstSeq; k < sequenceNumber; k++) {
-                    cliB.applyMsg(cliBMsgs.shift());
+                    cliB.applyMsg(cliBMsgs.shift()!);
                 }
                 if (checkTextMatch(sequenceNumber - 1)) {
                     return true;
@@ -1115,13 +1115,13 @@ export function TestPack(verbose = true) {
                     const dlen = randTextLength();
                     const preLen = cliA.getLength();
                     const pos = random.integer(0, preLen)(mt);
-                    const msg = cliA.makeOpMessage(cliA.removeRangeLocal(pos, pos + dlen), sequenceNumber++);
+                    const msg = cliA.makeOpMessage(cliA.removeRangeLocal(pos, pos + dlen)!, sequenceNumber++);
                     msg.minimumSequenceNumber = min;
                     cliAMsgs.push(msg);
                     cliB.applyMsg(msg);
                 }
                 for (let k = firstSeq; k < sequenceNumber; k++) {
-                    cliA.applyMsg(cliAMsgs.shift());
+                    cliA.applyMsg(cliAMsgs.shift()!);
                 }
                 if (checkTextMatch(sequenceNumber - 1)) {
                     return true;
@@ -1137,13 +1137,13 @@ export function TestPack(verbose = true) {
                     const dlen = randTextLength();
                     const preLen = cliB.getLength() - 1;
                     const pos = random.integer(0, preLen)(mt);
-                    const msg = cliB.makeOpMessage(cliB.removeRangeLocal(pos, pos + dlen), sequenceNumber++);
+                    const msg = cliB.makeOpMessage(cliB.removeRangeLocal(pos, pos + dlen)!, sequenceNumber++);
                     msg.minimumSequenceNumber = min;
                     cliBMsgs.push(msg);
                     cliA.applyMsg(msg);
                 }
                 for (let k = firstSeq; k < sequenceNumber; k++) {
-                    cliB.applyMsg(cliBMsgs.shift());
+                    cliB.applyMsg(cliBMsgs.shift()!);
                 }
                 if (checkTextMatch(sequenceNumber - 1)) {
                     return true;
@@ -1326,7 +1326,7 @@ export function TestPack(verbose = true) {
         }
         const removeOp = cli.removeRangeLocal(3, 5);
         cli.applyMsg(cli.makeOpMessage(createRemoveRangeOp(3, 6), 10, 9, "2"));
-        cli.applyMsg(cli.makeOpMessage(removeOp, 11));
+        cli.applyMsg(cli.makeOpMessage(removeOp!, 11));
         if (verbose) {
             log(cli.mergeTree.toString());
             for (let clientId = 0; clientId < 4; clientId++) {
@@ -1402,7 +1402,7 @@ function tst() {
     function addCorpus(_corpusContent: string, _corpusTree: TST<number>) {
         let count = 0;
         const re = /\b\w+\b/g;
-        let result: RegExpExecArray;
+        let result: RegExpExecArray | null;
         do {
             result = re.exec(_corpusContent);
             if (result) {
@@ -1496,7 +1496,7 @@ export type DocumentNode = string | DocumentTree;
 export class DocumentTree {
     pos = 0;
     ids = { box: 0, row: 0 };
-    id: string;
+    id: string | undefined;
     static randPack = new RandomPack();
 
     constructor(public name: string, public children: DocumentNode[]) {
@@ -1508,7 +1508,7 @@ export class DocumentTree {
             client.insertTextLocal(this.pos, text);
             this.pos += text.length;
         } else {
-            let id: number;
+            let id: number | undefined;
             if (docNode.name === "pg") {
                 client.insertMarkerLocal(this.pos, ReferenceType.Tile,
                     {
@@ -1538,7 +1538,7 @@ export class DocumentTree {
                 this.addToMergeTree(client, child);
             }
             if (docNode.name !== "pg") {
-                const etrid = `end-${docNode.name}${id.toString()}`;
+                const etrid = `end-${docNode.name}${id?.toString()}`;
                 client.insertMarkerLocal(this.pos, ReferenceType.NestEnd,
                     {
                         [reservedMarkerIdKey]: etrid,
@@ -1633,12 +1633,12 @@ export class DocumentTree {
         };
 
         let prevPos = -1;
-        let prevChild: DocumentNode;
+        let prevChild: DocumentNode | undefined;
 
         // log(client.mergeTree.toString());
         for (const rootChild of this.children) {
             if (prevPos >= 0) {
-                if ((typeof prevChild !== "string") && (prevChild.name === "row")) {
+                if ((typeof prevChild !== "string") && (prevChild?.name === "row")) {
                     const id = prevChild.id;
                     const endId = `end-${id}`;
                     const endRowMarker = <Marker>client.getMarkerFromId(endId);
@@ -1754,7 +1754,7 @@ function findReplacePerf(filename: string) {
                     client.getClientId(),
                     1,
                     false,
-                    undefined);
+                    undefined as any);
                 insertText(
                     client.mergeTree,
                     pos + i,
@@ -1767,7 +1767,7 @@ function findReplacePerf(filename: string) {
                 pos = pos + i + 3;
                 cReplaces++;
             } else {
-                pos += (curSeg.cachedLength - curSegOff.offset);
+                pos += (curSeg!.cachedLength - curSegOff!.offset!);
             }
         }
     }

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -23,7 +24,7 @@ describe("client.applyMsg", () => {
 
     it("Interleaved inserts, annotates, and deletes", () => {
         const changes = new Map<number, { msg: ISequencedDocumentMessage, segmentGroup: SegmentGroup }>();
-        assert.equal(client.mergeTree.pendingSegments.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
         for (let i = 0; i < 100; i++) {
             const len = client.getLength();
             const pos1 = Math.floor(len / 2);
@@ -35,7 +36,7 @@ describe("client.applyMsg", () => {
                     const msg = client.makeOpMessage(
                         client.removeRangeLocal(pos1, pos2),
                         i + 1);
-                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last() });
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last()! });
                     break;
                 }
 
@@ -43,7 +44,7 @@ describe("client.applyMsg", () => {
                 case 4: {
                     const str = `${i}`.repeat(imod6 + 5);
                     const msg = client.makeOpMessage(client.insertTextLocal(pos1, str), i + 1);
-                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last() });
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last()! });
                     break;
                 }
 
@@ -58,7 +59,7 @@ describe("client.applyMsg", () => {
                         },
                         undefined);
                     const msg = client.makeOpMessage(op, i + 1);
-                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last() });
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last()! });
                     break;
                 }
                 default:
@@ -66,9 +67,9 @@ describe("client.applyMsg", () => {
             }
         }
         for (let i = 0; i < 100; i++) {
-            const msg = changes.get(i).msg;
+            const msg = changes.get(i)!.msg;
             client.applyMsg(msg);
-            const segments = changes.get(i).segmentGroup.segments;
+            const segments = changes.get(i)!.segmentGroup.segments;
             for (const seg of segments) {
                 switch (i % 6) {
                     case 0:
@@ -85,12 +86,12 @@ describe("client.applyMsg", () => {
                 }
             }
         }
-        assert.equal(client.mergeTree.pendingSegments.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
         for (let i = 0; i < client.getText().length; i++) {
             const segmentInfo = client.getContainingSegment(i);
 
-            assert.notEqual(segmentInfo.segment.seq, UnassignedSequenceNumber, "all segments should be acked");
-            assert(segmentInfo.segment.segmentGroups.empty, "there should be no outstanding segmentGroups");
+            assert.notEqual(segmentInfo.segment?.seq, UnassignedSequenceNumber, "all segments should be acked");
+            assert(segmentInfo.segment?.segmentGroups.empty, "there should be no outstanding segmentGroups");
         }
     });
 
@@ -99,11 +100,11 @@ describe("client.applyMsg", () => {
 
         const segmentInfo = client.getContainingSegment(0);
 
-        assert.equal(segmentInfo.segment.seq, UnassignedSequenceNumber);
+        assert.equal(segmentInfo.segment?.seq, UnassignedSequenceNumber);
 
         client.applyMsg(client.makeOpMessage(op, 17));
 
-        assert.equal(segmentInfo.segment.seq, 17);
+        assert.equal(segmentInfo.segment?.seq, 17);
     });
 
     it("removeRangeLocal", () => {
@@ -111,11 +112,11 @@ describe("client.applyMsg", () => {
 
         const removeOp = client.removeRangeLocal(0, 1);
 
-        assert.equal(segmentInfo.segment.removedSeq, UnassignedSequenceNumber);
+        assert.equal(segmentInfo.segment?.removedSeq, UnassignedSequenceNumber);
 
         client.applyMsg(client.makeOpMessage(removeOp, 17));
 
-        assert.equal(segmentInfo.segment.removedSeq, 17);
+        assert.equal(segmentInfo.segment?.removedSeq, 17);
     });
 
     it("annotateSegmentLocal", () => {
@@ -128,11 +129,11 @@ describe("client.applyMsg", () => {
             props,
             undefined);
 
-        assert.equal(client.mergeTree.pendingSegments.count(), 1);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 1);
 
         client.applyMsg(client.makeOpMessage(op, 17));
 
-        assert.equal(client.mergeTree.pendingSegments.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
     });
 
     it("annotateSegmentLocal then removeRangeLocal", () => {
@@ -151,22 +152,22 @@ describe("client.applyMsg", () => {
             props,
             undefined);
 
-        assert.equal(client.mergeTree.pendingSegments.count(), 1);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 1);
 
         const removeOp = client.removeRangeLocal(start, end);
 
-        assert.equal(segmentInfo.segment.removedSeq, UnassignedSequenceNumber);
-        assert.equal(client.mergeTree.pendingSegments.count(), 2);
+        assert.equal(segmentInfo.segment?.removedSeq, UnassignedSequenceNumber);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 2);
 
         client.applyMsg(client.makeOpMessage(annotateOp, 17));
 
-        assert.equal(segmentInfo.segment.removedSeq, UnassignedSequenceNumber);
-        assert.equal(client.mergeTree.pendingSegments.count(), 1);
+        assert.equal(segmentInfo.segment?.removedSeq, UnassignedSequenceNumber);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 1);
 
         client.applyMsg(client.makeOpMessage(removeOp, 18));
 
-        assert.equal(segmentInfo.segment.removedSeq, 18);
-        assert.equal(client.mergeTree.pendingSegments.count(), 0);
+        assert.equal(segmentInfo.segment?.removedSeq, 18);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
     });
 
     it("multiple interleaved annotateSegmentLocal", () => {
@@ -191,12 +192,12 @@ describe("client.applyMsg", () => {
 
             annotateEnd = Math.floor(annotateEnd / 2);
         }
-        assert.equal(client.mergeTree.pendingSegments.count(), messages.length);
+        assert.equal(client.mergeTree.pendingSegments?.count(), messages.length);
 
         for (const msg of messages) {
             client.applyMsg(msg);
         }
-        assert.equal(client.mergeTree.pendingSegments.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
     });
 
     it("overlapping deletes", () => {
@@ -207,26 +208,26 @@ describe("client.applyMsg", () => {
         const intialText = client.getText();
         const initialLength = intialText.length;
 
-        assert.equal(segmentInfo.segment.removedSeq, undefined);
-        assert(segmentInfo.segment.segmentGroups.empty);
+        assert.equal(segmentInfo.segment?.removedSeq, undefined);
+        assert(segmentInfo.segment?.segmentGroups.empty);
 
         const removeOp = client.removeRangeLocal(start, end);
 
-        assert.equal(segmentInfo.segment.removedSeq, UnassignedSequenceNumber);
-        assert.equal(segmentInfo.segment.segmentGroups.size, 1);
+        assert.equal(segmentInfo.segment?.removedSeq, UnassignedSequenceNumber);
+        assert.equal(segmentInfo.segment?.segmentGroups.size, 1);
 
         const remoteMessage = client.makeOpMessage(removeOp, 17);
         remoteMessage.clientId = "remoteClient";
 
         client.applyMsg(remoteMessage);
 
-        assert.equal(segmentInfo.segment.removedSeq, remoteMessage.sequenceNumber);
-        assert.equal(segmentInfo.segment.segmentGroups.size, 1);
+        assert.equal(segmentInfo.segment?.removedSeq, remoteMessage.sequenceNumber);
+        assert.equal(segmentInfo.segment?.segmentGroups.size, 1);
 
         client.applyMsg(client.makeOpMessage(removeOp, 18));
 
-        assert.equal(segmentInfo.segment.removedSeq, remoteMessage.sequenceNumber);
-        assert(segmentInfo.segment.segmentGroups.empty);
+        assert.equal(segmentInfo.segment?.removedSeq, remoteMessage.sequenceNumber);
+        assert(segmentInfo.segment?.segmentGroups.empty);
         assert.equal(client.getLength(), initialLength - (end - start));
         assert.equal(client.getText(), intialText.substring(0, start) + intialText.substring(end));
     });
@@ -251,7 +252,7 @@ describe("client.applyMsg", () => {
         ];
 
         while (messages.length > 0) {
-            const msg = messages.shift();
+            const msg = messages.shift()!;
             clients.forEach((c)=>c.applyMsg(msg));
         }
 
@@ -279,7 +280,7 @@ describe("client.applyMsg", () => {
 
         const logger = new TestClientLogger(clients);
         while (messages.length > 0) {
-            const msg = messages.shift();
+            const msg = messages.shift()!;
             clients.forEach((c)=>c.applyMsg(msg));
         }
 
@@ -308,7 +309,7 @@ describe("client.applyMsg", () => {
 
         const logger = new TestClientLogger(clients);
         while (messages.length > 0) {
-            const msg = messages.shift();
+            const msg = messages.shift()!;
             clients.forEach((c)=>c.applyMsg(msg));
         }
 
@@ -335,7 +336,7 @@ describe("client.applyMsg", () => {
 
         const logger = new TestClientLogger(clients);
         while (messages.length > 0) {
-            const msg = messages.shift();
+            const msg = messages.shift()!;
             clients.forEach((c)=>c.applyMsg(msg));
         }
 
@@ -360,7 +361,7 @@ describe("client.applyMsg", () => {
 
         const logger = new TestClientLogger(clients);
         while (messages.length > 0) {
-            const msg = messages.shift();
+            const msg = messages.shift()!;
             clients.forEach((c)=>c.applyMsg(msg));
         }
 
@@ -384,7 +385,7 @@ describe("client.applyMsg", () => {
 
         ];
         while (messages.length > 0) {
-            const msg = messages.shift();
+            const msg = messages.shift()!;
             clients.forEach((c) => {
                 c.applyMsg(msg);
             });
@@ -398,7 +399,7 @@ describe("client.applyMsg", () => {
             clientB.makeOpMessage(clientB.insertTextLocal(1, "BBB"), ++seq),
         );
         while (messages.length > 0) {
-            const msg = messages.shift();
+            const msg = messages.shift()!;
             clients.forEach((c)=>c.applyMsg(msg));
         }
         logger.validate();
@@ -414,8 +415,8 @@ describe("client.applyMsg", () => {
         const insertOp = clientA.makeOpMessage(clientA.insertTextLocal(0, "AAA"), ++seq);
         [clientA, clientB].map((c) => c.applyMsg(insertOp));
 
-        const annotateOp = clientA.annotateRangeLocal(0, clientA.getLength(), { client: "A" }, undefined);
-        const seg = clientA.peekPendingSegmentGroups();
+        const annotateOp = clientA.annotateRangeLocal(0, clientA.getLength(), { client: "A" }, undefined)!;
+        const seg = clientA.peekPendingSegmentGroups()!;
 
         const removeOp = clientB.makeOpMessage(clientB.removeRangeLocal(0, clientB.getLength()), ++seq);
         [clientA, clientB].map((c) => c.applyMsg(removeOp));

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1,8 +1,9 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";

--- a/packages/dds/merge-tree/src/test/client.getPostion.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.getPostion.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -20,7 +22,7 @@ describe("client.getPosition", () => {
         client.startOrUpdateCollaboration(localUserLongId);
 
         const segOff = client.getContainingSegment(segPos);
-        assert(TextSegment.is(segOff.segment));
+        assert(TextSegment.is(segOff.segment!));
         assert.strictEqual(segOff.offset, 0);
         assert.strictEqual(segOff.segment.text, "o");
         segment = segOff.segment;

--- a/packages/dds/merge-tree/src/test/client.getPostion.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.getPostion.spec.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import { TextSegment } from "../textSegment";

--- a/packages/dds/merge-tree/src/test/client.localReference.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReference.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -27,7 +29,7 @@ describe("MergeTree.Client", () => {
         }
 
         const segInfo = client1.getContainingSegment(2);
-        const c1LocalRef = new LocalReference(client1, segInfo.segment, segInfo.offset, ReferenceType.Simple);
+        const c1LocalRef = new LocalReference(client1, segInfo.segment!, segInfo.offset, ReferenceType.Simple);
         client1.addLocalReference(c1LocalRef);
 
         assert.equal(c1LocalRef.toPosition(), 2);
@@ -43,7 +45,7 @@ describe("MergeTree.Client", () => {
         // this only works because zamboni hasn't run yet
         assert.equal(c1LocalRef.toPosition(), -1);
 
-        // this will force zamoni to run
+        // this will force Zamboni to run
         for (let i = 0; i < 5; i++) {
             const insert =
                 client1.makeOpMessage(
@@ -75,7 +77,7 @@ describe("MergeTree.Client", () => {
         }
 
         const segInfo = client1.getContainingSegment(2);
-        const c1LocalRef = new LocalReference(client1, segInfo.segment, segInfo.offset, ReferenceType.SlideOnRemove);
+        const c1LocalRef = new LocalReference(client1, segInfo.segment!, segInfo.offset, ReferenceType.SlideOnRemove);
         client1.addLocalReference(c1LocalRef);
 
         assert.equal(c1LocalRef.toPosition(), 2);
@@ -121,7 +123,7 @@ describe("MergeTree.Client", () => {
         }
 
         const segInfo = client1.getContainingSegment(2);
-        const c1LocalRef = new LocalReference(client1, segInfo.segment, segInfo.offset, ReferenceType.SlideOnRemove);
+        const c1LocalRef = new LocalReference(client1, segInfo.segment!, segInfo.offset, ReferenceType.SlideOnRemove);
         client1.addLocalReference(c1LocalRef);
 
         assert.equal(c1LocalRef.toPosition(), 2);
@@ -155,7 +157,7 @@ describe("MergeTree.Client", () => {
         }
 
         const segInfo = client1.getContainingSegment(2);
-        const c1LocalRef = new LocalReference(client1, segInfo.segment, segInfo.offset, ReferenceType.SlideOnRemove);
+        const c1LocalRef = new LocalReference(client1, segInfo.segment!, segInfo.offset, ReferenceType.SlideOnRemove);
         client1.addLocalReference(c1LocalRef);
 
         assert.equal(c1LocalRef.toPosition(), 2);

--- a/packages/dds/merge-tree/src/test/client.localReference.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReference.spec.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import { LocalReference } from "../localReference";

--- a/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -74,7 +76,7 @@ describe("MergeTree.Client", () => {
                         refs.push([]);
                         for(let t = 0; t < c.getLength(); t++) {
                             const seg = c.getContainingSegment(t);
-                            const lref = new LocalReference(c, seg.segment, seg.offset, ReferenceType.SlideOnRemove);
+                            const lref = new LocalReference(c, seg.segment!, seg.offset, ReferenceType.SlideOnRemove);
                             c.addLocalReference(lref);
                             lref.addProperties({t});
                             refs[i].push(lref);

--- a/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import random from "random-js";

--- a/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import random from "random-js";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";

--- a/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -31,7 +32,7 @@ function applyMessagesWithReconnect(
     let minSeq = 0;
     // log and apply all the ops created in the round
     while (messageDatas.length > 0) {
-        const [message, sg] = messageDatas.shift();
+        const [message, sg] = messageDatas.shift()!;
         if (message.clientId === clients[1].longClientId) {
             reconnectClientMsgs.push([message.contents as IMergeTreeOp, sg]);
         } else {
@@ -50,7 +51,7 @@ function applyMessagesWithReconnect(
             ));
         newMsg.minimumSequenceNumber = minSeq;
         // apply message doesn't use the segment group, so just pass undefined
-        reconnectMsgs.push([newMsg, undefined]);
+        reconnectMsgs.push([newMsg, undefined as any]);
     });
 
     return applyMessages(seq, reconnectMsgs, clients, logger);

--- a/packages/dds/merge-tree/src/test/client.replay.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.replay.spec.ts
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as fs from "fs";
 import assert from "assert";

--- a/packages/dds/merge-tree/src/test/client.replay.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.replay.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -34,10 +35,10 @@ describe("MergeTree.Client", () => {
                 const initialText = logger.validate();
                 assert.strictEqual(initialText, group.initialText, "Initial text not as expected");
                 for(const msg of group.msgs) {
-                    const msgClient = msgClients.get(msg.clientId);
+                    const msgClient = msgClients.get(msg.clientId)!;
                     while(msgClient.msgs.length > 0
                         && msg.referenceSequenceNumber > msgClient.client.getCurrentSeq()) {
-                        msgClient.client.applyMsg(msgClient.msgs.shift());
+                        msgClient.client.applyMsg(msgClient.msgs.shift()!);
                     }
                     const op = msg.contents as IMergeTreeOp;
                     msgClient.client.localTransaction(
@@ -47,7 +48,7 @@ describe("MergeTree.Client", () => {
 
                 msgClients.forEach((mc)=>{
                     while(mc.msgs.length > 0) {
-                        mc.client.applyMsg(mc.msgs.shift());
+                        mc.client.applyMsg(mc.msgs.shift()!);
                     }
                 });
                 const result = logger.validate();

--- a/packages/dds/merge-tree/src/test/client.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.spec.ts
@@ -182,7 +182,7 @@ describe("TestClient", () => {
             assert.equal(tile1.pos, 0, "Tile with label not at expected position");
         });
 
-        it("Should be able to find only preceding but not non preceeding tile with index out of bound", () => {
+        it("Should be able to find only preceding but not non preceding tile with index out of bound", () => {
             const tileLabel = "EOP";
             client.insertMarkerLocal(
                 0,

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
@@ -46,7 +46,7 @@ describe("MergeTree", () => {
                 currentSequenceNumber,
                 localClientId,
                 UnassignedSequenceNumber,
-                undefined);
+                undefined as any);
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.ANNOTATE]: 1,
@@ -77,7 +77,7 @@ describe("MergeTree", () => {
                 currentSequenceNumber,
                 localClientId,
                 UnassignedSequenceNumber,
-                undefined);
+                undefined as any);
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.ANNOTATE]: 1,
@@ -111,7 +111,7 @@ describe("MergeTree", () => {
                 currentSequenceNumber,
                 localClientId,
                 UnassignedSequenceNumber,
-                undefined);
+                undefined as any);
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.ANNOTATE]: 1,
@@ -130,7 +130,7 @@ describe("MergeTree", () => {
                 remoteSequenceNumber,
                 ++remoteSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
 
             const count = countOperations(mergeTree);
 
@@ -144,7 +144,7 @@ describe("MergeTree", () => {
                 currentSequenceNumber,
                 localClientId,
                 UnassignedSequenceNumber,
-                undefined);
+                undefined as any);
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.ANNOTATE]: 1,

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -31,7 +31,7 @@ describe("MergeTree", () => {
             UniversalSequenceNumber,
             LocalClientId,
             UniversalSequenceNumber,
-            undefined);
+            undefined as any);
 
         currentSequenceNumber = 0;
         mergeTree.insertSegments(
@@ -40,7 +40,7 @@ describe("MergeTree", () => {
             currentSequenceNumber,
             remoteClientId,
             ++currentSequenceNumber,
-            undefined);
+            undefined as any);
     });
 
     describe("annotateRange", () => {
@@ -56,12 +56,12 @@ describe("MergeTree", () => {
                     currentSequenceNumber,
                     remoteClientId,
                     currentSequenceNumber + 1,
-                    undefined);
+                    undefined as any);
 
                 const segmentInfo =
                     mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                 const segment = segmentInfo.segment as BaseSegment;
-                assert.equal(segment.properties.propertySource, "remote");
+                assert.equal(segment?.properties?.propertySource, "remote");
             });
 
             it("local", () => {
@@ -75,12 +75,12 @@ describe("MergeTree", () => {
                     currentSequenceNumber,
                     localClientId,
                     UnassignedSequenceNumber,
-                    undefined);
+                    undefined as any);
 
                 const segmentInfo =
                     mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                 const segment = segmentInfo.segment as BaseSegment;
-                assert.equal(segment.properties.propertySource, "local");
+                assert.equal(segment.properties?.propertySource, "local");
             });
         });
         describe("collaborating", () => {
@@ -103,14 +103,14 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
                 });
 
                 it("unsequenced local", () => {
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
-                    assert.equal(segment.properties.propertySource, "local");
+                    assert.equal(segment.properties?.propertySource, "local");
                 });
 
                 it("unsequenced local after unsequenced local", () => {
@@ -124,12 +124,12 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
-                    assert.equal(segment.properties.secondProperty, "local");
+                    assert.equal(segment.properties?.secondProperty, "local");
                 });
 
                 it("unsequenced local split", () => {
@@ -139,7 +139,7 @@ describe("MergeTree", () => {
 
                     const splitSegment = segment.splitAt(splitPos) as BaseSegment;
 
-                    assert.equal(splitSegment.properties.propertySource, "local");
+                    assert.equal(splitSegment.properties?.propertySource, "local");
                 });
 
                 it("unsequenced local after unsequenced local split", () => {
@@ -154,7 +154,7 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const splitOnlyProps = {
                         splitOnly: 1,
@@ -168,7 +168,7 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
@@ -179,14 +179,14 @@ describe("MergeTree", () => {
                     const splitSegment = splitSegmentInfo.segment as BaseSegment;
 
                     assert.equal(segment.segmentGroups.size, 2);
-                    assert.equal(segment.properties.propertySource, "local");
-                    assert.equal(segment.properties.secondChange, 1);
-                    assert(!segment.properties.splitOnly);
+                    assert.equal(segment.properties?.propertySource, "local");
+                    assert.equal(segment.properties?.secondChange, 1);
+                    assert(!segment.properties?.splitOnly);
 
                     assert.equal(splitSegment.segmentGroups.size, 3);
-                    assert.equal(splitSegment.properties.propertySource, "local");
-                    assert.equal(splitSegment.properties.secondChange, 1);
-                    assert.equal(splitSegment.properties.splitOnly, 1);
+                    assert.equal(splitSegment.properties?.propertySource, "local");
+                    assert.equal(splitSegment.properties?.secondChange, 1);
+                    assert.equal(splitSegment.properties?.splitOnly, 1);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -202,14 +202,14 @@ describe("MergeTree", () => {
                         });
 
                     assert.equal(segment.segmentGroups.size, 1);
-                    assert.equal(segment.properties.propertySource, "local");
-                    assert.equal(segment.properties.secondChange, 1);
-                    assert(!segment.properties.splitOnly);
+                    assert.equal(segment.properties?.propertySource, "local");
+                    assert.equal(segment.properties?.secondChange, 1);
+                    assert(!segment.properties?.splitOnly);
 
                     assert.equal(splitSegment.segmentGroups.size, 2);
-                    assert.equal(splitSegment.properties.propertySource, "local");
-                    assert.equal(splitSegment.properties.secondChange, 1);
-                    assert.equal(splitSegment.properties.splitOnly, 1);
+                    assert.equal(splitSegment.properties?.propertySource, "local");
+                    assert.equal(splitSegment.properties?.secondChange, 1);
+                    assert.equal(splitSegment.properties?.splitOnly, 1);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -225,14 +225,14 @@ describe("MergeTree", () => {
                         });
 
                     assert.equal(segment.segmentGroups.size, 0);
-                    assert.equal(segment.properties.propertySource, "local");
-                    assert.equal(segment.properties.secondChange, 1);
-                    assert(!segment.properties.splitOnly);
+                    assert.equal(segment.properties?.propertySource, "local");
+                    assert.equal(segment.properties?.secondChange, 1);
+                    assert(!segment.properties?.splitOnly);
 
                     assert.equal(splitSegment.segmentGroups.size, 1);
-                    assert.equal(splitSegment.properties.propertySource, "local");
-                    assert.equal(splitSegment.properties.secondChange, 1);
-                    assert.equal(splitSegment.properties.splitOnly, 1);
+                    assert.equal(splitSegment.properties?.propertySource, "local");
+                    assert.equal(splitSegment.properties?.secondChange, 1);
+                    assert.equal(splitSegment.properties?.splitOnly, 1);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -248,14 +248,14 @@ describe("MergeTree", () => {
                         });
 
                     assert.equal(segment.segmentGroups.size, 0);
-                    assert.equal(segment.properties.propertySource, "local");
-                    assert.equal(segment.properties.secondChange, 1);
-                    assert(!segment.properties.splitOnly);
+                    assert.equal(segment.properties?.propertySource, "local");
+                    assert.equal(segment.properties?.secondChange, 1);
+                    assert(!segment.properties?.splitOnly);
 
                     assert.equal(splitSegment.segmentGroups.size, 0);
-                    assert.equal(splitSegment.properties.propertySource, "local");
-                    assert.equal(splitSegment.properties.secondChange, 1);
-                    assert.equal(splitSegment.properties.splitOnly, 1);
+                    assert.equal(splitSegment.properties?.propertySource, "local");
+                    assert.equal(splitSegment.properties?.secondChange, 1);
+                    assert.equal(splitSegment.properties?.splitOnly, 1);
                 });
 
                 it("unsequenced local before remote", () => {
@@ -270,15 +270,15 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         remoteClientId,
                         ++currentSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
 
                     assert.equal(segment.segmentGroups.size, 1);
-                    assert.equal(segment.properties.propertySource, "local");
-                    assert.equal(segment.properties.remoteProperty, 1);
+                    assert.equal(segment.properties?.propertySource, "local");
+                    assert.equal(segment.properties?.remoteProperty, 1);
                 });
 
                 it("sequenced local", () => {
@@ -299,7 +299,7 @@ describe("MergeTree", () => {
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
                     assert.equal(segment.segmentGroups.size, 0);
-                    assert.equal(segment.properties.propertySource, "local");
+                    assert.equal(segment.properties?.propertySource, "local");
                 });
 
                 it("sequenced local before remote", () => {
@@ -327,15 +327,15 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         remoteClientId,
                         ++currentSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
 
                     assert.equal(segment.segmentGroups.size, 0);
-                    assert.equal(segment.properties.propertySource, "remote");
-                    assert.equal(segment.properties.remoteProperty, 1);
+                    assert.equal(segment.properties?.propertySource, "remote");
+                    assert.equal(segment.properties?.remoteProperty, 1);
                 });
 
                 it("three local changes", () => {
@@ -343,7 +343,7 @@ describe("MergeTree", () => {
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
 
-                    assert.equal(segment.properties.propertySource, "local");
+                    assert.equal(segment.properties?.propertySource, "local");
 
                     const props2 = {
                         propertySource: "local2",
@@ -357,10 +357,10 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
-                    assert.equal(segment.properties.propertySource, "local2");
-                    assert.equal(segment.properties.secondSource, 1);
+                    assert.equal(segment.properties?.propertySource, "local2");
+                    assert.equal(segment.properties?.secondSource, 1);
 
                     const props3 = {
                         thirdSource: 1,
@@ -373,11 +373,11 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
-                    assert.equal(segment.properties.propertySource, "local2");
-                    assert.equal(segment.properties.secondSource, 1);
-                    assert.equal(segment.properties.thirdSource, 1);
+                    assert.equal(segment.properties?.propertySource, "local2");
+                    assert.equal(segment.properties?.secondSource, 1);
+                    assert.equal(segment.properties?.thirdSource, 1);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -392,9 +392,9 @@ describe("MergeTree", () => {
                             } as ISequencedDocumentMessage,
                         });
 
-                    assert.equal(segment.properties.propertySource, "local2");
-                    assert.equal(segment.properties.secondSource, 1);
-                    assert.equal(segment.properties.thirdSource, 1);
+                    assert.equal(segment.properties?.propertySource, "local2");
+                    assert.equal(segment.properties?.secondSource, 1);
+                    assert.equal(segment.properties?.thirdSource, 1);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -409,9 +409,9 @@ describe("MergeTree", () => {
                             } as ISequencedDocumentMessage,
                         });
 
-                    assert.equal(segment.properties.propertySource, "local2");
-                    assert.equal(segment.properties.secondSource, 1);
-                    assert.equal(segment.properties.thirdSource, 1);
+                    assert.equal(segment.properties?.propertySource, "local2");
+                    assert.equal(segment.properties?.secondSource, 1);
+                    assert.equal(segment.properties?.thirdSource, 1);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -426,12 +426,12 @@ describe("MergeTree", () => {
                             } as ISequencedDocumentMessage,
                         });
 
-                    assert.equal(segment.properties.propertySource, "local2");
-                    assert.equal(segment.properties.secondSource, 1);
-                    assert.equal(segment.properties.thirdSource, 1);
+                    assert.equal(segment.properties?.propertySource, "local2");
+                    assert.equal(segment.properties?.secondSource, 1);
+                    assert.equal(segment.properties?.thirdSource, 1);
                 });
 
-                it("two local changes with interleved remote", () => {
+                it("two local changes with interleaved remote", () => {
                     mergeTree.annotateRange(
                         annotateStart,
                         annotateEnd,
@@ -442,7 +442,7 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -469,15 +469,15 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         remoteClientId,
                         ++currentSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
 
-                    assert.equal(segment.properties.remoteOnly, 1);
-                    assert.equal(segment.properties.propertySource, "remote");
-                    assert.equal(segment.properties.secondSource, "local2");
+                    assert.equal(segment.properties?.remoteOnly, 1);
+                    assert.equal(segment.properties?.propertySource, "remote");
+                    assert.equal(segment.properties?.secondSource, "local2");
                 });
             });
             describe("remote first", () => {
@@ -493,18 +493,18 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         remoteClientId,
                         ++currentSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
-                    assert(segmentInfo.segment.segmentGroups.empty);
+                    assert(segmentInfo.segment?.segmentGroups.empty);
                 });
                 it("remote only", () => {
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
-                    assert.equal(segment.properties.propertySource, "remote");
-                    assert.equal(segment.properties.remoteProperty, 1);
+                    assert.equal(segment.properties?.propertySource, "remote");
+                    assert.equal(segment.properties?.remoteProperty, 1);
                 });
 
                 it("split remote", () => {
@@ -513,8 +513,8 @@ describe("MergeTree", () => {
                     const segment = segmentInfo.segment as BaseSegment;
 
                     const splitSegment = segment.splitAt(1) as BaseSegment;
-                    assert.equal(splitSegment.properties.propertySource, "remote");
-                    assert.equal(splitSegment.properties.remoteProperty, 1);
+                    assert.equal(splitSegment.properties?.propertySource, "remote");
+                    assert.equal(splitSegment.properties?.remoteProperty, 1);
                 });
 
                 it("remote before unsequenced local", () => {
@@ -528,13 +528,13 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
-                    assert.equal(segment.properties.propertySource, "local");
-                    assert.equal(segment.properties.remoteProperty, 1);
+                    assert.equal(segment.properties?.propertySource, "local");
+                    assert.equal(segment.properties?.remoteProperty, 1);
                 });
 
                 it("remote before sequenced local", () => {
@@ -544,7 +544,7 @@ describe("MergeTree", () => {
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
-                    assert(segmentInfo.segment.segmentGroups.empty);
+                    assert(segmentInfo.segment?.segmentGroups.empty);
 
                     mergeTree.annotateRange(
                         annotateStart,
@@ -554,9 +554,9 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
-                    assert.equal(segmentInfo.segment.segmentGroups.size, 1);
+                    assert.equal(segmentInfo.segment?.segmentGroups.size, 1);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -571,9 +571,9 @@ describe("MergeTree", () => {
                             } as ISequencedDocumentMessage,
                         });
 
-                    assert(segmentInfo.segment.segmentGroups.empty);
-                    assert.equal(segmentInfo.segment.properties.propertySource, "local");
-                    assert.equal(segmentInfo.segment.properties.remoteProperty, 1);
+                    assert(segmentInfo.segment?.segmentGroups.empty);
+                    assert.equal(segmentInfo.segment?.properties?.propertySource, "local");
+                    assert.equal(segmentInfo.segment?.properties?.remoteProperty, 1);
                 });
             });
             describe("local with rewrite first", () => {
@@ -592,7 +592,7 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
                 });
 
                 it("unsequenced local after unsequenced local", () => {
@@ -607,13 +607,13 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
-                    assert.equal(segment.properties.propertySource, "local2");
-                    assert.equal(segment.properties.secondProperty, "local");
+                    assert.equal(segment.properties?.propertySource, "local2");
+                    assert.equal(segment.properties?.secondProperty, "local");
                 });
 
                 it("unsequenced local before remote", () => {
@@ -628,15 +628,15 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         remoteClientId,
                         ++currentSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
 
                     assert.equal(segment.segmentGroups.size, 1);
-                    assert.equal(segment.properties.propertySource, "local");
-                    assert(!segment.properties.remoteProperty);
+                    assert.equal(segment.properties?.propertySource, "local");
+                    assert(!segment.properties?.remoteProperty);
                 });
 
                 it("sequenced local before remote", () => {
@@ -665,18 +665,18 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         remoteClientId,
                         ++currentSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
 
                     assert.equal(segment.segmentGroups.size, 0);
-                    assert.equal(segment.properties.propertySource, "remote");
-                    assert.equal(segment.properties.remoteProperty, 1);
+                    assert.equal(segment.properties?.propertySource, "remote");
+                    assert.equal(segment.properties?.remoteProperty, 1);
                 });
 
-                it("two local changes with interleved remote", () => {
+                it("two local changes with interleaved remote", () => {
                     mergeTree.annotateRange(
                         annotateStart,
                         annotateEnd,
@@ -687,7 +687,7 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         localClientId,
                         UnassignedSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     mergeTree.ackPendingSegment(
                         {
@@ -715,15 +715,15 @@ describe("MergeTree", () => {
                         currentSequenceNumber,
                         remoteClientId,
                         ++currentSequenceNumber,
-                        undefined);
+                        undefined as any);
 
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
 
-                    assert(!segment.properties.remoteOnly);
-                    assert(!segment.properties.propertySource);
-                    assert.equal(segment.properties.secondSource, "local2");
+                    assert(!segment.properties?.remoteOnly);
+                    assert(!segment.properties?.propertySource);
+                    assert.equal(segment.properties?.secondSource, "local2");
                 });
             });
         });

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -88,13 +89,13 @@ const treeFactories: ITestTreeFactory[] = [
 
             const nodes: IMergeBlock[] = [mergeTree.root];
             while (nodes.length > 0) {
-                const node = nodes.pop();
+                const node = nodes.pop()!;
                 assert.equal(node.childCount, MaxNodesInBlock - 1);
-                const childernBlocks =
+                const childrenBlocks =
                     node.children
                         .map((v) => v as IMergeBlock)
                         .filter((v) => v === undefined);
-                nodes.push(...childernBlocks);
+                nodes.push(...childrenBlocks);
             }
 
             mergeTree.startCollaboration(
@@ -145,7 +146,7 @@ const treeFactories: ITestTreeFactory[] = [
                 localClientId,
                 UnassignedSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
             initialText = initialText.substring(remove);
 
             // remove from end
@@ -156,7 +157,7 @@ const treeFactories: ITestTreeFactory[] = [
                 localClientId,
                 UnassignedSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
             initialText = initialText.substring(0, initialText.length - remove);
 
             mergeTree.startCollaboration(

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -1,8 +1,9 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import {

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
@@ -43,7 +43,7 @@ describe("MergeTree", () => {
                 localClientId,
                 UnassignedSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.REMOVE]: 1,
@@ -65,7 +65,7 @@ describe("MergeTree", () => {
                 /* clientId: */ localClientId,
                 /* seq: */ UnassignedSequenceNumber,
                 /* overwrite: */ false,
-                /* opArgs */ undefined);
+                /* opArgs */ undefined as any);
 
             // In order for the removed segment to unlinked by zamboni, we need to ACK the segment
             // and advance the collaboration window's minSeq past the removedSeq.
@@ -104,7 +104,7 @@ describe("MergeTree", () => {
                 remoteClientId,
                 ++remoteSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
 
             const count = countOperations(mergeTree);
 
@@ -115,7 +115,7 @@ describe("MergeTree", () => {
                 localClientId,
                 UnassignedSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.REMOVE]: 1,
@@ -134,7 +134,7 @@ describe("MergeTree", () => {
                 localClientId,
                 UnassignedSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
 
             const count = countOperations(mergeTree);
 
@@ -145,7 +145,7 @@ describe("MergeTree", () => {
                 remoteClientId,
                 ++remoteSequenceNumber,
                 false,
-                undefined);
+                undefined as any);
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.REMOVE]: 1,

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -16,7 +17,7 @@ describe("MergeTree.markRangeRemoved", () => {
         for (const char of "hello world") {
             client.applyMsg(
                 client.makeOpMessage(
-                    client.insertTextLocal(client.getLength(), char),
+                    client.insertTextLocal(client.getLength(), char)!,
                     client.getCurrentSeq() + 1));
         }
         assert.equal(client.getText(), "hello world");
@@ -139,7 +140,7 @@ describe("MergeTree.markRangeRemoved", () => {
             let seq = 0;
 
             // Client 1 locally inserts and removes the letter "a".
-            const op1 = actual.insertTextLocal(0, "a");
+            const op1 = actual.insertTextLocal(0, "a")!;
             const op2 = actual.removeRangeLocal(0, 1);
 
             // Client 1 receives ACKs for op1 and op2.

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import { createInsertSegmentOp, createRemoveRangeOp } from "../opBuilder";
@@ -17,7 +17,7 @@ describe("MergeTree.markRangeRemoved", () => {
         for (const char of "hello world") {
             client.applyMsg(
                 client.makeOpMessage(
-                    client.insertTextLocal(client.getLength(), char)!,
+                    client.insertTextLocal(client.getLength(), char),
                     client.getCurrentSeq() + 1));
         }
         assert.equal(client.getText(), "hello world");

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -1,9 +1,10 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { strict as assert } from "assert";
 import * as fs from "fs";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -39,7 +41,7 @@ export const insertAtRefPos: TestOperation =
             return true;
         });
         if(segs.length > 0) {
-            const text = client.longClientId.repeat(random.integer(1, 3)(mt));
+            const text = client.longClientId!.repeat(random.integer(1, 3)(mt));
             const seg = random.pick(mt,segs);
             return client.insertAtReferencePositionLocal(
                 new LocalReference(client, seg, random.integer(0, seg.cachedLength - 1)(mt)),
@@ -145,10 +147,10 @@ export function generateOperationMessagesForClients(
         // and is our baseline
         const client = clients[random.integer(1, clients.length - 1)(mt)];
         const len = client.getLength();
-        const sg = client.mergeTree.pendingSegments.last();
+        const sg = client.mergeTree.pendingSegments?.last();
         let op: IMergeTreeOp | undefined;
         if (len === 0 || len < minLength) {
-            const text = client.longClientId.repeat(random.integer(1, 3)(mt));
+            const text = client.longClientId!.repeat(random.integer(1, 3)(mt));
             op = client.insertTextLocal(
                 random.integer(0, len)(mt),
                 text);
@@ -165,23 +167,23 @@ export function generateOperationMessagesForClients(
         }
         if (op !== undefined) {
             // Pre-check to avoid logger.toString() in the string template
-            if (sg === client.mergeTree.pendingSegments.last()) {
+            if (sg === client.mergeTree.pendingSegments?.last()) {
                 assert.notEqual(
                     sg,
-                    client.mergeTree.pendingSegments.last(),
+                    client.mergeTree.pendingSegments?.last(),
                     `op created but segment group not enqueued.${logger}`);
             }
             const message = client.makeOpMessage(op, --tempSeq);
             message.minimumSequenceNumber = minimumSequenceNumber;
             messages.push(
-                [message, client.peekPendingSegmentGroups(op.type === MergeTreeDeltaType.GROUP ? op.ops.length : 1)]);
+                [message, client.peekPendingSegmentGroups(op.type === MergeTreeDeltaType.GROUP ? op.ops.length : 1)!]);
         }
     }
     return messages;
 }
 
 export function generateClientNames(): string[] {
-    const clientNames = [];
+    const clientNames: string[] = [];
     function addClientNames(startChar: string, count: number) {
         const startCode = startChar.charCodeAt(0);
         for (let i = 0; i < count; i++) {
@@ -192,7 +194,7 @@ export function generateClientNames(): string[] {
     addClientNames("A", 26);
     addClientNames("a", 26);
     addClientNames("0", 17);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
     return clientNames;
 }
 
@@ -206,7 +208,7 @@ export function applyMessages(
     try{
         // log and apply all the ops created in the round
         while (messageData.length > 0) {
-            const [message] = messageData.shift();
+            const [message] = messageData.shift()!;
             message.sequenceNumber = ++seq;
             clients.forEach((c) => c.applyMsg(message));
         }

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import { IMergeTreeOp } from "../ops";

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -27,99 +29,99 @@ describe("resetPendingSegmentsToOp", () => {
     beforeEach(() => {
         client = new TestClient();
         client.startOrUpdateCollaboration("local user");
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
         opList = [];
 
         for (let i = 0; i < insertCount; i++) {
-            const op = client.insertTextLocal(i, "hello");
+            const op = client.insertTextLocal(i, "hello")!;
             opList.push(op);
-            assert.equal(client.mergeTree.pendingSegments.count(), i + 1);
+            assert.equal(client.mergeTree.pendingSegments?.count(), i + 1);
         }
     });
 
     it("acked insertSegment", async () => {
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 
     it("nacked insertSegment", async () => {
         const oldops = opList;
-        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments.first()));
+        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
         // we expect a nack op per segment since our original ops split segments
         // we should expect mores nack ops then original ops.
         // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments.count(), expectedSegmentCount);
+        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 
     it("acked removeRange", async () => {
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
 
-        opList.push(client.removeRangeLocal(0, client.getLength()));
+        opList.push(client.removeRangeLocal(0, client.getLength())!);
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 
     it("nacked removeRange", async () => {
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
 
-        opList.push(client.removeRangeLocal(0, client.getLength()));
-        opList.push(client.regeneratePendingOp(opList.shift(), client.mergeTree.pendingSegments.first()));
+        opList.push(client.removeRangeLocal(0, client.getLength())!);
+        opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
         // we expect a nack op per segment since our original ops split segments
         // we should expect mores nack ops then original ops.
         // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments.count(), expectedSegmentCount);
+        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 
     it("nacked insertSegment and removeRange", async () => {
-        opList.push(client.removeRangeLocal(0, client.getLength()));
+        opList.push(client.removeRangeLocal(0, client.getLength())!);
         const oldops = opList;
-        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments.first()));
+        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
 
-        assert.equal(client.mergeTree.pendingSegments.count(), expectedSegmentCount * 2);
+        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
 
         applyOpList(client);
 
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 
     it("acked annotateRange", async () => {
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
 
-        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined));
+        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 
     it("nacked annotateRange", async () => {
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
 
-        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined));
-        opList.push(client.regeneratePendingOp(opList.shift(), client.mergeTree.pendingSegments.first()));
+        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
+        opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
         // we expect a nack op per segment since our original ops split segments
         // we should expect mores nack ops then original ops.
         // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments.count(), expectedSegmentCount);
+        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 
     it("nacked insertSegment and annotateRange", async () => {
-        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined));
+        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
         const oldops = opList;
-        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments.first()));
+        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
         // we expect a nack op per segment since our original ops split segments
         // we should expect mores nack ops then original ops.
         // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments.count(), expectedSegmentCount * 2);
+        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
         applyOpList(client);
-        assert(client.mergeTree.pendingSegments.empty());
+        assert(client.mergeTree.pendingSegments?.empty());
     });
 });

--- a/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
+++ b/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
@@ -41,7 +41,7 @@ describe("segmentGroupCollection", () => {
         const dequeuedSegmentGroup = segment.segmentGroups.dequeue();
 
         assert.equal(segment.segmentGroups.size, segmentGroupCount - 1);
-        assert.equal(dequeuedSegmentGroup.segments.length, 1);
+        assert.equal(dequeuedSegmentGroup?.segments.length, 1);
         assert.equal(dequeuedSegmentGroup.segments[0], segment);
         assert.equal(dequeuedSegmentGroup, segmentGroup);
     });
@@ -80,7 +80,7 @@ describe("segmentGroupCollection", () => {
             const copySegmentGroup = segmentCopy.segmentGroups.dequeue();
 
             assert.equal(segmentGroup, copySegmentGroup);
-            assert.equal(segmentGroup.segments.length, 2);
+            assert.equal(segmentGroup?.segments.length, 2);
             assert.equal(segmentGroup.segments[0], segment);
             assert.equal(segmentGroup.segments[1], segmentCopy);
         }

--- a/packages/dds/merge-tree/src/test/snapshot.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -38,7 +39,7 @@ class TestString {
     }
 
     public insert(pos: number, text: string, increaseMsn: boolean) {
-        this.queue(this.client.insertTextLocal(pos, text, { segment: this.pending.length }), increaseMsn);
+        this.queue(this.client.insertTextLocal(pos, text, { segment: this.pending.length })!, increaseMsn);
     }
 
     public append(text: string, increaseMsn: boolean) {
@@ -46,7 +47,7 @@ class TestString {
     }
 
     public removeRange(start: number, end: number, increaseMsn: boolean) {
-        this.queue(this.client.removeRangeLocal(start, end), increaseMsn);
+        this.queue(this.client.removeRangeLocal(start, end)!, increaseMsn);
     }
 
     // Ensures the client's text matches the `expected` string and round-trips through a snapshot
@@ -83,7 +84,6 @@ class TestString {
             (id)=>this.client.getLongClientId(id));
 
         snapshot.extractSync();
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return snapshot.emit(TestClient.serializer, undefined!).summary;
     }
 

--- a/packages/dds/merge-tree/src/test/snapshot.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.spec.ts
@@ -1,8 +1,9 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage, ISummaryTree } from "@fluidframework/protocol-definitions";

--- a/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";

--- a/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -25,7 +26,6 @@ describe("snapshot", () => {
 
         const snapshot = new SnapshotLegacy(client1.mergeTree, client1.logger);
         snapshot.extractSync();
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const summaryTree = snapshot.emit([], serializer, undefined!);
         const services = MockStorage.createFromSummary(summaryTree.summary);
 
@@ -46,7 +46,7 @@ describe("snapshot", () => {
         const clients = [new TestClient(), new TestClient(), new TestClient()];
         clients[0].startOrUpdateCollaboration("0");
         for (let i = 0; i < SnapshotLegacy.sizeOfFirstChunk + 10; i++) {
-            const op = clients[0].insertTextLocal(clients[0].getLength(), `${i % 10}`, { segment: i });
+            const op = clients[0].insertTextLocal(clients[0].getLength(), `${i % 10}`, { segment: i })!;
             const msg = clients[0].makeOpMessage(op, i + 1);
             msg.minimumSequenceNumber = i + 1;
             clients[0].applyMsg(msg);
@@ -58,7 +58,6 @@ describe("snapshot", () => {
             const client2 = clients[i + 1];
             const snapshot = new SnapshotLegacy(client1.mergeTree, client1.logger);
             snapshot.extractSync();
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const summaryTree = snapshot.emit([], serializer, undefined!);
             const services = MockStorage.createFromSummary(summaryTree.summary);
             const runtime: Partial<IFluidDataStoreRuntime> = {

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -128,7 +128,7 @@ export class TestClient extends Client {
     public enqueueMsg(msg: ISequencedDocumentMessage) {
         this.q.enqueue(msg);
     }
-    public dequeueMsg(): ISequencedDocumentMessage {
+    public dequeueMsg(): ISequencedDocumentMessage | undefined {
         return this.q.dequeue();
     }
     public applyMessages(msgCount: number) {
@@ -211,7 +211,7 @@ export class TestClient extends Client {
         refSeq: number,
         longClientId: string,
     ) {
-        const segment = new Marker(markerDef.refType);
+        const segment = new Marker(markerDef.refType ?? ReferenceType.Tile);
         if (props) {
             segment.addProperties(props);
         }
@@ -227,18 +227,20 @@ export class TestClient extends Client {
     }
 
     public makeOpMessage(
-        op: IMergeTreeOp,
+        op: IMergeTreeOp | undefined,
         seq: number = UnassignedSequenceNumber,
         refSeq: number = this.getCurrentSeq(),
         longClientId?: string,
         minSeqNumber = 0) {
+        if(op === undefined) {
+            throw new Error("op cannot be undefined");
+        }
         const msg: ISequencedDocumentMessage = {
-            clientId: longClientId === undefined ? this.longClientId : longClientId,
+            clientId: longClientId ?? this.longClientId ?? "",
             clientSequenceNumber: 1,
             contents: op,
             metadata: undefined,
             minimumSequenceNumber: minSeqNumber,
-            origin: null,
             referenceSequenceNumber: refSeq,
             sequenceNumber: seq,
             timestamp: Date.now(),
@@ -260,7 +262,7 @@ export class TestClient extends Client {
             chunk = this.getText(start, start + TestClient.searchChunkSize);
 
             const result = chunk.match(target);
-            if (result !== null) {
+            if (result !== null && result.index) {
                 return { text: result[0], pos: (result.index + start) };
             }
             start += TestClient.searchChunkSize;

--- a/packages/dds/merge-tree/src/test/testServer.ts
+++ b/packages/dds/merge-tree/src/test/testServer.ts
@@ -28,10 +28,10 @@ import { TestClient } from "./testClient";
  */
 export class TestServer extends TestClient {
     seq = 1;
-    clients: TestClient[];
-    listeners: TestClient[]; // Listeners do not generate edits
-    clientSeqNumbers: Heap<ClientSeq>;
-    upstreamMap: RedBlackTree<number, number>;
+    clients: TestClient[] = [];
+    listeners: TestClient[] = []; // Listeners do not generate edits
+    clientSeqNumbers: Heap<ClientSeq> = new Heap<ClientSeq>([], clientSeqComparer);
+    upstreamMap: RedBlackTree<number, number> = new RedBlackTree<number, number>(compareNumbers);
     constructor(options?: PropertySet) {
         super(options);
     }
@@ -41,7 +41,7 @@ export class TestServer extends TestClient {
         for (const upstreamClient of upstreamClients) {
             this.clientSeqNumbers.add({
                 refSeq: upstreamClient.getCurrentSeq(),
-                clientId: upstreamClient.longClientId,
+                clientId: upstreamClient.longClientId ?? "",
             });
         }
     }
@@ -49,7 +49,7 @@ export class TestServer extends TestClient {
         this.clientSeqNumbers = new Heap<ClientSeq>([], clientSeqComparer);
         this.clients = clients;
         for (const client of clients) {
-            this.clientSeqNumbers.add({ refSeq: client.getCurrentSeq(), clientId: client.longClientId });
+            this.clientSeqNumbers.add({ refSeq: client.getCurrentSeq(), clientId: client.longClientId ?? "" });
         }
     }
     addListeners(listeners: TestClient[]) {
@@ -70,7 +70,7 @@ export class TestServer extends TestClient {
     transformUpstreamMessage(msg: ISequencedDocumentMessage) {
         if (msg.referenceSequenceNumber > 0) {
             msg.referenceSequenceNumber =
-                this.upstreamMap.get(msg.referenceSequenceNumber).data;
+                this.upstreamMap.get(msg.referenceSequenceNumber)?.data ?? 0;
         }
         msg.origin = {
             id: "A",
@@ -110,8 +110,7 @@ export class TestServer extends TestClient {
                 }
                 if (this.clients) {
                     let minCli = this.clientSeqNumbers.peek();
-                    // eslint-disable-next-line eqeqeq
-                    if (minCli && (minCli.clientId == msg.clientId) &&
+                    if (minCli && (minCli.clientId === msg.clientId) &&
                         (minCli.refSeq < msg.referenceSequenceNumber)) {
                         const cliSeq = this.clientSeqNumbers.get();
                         const oldSeq = cliSeq.refSeq;
@@ -141,7 +140,7 @@ export class TestServer extends TestClient {
         return false;
     }
     public incrementalGetText(start?: number, end?: number) {
-        const range: IIntegerRange = { start, end };
+        const range: Partial<IIntegerRange> = { start, end };
         if (range.start === undefined) {
             range.start = 0;
         }
@@ -195,8 +194,7 @@ export function checkTextMatchRelative(
     const client = server.clients[clientId];
     const serverText = new MergeTreeTextHelper(server.mergeTree).getText(refSeq, clientId);
     const cliText = client.checkQ.dequeue();
-    // eslint-disable-next-line eqeqeq
-    if ((cliText === undefined) || (cliText != serverText)) {
+    if ((cliText === undefined) || (cliText !== serverText)) {
         console.log(`mismatch `);
         console.log(msg);
         //        console.log(serverText);

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -32,7 +32,7 @@ export function insertMarker(
     refSeq: number,
     clientId: number,
     seq: number,
-    behaviors: ReferenceType, props: PropertySet, opArgs: IMergeTreeDeltaOpArgs,
+    behaviors: ReferenceType, props: PropertySet | undefined, opArgs: IMergeTreeDeltaOpArgs,
 ) {
     mergeTree.insertSegments(pos, [Marker.make(behaviors, props)], refSeq, clientId, seq, opArgs);
 }
@@ -44,8 +44,8 @@ export function insertText(
     clientId: number,
     seq: number,
     text: string,
-    props: PropertySet,
-    opArgs: IMergeTreeDeltaOpArgs,
+    props?: PropertySet,
+    opArgs?: IMergeTreeDeltaOpArgs,
 ) {
     mergeTree.insertSegments(pos, [TextSegment.make(text, props)], refSeq, clientId, seq, opArgs);
 }

--- a/packages/dds/merge-tree/src/test/tracking.spec.ts
+++ b/packages/dds/merge-tree/src/test/tracking.spec.ts
@@ -23,7 +23,7 @@ describe("MergeTree.tracking", () => {
 
             const segmentInfo = testClient.getContainingSegment(0);
 
-            assert(segmentInfo.segment.trackingCollection.empty);
+            assert(segmentInfo?.segment?.trackingCollection.empty);
         });
 
     it("Insert single segment with single tracking group",
@@ -41,10 +41,10 @@ describe("MergeTree.tracking", () => {
 
             const segmentInfo = testClient.getContainingSegment(0);
 
-            assert.equal(segmentInfo.segment.trackingCollection.trackingGroups.size, 1);
+            assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
         });
 
-    it("Spliting segment should split tracking group",
+    it("Splitting segment should split tracking group",
         () => {
             const trackingGroup = new TrackingGroup();
 
@@ -63,7 +63,7 @@ describe("MergeTree.tracking", () => {
 
             assert.equal(trackingGroup.size, 2);
             const segmentInfo = testClient.getContainingSegment(0);
-            assert.equal(segmentInfo.segment.trackingCollection.trackingGroups.size, 1);
+            assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
         });
 
     it("Zamboni should merge matching tracking groups",
@@ -84,19 +84,19 @@ describe("MergeTree.tracking", () => {
 
             assert.equal(trackingGroup.size, 3);
             let segmentInfo = testClient.getContainingSegment(0);
-            assert.equal(segmentInfo.segment.trackingCollection.trackingGroups.size, 1);
+            assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
             let seq = 1;
             ops.forEach((op) => testClient.applyMsg(testClient.makeOpMessage(op, ++seq)));
 
             assert.equal(trackingGroup.size, 3);
             segmentInfo = testClient.getContainingSegment(0);
-            assert.equal(segmentInfo.segment.trackingCollection.trackingGroups.size, 1);
+            assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
             testClient.updateMinSeq(seq);
 
             assert.equal(trackingGroup.size, 1);
             segmentInfo = testClient.getContainingSegment(0);
-            assert.equal(segmentInfo.segment.trackingCollection.trackingGroups.size, 1);
+            assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
         });
 });

--- a/packages/dds/merge-tree/src/test/tsconfig.json
+++ b/packages/dds/merge-tree/src/test/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 
 /* eslint-disable no-bitwise */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import path from "path";
 import random from "random-js";

--- a/packages/dds/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -36,7 +38,7 @@ export function propertyCopy() {
         map.set(a[i], v[i]);
     }
     let clockStart = clock();
-    let obj: MapLike<number>;
+    let obj: MapLike<number> = {};
     for (let j = 0; j < iterCount; j++) {
         obj = createMap<number>();
         for (let i = 0; i < propCount; i++) {
@@ -101,8 +103,7 @@ export function propertyCopy() {
     const grayMap = new Map<string, number>();
     for (let j = 0; j < iterCount; j++) {
         map.forEach((value, key) => {
-            // eslint-disable-next-line eqeqeq
-            if (diffMap.get(key) != value) {
+            if (diffMap.get(key) !== value) {
                 grayMap.set(key, 1);
             }
         });
@@ -124,7 +125,7 @@ function makeBookmarks(client: TestClient, bookmarkCount: number) {
         if (i & 1) {
             refType = ReferenceType.SlideOnRemove;
         }
-        const lref = new LocalReference(client, segoff.segment, segoff.offset, refType);
+        const lref = new LocalReference(client, segoff.segment!, segoff.offset, refType);
         client.mergeTree.addLocalReference(lref);
         bookmarks.push(lref);
     }
@@ -152,13 +153,13 @@ function measureFetch(startFile: string, withBookmarks = false) {
             //     caBegin = 0;
             // }
             // curPG.pos is ca end
-            const curPG = client.findTile(pos, "pg", false);
-            const properties = curPG.tile.properties;
-            const curSegOff = client.getContainingSegment(pos);
-            const curSeg = curSegOff.segment;
+            const curPG = client.findTile(pos, "pg", false)!;
+            const properties = curPG.tile.properties!;
+            const curSegOff = client.getContainingSegment(pos)!;
+            const curSeg = curSegOff.segment!;
             // Combine paragraph and direct properties
             extend(properties, curSeg.properties);
-            pos += (curSeg.cachedLength - curSegOff.offset);
+            pos += (curSeg.cachedLength - curSegOff.offset!);
             count++;
         }
     }


### PR DESCRIPTION
Merge Tree tests didn't have strict nulls enabled, which kept biting me when making changes. This PR enabled them, but adds lots of non-null assertions, and a couple any casts to avoid issues in existing cases. While the workarounds are not always great it seems better to have strict nulls enabled for future work.