### PR TITLE
Property reason was being unconditionally overwritten when sending summarizeAttemptDelay event

### DIFF
--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -379,9 +379,8 @@ export class RunningSummarizer implements IDisposable {
                     this.logger.sendPerformanceEvent({
                         eventName: "SummarizeAttemptDelay",
                         duration: delaySeconds,
+                        summaryNackDelay: overrideDelaySeconds !== undefined ? "nack with retryAfter" : undefined,
                         ...summarizeProps,
-                        // summarizeProps has its own reason.
-                        reason: overrideDelaySeconds !== undefined ? "nack with retryAfter" : summarizeProps.reason,
                     });
                     await delay(delaySeconds * 1000);
                 }

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -379,8 +379,9 @@ export class RunningSummarizer implements IDisposable {
                     this.logger.sendPerformanceEvent({
                         eventName: "SummarizeAttemptDelay",
                         duration: delaySeconds,
-                        reason: overrideDelaySeconds !== undefined ? "nack with retryAfter" : undefined,
                         ...summarizeProps,
+                        // summarizeProps has its own reason.
+                        reason: overrideDelaySeconds !== undefined ? "nack with retryAfter" : summarizeProps.reason,
                     });
                     await delay(delaySeconds * 1000);
                 }

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -379,7 +379,7 @@ export class RunningSummarizer implements IDisposable {
                     this.logger.sendPerformanceEvent({
                         eventName: "SummarizeAttemptDelay",
                         duration: delaySeconds,
-                        summaryNackDelay: overrideDelaySeconds !== undefined ? "nack with retryAfter" : undefined,
+                        summaryNackDelay: overrideDelaySeconds !== undefined,
                         ...summarizeProps,
                     });
                     await delay(delaySeconds * 1000);


### PR DESCRIPTION
Fix for #10018  - when we created the reason field from the Summary, we missed the summarizeAttemptDelay as it had its own reason. 