### PR TITLE
Enable formatting rules in minimal lint config

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -128,6 +128,36 @@ module.exports = {
         "require-atomic-updates": "off",
         "dot-notation": "off", // Superseded by @typescript-eslint/dot-notation
         "no-unused-expressions": "off", // Superseded by @typescript-eslint/no-unused-expressions
+
+        // FORMATTING RULES
+        "@typescript-eslint/brace-style": [
+            "warn",
+            "1tbs",
+            {
+                "allowSingleLine": true,
+            },
+        ],
+        "@typescript-eslint/comma-spacing": "error",
+        "@typescript-eslint/func-call-spacing": "error",
+        "@typescript-eslint/keyword-spacing": "error",
+        "@typescript-eslint/object-curly-spacing": [
+            "error",
+            "always",
+        ],
+        "@typescript-eslint/space-before-function-paren": [
+            "error",
+            {
+                "anonymous": "never",
+                "asyncArrow": "always",
+                "named": "never"
+            }
+        ],
+        "@typescript-eslint/space-infix-ops": "error",
+        "@typescript-eslint/type-annotation-spacing": "error",
+        "array-bracket-spacing": "error",
+        "arrow-spacing": "error",
+        "block-spacing": "error",
+        "key-spacing": "error",
     },
     "overrides": [
         {
@@ -143,6 +173,17 @@ module.exports = {
             "files": ["*.spec.ts", "src/test/**"],
             "rules": {
                 "@typescript-eslint/unbound-method": "off", // This rule has false positives in many of our test projects.
+            }
+        },
+        {
+            // Rules only for type validation files
+            "files": ["**/types/*validate*Previous.ts"],
+            "rules": {
+                "@typescript-eslint/comma-spacing": "off",
+                "@typescript-eslint/consistent-type-imports": "off",
+                "@typescript-eslint/no-explicit-any": "off",
+                "@typescript-eslint/no-unsafe-argument": "off",
+                "max-lines": "off",
             }
         },
     ],

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -131,7 +131,7 @@ module.exports = {
 
         // FORMATTING RULES
         "@typescript-eslint/brace-style": [
-            "warn",
+            "error",
             "1tbs",
             {
                 "allowSingleLine": true,

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -51,7 +51,11 @@
             "error"
         ],
         "@typescript-eslint/brace-style": [
-            "off"
+            "warn",
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
         ],
         "@typescript-eslint/comma-dangle": [
             "error",
@@ -67,7 +71,7 @@
             }
         ],
         "@typescript-eslint/comma-spacing": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/consistent-type-assertions": [
             "error",
@@ -92,7 +96,7 @@
             "off"
         ],
         "@typescript-eslint/func-call-spacing": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/indent": [
             "off"
@@ -101,7 +105,7 @@
             "off"
         ],
         "@typescript-eslint/keyword-spacing": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/member-delimiter-style": [
             "off"
@@ -247,7 +251,8 @@
             "error"
         ],
         "@typescript-eslint/object-curly-spacing": [
-            "off"
+            "error",
+            "always"
         ],
         "@typescript-eslint/prefer-as-const": [
             "error"
@@ -320,12 +325,21 @@
         "@typescript-eslint/unified-signatures": [
             "error"
         ],
+        "array-bracket-spacing": [
+            "error"
+        ],
         "arrow-body-style": [
             "off"
         ],
         "arrow-parens": [
             "error",
             "always"
+        ],
+        "arrow-spacing": [
+            "error"
+        ],
+        "block-spacing": [
+            "error"
         ],
         "brace-style": [
             "off"
@@ -450,6 +464,9 @@
             "error"
         ],
         "import/order": [
+            "error"
+        ],
+        "key-spacing": [
             "error"
         ],
         "keyword-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -51,7 +51,7 @@
             "error"
         ],
         "@typescript-eslint/brace-style": [
-            "warn",
+            "error",
             "1tbs",
             {
                 "allowSingleLine": true

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -51,7 +51,11 @@
             "error"
         ],
         "@typescript-eslint/brace-style": [
-            "off"
+            "warn",
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
         ],
         "@typescript-eslint/comma-dangle": [
             "error",
@@ -67,7 +71,7 @@
             }
         ],
         "@typescript-eslint/comma-spacing": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/consistent-type-assertions": [
             "error",
@@ -92,7 +96,7 @@
             "off"
         ],
         "@typescript-eslint/func-call-spacing": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/indent": [
             "off"
@@ -101,7 +105,7 @@
             "off"
         ],
         "@typescript-eslint/keyword-spacing": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/member-delimiter-style": [
             "off"
@@ -247,7 +251,8 @@
             "error"
         ],
         "@typescript-eslint/object-curly-spacing": [
-            "off"
+            "error",
+            "always"
         ],
         "@typescript-eslint/prefer-as-const": [
             "error"
@@ -320,12 +325,21 @@
         "@typescript-eslint/unified-signatures": [
             "error"
         ],
+        "array-bracket-spacing": [
+            "error"
+        ],
         "arrow-body-style": [
             "off"
         ],
         "arrow-parens": [
             "error",
             "always"
+        ],
+        "arrow-spacing": [
+            "error"
+        ],
+        "block-spacing": [
+            "error"
         ],
         "brace-style": [
             "off"
@@ -450,6 +464,9 @@
             "error"
         ],
         "import/order": [
+            "error"
+        ],
+        "key-spacing": [
             "error"
         ],
         "keyword-spacing": [

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -51,7 +51,7 @@
             "error"
         ],
         "@typescript-eslint/brace-style": [
-            "warn",
+            "error",
             "1tbs",
             {
                 "allowSingleLine": true


### PR DESCRIPTION
This is a follow-up to #10056, which pre-emptively applied the rules in this PR to the repo.