### PR TITLE
update TypeScript to 4.5.5 for everything except the top level lerna packages

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -3660,9 +3660,9 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typescript": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
-      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -36,6 +36,6 @@
     "eslint": "~8.6.0",
     "node-jq": "^2.3.3",
     "sort-json": "^2.0.1",
-    "typescript": "^4.5.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -5651,9 +5651,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -13419,9 +13419,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -120,7 +120,7 @@
     "sinon": "^7.4.2",
     "ts-jest": "^26.4.4",
     "ts-node": "^7.0.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "jest-junit": {

--- a/common/lib/common-utils/src/test/mocha/assert.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/assert.spec.ts
@@ -12,7 +12,7 @@ describe("Assert", () => {
         for (const shortCode of ["0x000", "0x03a", "0x200", "0x4321"]) {
             try {
                 assert(false, Number.parseInt(shortCode, 16));
-            } catch (e) {
+            } catch (e: any) {
                 strict(e instanceof Error, "not an error");
                 strict.strictEqual(
                     e.message,

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -5596,9 +5596,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -5528,9 +5528,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -5568,9 +5568,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -5536,9 +5536,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/server/azure-local-service/package-lock.json
+++ b/server/azure-local-service/package-lock.json
@@ -7569,9 +7569,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typewise": {

--- a/server/azure-local-service/package.json
+++ b/server/azure-local-service/package.json
@@ -54,7 +54,7 @@
     "forever": "^3.0.4",
     "rimraf": "^2.6.2",
     "ts-node": "^8.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   },
   "engines": {
     "node": ">=12.17.0"

--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -14287,9 +14287,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -12744,9 +12744,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -80,6 +80,6 @@
     "run-script-os": "^1.1.5",
     "sillyname": "^0.1.0",
     "supertest": "^3.4.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -84,6 +84,6 @@
     "rimraf": "^2.6.3",
     "sillyname": "^0.1.0",
     "supertest": "^3.4.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -52,7 +52,7 @@ export async function exists(
     try {
         const fileOrDirectoryStats = await fileSystemManager.promises.stat(fileOrDirectoryPath);
         return fileOrDirectoryStats;
-    } catch (error) {
+    } catch (error: any) {
         if (error?.code === "ENOENT") {
             // File/Directory does not exist.
             return false;
@@ -92,7 +92,7 @@ export async function retrieveLatestFullSummaryFromStorage(
         // TODO: This will be converted back to a JSON string for the HTTP response
         const summary: IWholeFlatSummary = JSON.parse(summaryFile.toString());
         return summary;
-    } catch (error) {
+    } catch (error: any) {
         if (error?.code === "ENOENT") {
             // File does not exist.
             return undefined;

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -81,6 +81,6 @@
     "rimraf": "^2.6.3",
     "sillyname": "^0.1.0",
     "supertest": "^3.4.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -15746,9 +15746,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -13840,9 +13840,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -79,6 +79,6 @@
     "run-script-os": "^1.1.5",
     "supertest": "^3.3.0",
     "tslint": "^5.12.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -84,6 +84,6 @@
     "rimraf": "^2.6.2",
     "sinon": "^9.2.3",
     "supertest": "^3.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -70,6 +70,6 @@
     "rimraf": "^2.6.2",
     "supertest": "^3.3.0",
     "tslint": "^5.12.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -18683,9 +18683,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true
 		},
 		"typescript-formatter": {

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -11339,9 +11339,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -86,6 +86,6 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "run-script-os": "^1.1.5",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -80,7 +80,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -63,7 +63,7 @@ export class Partition extends EventEmitter {
                     }
 
                     callback();
-                } catch (error) {
+                } catch (error: any) {
                     callback(error);
                 }
             },

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -98,7 +98,7 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.46.0"
   }

--- a/server/routerlicious/packages/lambdas/src/moira/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/lambda.ts
@@ -223,7 +223,7 @@ export class MoiraLambda implements IPartitionLambda {
                     Lumberjack.error(logMessage, lumberProperties);
                 }
             }
-        } catch (e) {
+        } catch (e: any) {
             const logMessage = `Commit failed. ${e.message}`;
             this.context.log?.error(logMessage);
             if (this.serviceConfiguration.enableLumberjack) {

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -93,7 +93,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^4.9.2"

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -93,7 +93,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -86,7 +86,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -121,7 +121,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "supertest": "^3.1.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -95,7 +95,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -58,7 +58,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -59,7 +59,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -55,7 +55,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -99,7 +99,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "supertest": "^3.1.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -80,7 +80,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -93,7 +93,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "supertest": "^3.1.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -101,7 +101,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -85,7 +85,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -8167,9 +8167,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typewise": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -110,7 +110,7 @@
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
     "ts-node": "^8.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   },
   "engines": {
     "node": ">=12.17.0"

--- a/server/tinylicious/src/runner.ts
+++ b/server/tinylicious/src/runner.ts
@@ -46,7 +46,7 @@ export class TinyliciousRunner implements IRunner {
             await this.ensurePortIsFree();
         } catch (e) {
             if (this.config.get("exitOnPortConflict")) {
-                winston.info(e.message);
+                winston.info(e);
                 return;
             }
             throw e;

--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -4738,9 +4738,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -60,6 +60,6 @@
     "eslint-plugin-unicorn": "~40.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/tools/build-tools/package-lock.json
+++ b/tools/build-tools/package-lock.json
@@ -3281,9 +3281,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
-      "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -71,6 +71,6 @@
     "@types/shelljs": "^0.8.8",
     "@types/webpack": "^4.41.22",
     "mocha": "^8.4.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.5"
   }
 }

--- a/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
@@ -316,7 +316,7 @@ async function main() {
                 await writeReleaseVersions(context);
                 break;
         }
-    } catch (e) {
+    } catch (e: any) {
         if (!e.fatal) { throw e; }
         console.error(`ERROR: ${e.message}`);
         if (paramClean) {

--- a/tools/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
+++ b/tools/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
@@ -18,7 +18,7 @@ function main() {
             throw new Error("failed to get package information");
         }
     } catch (e) {
-        console.error(e.toString());
+        console.error(e);
         process.exit(-1);
     }
 
@@ -37,7 +37,7 @@ function main() {
                 console.log(`found bundleAnalysis for ${pkg.name}`);
                 fse.copySync(packageAnalysisPath, path.join(analysesDestPath, pkg.name), {recursive: true});
             } catch (e) {
-                console.error(e.toString());
+                console.error(e);
                 process.exit(-1);
             }
         }

--- a/tools/build-tools/src/bundleSizeAnalysis/runBundleAnalyses.ts
+++ b/tools/build-tools/src/bundleSizeAnalysis/runBundleAnalyses.ts
@@ -12,7 +12,7 @@ function main() {
     try {
         child_process.execSync(`npx danger ci -d ${__dirname}/dangerfile.js`, { stdio: "inherit" });
     } catch (e) {
-        console.error(e.toString());
+        console.error(e);
         process.exit(-1);
     }
 }

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -33,7 +33,7 @@ export class LesscTask extends LeafTask {
                 this.logVerboseNotUpToDate();
             }
             return result;
-        } catch (e) {
+        } catch (e: any) {
             logVerbose(`${this.node.pkg.nameColored}: ${e.message}`);
             this.logVerboseTrigger("failed to get file stats");
             return false;
@@ -129,7 +129,7 @@ export class CopyfilesTask extends LeafTask {
                 }
             }
             return true;
-        } catch (e) {
+        } catch (e: any) {
             logVerbose(`${this.node.pkg.nameColored}: ${e.message}`);
             this.logVerboseTrigger("failed to get file stats");
             return false;

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -119,7 +119,7 @@ export class TscTask extends LeafTask {
                     this.logVerboseTrigger(`version mismatch for ${key}, ${hash}, ${fileInfos[key].version}`);
                     return false;
                 }
-            } catch (e) {
+            } catch (e: any) {
                 this.logVerboseTrigger(`exception generating hash for ${key}`);
                 logVerbose(e.stack);
                 return false;

--- a/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
@@ -28,7 +28,7 @@ export async function lint(message: WorkerMessage): Promise<WorkerExecResult> {
         let formatter;
         try {
             formatter = await engine.loadFormatter("stylish");
-        } catch (e) {
+        } catch (e: any) {
             console.error(e.message);
             return { code: 2 };
         }

--- a/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
@@ -36,7 +36,7 @@ async function messageHandler(msg: WorkerMessage): Promise<WorkerExecResult> {
         } else {
             throw new Error(`Invalid workerName ${msg.workerName}`);
         }
-    } catch (e) {
+    } catch (e: any) {
         // any unhandled exception thrown is going to rerun on main thread.
         res = {
             error: {

--- a/tools/build-tools/src/layerCheck/layerCheck.ts
+++ b/tools/build-tools/src/layerCheck/layerCheck.ts
@@ -120,7 +120,7 @@ async function main() {
         }
 
         console.log(`Layer check passed (${packages.packages.length} packages)`)
-    } catch (e) {
+    } catch (e: any) {
         console.error(e.message);
         process.exit(-2);
     }

--- a/tools/bundle-size-tools/package-lock.json
+++ b/tools/bundle-size-tools/package-lock.json
@@ -246,9 +246,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "underscore": {
       "version": "1.13.1",

--- a/tools/bundle-size-tools/package.json
+++ b/tools/bundle-size-tools/package.json
@@ -22,7 +22,7 @@
     "jszip": "^3.2.2",
     "msgpack-lite": "^0.1.26",
     "pako": "^1.0.10",
-    "typescript": "^3.7.4"
+    "typescript": "~4.5.5"
   },
   "devDependencies": {
     "@types/jszip": "^3.4.1",

--- a/tools/test-tools/package-lock.json
+++ b/tools/test-tools/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     }
   }

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -21,6 +21,6 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^14.18.0",
-    "typescript": "^3.7.4"
+    "typescript": "~4.5.5"
   }
 }

--- a/tools/test-tools/src/assignTestPorts.ts
+++ b/tools/test-tools/src/assignTestPorts.ts
@@ -17,7 +17,7 @@ function main() {
             throw new Error("stdin input was not package array");
         }
     } catch (e) {
-        console.error(e.toString());
+        console.error(e);
         process.exit(-1);
     }
 


### PR DESCRIPTION
Update TypeScript in all packages that are not part of the large lerna managed set of packaged defined in the top-level directory.
This is a subset of what was attempted in #9875.
Makes progress on #7817