### PR TITLE
Don't process messages in MockContainerRuntimeForReconnection while disconnected

### DIFF
--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -142,6 +142,8 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
     get connected(): boolean;
     set connected(connected: boolean);
     // (undocumented)
+    process(message: ISequencedDocumentMessage): void;
+    // (undocumented)
     submit(messageContent: any, localOpMetadata: unknown): number;
 }
 

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -33,11 +33,11 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
         this._connected = connected;
 
         if (connected) {
-            this.clientSequenceNumber = 0;
             for (const remoteMessage of this.pendingRemoteMessages) {
                 this.process(remoteMessage);
             }
             this.pendingRemoteMessages.length = 0;
+            this.clientSequenceNumber = 0;
             // We should get a new clientId on reconnection.
             this.clientId = uuid();
             // Update the clientId in FluidDataStoreRuntime.

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -34,14 +34,14 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 
         if (connected) {
             this.clientSequenceNumber = 0;
-            // We should get a new clientId on reconnection.
-            this.clientId = uuid();
-            // Update the clientId in FluidDataStoreRuntime.
-            this.dataStoreRuntime.clientId = this.clientId;
             for (const remoteMessage of this.pendingRemoteMessages) {
                 this.process(remoteMessage);
             }
             this.pendingRemoteMessages.length = 0;
+            // We should get a new clientId on reconnection.
+            this.clientId = uuid();
+            // Update the clientId in FluidDataStoreRuntime.
+            this.dataStoreRuntime.clientId = this.clientId;
             // On reconnection, ask the DDSes to resubmit pending messages.
             this.reSubmitMessages();
         } else {


### PR DESCRIPTION
This behavior was a bit confusing for me while writing some reconnect tests. In theory it doesn't prevent one from writing the tests they want for 2-client tests, but it makes things slightly more subtle. Consider:

```typescript
runtime1.connected = false;
client1.submitOp(op1);
client2.submitOp(op2);
containerRuntimeFactory.processAllMessages();
client1.submitOp(op3);
runtime1.connected = true;
```

These ops will be sequenced in order: `[op2, op1, op3]` with and without this change. But without this change, `op3`'s reference sequence number would be 1 whereas with it it will be 0. This has some implications for reconnections, which may involve rebasing ops.

If this is a 2-client test and the desired behavior was for both op1 and op3 to have refSeq 0, the test writer could just omit the call to `containerRuntimeFactory.processAllMessages()`. But it is unintuitive that `runtime1` would receive messages in the first place while "disconnected."