### PR TITLE
Add mocha configuration for SharedTree workspace

### DIFF
--- a/experimental/dds/tree/.vscode/SharedTree.code-workspace
+++ b/experimental/dds/tree/.vscode/SharedTree.code-workspace
@@ -1,0 +1,12 @@
+{
+    "folders": [
+      {
+        "name": "FluidFramework",
+        "path": "../../../../"
+      },
+      {
+        "name": "@fluid-experimental/tree",
+        "path": ".."
+      }
+    ],
+  }

--- a/experimental/dds/tree/.vscode/settings.json
+++ b/experimental/dds/tree/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"mochaExplorer.files": ["dist/**/*.tests.js"],
+	"mochaExplorer.pruneFiles": true,
+	"mochaExplorer.require": "node_modules/@fluidframework/mocha-test-setup",
+	"mochaExplorer.timeout": 999999
+}

--- a/experimental/dds/tree/src/test/.mocharc.js
+++ b/experimental/dds/tree/src/test/.mocharc.js
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+'use strict';
+
+const config = {
+	require: ['@fluidframework/mocha-test-setup'],
+};
+
+module.exports = config;

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -300,7 +300,10 @@ export async function setUpLocalServerTestSharedTree(
 	};
 
 	function makeTestLoader(provider: TestObjectProvider): IHostLoader {
-		return provider.makeTestLoader({ loaderProps: { options: { maxClientLeaveWaitTime: 1000 } } });
+		const fluidEntryPoint = runtimeFactory();
+		return provider.createLoader([[defaultCodeDetails, fluidEntryPoint]], {
+			options: { maxClientLeaveWaitTime: 1000 },
+		});
 	}
 
 	let provider: TestObjectProvider;

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -300,10 +300,7 @@ export async function setUpLocalServerTestSharedTree(
 	};
 
 	function makeTestLoader(provider: TestObjectProvider): IHostLoader {
-		const fluidEntryPoint = runtimeFactory();
-		return provider.createLoader([[defaultCodeDetails, fluidEntryPoint]], {
-			options: { maxClientLeaveWaitTime: 1000 },
-		});
+		return provider.makeTestLoader({ loaderProps: { options: { maxClientLeaveWaitTime: 1000 } } });
 	}
 
 	let provider: TestObjectProvider;


### PR DESCRIPTION
In addition to fixing some mocha configurations which were causing test failures, this provides a VS Code workspace file for the experimental tree package. Using this workspace directs vs code to use a settings file local to the tree package, which now sets up the Mocha Test Explorer extension properly.