### PR TITLE
Add additional check to volunteer and abandon

### DIFF
--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -157,6 +157,8 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
         super(id, runtime, attributes);
 
         this.opWatcher.on("volunteer", (taskId: string, clientId: string, local: boolean, messageId: number) => {
+            // We're tracking local ops from this connection. Filter out local ops during "connecting"
+            // state since these were sent on the prior connection and were already cleared from the latestPendingOps.
             if (runtime.connected && local) {
                 const pendingOp = this.latestPendingOps.get(taskId);
                 assert(pendingOp !== undefined, 0x07b /* "Unexpected op" */);

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -157,7 +157,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
         super(id, runtime, attributes);
 
         this.opWatcher.on("volunteer", (taskId: string, clientId: string, local: boolean, messageId: number) => {
-            if (local) {
+            if (runtime.connected && local) {
                 const pendingOp = this.latestPendingOps.get(taskId);
                 assert(pendingOp !== undefined, 0x07b /* "Unexpected op" */);
                 // Need to check the id, since it's possible to volunteer and abandon multiple times before the acks
@@ -172,7 +172,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
         });
 
         this.opWatcher.on("abandon", (taskId: string, clientId: string, local: boolean, messageId: number) => {
-            if (local) {
+            if (runtime.connected && local) {
                 const pendingOp = this.latestPendingOps.get(taskId);
                 assert(pendingOp !== undefined, 0x07d /* "Unexpected op" */);
                 // Need to check the id, since it's possible to abandon and volunteer multiple times before the acks


### PR DESCRIPTION
After some investigation, we were hitting this assert because we were determining the message to be local despite having a new clientId on reconnect. As such, we need an additional check to make sure that the message we're processing is actually from the currently connected clientId. 

I've verified locally by running the the test-service-load suite locally that the asserts are no longer being hit. Furthermore, I have verified that this additional check is catching the intended cases by adding an else if statement where `!runtime.connected && local` evaluates to true and logging the pendingOps map. These are the cases where the pendingOps map is empty and we're hitting the asserts.

fixes #6689, fixes #6083