### PR TITLE
Throw a consistent error from waitContainerToCatchUp on container close

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -178,7 +178,7 @@ export async function waitContainerToCatchUp(container: IContainer) {
     return new Promise<boolean>((resolve, reject) => {
         const deltaManager = container.deltaManager;
 
-        container.on("closed", (err?: IErrorBase | undefined) => reject(err ?? containerClosedMessage));
+        container.on("closed", (err?: IErrorBase | undefined) => reject(err ?? new Error(containerClosedMessage)));
 
         const waitForOps = () => {
             assert(container.connectionState !== ConnectionState.Disconnected,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -30,6 +30,7 @@ import {
     IContainerLoadMode,
     IFluidCodeDetails,
     isFluidCodeDetails,
+    IErrorBase,
 } from "@fluidframework/container-definitions";
 import {
     DataCorruptionError,
@@ -169,14 +170,15 @@ export enum ConnectionState {
  */
 export async function waitContainerToCatchUp(container: IContainer) {
     // Make sure we stop waiting if container is closed.
+    const containerClosedMessage = "Container is closed";
     if (container.closed) {
-        throw new Error("Container is closed");
+        throw new Error(containerClosedMessage);
     }
 
     return new Promise<boolean>((resolve, reject) => {
         const deltaManager = container.deltaManager;
 
-        container.on("closed", reject);
+        container.on("closed", (err?: IErrorBase | undefined) => reject(err ?? containerClosedMessage));
 
         const waitForOps = () => {
             assert(container.connectionState !== ConnectionState.Disconnected,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -30,7 +30,6 @@ import {
     IContainerLoadMode,
     IFluidCodeDetails,
     isFluidCodeDetails,
-    IErrorBase,
 } from "@fluidframework/container-definitions";
 import {
     DataCorruptionError,
@@ -179,7 +178,7 @@ export async function waitContainerToCatchUp(container: IContainer) {
     return new Promise<boolean>((resolve, reject) => {
         const deltaManager = container.deltaManager;
 
-        const closedCallback = (err?: IErrorBase | undefined) => {
+        const closedCallback = (err?: ICriticalContainerError | undefined) => {
             const baseMessage = "Container closed while waiting to catch up";
             reject(
                 err !== undefined

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -168,6 +168,7 @@ export enum ConnectionState {
  * @returns true: container is up to date, it processed all the ops that were know at the time of first connection
  *          false: storage does not provide indication of how far the client is. Container processed
  *          all the ops known to it, but it maybe still behind.
+ * @throws an error beginning with `"Container closed"` if the container is closed before it catches up.
  */
 export async function waitContainerToCatchUp(container: IContainer) {
     // Make sure we stop waiting if container is closed.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -179,6 +179,7 @@ export async function waitContainerToCatchUp(container: IContainer) {
         const deltaManager = container.deltaManager;
 
         const closedCallback = (err?: ICriticalContainerError | undefined) => {
+            container.off("closed", closedCallback);
             const baseMessage = "Container closed while waiting to catch up";
             reject(
                 err !== undefined


### PR DESCRIPTION
Whiteboard rollout is currently delayed due to confusion due to undefined errors being thrown from `waitContainerToCatchUp`. These errors are probably not legitimate (e.g. user closed meeting window while whiteboard was loading, which closes container mid-catchup), but it was somewhat difficult for Whiteboard to track down the source of them. This change adjusts the container close rejection logic in `waitContainerToCatchUp` to explicitly throw either the error that closed the container, or an identical message to the synchronous case.