### PR TITLE
9818 track size of quorum when summary is generated

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -374,6 +374,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly gcTotalBlobsSize?: number;
     readonly nonSystemOpsSinceLastSummary: number;
     readonly opsSizesSinceLastSummary: number;
+    readonly quorumSize?: number;
     readonly summarizedDataStoreCount: number;
 }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1625,7 +1625,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             online: OnlineStatus[isOnline()],
             lastVisible: this.lastVisible !== undefined ? performance.now() - this.lastVisible : undefined,
             checkpointSequenceNumber,
-            quorumSize: this.getQuorum().getMembers().size,
+            quorumSize: this._protocolHandler?.quorum.getMembers().size,
             ...this._deltaManager.connectionProps,
         });
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1223,6 +1223,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return {
             sequenceNumber: attributes.sequenceNumber,
             version: versionId,
+            quorumSize: this.getQuorum().getMembers().size,
         };
     }
 
@@ -1625,6 +1626,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             online: OnlineStatus[isOnline()],
             lastVisible: this.lastVisible !== undefined ? performance.now() - this.lastVisible : undefined,
             checkpointSequenceNumber,
+            quorumSize: this.getQuorum().getMembers().size,
             ...this._deltaManager.connectionProps,
         });
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1223,7 +1223,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return {
             sequenceNumber: attributes.sequenceNumber,
             version: versionId,
-            quorumSize: this.getQuorum().getMembers().size,
         };
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2385,6 +2385,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 gcTotalBlobsSize: gcSummaryTreeStats?.totalBlobSize,
                 opsSizesSinceLastSummary: this.opTracker.opsSizeAccumulator,
                 nonSystemOpsSinceLastSummary: this.opTracker.nonSystemOpCount,
+                quorumSize: this.getQuorum().getMembers().size,
                 ...partialStats,
             };
             const generateSummaryData = {

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -151,6 +151,8 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly opsSizesSinceLastSummary: number;
     /** Number of non-system ops since the last summary @see isSystemMessage */
     readonly nonSystemOpsSinceLastSummary: number;
+    /** Number of members in the quorum at when summary was generated. */
+    readonly quorumSize?: number;
 }
 
 /** Base results for all submitSummary attempts. */


### PR DESCRIPTION
Also tracks size of quorum when logging container connection state changes
#9818