### PR TITLE
Update definition of public/private for repo policy check

### DIFF
--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/collaborative-textarea",
   "version": "0.59.3000",
+  "private": true,
   "description": "A minimal example using the react collaborative-textarea",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/contact-collection",
   "version": "0.59.3000",
+  "private": true,
   "description": "Example of using a Fluid Object as a collection of items",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/apps/likes/package.json
+++ b/examples/apps/likes/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/likes",
   "version": "0.59.3000",
+  "private": true,
   "description": "A Fluid object for storing like counts using pre-build DDS hooks",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/spaces",
   "version": "0.59.3000",
+  "private": true,
   "description": "Spaces is a grid layout component",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/view-framework-sampler",
   "version": "0.59.3000",
+  "private": true,
   "description": "Example of integrating a Fluid data object with a variety of view frameworks.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/badge",
   "version": "0.59.3000",
+  "private": true,
   "description": "Badge Fluid example component",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/canvas",
   "version": "0.59.3000",
+  "private": true,
   "description": "Fluid ink canvas",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/clicker-context",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid object sample to implement a collaborative counter using Fluid React hooks",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/clicker-function",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid object sample to implement a collaborative counter using Fluid React hooks",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/clicker-react",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid object sample to implement a collaborative counter.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/clicker-reducer",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid object sample to implement a collaborative counter using Fluid React hooks",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/clicker-with-hook",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid object sample to implement a collaborative counter using the synced counter hook",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/clicker",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid component sample to implement a collaborative counter.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/client-ui-lib",
   "version": "0.59.3000",
+  "private": true,
   "description": "Fluid client UI",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/codemirror",
   "version": "0.59.3000",
+  "private": true,
   "description": "Simple markdown editor",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/diceroller",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid Container & Object sample to implement a collaborative dice roller.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/focus-tracker",
   "version": "0.59.3000",
+  "private": true,
   "description": "Example Data Object that tracks page focus for Audience members using signals.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/image-gallery",
   "version": "0.59.3000",
+  "private": true,
   "description": "Image Gallery with pretty layout",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/key-value-cache",
   "version": "0.59.3000",
+  "private": true,
   "description": "Key-value cache that runs in the node.js service",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/monaco",
   "version": "0.59.3000",
+  "private": true,
   "description": "Monaco code editor",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-constellation-model",
   "version": "0.59.3000",
+  "private": true,
   "description": "Constellation model for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-constellation-view",
   "version": "0.59.3000",
+  "private": true,
   "description": "View for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-container",
   "version": "0.59.3000",
+  "private": true,
   "description": "Container for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-coordinate-model",
   "version": "0.59.3000",
+  "private": true,
   "description": "Coordinate model for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-coordinate-interface",
   "version": "0.59.3000",
+  "private": true,
   "description": "Interface for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-plot-coordinate-view",
   "version": "0.59.3000",
+  "private": true,
   "description": "View for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-slider-coordinate-view",
   "version": "0.59.3000",
+  "private": true,
   "description": "View for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/multiview-triangle-view",
   "version": "0.59.3000",
+  "private": true,
   "description": "View for multiview sample",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/musica",
   "version": "0.59.3000",
+  "private": true,
   "description": "Play music collaboratively",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/pond",
   "version": "0.59.3000",
+  "private": true,
   "description": "Grab bag of Fluid scenarios in one Fluid Container.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/primitives",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid container sample to showcase some of the distributed data structures.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/prosemirror",
   "version": "0.59.3000",
+  "private": true,
   "description": "ProseMirror",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/shared-text",
   "version": "0.59.3000",
+  "private": true,
   "description": "Shared text",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/simple-fluidobject-embed",
   "version": "0.59.3000",
+  "private": true,
   "description": "Simple Fluid object embed container",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/smde",
   "version": "0.59.3000",
+  "private": true,
   "description": "Simple markdown editor",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@fluid-example/table-document",
   "version": "0.59.3000",
-  "description": "Chaincode component containing a table's data",
+  "private": true,
+  "description": "Data object containing a table's data",
   "homepage": "https://fluidframework.com",
   "repository": {
     "type": "git",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@fluid-example/table-view",
   "version": "0.59.3000",
-  "description": "Chaincode component that provides a view for a table-document.",
+  "private": true,
+  "description": "Data object that provides a view for a table-document.",
   "homepage": "https://fluidframework.com",
   "repository": {
     "type": "git",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/task-selection",
   "version": "0.59.3000",
+  "private": true,
   "description": "Example demonstrating selecting a unique task amongst connected Fluid clients",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@fluid-example/todo",
   "version": "0.59.3000",
-  "description": "Simple todo canvas.",
+  "private": true,
+  "description": "Simple todo app",
   "homepage": "https://fluidframework.com",
   "repository": {
     "type": "git",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@fluid-example/vltava",
   "version": "0.59.3000",
-  "description": "Vltava is a Application Experience",
+  "private": true,
+  "description": "Application that hosts various data objects",
   "homepage": "https://fluidframework.com",
   "repository": {
     "type": "git",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/webflow",
   "version": "0.59.3000",
+  "private": true,
   "description": "Collaborative markdown editor.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/app-integration-container-views",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid Container & data store sample to implement a collaborative dice roller as a standalone app.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/app-integration-external-controller",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/app-integration-external-views",
   "version": "0.59.3000",
+  "private": true,
   "description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/app-integration-schema-upgrade",
   "version": "0.59.3000",
+  "private": true,
   "description": "Using external data to initialize the container state and serialize out afterwards.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/host-service-interfaces",
   "version": "0.59.3000",
+  "private": true,
   "description": "Example host service interfaces",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/iframe-host",
   "version": "0.59.3000",
+  "private": true,
   "description": "IFrame Host",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/bundle-size-tests",
   "version": "0.59.3000",
+  "private": true,
   "description": "A package for understanding the bundle size of Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-example/example-utils",
   "version": "0.59.3000",
+  "private": true,
   "description": "Shared utilities used by examples.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/experimental/PropertyDDS/services/property-query-service/LICENSE
+++ b/experimental/PropertyDDS/services/property-query-service/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/experimental/PropertyDDS/services/property-query-service/README.md
+++ b/experimental/PropertyDDS/services/property-query-service/README.md
@@ -1,4 +1,4 @@
-# @fluid-experimental/property-query-service
+# @fluid-internal/property-query-service
 # Moira Service
 A service that maintains a representation of the commit history which allows random access at arbitrary commits.
 

--- a/experimental/PropertyDDS/services/property-query-service/package.json
+++ b/experimental/PropertyDDS/services/property-query-service/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@fluid-experimental/property-query-service",
+  "name": "@fluid-internal/property-query-service",
   "version": "0.59.3000",
+  "private": true,
   "description": "Moira service",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/experimental/PropertyDDS/services/property-query-service/package.json
+++ b/experimental/PropertyDDS/services/property-query-service/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-experimental/property-query-service",
   "version": "0.59.3000",
-  "private": true,
   "description": "Moira service",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/experimental/examples/bubblebench/baseline/README.md
+++ b/experimental/examples/bubblebench/baseline/README.md
@@ -1,4 +1,4 @@
-# @fluid-experimental/bubblebench-baseline
+# @fluid-example/bubblebench-baseline
 
 ## Getting Started
 
@@ -6,7 +6,7 @@ You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
    a. For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-experimental/bubblebench`
+      `npm run build:fast -- --nolint @fluid-example/bubblebench`
 1. Run `npm run start` from this directory (experimental/examples/bubblebench/baseline) and open <http://localhost:8080> in a web browser to see the app running.
 <!-- AUTO-GENERATED-CONTENT:END -->
 

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -42,8 +42,8 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
+    "@fluid-example/bubblebench-common": "^0.59.3000",
     "@fluid-example/example-utils": "^0.59.3000",
-    "@fluid-experimental/bubblebench-common": "^0.59.3000",
     "@fluidframework/aqueduct": "^0.59.3000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.1000",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@fluid-experimental/bubblebench-baseline",
+  "name": "@fluid-example/bubblebench-baseline",
   "version": "0.59.3000",
+  "private": true,
   "description": "Bubblemark inspired DDS benchmark",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/experimental/examples/bubblebench/common/README.md
+++ b/experimental/examples/bubblebench/common/README.md
@@ -1,3 +1,3 @@
-# @fluid-experimental/bubblebench-common
+# @fluid-example/bubblebench-common
 
 Fluid/DDS-agnostic code shared by Bubblebench benchmarks.

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@fluid-experimental/bubblebench-common",
+  "name": "@fluid-example/bubblebench-common",
   "version": "0.59.3000",
+  "private": true,
   "description": "Bubblemark inspired DDS benchmark",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/experimental/examples/bubblebench/ot/README.md
+++ b/experimental/examples/bubblebench/ot/README.md
@@ -1,4 +1,4 @@
-# @fluid-experimental/bubblebench-ot
+# @fluid-example/bubblebench-ot
 
 ## Getting Started
 
@@ -6,7 +6,7 @@ You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
    a. For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-experimental/bubblebench-ot`
+      `npm run build:fast -- --nolint @fluid-example/bubblebench-ot`
 1. Run `npm run start` from this directory (experimental/examples/bubblebench/ot) and open <http://localhost:8080> in a web browser to see the app running.
 <!-- AUTO-GENERATED-CONTENT:END -->
 

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@fluid-experimental/bubblebench-ot",
+  "name": "@fluid-example/bubblebench-ot",
   "version": "0.59.3000",
+  "private": true,
   "description": "Bubblemark inspired DDS benchmark",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -42,8 +42,8 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
+    "@fluid-example/bubblebench-common": "^0.59.3000",
     "@fluid-example/example-utils": "^0.59.3000",
-    "@fluid-experimental/bubblebench-common": "^0.59.3000",
     "@fluid-experimental/sharejs-json1": "^0.59.3000",
     "@fluidframework/aqueduct": "^0.59.3000",
     "@fluidframework/common-definitions": "^0.20.1",

--- a/experimental/examples/bubblebench/sharedtree/README.md
+++ b/experimental/examples/bubblebench/sharedtree/README.md
@@ -1,4 +1,4 @@
-# @fluid-experimental/bubblebench-sharedtree
+# @fluid-example/bubblebench-sharedtree
 
 ## Getting Started
 
@@ -6,7 +6,7 @@ You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
    a. For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-experimental/bubblebench`
+      `npm run build:fast -- --nolint @fluid-example/bubblebench`
 1. Run `npm run start` from this directory (experimental/examples/bubblebench/sharedtree) and open <http://localhost:8080> in a web browser to see the app running.
 <!-- AUTO-GENERATED-CONTENT:END -->
 

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -42,8 +42,8 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
+    "@fluid-example/bubblebench-common": "^0.59.3000",
     "@fluid-example/example-utils": "^0.59.3000",
-    "@fluid-experimental/bubblebench-common": "^0.59.3000",
     "@fluid-experimental/tree": "^0.59.3000",
     "@fluidframework/aqueduct": "^0.59.3000",
     "@fluidframework/common-definitions": "^0.20.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@fluid-experimental/bubblebench-sharedtree",
+  "name": "@fluid-example/bubblebench-sharedtree",
   "version": "0.59.3000",
+  "private": true,
   "description": "Bubblemark inspired DDS benchmark",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-tools/fluidapp-odsp-urlresolver",
   "version": "0.59.3000",
-  "private": true,
   "description": "Url Resolver for Fluid app urls.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-tools/fluidapp-odsp-urlresolver",
   "version": "0.59.3000",
+  "private": true,
   "description": "Url Resolver for Fluid app urls.",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-internal/test-app-insights-logger",
   "version": "0.59.3000",
+  "private": true,
   "description": "Azure Application Insights logger for Fluid tests",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-internal/test-service-load",
   "version": "0.59.3000",
+  "private": true,
   "description": "Service load tests",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-tools/fetch-tool",
   "version": "0.59.3000",
+  "private": true,
   "description": "Console tool to fetch Fluid data from relay service",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-tools/fetch-tool",
   "version": "0.59.3000",
-  "private": true,
   "description": "Console tool to fetch Fluid data from relay service",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-tools/webpack-fluid-loader",
   "version": "0.59.3000",
+  "private": true,
   "description": "Fluid object loader for webpack-dev-server",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-tools/webpack-fluid-loader",
   "version": "0.59.3000",
-  "private": true,
   "description": "Fluid object loader for webpack-dev-server",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-tools/benchmark",
   "version": "0.40.0",
+  "private": true,
   "description": "Benchmarking tools",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-tools/benchmark",
   "version": "0.40.0",
-  "private": true,
   "description": "Benchmarking tools",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -31,11 +31,6 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 // Packages which do not publish on NPM
 function packageShouldBePrivate(name: string): boolean {
-    // allow test packages to be published
-    if (name.startsWith("@fluid-internal/test-")) {
-        return false;
-    }
-
     return (
         name === "root" // monorepo roots
         || name.startsWith("@fluid-internal")

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -31,7 +31,7 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 // Packages which do not publish on NPM
 function packageShouldBePrivate(name: string): boolean {
-    // allow test packages to be packaged
+    // allow test packages to be published
     if (name.startsWith("@fluid-internal/test-")) {
         return false;
     }

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -29,6 +29,7 @@ or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.micr
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 `;
 
+// Packages which do not publish on NPM
 function packageShouldBePrivate(name: string): boolean {
     // allow test packages to be packaged
     if (name.startsWith("@fluid-internal/test-")) {
@@ -36,14 +37,19 @@ function packageShouldBePrivate(name: string): boolean {
     }
 
     return (
-        name === "root" || // minirepo roots
-        name.startsWith("@fluid-internal"));
+        name === "root" // minirepo roots
+        || name.startsWith("@fluid-internal")
+        || name.startsWith("@fluid-example")
+        || name.startsWith("@fluid-tools")
+    );
 }
 
+// Packages which publish on NPM
 function packageShouldNotBePrivate(name: string): boolean {
     return (
-        name.startsWith("@fluidframework") ||
-        name.startsWith("@fluid-example"));
+        name.startsWith("@fluidframework")
+        || name.startsWith("@fluid-experimental")
+    );
 }
 
 type IReadmeInfo = {

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -40,7 +40,6 @@ function packageShouldBePrivate(name: string): boolean {
         name === "root" // monorepo roots
         || name.startsWith("@fluid-internal")
         || name.startsWith("@fluid-example")
-        || name.startsWith("@fluid-tools")
     );
 }
 

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -37,7 +37,7 @@ function packageShouldBePrivate(name: string): boolean {
     }
 
     return (
-        name === "root" // minirepo roots
+        name === "root" // monorepo roots
         || name.startsWith("@fluid-internal")
         || name.startsWith("@fluid-example")
         || name.startsWith("@fluid-tools")


### PR DESCRIPTION
In #10028 I discovered that examples are considered public, which seems an incorrect labeling since we don't publish them to NPM (and I believe the purpose of this check is to ensure published packages don't depend on non-published packages).  This change would do the following:

1. Define "public" and "private" based on whether the packages publish to NPM
    * Public: `@fluidframework`, `@fluid-experimental`
    * Private: `@fluid-internal`, `@fluid-example`, `@fluid-tools`
2. Update the "private" flags in package.json files to match this definition
3. Convert the bubblebench packages to "example" rather than "experimental" -- they were always under an examples subdirectory, I think this was just an oversight.
4. Add a missing LICENSE file to property-query-service.