### PR TITLE
'getkeys' must escape quotes when exporting env vars

### DIFF
--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -49,7 +49,8 @@ async function execAsync(command) {
 async function setEnv(name, value) {
     const shell = process.env.SHELL ? process.env.SHELL.split('/').pop() : null;
     const termProgram = process.env.TERM_PROGRAM;
-    const setString = `export ${name}="${value}"`;
+    const escapedValue = value.split('"').join('\\"');
+    const setString = `export ${name}="${escapedValue}"`;
     switch (shell) {
         case "bash":
             const destFile = termProgram === "Apple_Terminal" ? "~/.bash_profile" : "~/.bashrc";
@@ -59,7 +60,6 @@ async function setEnv(name, value) {
         case "fish":
             return execAsync(`set -xU '${name}' '${value}'`, { "shell": process.env.SHELL });
         default: // windows
-            const escapedValue = value.split('"').join('\\"');
             return execAsync(`setx ${name} "${escapedValue}"`);
     }
 }

--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -3,13 +3,71 @@
  * Licensed under the MIT License.
  */
 
-msRestAzure = require('ms-rest-azure');
-keyVault = require('azure-keyvault');
-rcTools = require('@fluidframework/tool-utils');
+const fs =  require("fs");
+const os =  require("os");
+const path =  require("path");
+const util =  require("util");
 const { exec } = require('child_process');
+const msRestAzure = require("ms-rest-azure");
+const keyVault = require("azure-keyvault");
+const rcTools = require("@fluidframework/tool-utils");
+
+const appendFile = util.promisify(fs.appendFile);
+
+// Wraps the given string in quotes, escaping any quotes already present in the string
+// with '\"', which is compatible with cmd, bash, and zsh.
+function quote(str) {
+    return `"${str.split('"').join('\\"')}"`;
+}
+
+// Converts the given 'entries' [key, value][] array into export statements for bash
+// and zsh, appending the result to the given 'shellRc' file.
+async function exportToShellRc(shellRc, entries) {
+    const rcPath = path.join(os.homedir(), shellRc);
+    console.log(`Writing '${rcPath}'.`);
+
+    const stmts = `\n# Fluid dev/test secrets\n${
+        entries.map(([key, value]) => `export ${key}=${quote(value)}`).join("\n")
+    }\n`;
+
+    return appendFile(rcPath, stmts, "utf-8");
+}
+
+// Persists the given 'env' map to the users environment.  The method used depends
+// on the user's platform and login shell.
+async function saveEnv(env) {
+    const entries = Object.entries(env);
+
+    // Note that 'SHELL' return's the user's login shell, which isn't necessarily
+    // the shell used to launch node (e.g., if the user is running a nested shell).
+    // However, the environment will be inherited when their preferred shell is
+    // launched from the login shell.
+    const shell = process.env.SHELL;
+    const shellName = path.basename(shell);
+    switch (shellName) {
+        case "bash":
+            return exportToShellRc(
+                // '.bash_profile' is used for the "login shell" ('bash -l').
+                process.env.TERM_PROGRAM === "Apple_Terminal"
+                    ? ".bash_profile"
+                    : ".bashrc",
+                entries);
+        case "zsh":
+            return exportToShellRc(".zshrc", entries);
+        default:
+            if (!process.platform === "win32") {
+                console.error(`Unsupported shell: '${shellName}'.`);
+            } else {
+                // On Windows, invoke 'setx' to update the user's persistent environment variables.
+                return Promise.all(
+                    entries.map(([key, value]) => execAsync(`setx ${key} ${quote(value)}`))
+                );
+            }
+    }
+}
 
 async function getKeys(keyVaultClient, rc, vaultName) {
-    console.log(`Getting secrets from ${vaultName}...`);
+    console.log(`\nGetting secrets from ${vaultName}:`);
     const secretList = await keyVaultClient.getSecrets(vaultName);
     const p = [];
     for (const secret of secretList) {
@@ -20,8 +78,7 @@ async function getKeys(keyVaultClient, rc, vaultName) {
                 p.push((async () => {
                     const response = await keyVaultClient.getSecret(vaultName, secretName);
                     const envName = secretName.split('-').join('__'); // secret name can't contain underscores
-                    console.log(`Setting environment variable ${envName}...`);
-                    await setEnv(envName, response.value);
+                    console.log(`  ${envName}`);
                     rc.secrets[envName] = response.value;
                 })());;
             }
@@ -44,24 +101,6 @@ async function execAsync(command) {
             res(stdout);
         });
     });
-}
-
-async function setEnv(name, value) {
-    const shell = process.env.SHELL ? process.env.SHELL.split('/').pop() : null;
-    const termProgram = process.env.TERM_PROGRAM;
-    const escapedValue = value.split('"').join('\\"');
-    const setString = `export ${name}="${escapedValue}"`;
-    switch (shell) {
-        case "bash":
-            const destFile = termProgram === "Apple_Terminal" ? "~/.bash_profile" : "~/.bashrc";
-            return execAsync(`${setString} && echo '${setString}' >> ${destFile}`);
-        case "zsh":
-            return execAsync(`${setString} && echo '${setString}' >> ~/.zshrc`);
-        case "fish":
-            return execAsync(`set -xU '${name}' '${value}'`, { "shell": process.env.SHELL });
-        default: // windows
-            return execAsync(`setx ${name} "${escapedValue}"`);
-    }
 }
 
 class AzCliKeyVaultClient {
@@ -112,24 +151,33 @@ async function getClient() {
 }
 
 (async () => {
-    const rcP = rcTools.loadRC();
-    const clientP = getClient();
-    const [client, rc] = await Promise.all([clientP, rcP]);
+    const rc = await rcTools.loadRC();
 
     if (rc.secrets === undefined) {
         rc.secrets = {};
     }
 
-    // Primary key vault for test/dev secrets shared by Microsoft-internal teams working on FF
-    await getKeys(client, rc, "prague-key-vault");
+    // For debugging, change the following to 'false' to skip connecting to
+    // Azure Key Vault and instead use the secrets cached in '~/.fluidtoolrc'.
+    if (true) {
+        const client = await getClient();
 
-    try {
-        // Key Vault with restricted access for the FF dev team only
-        await getKeys(client, rc, "ff-internal-dev-secrets");
-        console.log("Overrode defaults with values from the FF internal keyvault.");
-    } catch (e) { }
+        // Primary key vault for test/dev secrets shared by Microsoft-internal teams working on FF
+        await getKeys(client, rc, "prague-key-vault");
+
+        try {
+            // Key Vault with restricted access for the FF dev team only
+            await getKeys(client, rc, "ff-internal-dev-secrets");
+            console.log("\nNote: Default dev/test secrets overwritten with values from internal key vault.");
+        } catch (e) { }
+    }
+    
+    console.log(`\nWriting '${path.join(os.homedir(), ".fluidtoolrc")}'.`);
     await rcTools.saveRC(rc);
+    await saveEnv(rc.secrets);
+
+    console.warn(`\nFor the new environment to take effect, please restart your terminal or dev container.\n`)
 })().catch(e => {
-    console.error(`FATAL ERROR: ${e.stack}`);
+    console.error(`FATAL ERROR: ${e}`);
     process.exit(-1);
 });

--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -176,7 +176,7 @@ async function getClient() {
     await rcTools.saveRC(rc);
     await saveEnv(rc.secrets);
 
-    console.warn(`\nFor the new environment to take effect, please restart your terminal or dev container.\n`)
+    console.warn(`\nFor the new environment to take effect, please restart your terminal.\n`)
 })().catch(e => {
     console.error(`FATAL ERROR: ${e}`);
     process.exit(-1);


### PR DESCRIPTION
Before this change, running 'getkeys' would result in an unparsable '.bashrc' due to quotes not being escaped.

Includes some additional minor improvements.