### PR TITLE
Fix for 9905 - Investigate negative numbers on Summary's timeSinceLastAttempt field

### DIFF
--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -258,9 +258,10 @@ export class RunningSummarizer implements IDisposable {
         this.summaryCollection.unsetPendingAckTimerTimeoutCallback();
 
         if (waitStartResult.result === "done" && waitStartResult.value !== undefined) {
-            this.heuristicData.initialize({
+            this.heuristicData.updateWithPendingSummaryAckInfo({
                 refSequenceNumber: waitStartResult.value.summaryOp.referenceSequenceNumber,
-                summaryTime: waitStartResult.value.summaryOp.timestamp,
+                // This will be the Summarizer starting point so only use timestamps from client's machine.
+                summaryTime: Date.now(),
                 summarySequenceNumber: waitStartResult.value.summaryOp.sequenceNumber,
             });
         }

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -258,7 +258,7 @@ export class RunningSummarizer implements IDisposable {
         this.summaryCollection.unsetPendingAckTimerTimeoutCallback();
 
         if (waitStartResult.result === "done" && waitStartResult.value !== undefined) {
-            this.heuristicData.updateWithPendingSummaryAckInfo({
+            this.heuristicData.updateWithLastSummaryAckInfo({
                 refSequenceNumber: waitStartResult.value.summaryOp.referenceSequenceNumber,
                 // This will be the Summarizer starting point so only use timestamps from client's machine.
                 summaryTime: Date.now(),

--- a/packages/runtime/container-runtime/src/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summarizerHeuristics.ts
@@ -29,7 +29,7 @@ export class SummarizeHeuristicData implements ISummarizeHeuristicData {
         this._lastSuccessfulSummary = { ...attemptBaseline };
     }
 
-    public initialize(lastSummary: Readonly<ISummarizeAttempt>) {
+    public updateWithPendingSummaryAckInfo(lastSummary: Readonly<ISummarizeAttempt>) {
         this._lastAttempt = lastSummary;
         this._lastSuccessfulSummary = { ...lastSummary };
     }

--- a/packages/runtime/container-runtime/src/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summarizerHeuristics.ts
@@ -29,7 +29,7 @@ export class SummarizeHeuristicData implements ISummarizeHeuristicData {
         this._lastSuccessfulSummary = { ...attemptBaseline };
     }
 
-    public updateWithPendingSummaryAckInfo(lastSummary: Readonly<ISummarizeAttempt>) {
+    public updateWithLastSummaryAckInfo(lastSummary: Readonly<ISummarizeAttempt>) {
         this._lastAttempt = lastSummary;
         this._lastSuccessfulSummary = { ...lastSummary };
     }

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -352,7 +352,7 @@ export interface ISummarizeHeuristicData {
      * Updates lastAttempt and lastSuccessfulAttempt based on the last summary.
      * @param lastSummary - last ack summary
      */
-    updateWithPendingSummaryAckInfo(lastSummary: Partial<ISummarizeAttempt>): void;
+    updateWithLastSummaryAckInfo(lastSummary: ISummarizeAttempt): void;
 
     /**
      * Records a summary attempt. If the attempt was successfully sent,

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -349,10 +349,10 @@ export interface ISummarizeHeuristicData {
     readonly lastSuccessfulSummary: Readonly<ISummarizeAttempt>;
 
     /**
-     * Initializes lastAttempt and lastSuccessfulAttempt based on the last summary.
+     * Updates lastAttempt and lastSuccessfulAttempt based on the last summary.
      * @param lastSummary - last ack summary
      */
-    initialize(lastSummary: ISummarizeAttempt): void;
+    updateWithPendingSummaryAckInfo(lastSummary: Partial<ISummarizeAttempt>): void;
 
     /**
      * Records a summary attempt. If the attempt was successfully sent,

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -238,7 +238,7 @@ export class SummaryGenerator {
         const logger = ChildLogger.create(this.logger, undefined, { all: summarizeProps });
 
         // Note: timeSinceLastAttempt and timeSinceLastSummary for the
-        // first summary are basically teh time since the summarizer was loaded.
+        // first summary are basically the time since the summarizer was loaded.
         const timeSinceLastAttempt = Date.now() - this.heuristicData.lastAttempt.summaryTime;
         const timeSinceLastSummary = Date.now() - this.heuristicData.lastSuccessfulSummary.summaryTime;
         let summarizeTelemetryProps: SummaryGeneratorTelemetry = {

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -237,6 +237,8 @@ export class SummaryGenerator {
         const { refreshLatestAck, fullTree } = options;
         const logger = ChildLogger.create(this.logger, undefined, { all: summarizeProps });
 
+        // Note: timeSinceLastAttempt and timeSinceLastSummary for the
+        // first summary are basically teh time since the summarizer was loaded.
         const timeSinceLastAttempt = Date.now() - this.heuristicData.lastAttempt.summaryTime;
         const timeSinceLastSummary = Date.now() - this.heuristicData.lastSuccessfulSummary.summaryTime;
         let summarizeTelemetryProps: SummaryGeneratorTelemetry = {


### PR DESCRIPTION
Fix #9905  - Do not user server timestamp during the first summary. 