### PR TITLE
Change comma-dangle lint rule to always-multiline

### DIFF
--- a/common/build/eslint-config-fluid/eslint7.js
+++ b/common/build/eslint-config-fluid/eslint7.js
@@ -47,16 +47,7 @@ module.exports = {
         "@typescript-eslint/brace-style": "off",
         "@typescript-eslint/comma-dangle": [
             "error",
-            {
-                "arrays": "always-multiline",
-                "enums": "always-multiline",
-                "exports": "always-multiline",
-                "functions": "always-multiline",
-                "generics": "never",
-                "imports": "always-multiline",
-                "objects": "always-multiline",
-                "tuples": "always-multiline",
-            }
+            "always-multiline",
         ],
         "@typescript-eslint/comma-spacing": "off",
         "@typescript-eslint/consistent-type-assertions": [

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -55,16 +55,7 @@
         ],
         "@typescript-eslint/comma-dangle": [
             "error",
-            {
-                "arrays": "always-multiline",
-                "enums": "always-multiline",
-                "exports": "always-multiline",
-                "functions": "always-multiline",
-                "generics": "never",
-                "imports": "always-multiline",
-                "objects": "always-multiline",
-                "tuples": "always-multiline"
-            }
+            "always-multiline"
         ],
         "@typescript-eslint/comma-spacing": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -55,16 +55,7 @@
         ],
         "@typescript-eslint/comma-dangle": [
             "error",
-            {
-                "arrays": "always-multiline",
-                "enums": "always-multiline",
-                "exports": "always-multiline",
-                "functions": "always-multiline",
-                "generics": "never",
-                "imports": "always-multiline",
-                "objects": "always-multiline",
-                "tuples": "always-multiline"
-            }
+            "always-multiline"
         ],
         "@typescript-eslint/comma-spacing": [
             "off"


### PR DESCRIPTION
I can't apply these changes to the repo pre-emptively because the rule is already enabled, but with different settings.

Related to #6070.