### PR TITLE
Update private/public package determination in policy-check

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -49,7 +49,7 @@ function packageMustPublishToNPM(name: string): boolean {
 /**
  * Whether the package is known to be an internally published package but not to NPM.
  * Note that packages published to NPM will also be published internally, however.
- * This should be a minmal set required for legacy compat of internal partners or internal CI requirements.
+ * This should be a minimal set required for legacy compat of internal partners or internal CI requirements.
  */
 function packageMustPublishToInternalFeedOnly(name: string): boolean {
     return (

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -29,23 +29,85 @@ or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.micr
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 `;
 
-// Packages which definitely should not publish on NPM
-function packageShouldBePrivate(name: string): boolean {
-    // allow test packages to be published
-    if (name.startsWith("@fluid-internal/test-")) {
-        return false;
-    }
+// Some of our package scopes definitely should publish, and others should never publish.  If they should never
+// publish, we want to add the "private": true flag to their package.json to prevent publishing, and conversely if
+// they should always publish we should ensure the "private": true flag is not present.  There is then a third
+// category of packages which may elect whether or not to publish -- we leave the choice up to those individual
+// packages whether to set the flag.
 
+/**
+ * Whether the package is known to be a publicly published package for general use.
+ */
+function packageMustPublishToNPM(name: string): boolean {
     return (
-        name === "root" // monorepo roots
-        || name.startsWith("@fluid-internal")
-        || name.startsWith("@fluid-example")
+        name.startsWith("@fluidframework/")
+        || name === "fluid-framework"
+        || name === "tinylicious"
     );
 }
 
-// Packages which definitely should publish on NPM
-function packageShouldNotBePrivate(name: string): boolean {
-    return name.startsWith("@fluidframework");
+/**
+ * Whether the package is known to be an internally published package but not to NPM.
+ * Note that packages published to NPM will also be published internally, however.
+ * This should be a minmal set required for legacy compat of internal partners or internal CI requirements.
+ */
+function packageMustPublishToInternalFeedOnly(name: string): boolean {
+    return (
+        // TODO: We may not need to publish test packages to the internal feed, remove these exceptions if possible.
+        name === "@fluid-internal/test-app-insights-logger"
+        || name === "@fluid-internal/test-service-load"
+        // Most examples should be private, but table-document needs to publish internally for legacy compat
+        || name === "@fluid-example/table-document"
+    );
+}
+
+/**
+ * Whether the package has the option to publicly publish if it chooses.
+ * For example, an experimental package may choose to remain unpublished until it's ready for customers to try it out.
+ */
+function packageMayChooseToPublishToNPM(name: string): boolean {
+    return (
+        name.startsWith("@fluid-experimental/")
+        || name.startsWith("@fluid-tools/")
+    );
+}
+
+/**
+ * If we haven't explicitly OK'd the package scope to publish in one of the categories above, it must be marked
+ * private to prevent publishing.
+ */
+function packageMustBePrivate(name: string): boolean {
+    return !(
+        packageMustPublishToNPM(name)
+        || packageMustPublishToInternalFeedOnly(name)
+        || packageMayChooseToPublishToNPM(name)
+    );
+}
+
+/**
+ * If we know a package needs to publish somewhere, then it must not be marked private to allow publishing.
+ */
+function packageMustNotBePrivate(name: string): boolean {
+    return (
+        packageMustPublishToNPM(name)
+        || packageMustPublishToInternalFeedOnly(name)
+    );
+}
+
+/**
+ * Whether the package either belongs to a known Fluid package scope or is a known unscoped package.
+ */
+ function packageIsFluidPackage(name: string): boolean {
+    return (
+        name.startsWith("@fluidframework/")
+        || name.startsWith("@fluid-example/")
+        || name.startsWith("@fluid-experimental/")
+        || name.startsWith("@fluid-internal/")
+        || name.startsWith("@fluid-tools/")
+        || name === "fluid-framework"
+        || name === "fluidframework-docs"
+        || name === "tinylicious"
+    );
 }
 
 type IReadmeInfo = {
@@ -170,34 +232,66 @@ export const handlers: Handler[] = [
         },
     },
     {
-        name: "npm-private-packages",
+        // Verify that we're not introducing new scopes or unscoped packages unintentionally.
+        // If you'd like to introduce a new package scope or a new unscoped package, please discuss it first.
+        name: "npm-strange-package-name",
         match,
         handler: file => {
-            let json;
+            let json: { name: string };
             try {
                 json = JSON.parse(readFile(file));
             } catch (err) {
                 return 'Error parsing JSON file: ' + file;
             }
 
-            const ret = [];
-
-            if (json.private && packageShouldNotBePrivate(json.name)) {
-                ret.push(`package ${json.name} should not be marked private`)
+            // "root" is the package name for monorepo roots, so ignore them
+            if (!packageIsFluidPackage(json.name) && json.name !== "root") {
+                const matched = json.name.match(/^(@.+)\//);
+                if (matched !== null) {
+                    return `Scope ${matched[1]} is an unexpected Fluid scope`;
+                } else {
+                    return `Package ${json.name} is an unexpected unscoped package`;
+                }
+            }
+        },
+    },
+    {
+        // Verify that packages are correctly marked private or not.
+        // Also verify that non-private packages don't take dependency on private packages.
+        name: "npm-private-packages",
+        match,
+        handler: file => {
+            let json: { name: string, private?: boolean, dependencies: Record<string, string> };
+            try {
+                json = JSON.parse(readFile(file));
+            } catch (err) {
+                return 'Error parsing JSON file: ' + file;
             }
 
-            // Falsey check is correct since packages publish by default  (i.e. missing "private" field means false)
-            if (!json.private && packageShouldBePrivate(json.name)) {
-                ret.push(`package ${json.name} should be marked private`)
+            const errors = [];
+
+            if (json.private && packageMustNotBePrivate(json.name)) {
+                errors.push(`Package ${json.name} must not be marked private`);
+            }
+
+            // Packages publish by default, so we need an explicit true flag to suppress publishing.
+            if (json.private !== true && packageMustBePrivate(json.name)) {
+                errors.push(`Package ${json.name} must be marked private`);
             }
 
             const deps = Object.keys(json.dependencies ?? {});
-            if (!json.private && deps.some(packageShouldBePrivate)) {
-                ret.push(`published package should not depend on an internal package`);
+            // TODO: Ideally we should check whether the dependency actually is marked private (in the case of
+            // packages which have a choice).  So this is just an approximation given packages that we know must
+            // be private.
+            if (
+                json.private !== true
+                && deps.some((name) => packageIsFluidPackage(name) && packageMustBePrivate(name))
+            ) {
+                errors.push(`Non-private package must not depend on a private package`);
             }
 
-            if (ret.length > 0) {
-                return `Package.json ${ret.join(newline)}`;
+            if (errors.length > 0) {
+                return `package.json private flag violations: ${newline}${errors.join(newline)}`;
             }
         },
     },

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -29,6 +29,7 @@ or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.micr
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 `;
 
+// Packages which do not publish on NPM
 function packageShouldBePrivate(name: string): boolean {
     // allow test packages to be packaged
     if (name.startsWith("@fluid-internal/test-")) {
@@ -36,14 +37,19 @@ function packageShouldBePrivate(name: string): boolean {
     }
 
     return (
-        name === "root" || // minirepo roots
-        name.startsWith("@fluid-internal"));
+        name === "root" // minirepo roots
+        || name.startsWith("@fluid-internal")
+        || name.startsWith("@fluid-example")
+        || name.startsWith("@fluid-tools")
+    );
 }
 
+// Packages which publish on NPM
 function packageShouldNotBePrivate(name: string): boolean {
     return (
-        name.startsWith("@fluidframework") ||
-        name.startsWith("@fluid-example"));
+        name.startsWith("@fluidframework")
+        || name.startsWith("@fluid-experimental")
+    );
 }
 
 type IReadmeInfo = {

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -40,7 +40,6 @@ function packageShouldBePrivate(name: string): boolean {
         name === "root" // minirepo roots
         || name.startsWith("@fluid-internal")
         || name.startsWith("@fluid-example")
-        || name.startsWith("@fluid-tools")
     );
 }
 

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -29,26 +29,23 @@ or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.micr
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 `;
 
-// Packages which do not publish on NPM
+// Packages which definitely should not publish on NPM
 function packageShouldBePrivate(name: string): boolean {
-    // allow test packages to be packaged
+    // allow test packages to be published
     if (name.startsWith("@fluid-internal/test-")) {
         return false;
     }
 
     return (
-        name === "root" // minirepo roots
+        name === "root" // monorepo roots
         || name.startsWith("@fluid-internal")
         || name.startsWith("@fluid-example")
     );
 }
 
-// Packages which publish on NPM
+// Packages which definitely should publish on NPM
 function packageShouldNotBePrivate(name: string): boolean {
-    return (
-        name.startsWith("@fluidframework")
-        || name.startsWith("@fluid-experimental")
-    );
+    return name.startsWith("@fluidframework");
 }
 
 type IReadmeInfo = {

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -31,11 +31,6 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 // Packages which definitely should not publish on NPM
 function packageShouldBePrivate(name: string): boolean {
-    // allow test packages to be published
-    if (name.startsWith("@fluid-internal/test-")) {
-        return false;
-    }
-
     return (
         name === "root" // monorepo roots
         || name.startsWith("@fluid-internal")

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -31,6 +31,11 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 // Packages which definitely should not publish on NPM
 function packageShouldBePrivate(name: string): boolean {
+    // allow test packages to be published
+    if (name.startsWith("@fluid-internal/test-")) {
+        return false;
+    }
+
     return (
         name === "root" // monorepo roots
         || name.startsWith("@fluid-internal")


### PR DESCRIPTION
In #10028 I discovered that examples are considered public, which seems an incorrect labeling since we don't publish them to NPM (and I believe the purpose of this check is to ensure published packages don't depend on non-published packages).  This change does the following:

* Updates the logic for the public/private policy-check, to be private by default unless explicitly permitted to be public.
* Adds an explicit category of "may be public":
    * `@fluid-tools` -- pending further discussion since we publish these, but they are not good for anyone to take package dependencies on.
    * `@fluid-experimental` -- we publish these and customers should import/try them out in a preview capacity, but we should block their usage in non-experimental packages within our own repo.  We may also like having the capability to put a package under the namespace but explicitly choose not to publish it until it's reached a certain level of quality.
* Moves `@fluid-example` to be private (except `@fluid-example/table-document` which needs to be published to the internal feed for compat purposes).
* Adds a check for unexpected package names and scopes - I needed this anyway for the public/private check and seems reasonable to help avoid typos and such
* Lots of comments to explain the policy and exceptions

I intend to then publish a new build-tools and follow up with the repo updates in #10040