### PR TITLE
Remove expected error code as it only thrown by local driver

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -267,6 +267,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
         // new handle works
         assert.strictEqual(bufferToString(await (dataStore._root.get("my blob")).get(), "utf-8"), text);
+        container.close();
     });
 
     it("serialize/rehydrate container with blobs", async function() {
@@ -320,6 +321,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const attachedDataStore = await requestFluidObject<ITestDataObject>(attachedContainer, "default");
         await provider.ensureSynchronized();
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
+        detachedContainer.close();
     });
 
     itExpects("serialize/rehydrate then attach", [
@@ -350,6 +352,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const attachedDataStore = await requestFluidObject<ITestDataObject>(attachedContainer, "default");
         await provider.ensureSynchronized();
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
+        rehydratedContainer.close();
     });
 
     itExpects("serialize/rehydrate multiple times then attach", [
@@ -383,6 +386,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const attachedDataStore = await requestFluidObject<ITestDataObject>(attachedContainer, "default");
         await provider.ensureSynchronized();
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
+        container.close();
     });
 
     it("rehydrating without detached blob storage results in error", async function() {

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -237,10 +237,9 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
     });
 
-    it("works in detached container", async function() {
-        if(provider.driver.type !== "odsp") {
-            this.skip();
-        }
+    itExpects("works in detached container", [
+        { eventName: "fluid:telemetry:Container:ContainerClose" },
+    ], async function() {
         const detachedBlobStorage = new MockDetachedBlobStorage();
         const loader = provider.makeTestLoader({ ...testContainerConfig, loaderProps: {detachedBlobStorage}});
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -253,13 +252,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         dataStore._root.set("my blob", blobHandle);
         assert.strictEqual(bufferToString(await (dataStore._root.get("my blob")).get(), "utf-8"), text);
 
-        const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-        if (provider.driver.type !== "odsp") {
-            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
-        }
-        await attachP;
+        await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
 
         // make sure we're getting the blob from actual storage
         detachedBlobStorage.blobs.clear();
@@ -289,10 +282,9 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await rehydratedDataStore._root.get("my blob").get(), "utf-8"), text);
     });
 
-    it("redirect table saved in snapshot", async function() {
-        if(provider.driver.type !== "odsp") {
-            this.skip();
-        }
+    itExpects("redirect table saved in snapshot", [
+        { eventName: "fluid:telemetry:Container:ContainerClose" },
+    ], async function() {
         const detachedBlobStorage = new MockDetachedBlobStorage();
         const loader = provider.makeTestLoader({ ...testContainerConfig, loaderProps: {detachedBlobStorage}});
         const detachedContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -307,13 +299,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         detachedDataStore._root.set("my other blob",
             await detachedDataStore._runtime.uploadBlob(stringToBuffer("more text", "utf-8")));
 
-        const attachP = detachedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
-        if (provider.driver.type !== "odsp") {
-            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
-        }
-        await attachP;
+        await detachedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
         detachedBlobStorage.blobs.clear();
 
         const url = getUrlFromItemId((detachedContainer.resolvedUrl as IOdspResolvedUrl).itemId, provider);
@@ -324,10 +310,9 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
     });
 
-    it("serialize/rehydrate then attach", async function() {
-        if(provider.driver.type !== "odsp") {
-            this.skip();
-        }
+    itExpects("serialize/rehydrate then attach", [
+        { eventName: "fluid:telemetry:Container:ContainerClose" },
+    ], async function() {
         const loader = provider.makeTestLoader(
             {...testContainerConfig, loaderProps: {detachedBlobStorage: new MockDetachedBlobStorage()}});
         const serializeContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -349,10 +334,9 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
     });
 
-    it("serialize/rehydrate multiple times then attach", async function() {
-        if(provider.driver.type !== "odsp") {
-            this.skip();
-        }
+    itExpects("serialize/rehydrate multiple times then attach", [
+        { eventName: "fluid:telemetry:Container:ContainerClose" },
+    ], async function() {
         const loader = provider.makeTestLoader(
             {...testContainerConfig, loaderProps: {detachedBlobStorage: new MockDetachedBlobStorage()}});
         let container = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -368,13 +352,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
             container = await loader.rehydrateDetachedContainerFromSnapshot(snapshot);
         }
 
-        const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-        if (provider.driver.type !== "odsp") {
-            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
-        }
-        await attachP;
+        await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
 
         const url = getUrlFromItemId((container.resolvedUrl as IOdspResolvedUrl).itemId, provider);
         const attachedContainer = await provider.makeTestLoader(testContainerConfig).resolve({ url });

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -237,11 +237,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
     });
 
-    itExpects("works in detached container", [
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "0x202" },
-    ], async function() {
-        // GitHub issue: #9534
-        if(provider.driver.type === "tinylicious") {
+    it("works in detached container", async function() {
+        if(provider.driver.type !== "odsp") {
             this.skip();
         }
         const detachedBlobStorage = new MockDetachedBlobStorage();
@@ -292,10 +289,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await rehydratedDataStore._root.get("my blob").get(), "utf-8"), text);
     });
 
-    itExpects("redirect table saved in snapshot",[
-        { eventName: "fluid:telemetry:Container:ContainerClose", message: "0x202" },
-    ], async function() {
-        if(provider.driver.type === "tinylicious") {
+    it("redirect table saved in snapshot", async function() {
+        if(provider.driver.type !== "odsp") {
             this.skip();
         }
         const detachedBlobStorage = new MockDetachedBlobStorage();
@@ -329,11 +324,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
     });
 
-    itExpects("serialize/rehydrate then attach", [
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "0x202" },
-    ], async function() {
-        // GitHub issue: #9534
-        if(provider.driver.type === "tinylicious") {
+    it("serialize/rehydrate then attach", async function() {
+        if(provider.driver.type !== "odsp") {
             this.skip();
         }
         const loader = provider.makeTestLoader(
@@ -348,13 +340,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         serializeContainer.close();
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshot);
 
-        const attachP = rehydratedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
-        if (provider.driver.type !== "odsp") {
-            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
-        }
-        await attachP;
+        await rehydratedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
 
         const url = getUrlFromItemId((rehydratedContainer.resolvedUrl as IOdspResolvedUrl).itemId, provider);
         const attachedContainer = await provider.makeTestLoader(testContainerConfig).resolve({ url });
@@ -363,11 +349,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
     });
 
-    itExpects("serialize/rehydrate multiple times then attach", [
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "0x202" },
-    ], async function() {
-        // GitHub issue: #9534
-        if(provider.driver.type === "tinylicious") {
+    it("serialize/rehydrate multiple times then attach", async function() {
+        if(provider.driver.type !== "odsp") {
             this.skip();
         }
         const loader = provider.makeTestLoader(

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -252,7 +252,13 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         dataStore._root.set("my blob", blobHandle);
         assert.strictEqual(bufferToString(await (dataStore._root.get("my blob")).get(), "utf-8"), text);
 
-        await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        if (provider.driver.type !== "odsp") {
+            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+        }
+        await attachP;
 
         // make sure we're getting the blob from actual storage
         detachedBlobStorage.blobs.clear();
@@ -299,7 +305,13 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         detachedDataStore._root.set("my other blob",
             await detachedDataStore._runtime.uploadBlob(stringToBuffer("more text", "utf-8")));
 
-        await detachedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        const attachP = detachedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        if (provider.driver.type !== "odsp") {
+            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+        }
+        await attachP;
         detachedBlobStorage.blobs.clear();
 
         const url = getUrlFromItemId((detachedContainer.resolvedUrl as IOdspResolvedUrl).itemId, provider);
@@ -325,7 +337,13 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         serializeContainer.close();
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshot);
 
-        await rehydratedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        const attachP = rehydratedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        if (provider.driver.type !== "odsp") {
+            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+        }
+        await attachP;
 
         const url = getUrlFromItemId((rehydratedContainer.resolvedUrl as IOdspResolvedUrl).itemId, provider);
         const attachedContainer = await provider.makeTestLoader(testContainerConfig).resolve({ url });
@@ -352,7 +370,13 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
             container = await loader.rehydrateDetachedContainerFromSnapshot(snapshot);
         }
 
-        await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+        if (provider.driver.type !== "odsp") {
+            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+        }
+        await attachP;
 
         const url = getUrlFromItemId((container.resolvedUrl as IOdspResolvedUrl).itemId, provider);
         const attachedContainer = await provider.makeTestLoader(testContainerConfig).resolve({ url });


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/9446
The error code 0x202 is only thrown by local driver. We want this test to expect container close for all drivers except the odsp driver. So, this is required.