### PR TITLE
update package-locks for a clean npm install

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -187,34 +187,6 @@
         "@fluidframework/core-interfaces": "^0.43.1000",
         "@fluidframework/driver-definitions": "^0.46.1000",
         "@fluidframework/protocol-definitions": "^0.1028.1000"
-      },
-      "dependencies": {
-        "@fluidframework/core-interfaces": {
-          "version": "0.43.1000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
-          "integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA==",
-          "dev": true
-        },
-        "@fluidframework/driver-definitions": {
-          "version": "0.46.1000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-          "integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-          "dev": true,
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^0.43.1000",
-            "@fluidframework/protocol-definitions": "^0.1028.1000"
-          }
-        },
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.1000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-          "integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-          "dev": true,
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        }
       }
     },
     "@fluidframework/core-interfaces": {

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -191,23 +191,6 @@
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/core-interfaces": "^0.43.1000",
         "@fluidframework/protocol-definitions": "^0.1028.1000"
-      },
-      "dependencies": {
-        "@fluidframework/core-interfaces": {
-          "version": "0.43.1000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
-          "integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA==",
-          "dev": true
-        },
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.1000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-          "integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-          "dev": true,
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        }
       }
     },
     "@fluidframework/eslint-config-fluid": {


### PR DESCRIPTION
`git clean -dxf && npm i && npm run build:fast -- --all --install` on `main` produced this diff.
It is unclear how we got into a state where this would produce a diff, or why `npm ci` does not object (maybe because this diff just removes packages and does not add any?), but not having a diff when doing this is probably better.