### PR TITLE
Convert more public API usages of ChangeInternal to use opaque handle type

### DIFF
--- a/api-report/experimental-tree.api.md
+++ b/api-report/experimental-tree.api.md
@@ -517,6 +517,12 @@ export interface InsertInternal_0_0_2 {
 }
 
 // @public
+export interface InternalizedChange {
+    // (undocumented)
+    InternalChangeBrand: '2cae1045-61cf-4ef7-a6a3-8ad920cb7ab3';
+}
+
+// @public
 export type InternedStringId = number & {
     readonly InternedStringId: 'e221abc9-9d17-4493-8db0-70c871a1c27c';
 };
@@ -819,9 +825,9 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     constructor(runtime: IFluidDataStoreRuntime, id: string, writeFormat: WriteFormat, summarizeHistory?: false | {
         uploadEditChunks: boolean;
     }, expensiveValidation?: boolean);
-    applyEdit(...changes: Change[]): Edit<unknown>;
+    applyEdit(...changes: Change[]): Edit<InternalizedChange>;
     // (undocumented)
-    applyEdit(changes: Change[]): Edit<unknown>;
+    applyEdit(changes: Change[]): Edit<InternalizedChange>;
     // @internal
     applyEditInternal(editOrChanges: Edit<ChangeInternal> | readonly ChangeInternal[]): Edit<ChangeInternal>;
     protected applyStashedOp(op: unknown): void;
@@ -831,9 +837,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     // (undocumented)
     get currentView(): RevisionView;
     // (undocumented)
-    get edits(): OrderedEditSet;
-    // @internal (undocumented)
-    get editsInternal(): OrderedEditSet<ChangeInternal>;
+    get edits(): OrderedEditSet<InternalizedChange>;
     // @internal
     equals(sharedTree: SharedTree): boolean;
     generateNodeId(override?: string): NodeId;
@@ -863,7 +867,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     protected registerCore(): void;
     revert(editId: EditId): EditId | undefined;
     // @internal
-    revertChanges(changes: readonly ChangeInternal[], before: RevisionView): ChangeInternal[] | undefined;
+    revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined;
     // @internal
     saveSerializedSummary(options?: {
         serializer?: IFluidSerializer;

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -15,7 +15,7 @@
   "module": "lib/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "concurrently npm:build:compile npm:lint",
+    "build": "concurrently npm:build:compile npm:lint && npm run build:docs",
     "build:compile": "concurrently npm:tsc npm:build:esnext",
     "build:docs": "api-extractor run --local --typescript-compiler-folder ../../../node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",

--- a/experimental/dds/tree/src/Checkout.ts
+++ b/experimental/dds/tree/src/Checkout.ts
@@ -323,7 +323,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 	public revert(editId: EditId): void {
 		assert(this.currentEdit !== undefined);
 		const index = this.tree.edits.getIndexOfId(editId);
-		const edit = this.tree.editsInternal.getEditInSessionAtIndex(index);
+		const edit = this.tree.edits.getEditInSessionAtIndex(index);
 		const before = this.tree.logViewer.getRevisionViewInSession(index);
 		const changes = this.tree.revertChanges(edit.changes, before);
 		if (changes !== undefined) {

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -563,14 +563,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 		return this.editLog as unknown as OrderedEditSet<InternalizedChange>;
 	}
 
-	/**
-	 * @returns the edit history of the tree. The format of the contents of edits are subject to change and should not be relied upon.
-	 * @internal
-	 */
-	public get editsInternal(): OrderedEditSet<ChangeInternal> {
-		return this.editLog;
-	}
-
 	private deserializeHandle(serializedHandle: string): IFluidHandle<ArrayBufferLike> {
 		const deserializeHandle = this.serializer.parse(serializedHandle);
 		assert(typeof deserializeHandle === 'object');
@@ -1134,7 +1126,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 
 		const unifyHistoricalIds = (context: NodeIdContext): void => {
 			for (let i = 0; i < this.editLog.numberOfSequencedEdits; i++) {
-				const edit = this.editsInternal.getEditInSessionAtIndex(i);
+				const edit = this.editLog.getEditInSessionAtIndex(i);
 				convertEditIds(edit, (id) => context.generateNodeId(this.convertToStableNodeId(id)));
 			}
 		};
@@ -1147,7 +1139,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 			unifyHistoricalIds(ghostContext);
 			// The same logic applies to string interning, so intern all the strings in the history (superset of those in the current view)
 			for (let i = 0; i < this.editLog.numberOfSequencedEdits; i++) {
-				this.internStringsFromEdit(this.editsInternal.getEditInSessionAtIndex(i));
+				this.internStringsFromEdit(this.editLog.getEditInSessionAtIndex(i));
 			}
 		} else {
 			// Clients do not have the full history, but all share the same current view (sequenced). They can all finalize the same final
@@ -1306,7 +1298,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 */
 	public revert(editId: EditId): EditId | undefined {
 		const index = this.edits.getIndexOfId(editId);
-		const edit = this.editLog.getEditInSessionAtIndex(index);
+		const edit = this.edits.getEditInSessionAtIndex(index);
 		const before = this.logViewer.getRevisionViewInSession(index);
 		const changes = this.revertChanges(edit.changes, before);
 		if (changes === undefined) {
@@ -1323,8 +1315,8 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * @returns the inverse of `changes` or undefined if the changes could not be inverted for the given tree state.
 	 * @internal
 	 */
-	public revertChanges(changes: readonly ChangeInternal[], before: RevisionView): ChangeInternal[] | undefined {
-		return revert(changes, before);
+	public revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined {
+		return revert(changes as unknown as readonly ChangeInternal[], before);
 	}
 
 	/**

--- a/experimental/dds/tree/src/SummaryTestUtilities.ts
+++ b/experimental/dds/tree/src/SummaryTestUtilities.ts
@@ -29,7 +29,7 @@ export interface UploadedEditChunkContents {
  */
 export async function getUploadedEditChunkContents(sharedTree: SharedTree): Promise<UploadedEditChunkContents[]> {
 	const editChunks: UploadedEditChunkContents[] = [];
-	const { editChunks: editsOrHandles } = (sharedTree.editsInternal as EditLog<ChangeInternal>).getEditLogSummary();
+	const { editChunks: editsOrHandles } = (sharedTree.edits as unknown as EditLog<ChangeInternal>).getEditLogSummary();
 	for (const { chunk } of editsOrHandles) {
 		if (!Array.isArray(chunk)) {
 			const handle = chunk as FluidEditHandle;

--- a/experimental/dds/tree/src/Transaction.ts
+++ b/experimental/dds/tree/src/Transaction.ts
@@ -111,8 +111,8 @@ export class Transaction extends TypedEventEmitter<TransactionEvents> {
 			if (this.transaction.changes.length > 0) {
 				const result = this.transaction.close();
 				const edit: Edit<ChangeInternal> = { id: newEditId(), changes: result.changes };
-				if (this.tree.editsInternal instanceof CachingLogViewer) {
-					this.tree.editsInternal.setKnownEditingResult(edit, result);
+				if (this.tree.edits instanceof CachingLogViewer) {
+					this.tree.edits.setKnownEditingResult(edit, result);
 				}
 				this.tree.applyEditInternal(edit);
 			}

--- a/experimental/dds/tree/src/index.ts
+++ b/experimental/dds/tree/src/index.ts
@@ -56,6 +56,7 @@ export {
 	ConstraintEffect,
 	Edit,
 	ChangeInternal,
+	InternalizedChange,
 	ChangeNode,
 	ChangeNode_0_0_2,
 	EditLogSummary,

--- a/experimental/dds/tree/src/test/Summary.tests.ts
+++ b/experimental/dds/tree/src/test/Summary.tests.ts
@@ -30,6 +30,7 @@ import { sequencedIdNormalizer } from '../NodeIdUtilities';
 import { expectDefined } from './utilities/TestCommon';
 import { TestFluidSerializer } from './utilities/TestSerializer';
 import {
+	getEditLogInternal,
 	getIdNormalizerFromSharedTree,
 	makeNodeIdContext,
 	setUpLocalServerTestSharedTree,
@@ -421,12 +422,12 @@ async function expectSharedTreesEqual(
 		const roundTrip = <T>(obj: T): T => JSON.parse(JSON.stringify(obj)) as T;
 
 		const editA = roundTrip(
-			convertEditIds(await sharedTreeA.editsInternal.getEditAtIndex(i), (id) =>
+			convertEditIds(await getEditLogInternal(sharedTreeA).getEditAtIndex(i), (id) =>
 				sharedTreeA.convertToStableNodeId(id)
 			)
 		);
 		const editB = roundTrip(
-			convertEditIds(await sharedTreeB.editsInternal.getEditAtIndex(i), (id) =>
+			convertEditIds(await getEditLogInternal(sharedTreeB).getEditAtIndex(i), (id) =>
 				sharedTreeB.convertToStableNodeId(id)
 			)
 		);

--- a/experimental/dds/tree/src/test/fuzz/SharedTreeFuzzTests.ts
+++ b/experimental/dds/tree/src/test/fuzz/SharedTreeFuzzTests.ts
@@ -109,8 +109,8 @@ export async function performFuzzActions(
 						const first = trees[0].tree;
 						for (let i = 1; i < trees.length; i++) {
 							const tree = trees[i].tree;
-							const editLogA = first.editsInternal as EditLog<ChangeInternal>;
-							const editLogB = tree.editsInternal as EditLog<ChangeInternal>;
+							const editLogA = first.edits;
+							const editLogB = tree.edits;
 							const minEdits = Math.min(editLogA.length, editLogB.length);
 							for (let j = 0; j < minEdits - 1; j++) {
 								const editA = await editLogA.getEditAtIndex(editLogA.length - j - 1);

--- a/experimental/dds/tree/src/test/utilities/PendingLocalStateTests.ts
+++ b/experimental/dds/tree/src/test/utilities/PendingLocalStateTests.ts
@@ -13,6 +13,7 @@ import type { EditLog } from '../../EditLog';
 import { SharedTree } from '../../SharedTree';
 import { Change, StablePlace } from '../../ChangeTypes';
 import {
+	getEditLogInternal,
 	LocalServerSharedTreeTestingComponents,
 	LocalServerSharedTreeTestingOptions,
 	setUpTestTree,
@@ -80,7 +81,7 @@ export function runPendingLocalStateTests(
 					const container3 = await loader.resolve({ url }, pendingLocalState);
 					const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, '/');
 					const tree3 = await dataObject3.getSharedObject<SharedTree>(documentId);
-					expect((tree3.editsInternal as EditLog<ChangeInternal>).isLocalEdit(edit.id)).to.be.true; // Kludge
+					expect((tree3.edits as unknown as EditLog<ChangeInternal>).isLocalEdit(edit.id)).to.be.true; // Kludge
 
 					await testObjectProvider.ensureSynchronized();
 
@@ -99,10 +100,10 @@ export function runPendingLocalStateTests(
 
 					const stableEdit = stabilizeEdit(tree, edit as unknown as Edit<ChangeInternal>);
 					expect(
-						stabilizeEdit(tree2, (await tree2.editsInternal.tryGetEdit(edit.id)) ?? fail())
+						stabilizeEdit(tree2, (await getEditLogInternal(tree2).tryGetEdit(edit.id)) ?? fail())
 					).to.deep.equal(stableEdit);
 					expect(
-						stabilizeEdit(tree3, (await tree3.editsInternal.tryGetEdit(edit.id)) ?? fail())
+						stabilizeEdit(tree3, (await getEditLogInternal(tree3).tryGetEdit(edit.id)) ?? fail())
 					).to.deep.equal(stableEdit);
 					expect(tree2.edits.length).to.equal(initialEditLogLength + 1);
 					expect(tree3.edits.length).to.equal(initialEditLogLength + 1);

--- a/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
@@ -1363,10 +1363,11 @@ export function runSharedTreeOperationsTests(
 					const { internedStrings } = tree.saveSummary() as SharedTreeSummary;
 
 					const log = getEditLogInternal(tree);
+					const log2 = getEditLogInternal(secondTree);
 					const insertEdit = normalizeEdit(tree, log.getEditInSessionAtIndex(1));
 					const moveEdit = normalizeEdit(tree, log.getEditInSessionAtIndex(2));
-					const insertEdit2 = normalizeEdit(secondTree, log.getEditInSessionAtIndex(1));
-					const moveEdit2 = normalizeEdit(secondTree, log.getEditInSessionAtIndex(2));
+					const insertEdit2 = normalizeEdit(secondTree, log2.getEditInSessionAtIndex(1));
+					const moveEdit2 = normalizeEdit(secondTree, log2.getEditInSessionAtIndex(2));
 					expect(insertEdit).to.deep.equal(insertEdit2);
 					expect(moveEdit).to.deep.equal(moveEdit2);
 					expect(tree.equals(secondTree)).to.be.true;

--- a/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
@@ -69,6 +69,7 @@ import {
 	applyNoop,
 	getIdNormalizerFromSharedTree,
 	waitForSummary,
+	getEditLogInternal,
 } from './TestUtilities';
 
 function revertEditInTree(tree: SharedTree, edit: EditId): EditId | undefined {
@@ -1294,7 +1295,7 @@ export function runSharedTreeOperationsTests(
 			});
 
 			// Verify we loaded a no-history summary.
-			expect(tree3.editsInternal.length).to.equal(1);
+			expect(tree3.edits.length).to.equal(1);
 
 			let unexpectedHistoryChunkCount = 0;
 			tree3.on(SharedTreeDiagnosticEvent.UnexpectedHistoryChunk, () => unexpectedHistoryChunkCount++);
@@ -1361,10 +1362,11 @@ export function runSharedTreeOperationsTests(
 					containerRuntimeFactory.processAllMessages();
 					const { internedStrings } = tree.saveSummary() as SharedTreeSummary;
 
-					const insertEdit = normalizeEdit(tree, tree.editsInternal.getEditInSessionAtIndex(1));
-					const moveEdit = normalizeEdit(tree, tree.editsInternal.getEditInSessionAtIndex(2));
-					const insertEdit2 = normalizeEdit(secondTree, secondTree.editsInternal.getEditInSessionAtIndex(1));
-					const moveEdit2 = normalizeEdit(secondTree, secondTree.editsInternal.getEditInSessionAtIndex(2));
+					const log = getEditLogInternal(tree);
+					const insertEdit = normalizeEdit(tree, log.getEditInSessionAtIndex(1));
+					const moveEdit = normalizeEdit(tree, log.getEditInSessionAtIndex(2));
+					const insertEdit2 = normalizeEdit(secondTree, log.getEditInSessionAtIndex(1));
+					const moveEdit2 = normalizeEdit(secondTree, log.getEditInSessionAtIndex(2));
 					expect(insertEdit).to.deep.equal(insertEdit2);
 					expect(moveEdit).to.deep.equal(moveEdit2);
 					expect(tree.equals(secondTree)).to.be.true;
@@ -1413,7 +1415,7 @@ export function runSharedTreeOperationsTests(
 
 					const uncompressedEdits: EditWithoutId<ChangeInternal>[] = [
 						{
-							changes: tree.editsInternal.getEditInSessionAtIndex(0).changes,
+							changes: getEditLogInternal(tree).getEditInSessionAtIndex(0).changes,
 						},
 					];
 

--- a/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
@@ -507,7 +507,7 @@ export function runSharedTreeVersioningTests(
 					version: newVersion,
 				};
 				containerRuntimeFactory.pushMessage({ contents: op });
-				(tree.editsInternal as EditLog).getLocalEdits = () => {
+				(tree.edits as EditLog).getLocalEdits = () => {
 					throw new Error('Simulated issue in update');
 				};
 				const matchesFailedVersionUpdate = (event: ITelemetryBaseEvent) =>

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -53,6 +53,7 @@ import { newEdit, setTrait } from '../../EditUtilities';
 import { SharedTree } from '../../SharedTree';
 import { BuildNode, Change, StablePlace } from '../../ChangeTypes';
 import { convertEditIds } from '../../IdConversion';
+import { OrderedEditSet } from '../../EditLog';
 import { buildLeaf, RefreshingTestTree, SimpleTestTree, TestTree } from './TestNode';
 
 /** Objects returned by setUpTestSharedTree */
@@ -583,6 +584,10 @@ export function stabilizeEdit(
 	edit: Edit<ChangeInternal>
 ): Edit<ReplaceRecursive<ChangeInternal, NodeId, StableNodeId>> {
 	return convertEditIds(edit, (id) => tree.convertToStableNodeId(id));
+}
+
+export function getEditLogInternal(tree: SharedTree): OrderedEditSet<ChangeInternal> {
+	return tree.edits as unknown as OrderedEditSet<ChangeInternal>;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #9950. Removes `editsInternal` and adjusts `revertChanges` to take in `InternalizedChange`-based types rather than `ChangeInternal` ones.