### PR TITLE
Avoiding Lumberjack error logs on unit tests and non-server environments

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,6 +32,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
             - login__microsoft__clientId
             - login__microsoft__secret
             - login__accounts
@@ -44,6 +45,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     deli:
         image: prague.azurecr.io/prague:12579
@@ -51,6 +53,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     scriptorium:
         image: prague.azurecr.io/prague:12579
@@ -58,6 +61,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     broadcaster:
         image: prague.azurecr.io/prague:12579
@@ -65,6 +69,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     scribe:
         image: prague.azurecr.io/prague:12579
@@ -72,6 +77,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     riddler:
         image: prague.azurecr.io/prague:12579
@@ -81,6 +87,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     historian:
         image: prague.azurecr.io/historian:5109
@@ -89,12 +96,14 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     gitrest:
         image: prague.azurecr.io/gitrest:4048
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         volumes:
             - git:/home/node/documents
         restart: always

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
             - login__microsoft__clientId
             - login__microsoft__secret
             - login__accounts
@@ -45,7 +45,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     deli:
         image: prague.azurecr.io/prague:12579
@@ -53,7 +53,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     scriptorium:
         image: prague.azurecr.io/prague:12579
@@ -61,7 +61,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     broadcaster:
         image: prague.azurecr.io/prague:12579
@@ -69,7 +69,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     scribe:
         image: prague.azurecr.io/prague:12579
@@ -77,7 +77,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     riddler:
         image: prague.azurecr.io/prague:12579
@@ -87,7 +87,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     historian:
         image: prague.azurecr.io/historian:5109
@@ -96,14 +96,14 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     gitrest:
         image: prague.azurecr.io/gitrest:4048
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         volumes:
             - git:/home/node/documents
         restart: always

--- a/server/charts/fluid-metrics/templates/metrics-deployment.yaml
+++ b/server/charts/fluid-metrics/templates/metrics-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "routerlicious:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/charts/fluid-metrics/templates/metrics-deployment.yaml
+++ b/server/charts/fluid-metrics/templates/metrics-deployment.yaml
@@ -28,6 +28,8 @@ spec:
           value: "routerlicious:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /home/node/server/config.json

--- a/server/charts/historian/templates/gitrest-deployment.yaml
+++ b/server/charts/historian/templates/gitrest-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: data

--- a/server/charts/historian/templates/gitrest-deployment.yaml
+++ b/server/charts/historian/templates/gitrest-deployment.yaml
@@ -42,6 +42,8 @@ spec:
         env:
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: data
           mountPath: /home/node/documents

--- a/server/charts/historian/templates/historian-deployment.yaml
+++ b/server/charts/historian/templates/historian-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: "routerlicious:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/charts/historian/templates/historian-deployment.yaml
+++ b/server/charts/historian/templates/historian-deployment.yaml
@@ -34,6 +34,8 @@ spec:
           value: "routerlicious:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /home/node/server/packages/historian/config.json

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -20,7 +20,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -35,7 +35,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -50,7 +50,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -65,7 +65,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -80,7 +80,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -95,7 +95,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -114,7 +114,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -130,7 +130,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - ./historian:/home/node/server
     restart: on-failure
@@ -141,7 +141,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
-      - IS_SERVER=true
+      - IS_FLUID_SERVER=true
     volumes:
       - git:/home/node/documents
       - ./gitrest:/home/node/server

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -34,6 +35,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -48,6 +50,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -62,6 +65,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -76,6 +80,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -90,6 +95,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -108,6 +114,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules/zookeeper
@@ -123,6 +130,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - ./historian:/home/node/server
     restart: on-failure
@@ -133,6 +141,7 @@ services:
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development
+      - IS_SERVER=true
     volumes:
       - git:/home/node/documents
       - ./gitrest:/home/node/server

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     deli:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -16,7 +16,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     scriptorium:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -24,7 +24,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     copier:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -32,7 +32,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     scribe:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -40,7 +40,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     foreman:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -48,7 +48,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     riddler:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -58,7 +58,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     historian:
         image: mcr.microsoft.com/fluidframework/routerlicious/historian:latest
@@ -67,14 +67,14 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     gitrest:
         image: mcr.microsoft.com/fluidframework/routerlicious/gitrest:latest
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         volumes:
             - git:/home/node/documents
         restart: always

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     deli:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -15,6 +16,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     scriptorium:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -22,6 +24,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     copier:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -29,6 +32,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     scribe:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -36,6 +40,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     foreman:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -43,6 +48,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     riddler:
         image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
@@ -52,6 +58,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     historian:
         image: mcr.microsoft.com/fluidframework/routerlicious/historian:latest
@@ -60,12 +67,14 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     gitrest:
         image: mcr.microsoft.com/fluidframework/routerlicious/gitrest:latest
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         volumes:
             - git:/home/node/documents
         restart: always

--- a/server/historian/docker-compose.yml
+++ b/server/historian/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     gitrest:
         image: prague.azurecr.io/gitrest:1038

--- a/server/historian/docker-compose.yml
+++ b/server/historian/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     gitrest:
         image: prague.azurecr.io/gitrest:1038

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -17,6 +17,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     deli:
         build:
@@ -26,6 +27,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     scriptorium:
         build:
@@ -35,6 +37,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     copier:
         build:
@@ -44,6 +47,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     scribe:
         build:
@@ -53,6 +57,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     foreman:
         build:
@@ -62,6 +67,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     riddler:
         build:
@@ -73,6 +79,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     historian:
         image: mcr.microsoft.com/fluidframework/routerlicious/historian:latest
@@ -81,12 +88,14 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         restart: always
     gitrest:
         image: mcr.microsoft.com/fluidframework/routerlicious/gitrest:latest
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
+            - IS_SERVER=true
         volumes:
             - git:/home/node/documents
         restart: always

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     deli:
         build:
@@ -27,7 +27,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     scriptorium:
         build:
@@ -37,7 +37,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     copier:
         build:
@@ -47,7 +47,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     scribe:
         build:
@@ -57,7 +57,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     foreman:
         build:
@@ -67,7 +67,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     riddler:
         build:
@@ -79,7 +79,7 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     historian:
         image: mcr.microsoft.com/fluidframework/routerlicious/historian:latest
@@ -88,14 +88,14 @@ services:
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         restart: always
     gitrest:
         image: mcr.microsoft.com/fluidframework/routerlicious/gitrest:latest
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
-            - IS_SERVER=true
+            - IS_FLUID_SERVER=true
         volumes:
             - git:/home/node/documents
         restart: always

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
@@ -34,6 +34,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/functions/deli/config.json

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
@@ -33,6 +33,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/functions/deli/config.json

--- a/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
@@ -33,6 +33,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/functions/deli/config.json

--- a/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
@@ -36,6 +36,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
@@ -39,6 +39,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
@@ -36,6 +36,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
-        - name: IS_SERVER
+        - name: IS_FLUID_SERVER
           value: true
         volumeMounts:
         - name: config

--- a/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
@@ -36,6 +36,8 @@ spec:
           value: "fluid:*"
         - name: NODE_ENV
           value: production
+        - name: IS_SERVER
+          value: true
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -118,19 +118,21 @@ export interface ILumberjackSchemaValidationResult {
 
 // Helper method to assist with handling Lumberjack/Lumber errors depending on the context.
 export function handleError(eventName: LumberEventName, errMsg: string, engineList: ILumberjackEngine[]) {
-    const err = new Error(errMsg);
-    // If there is no LumberjackEngine specified, making the list empty,
-    // we log the error to the console as a last resort, so the information can
-    // be found in raw logs.
-    if (engineList.length === 0) {
-        console.error(serializeError(err));
-    } else {
-        // Otherwise, we log the error through the current LumberjackEngines.
-        const errLumber = new Lumber<LumberEventName>(
-            eventName,
-            LumberType.Metric,
-            engineList);
-        errLumber.error(errMsg, err);
+    if (process.env.IS_SERVER) {
+        const err = new Error(errMsg);
+        // If there is no LumberjackEngine specified, making the list empty,
+        // we log the error to the console as a last resort, so the information can
+        // be found in raw logs.
+        if (engineList.length === 0) {
+            console.error(serializeError(err));
+        } else {
+            // Otherwise, we log the error through the current LumberjackEngines.
+            const errLumber = new Lumber<LumberEventName>(
+                eventName,
+                LumberType.Metric,
+                engineList);
+            errLumber.error(errMsg, err);
+        }
     }
 }
 

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -118,7 +118,7 @@ export interface ILumberjackSchemaValidationResult {
 
 // Helper method to assist with handling Lumberjack/Lumber errors depending on the context.
 export function handleError(eventName: LumberEventName, errMsg: string, engineList: ILumberjackEngine[]) {
-    if (process.env.IS_SERVER) {
+    if (typeof window === "undefined" && process?.env?.IS_FLUID_SERVER) {
         const err = new Error(errMsg);
         // If there is no LumberjackEngine specified, making the list empty,
         // we log the error to the console as a last resort, so the information can

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -8,6 +8,9 @@ import { Lumber } from "./lumber";
 import { LumberEventName } from "./lumberEventNames";
 import { Lumberjack } from "./lumberjack";
 
+const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
+const isNode = typeof process !== "undefined" && process.versions != null && process.versions.node != null;
+
 export enum LogLevel {
     Error,
     Warning,
@@ -118,7 +121,8 @@ export interface ILumberjackSchemaValidationResult {
 
 // Helper method to assist with handling Lumberjack/Lumber errors depending on the context.
 export function handleError(eventName: LumberEventName, errMsg: string, engineList: ILumberjackEngine[]) {
-    if (typeof window === "undefined" && process?.env?.IS_FLUID_SERVER) {
+    // We only want to log Lumberjack errors if running on a Fluid server instance.
+    if (!isBrowser && isNode && process?.env?.IS_FLUID_SERVER) {
         const err = new Error(errMsg);
         // If there is no LumberjackEngine specified, making the list empty,
         // we log the error to the console as a last resort, so the information can


### PR DESCRIPTION
`Lumberjack` includes an error handling helper called `handleError()` that can bring attention to issues such as improper setup through error logs. In production environments, that helper has proven to be useful to identify issues in the telemetry pipeline.

On the other hand, in some situations like unit testing and client packages that depend on some server packages, those error logs are not appropriate and can become very noisy, especially since Lumberjack might not be always configured properly in those situations/environments (an example with details can be found here: https://github.com/microsoft/FluidFramework/issues/9370)

In this PR, I'm trying to fix that: keeping `handleError()` in the server side, and making it a no-op in other environments like UTs. That is done with the help of a new environment variable, `IS_FLUID_SERVER`, which indicates whether the code is running on a Fluid server instance (e.g. r11s Docker, AKS, etc) or not. Ideally, I would have preferred to use `NODE_ENV` for that. But `NODE_ENV` is also set in Webpack and other non-server places (examples [here](https://github.com/microsoft/FluidFramework/blob/9c767dc4834c0bd2894fe21a0ce491951854c0c9/experimental/dds/tree/.env-cmdrc.json), [here](https://github.com/microsoft/FluidFramework/blob/9c767dc4834c0bd2894fe21a0ce491951854c0c9/experimental/dds/tree-graphql/.env-cmdrc.json), [here](https://github.com/microsoft/FluidFramework/blob/09df4d28a5dab14d3b61ff2bb68fc1d2de1b42b0/packages/tools/webpack-fluid-loader/webpack.config.js) and [here](https://github.com/microsoft/FluidFramework/blob/602cf06fb312b9ca1a6064724d56af7d63e0b9e3/docs/themes/thxvscode/assets/js/webpack.config.js)). `IS_FLUID_SERVER` can be used from now on to indicate whether Fluid server code is running on an actual server environment or not.