### PR TITLE
Update 3 webpack configs that were left in a bad state from webpack-cli version migration

### DIFF
--- a/examples/data-objects/monaco/webpack.config.js
+++ b/examples/data-objects/monaco/webpack.config.js
@@ -30,11 +30,13 @@ module.exports = env => {
                     }],
                     exclude: /node_modules/
                 },
-                {
-                    test: /\.js$/,
-                    use: [require.resolve("source-map-loader")],
-                    enforce: "pre"
-                },
+                // This example currently has missing sourcemap issues.
+                // Disabling source mapping allows it to be runnable with these issues.
+                // {
+                //     test: /\.js$/,
+                //     use: [require.resolve("source-map-loader")],
+                //     enforce: "pre"
+                // },
                 {
                     test: /\.css$/,
                     use: [
@@ -83,8 +85,6 @@ module.exports = env => {
         },
         devServer: {
             host: "0.0.0.0",
-            onBeforeSetupMiddleware: (devServer) => fluidRoute.before(devServer.app, devServer, env),
-            onAfterSetupMiddleware: (devServer) => fluidRoute.after(devServer.app, devServer, __dirname, env),
         },
         // This impacts which files are watched by the dev server (and likely by webpack if watch is true).
         // This should be configurable under devServer.static.watch

--- a/examples/data-objects/table-view/webpack.config.js
+++ b/examples/data-objects/table-view/webpack.config.js
@@ -81,13 +81,14 @@ module.exports = env => {
                 libraryTarget: "umd",
                 globalObject: 'self',
             },
-            devServer: {
-                onBeforeSetupMiddleware: (devServer) => fluidRoute.before(devServer.app, devServer, env),
-                onAfterSetupMiddleware: (devServer) => fluidRoute.after(devServer.app, devServer, __dirname, env),
-                watchOptions: {
-                    ignored: "**/node_modules/**",
-                }
-            },
+            // This impacts which files are watched by the dev server (and likely by webpack if watch is true).
+            // This should be configurable under devServer.static.watch
+            // (see https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) but that does not seem to work.
+            // The CLI options for disabling watching don't seem to work either, so this may be a symptom of using webpack4 with the newer webpack-cli and webpack-dev-server.
+            watchOptions: {
+                ignored: "**/node_modules/**",
+            }
         },
-        isProduction ? require("./webpack.prod") : require("./webpack.dev"));
+        isProduction ? require("./webpack.prod") : require("./webpack.dev"),
+        fluidRoute.devServerConfig(__dirname, env));
 };

--- a/examples/data-objects/webflow/webpack.config.js
+++ b/examples/data-objects/webflow/webpack.config.js
@@ -81,13 +81,14 @@ module.exports = env => {
                 libraryTarget: "umd",
                 globalObject: 'self',
             },
-            devServer: {
-                onBeforeSetupMiddleware: (devServer) => fluidRoute.before(devServer.app, devServer, env),
-                onAfterSetupMiddleware: (devServer) => fluidRoute.after(devServer.app, devServer, __dirname, env),
-                watchOptions: {
-                    ignored: "**/node_modules/**",
-                }
-            },
+            // This impacts which files are watched by the dev server (and likely by webpack if watch is true).
+            // This should be configurable under devServer.static.watch
+            // (see https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) but that does not seem to work.
+            // The CLI options for disabling watching don't seem to work either, so this may be a symptom of using webpack4 with the newer webpack-cli and webpack-dev-server.
+            watchOptions: {
+                ignored: "**/node_modules/**",
+            }
         },
-        isProduction ? require("./webpack.prod") : require("./webpack.dev"));
+        isProduction ? require("./webpack.prod") : require("./webpack.dev"),
+        fluidRoute.devServerConfig(__dirname, env));
 };


### PR DESCRIPTION
These examples were able to webpack, but failed when run interactively due to part of the webpack.config updating being missed.