### PR TITLE
Update @fluid-experimental/tree API report

### DIFF
--- a/api-report/experimental-tree.api.md
+++ b/api-report/experimental-tree.api.md
@@ -859,6 +859,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     // (undocumented)
     protected readonly logger: ITelemetryLogger;
     get logViewer(): LogViewer;
+    mergeEditsFrom(other: SharedTree, edits: Iterable<Edit<InternalizedChange>>, stableIdRemapper?: (id: StableNodeId) => StableNodeId): EditId[];
     // (undocumented)
     protected onDisconnect(): void;
     // (undocumented)


### PR DESCRIPTION
Merge-base of #9940 was before the fix to include `build:docs` as part of the `build` script, and did not properly update the API report file.