### PR TITLE
Add localSeq information to mapKernel value operations

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -257,7 +257,7 @@ export interface ISharedString extends SharedSegmentSequence<SharedStringSegment
 // @public
 export interface IValueOpEmitter {
     // @alpha
-    emit(opName: string, previousValue: any, params: any): void;
+    emit(opName: string, previousValue: any, params: any, localOpMetadata: unknown): void;
 }
 
 // @public @deprecated (undocumented)

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -923,7 +923,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
                 start,
             };
             // Local ops get submitted to the server. Remote ops have the deserializer run.
-            this.emitter.emit("add", undefined, serializedInterval, this.getNextLocalSeq());
+            this.emitter.emit("add", undefined, serializedInterval, { localSeq: this.getNextLocalSeq() });
         }
 
         this.emit("addInterval", interval, true, undefined);
@@ -937,7 +937,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
         if (interval) {
             // Local ops get submitted to the server. Remote ops have the deserializer run.
             if (local) {
-                this.emitter.emit("delete", undefined, interval.serialize(this.client), this.getNextLocalSeq());
+                this.emitter.emit("delete", undefined, interval.serialize(this.client), { localSeq: this.getNextLocalSeq() });
             } else {
                 if (this.onDeserialize) {
                     this.onDeserialize(interval);
@@ -977,7 +977,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
             serializedInterval.end = undefined;
             serializedInterval.properties = props;
             serializedInterval.properties[reservedIntervalIdKey] = interval.getIntervalId();
-            this.emitter.emit("change", undefined, serializedInterval, this.getNextLocalSeq());
+            this.emitter.emit("change", undefined, serializedInterval, { localSeq: this.getNextLocalSeq() });
             this.emit("propertyChanged", interval, deltaProps);
         }
         this.emit("changeInterval", interval, true, undefined);
@@ -1003,7 +1003,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
                 {
                     [reservedIntervalIdKey]: interval.getIntervalId(),
                 };
-            this.emitter.emit("change", undefined, serializedInterval, this.getNextLocalSeq());
+            this.emitter.emit("change", undefined, serializedInterval, { localSeq: this.getNextLocalSeq() });
             this.addPendingChange(id, serializedInterval);
         }
         this.emit("changeInterval", interval, true, undefined);
@@ -1176,7 +1176,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
             // Local ops get submitted to the server. Remote ops have the deserializer run.
             if (local) {
                 // Review: Is this case possible?
-                this.emitter.emit("add", undefined, serializedInterval, this.getNextLocalSeq());
+                this.emitter.emit("add", undefined, serializedInterval, { localSeq: this.getNextLocalSeq() });
             } else {
                 if (this.onDeserialize) {
                     this.onDeserialize(interval);

--- a/packages/dds/sequence/src/mapKernelInterfaces.ts
+++ b/packages/dds/sequence/src/mapKernelInterfaces.ts
@@ -31,9 +31,10 @@ export interface IValueOpEmitter {
      * @param opName - Name of the emitted operation
      * @param previousValue - JSONable previous value as defined by the value type
      * @param params - JSONable params for the operation as defined by the value type
+     * @param localOpMetadata - JSONable local metadata which should be submitted with the op
      * @alpha
      */
-    emit(opName: string, previousValue: any, params: any): void;
+    emit(opName: string, previousValue: any, params: any, localOpMetadata: unknown): void;
 }
 
 /**
@@ -72,9 +73,16 @@ export interface IValueOperation<T> {
      * @param params - The params on the incoming operation
      * @param local - Whether the operation originated from this client
      * @param message - The operation itself
+     * @param localOpMetadata - any local metadata submitted by `IValueOpEmitter.emit`.
      * @alpha
      */
-    process(value: T, params: any, local: boolean, message: ISequencedDocumentMessage | undefined);
+    process(
+        value: T,
+        params: any,
+        local: boolean,
+        message: ISequencedDocumentMessage | undefined,
+        localOpMetadata: unknown
+    );
 }
 
 /**


### PR DESCRIPTION
This information is needed to implement rebasing of interval ops on reconnection; without it it's impossible to know which local segments should be included.