### PR TITLE
Remove deprecated function IDeltaManager.close()

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -22,6 +22,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Remove IFluidSerializer from core-interfaces](#Remove-IFluidSerializer-from-core-interfaces)
 - [Remove IFluidSerializer from IFluidObject](#Remove-IFluidSerializer-from-IFluidObject)
 - [Remove write method from IDocumentStorageService](#Remove-Write-Method-from-IDocumentStorageService)
+- [Remove IDeltaManager.close()](#remove-ideltamanagerclose)
 
 ### Remove IFluidSerializer from core-interfaces
 `IFluidSerializer` was deprecated from core-interfaces in 0.55 and is now removed. Use `IFluidSerializer` in shared-object-base instead.
@@ -31,6 +32,10 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ### Remove Write Method from IDocumentStorageService
 The `IDocumentStorageService.write(...)` method within the `@fluidframework/driver-definitions` package has been removed. Please remove all usage/implementation of this method if present.
+
+### Remove IDeltaManager.close()
+The method `IDeltaManager.close()` was deprecated in 0.54 and is now removed.
+Use IContainer.close() or IContainerContext.closeFn() instead, and pass an error object if applicable.
 
 # 0.59
 

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -245,8 +245,6 @@ export interface IDeltaHandlerStrategy {
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender, IDisposable {
     readonly active: boolean;
     readonly clientDetails: IClientDetails;
-    // @deprecated (undocumented)
-    close(): void;
     readonly hasCheckpointSequenceNumber: boolean;
     readonly inbound: IDeltaQueue<T>;
     readonly inboundSignal: IDeltaQueue<ISignalMessage>;

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -77,6 +77,12 @@
       },
       "InterfaceDeclaration_IContainerContext": {
         "backCompat": false
+      },
+      "InterfaceDeclaration_IContainer": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IDeltaManager": {
+        "backCompat": false
       }
     }
   }

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -150,9 +150,6 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 
     readonly readOnlyInfo: ReadOnlyInfo;
 
-    /** @deprecated - Use Container.close() or IContainerContext.closeFn() */
-    close(): void;
-
     /** Submit a signal to the service to be broadcast to other connected clients, but not persisted */
     submitSignal(content: any): void;
 }

--- a/common/lib/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/common/lib/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -348,6 +348,7 @@ declare function get_current_InterfaceDeclaration_IContainer():
 declare function use_old_InterfaceDeclaration_IContainer(
     use: TypeOnly<old.IContainer>);
 use_old_InterfaceDeclaration_IContainer(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainer());
 
 /*
@@ -493,6 +494,7 @@ declare function get_current_InterfaceDeclaration_IDeltaManager():
 declare function use_old_InterfaceDeclaration_IDeltaManager(
     use: TypeOnly<old.IDeltaManager<any,any>>);
 use_old_InterfaceDeclaration_IDeltaManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaManager());
 
 /*


### PR DESCRIPTION
Deprecated in #8589.  Use Container.close() or IContainerContext.closeFn(), which can take an error if applicable.