### PR TITLE
Main: Bump back compat version after release

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1966,20 +1966,20 @@
 			}
 		},
 		"@fluid-experimental/task-manager-previous": {
-			"version": "npm:@fluid-experimental/task-manager@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-0.59.1000.tgz",
-			"integrity": "sha512-14U5Fumd4UjBHBXsgclXzRo6+GLUGzp2l1CXN6olKufCuKCRpgLwFMpYUk0FcJmabwxkRg2c8+rg5MBw3TdpXg==",
+			"version": "npm:@fluid-experimental/task-manager@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-0.59.2000.tgz",
+			"integrity": "sha512-N98R0S67rG7bFYKiv/zPIjXh0FM9IriAWPyQags2M6uKVuuzhzZO0oZRQxNbCFHjyMJGZGtxFxcY1K/FtGRy2A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			}
 		},
 		"@fluid-tools/benchmark": {
@@ -1994,50 +1994,50 @@
 			}
 		},
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-g+T8MGBeIl92LMKddok6tev9rKWZ528sYVLhGUnp102nYWztbCmOEAslAXjO0oSzJXjIfowwI4+IJo+j2yx3jQ==",
+			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-0.59.2000.tgz",
+			"integrity": "sha512-8o2whTlVg1M7OuTCswLhWJJMoUAlkeXkVLjGKsi7cKP1cIlkt5a0sLUrEY2yvnJLuN8ZdRg4/pPXuZBxCaDslg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000"
+				"@fluidframework/odsp-driver": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000"
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-0.59.1000.tgz",
-			"integrity": "sha512-sihDV79PZ9nivswV9UfPb0aLq9e+Q16ieGRKtzQUkKRvNmDAt2Ru8lm7xeoJpLgVlOYwUiL0CW244WVCyx4pBg==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-0.59.2000.tgz",
+			"integrity": "sha512-W/RbrZz9hWYpOrIpTX4nKITCnV5+fAph3xbIW7+93i/yB6EEFRTASpcFgwwsLGTwQL/k1a3d/6cMJIn8a7dyvg==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2000",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/local-driver": "^0.59.2000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2000",
+				"@fluidframework/odsp-driver": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
 				"@fluidframework/server-local-server": "^0.1036.1000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
-				"@fluidframework/tool-utils": "^0.59.1000",
-				"@fluidframework/view-adapters": "^0.59.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
-				"@fluidframework/web-code-loader": "^0.59.1000",
+				"@fluidframework/test-runtime-utils": "^0.59.2000",
+				"@fluidframework/tool-utils": "^0.59.2000",
+				"@fluidframework/view-adapters": "^0.59.2000",
+				"@fluidframework/view-interfaces": "^0.59.2000",
+				"@fluidframework/web-code-loader": "^0.59.2000",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
-				"nconf": "^0.11.0",
+				"nconf": "^0.11.4",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1",
-				"webpack-dev-server": "^3.8.0"
+				"webpack-dev-server": "4.0.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -2208,479 +2208,98 @@
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
 				},
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						}
-					}
-				},
-				"binary-extensions": {
-					"version": "1.13.1",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-				},
-				"chokidar": {
-					"version": "2.1.8",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-					"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"default-gateway": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
-					"integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
-					"requires": {
-						"execa": "^1.0.0",
-						"ip-regex": "^2.1.0"
-					}
-				},
-				"fsevents": {
-					"version": "1.2.13",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-					"optional": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"nan": "^2.12.1"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"html-entities": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-					"integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA=="
-				},
-				"http-proxy-middleware": {
-					"version": "0.19.1",
-					"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-					"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
-					"requires": {
-						"http-proxy": "^1.17.0",
-						"is-glob": "^4.0.0",
-						"lodash": "^4.17.11",
-						"micromatch": "^3.1.10"
-					}
-				},
-				"import-local": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
-					}
-				},
-				"internal-ip": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
-					"integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
-					"requires": {
-						"default-gateway": "^4.2.0",
-						"ipaddr.js": "^1.9.0"
-					}
-				},
-				"ip-regex": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-				},
-				"is-binary-path": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-					"requires": {
-						"binary-extensions": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
 				"jwt-decode": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
 					"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
 				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-				},
-				"p-retry": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-					"integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
-					"requires": {
-						"retry": "^0.12.0"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"resolve-cwd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-					"requires": {
-						"resolve-from": "^3.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"webpack-dev-server": {
-					"version": "3.11.3",
-					"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
-					"integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
-					"requires": {
-						"ansi-html-community": "0.0.8",
-						"bonjour": "^3.5.0",
-						"chokidar": "^2.1.8",
-						"compression": "^1.7.4",
-						"connect-history-api-fallback": "^1.6.0",
-						"debug": "^4.1.1",
-						"del": "^4.1.1",
-						"express": "^4.17.1",
-						"html-entities": "^1.3.1",
-						"http-proxy-middleware": "0.19.1",
-						"import-local": "^2.0.0",
-						"internal-ip": "^4.3.0",
-						"ip": "^1.1.5",
-						"is-absolute-url": "^3.0.3",
-						"killable": "^1.0.1",
-						"loglevel": "^1.6.8",
-						"opn": "^5.5.0",
-						"p-retry": "^3.0.1",
-						"portfinder": "^1.0.26",
-						"schema-utils": "^1.0.0",
-						"selfsigned": "^1.10.8",
-						"semver": "^6.3.0",
-						"serve-index": "^1.9.1",
-						"sockjs": "^0.3.21",
-						"sockjs-client": "^1.5.0",
-						"spdy": "^4.0.2",
-						"strip-ansi": "^3.0.1",
-						"supports-color": "^6.1.0",
-						"url": "^0.11.0",
-						"webpack-dev-middleware": "^3.7.2",
-						"webpack-log": "^2.0.0",
-						"ws": "^6.2.1",
-						"yargs": "^13.3.2"
-					},
-					"dependencies": {
-						"ws": {
-							"version": "6.2.2",
-							"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-							"integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-							"requires": {
-								"async-limiter": "~1.0.0"
-							}
-						}
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
 				}
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.59.1000.tgz",
-			"integrity": "sha512-2Vvr2Ofl+1yfPLal/kkwQyfatx2Q7sP+VbwvUIi3sAe8M86+e6Enk+cv8hddtk3GhtmycqhKvDcOeepXc8JB3w==",
+			"version": "npm:@fluidframework/agent-scheduler@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.59.2000.tgz",
+			"integrity": "sha512-AalyBFbeZ6LFyyv4nK9F8l3WCsDPFrFksJ2J/IxbFkSiSyRlBDvWxIHfbkodyo3DqlDq26TorZsjPe+DPapi0w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/register-collection": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
+				"@fluidframework/register-collection": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.1000.tgz",
-			"integrity": "sha512-mzYuHMt2ww3ZfG0SpwFLRekqn4xYybikHxuJSTaejijSYZSZxuU8ZZO3juZRM8/p/pGdJQac9dnqHMVY38xt/Q==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.2000.tgz",
+			"integrity": "sha512-0OnZ2M9GRfQHvwagZZqaeMIZ5eAsPxk54kyeir+0O+q6L+Q0EIylw50YAY4fTK22xDyt8er8DMDUYXPlc4MXHA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
+				"@fluidframework/container-runtime": "^0.59.2000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/synthesize": "^0.59.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
+				"@fluidframework/request-handler": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/synthesize": "^0.59.2000",
+				"@fluidframework/view-interfaces": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.1000.tgz",
-			"integrity": "sha512-mzYuHMt2ww3ZfG0SpwFLRekqn4xYybikHxuJSTaejijSYZSZxuU8ZZO3juZRM8/p/pGdJQac9dnqHMVY38xt/Q==",
+			"version": "npm:@fluidframework/aqueduct@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.2000.tgz",
+			"integrity": "sha512-0OnZ2M9GRfQHvwagZZqaeMIZ5eAsPxk54kyeir+0O+q6L+Q0EIylw50YAY4fTK22xDyt8er8DMDUYXPlc4MXHA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
+				"@fluidframework/container-runtime": "^0.59.2000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/synthesize": "^0.59.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
+				"@fluidframework/request-handler": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/synthesize": "^0.59.2000",
+				"@fluidframework/view-interfaces": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/azure-client-previous": {
-			"version": "npm:@fluidframework/azure-client@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-0.59.1000.tgz",
-			"integrity": "sha512-AzWMorHSjvKr8rOU/8Qu/04t+PeSqMgClusNh3y2lLzmijLZvyFQ1QrMk62ki8cMPgztSZUyl49LwObEywWKYQ==",
+			"version": "npm:@fluidframework/azure-client@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-0.59.2000.tgz",
+			"integrity": "sha512-eZOoIAQ5JZcBvDJppg227r5JTJrWXQMJzKJ9EZZ2ub4pR3LTTjiZir3AiIM1JqqwvG0hRb/IUBGg2V78o7Z8Dw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/fluid-static": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/fluid-static": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
@@ -2737,9 +2356,9 @@
 			}
 		},
 		"@fluidframework/azure-service-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.1000.tgz",
-			"integrity": "sha512-GBKZ/l+nJHigo7LsSQwj3WFBm33WNd2N4ivR5jjlGSjvixz1C/Am9w517WdlV2l1T6sLFZp2prwHbWJIsngOvA==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.2000.tgz",
+			"integrity": "sha512-n6DskhMT+BsaG4zGsAIb4aSXbnUTx4pqJSNI0ra5Uik8Czy8G8fAloizK4uVGThNEaNri91snhodY34Esx5s2A==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"jsrsasign": "^10.2.0",
@@ -2747,9 +2366,9 @@
 			}
 		},
 		"@fluidframework/azure-service-utils-previous": {
-			"version": "npm:@fluidframework/azure-service-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.1000.tgz",
-			"integrity": "sha512-GBKZ/l+nJHigo7LsSQwj3WFBm33WNd2N4ivR5jjlGSjvixz1C/Am9w517WdlV2l1T6sLFZp2prwHbWJIsngOvA==",
+			"version": "npm:@fluidframework/azure-service-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.2000.tgz",
+			"integrity": "sha512-n6DskhMT+BsaG4zGsAIb4aSXbnUTx4pqJSNI0ra5Uik8Czy8G8fAloizK4uVGThNEaNri91snhodY34Esx5s2A==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"jsrsasign": "^10.2.0",
@@ -2848,31 +2467,31 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.1000.tgz",
-			"integrity": "sha512-gR/TbtAg1OLMSh1cAdpJpPtlCPlEkcROqvozmBsXVRNiZAncDvMGolmJSgjjC4E2+dVcQHtbPOZwf9ezV0m5pg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.2000.tgz",
+			"integrity": "sha512-3MAIDJ5J+ifdEp4HNUe8YHJNPqeE5OIAQrMeWlE+dFu4UZofs1fql4QsOqwWeXWTHDpYHvguRiHdAhNkR3JhxA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.1000.tgz",
-			"integrity": "sha512-gR/TbtAg1OLMSh1cAdpJpPtlCPlEkcROqvozmBsXVRNiZAncDvMGolmJSgjjC4E2+dVcQHtbPOZwf9ezV0m5pg==",
+			"version": "npm:@fluidframework/cell@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.2000.tgz",
+			"integrity": "sha512-3MAIDJ5J+ifdEp4HNUe8YHJNPqeE5OIAQrMeWlE+dFu4UZofs1fql4QsOqwWeXWTHDpYHvguRiHdAhNkR3JhxA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -2912,20 +2531,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.1000.tgz",
-			"integrity": "sha512-xK6jqL9ZBmVpJlCcCZ4MhO4GIhFgE4W07ZHZ8Dubq6Mtusi6wJ/knpiGRmHoNmPQCx2ZKi8SNy+LPTzH0HdzXg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.2000.tgz",
+			"integrity": "sha512-I1cJyGtxj3UcdmJeGIlOEjWqlo2EzHR9v5Q0lOoOfbnF6sbKcMLQWMErddvOXlr4w7HP8JyiH2TDjzdllwxslA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2951,20 +2570,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.1000.tgz",
-			"integrity": "sha512-xK6jqL9ZBmVpJlCcCZ4MhO4GIhFgE4W07ZHZ8Dubq6Mtusi6wJ/knpiGRmHoNmPQCx2ZKi8SNy+LPTzH0HdzXg==",
+			"version": "npm:@fluidframework/container-loader@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.2000.tgz",
+			"integrity": "sha512-I1cJyGtxj3UcdmJeGIlOEjWqlo2EzHR9v5Q0lOoOfbnF6sbKcMLQWMErddvOXlr4w7HP8JyiH2TDjzdllwxslA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2990,25 +2609,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.1000.tgz",
-			"integrity": "sha512-AGNUBNrrfINALPd6DcgJMZg6TGkRvjWYjpoE73GwhYfFwBOs0ClRbt2ErJtjV+fOa3+2p2iGCnKJlLwQ+zAnvA==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.2000.tgz",
+			"integrity": "sha512-mV8+KYJN1scV4lH4GsJ9UzeN07XiGhHNJkFvvCHNAMDNRFg+LnhF09xjbuREMbfuBvxaaWXSSsT98i9jIAO3eQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/garbage-collector": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -3032,53 +2651,53 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-OUACev+V9UWQfO7oQ8GLN8vPwCKoMp9FrTKvzHXxBLVK/+RiXaKS0yOtPlskLkhdDLid1SzDslHsRoLq6VCjeA==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.2000.tgz",
+			"integrity": "sha512-CSN7aHH/h9YC2ijqSQRFM8eni+tG+QgHETH1s7wLQnaL8RZkdBc2muxafJogwBzPz3X6DPvJRPouWszMk3B24g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-OUACev+V9UWQfO7oQ8GLN8vPwCKoMp9FrTKvzHXxBLVK/+RiXaKS0yOtPlskLkhdDLid1SzDslHsRoLq6VCjeA==",
+			"version": "npm:@fluidframework/container-runtime-definitions@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.2000.tgz",
+			"integrity": "sha512-CSN7aHH/h9YC2ijqSQRFM8eni+tG+QgHETH1s7wLQnaL8RZkdBc2muxafJogwBzPz3X6DPvJRPouWszMk3B24g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.1000.tgz",
-			"integrity": "sha512-AGNUBNrrfINALPd6DcgJMZg6TGkRvjWYjpoE73GwhYfFwBOs0ClRbt2ErJtjV+fOa3+2p2iGCnKJlLwQ+zAnvA==",
+			"version": "npm:@fluidframework/container-runtime@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.2000.tgz",
+			"integrity": "sha512-mV8+KYJN1scV4lH4GsJ9UzeN07XiGhHNJkFvvCHNAMDNRFg+LnhF09xjbuREMbfuBvxaaWXSSsT98i9jIAO3eQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/garbage-collector": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -3102,27 +2721,27 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.1000.tgz",
-			"integrity": "sha512-ChBj7qam/xyBVvsSxjmcBi0R9XVnvOJfw4Tb991S2qJDi5XFPSVImk1PQd1f5SzmAfC2O9Vasm8uqoYeMCUKyQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.2000.tgz",
+			"integrity": "sha512-IX5s0yHcWBLlEbCTkFCWL7KwenNBlqfxhsiR8H6ObcEYa6ZdkWX4SI7poqRJbDoYNbPcR6/Lk17znnG0EsbKNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.1000.tgz",
-			"integrity": "sha512-ChBj7qam/xyBVvsSxjmcBi0R9XVnvOJfw4Tb991S2qJDi5XFPSVImk1PQd1f5SzmAfC2O9Vasm8uqoYeMCUKyQ==",
+			"version": "npm:@fluidframework/container-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.2000.tgz",
+			"integrity": "sha512-IX5s0yHcWBLlEbCTkFCWL7KwenNBlqfxhsiR8H6ObcEYa6ZdkWX4SI7poqRJbDoYNbPcR6/Lk17znnG0EsbKNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/core-interfaces": {
@@ -3131,70 +2750,70 @@
 			"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
 		},
 		"@fluidframework/counter": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.1000.tgz",
-			"integrity": "sha512-T+8rYBdXd7EQTvO4N0l+ISlY2zo0+Yf/yjDXC0pAPCtbAaMCrWPUblRUemHgKtCNlfYrO05GVflkYWq/FLi1zg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.2000.tgz",
+			"integrity": "sha512-Bzt7sxsB3cNo4RkP0c9nTFtHY2R34EKQdGjHfkSYaQZKj6QmbXI5yGvAbfWJOzgJDx1Av7DJrjt96oPjZLU4OQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.1000.tgz",
-			"integrity": "sha512-T+8rYBdXd7EQTvO4N0l+ISlY2zo0+Yf/yjDXC0pAPCtbAaMCrWPUblRUemHgKtCNlfYrO05GVflkYWq/FLi1zg==",
+			"version": "npm:@fluidframework/counter@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.2000.tgz",
+			"integrity": "sha512-Bzt7sxsB3cNo4RkP0c9nTFtHY2R34EKQdGjHfkSYaQZKj6QmbXI5yGvAbfWJOzgJDx1Av7DJrjt96oPjZLU4OQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-0.59.1000.tgz",
-			"integrity": "sha512-F7SuZHcowq5rhhS95G8gEn1GERNfrCErIfVgtFiuyCFF2uAsvaW0GHSIIi6Dv3Em0dagVZtCZOTfCtsAolTK6Q==",
+			"version": "npm:@fluidframework/data-object-base@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-0.59.2000.tgz",
+			"integrity": "sha512-kihdyyedSiye4JZjEiVh4F+ktuFEabZ85VZuHSgjtHlJRCT/wN8yYmfpu00zKLtGu00UgWKBR05lkO023foVDQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
+				"@fluidframework/container-runtime": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/request-handler": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.1000.tgz",
-			"integrity": "sha512-C/2uXuy8wHXv98fRQeAsA7Cww8n4JA0yjsjMXIesJCRsj93XMAGyqzN+PPXTsLF2gu5I06PcKF2BB19WjUQYBQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.2000.tgz",
+			"integrity": "sha512-amY/4sOXJ5yEcBE6Wkv3HI63dfCqk57E2wJVT5Kcscl3YQ/o99JQIqU0E5KRFJzhS6zc0P8Lt9ncyt22WbY5/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/garbage-collector": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3218,52 +2837,52 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.1000.tgz",
-			"integrity": "sha512-/YMoDxDp1CX8YtvnCiu3ndbPgpOg5MrKAANF/0vSAbPTODM1PGxnOTsXW8zKbjY9CstM4jbIGpx0oq6JKJIJKQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.2000.tgz",
+			"integrity": "sha512-GeIOEvIf0GBtr9cRLnY9KWVbQe2sIuhl6EcYqux+jIdaUP6wK7qYQ/NVteXMIVyMhNBy5mwJjhnByOY3QJe6Bw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.1000.tgz",
-			"integrity": "sha512-/YMoDxDp1CX8YtvnCiu3ndbPgpOg5MrKAANF/0vSAbPTODM1PGxnOTsXW8zKbjY9CstM4jbIGpx0oq6JKJIJKQ==",
+			"version": "npm:@fluidframework/datastore-definitions@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.2000.tgz",
+			"integrity": "sha512-GeIOEvIf0GBtr9cRLnY9KWVbQe2sIuhl6EcYqux+jIdaUP6wK7qYQ/NVteXMIVyMhNBy5mwJjhnByOY3QJe6Bw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.1000.tgz",
-			"integrity": "sha512-C/2uXuy8wHXv98fRQeAsA7Cww8n4JA0yjsjMXIesJCRsj93XMAGyqzN+PPXTsLF2gu5I06PcKF2BB19WjUQYBQ==",
+			"version": "npm:@fluidframework/datastore@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.2000.tgz",
+			"integrity": "sha512-amY/4sOXJ5yEcBE6Wkv3HI63dfCqk57E2wJVT5Kcscl3YQ/o99JQIqU0E5KRFJzhS6zc0P8Lt9ncyt22WbY5/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/garbage-collector": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3287,54 +2906,54 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-0.59.1000.tgz",
-			"integrity": "sha512-IqMJjbrgS8bGXq1v1wXJ5O/W+lufn8e9NGcNxTjYpg1IA5rHDT01FaaDhEylR/7Jx5LGFPhryBw/W0kh5XRSzw==",
+			"version": "npm:@fluidframework/dds-interceptions@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-0.59.2000.tgz",
+			"integrity": "sha512-c0j/FyU1J6SX9IQf5ieusl+vLFC0vBqpHC2Aw6Mn6p6hMhZMz5ynJTvgAeFsx89gYIz5fDsmstgKK2grd+oq4A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/sequence": "^0.59.1000"
+				"@fluidframework/map": "^0.59.2000",
+				"@fluidframework/merge-tree": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/sequence": "^0.59.2000"
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-0.59.1000.tgz",
-			"integrity": "sha512-cukrgsdo0wJBiNyDXY1ghE/5oNoF6prZO4Vj0x8lfAKGU3fCnsH1rcBKrLj1abSlEMC+DNNSbrtkJK2szXsn1g==",
+			"version": "npm:@fluidframework/debugger@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-0.59.2000.tgz",
+			"integrity": "sha512-fzEGGdb3KjFfOr7Yto3eSsRGkqPUDkTJls19/QzjqYm3mdl8KQN9Wzllj91HgzAPIvaLK+FZyb6UrfEYaDGreg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/replay-driver": "^0.59.1000",
+				"@fluidframework/replay-driver": "^0.59.2000",
 				"jsonschema": "^1.2.6"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.1000.tgz",
-			"integrity": "sha512-C3J7L1vZfw1/nqV8erGIxHJ0sA2j2uIvIV/bEePW5fyP55GBSJKXOkuNFVbgYKjFJiykpLHIjMMfZCrLnY/VwA==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.2000.tgz",
+			"integrity": "sha512-tDOp2fpXDiOuJp+tbTrfRYi19GOZ9n6QLIkwyviMa4w2zoAvhRbRB94i8gTI2LYDgfJsXLW8Za/d2K76i07hog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.1000.tgz",
-			"integrity": "sha512-C3J7L1vZfw1/nqV8erGIxHJ0sA2j2uIvIV/bEePW5fyP55GBSJKXOkuNFVbgYKjFJiykpLHIjMMfZCrLnY/VwA==",
+			"version": "npm:@fluidframework/driver-base@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.2000.tgz",
+			"integrity": "sha512-tDOp2fpXDiOuJp+tbTrfRYi19GOZ9n6QLIkwyviMa4w2zoAvhRbRB94i8gTI2LYDgfJsXLW8Za/d2K76i07hog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/driver-definitions": {
@@ -3348,9 +2967,9 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.1000.tgz",
-			"integrity": "sha512-VZtoV+8sEzBtyRbXU6fbaZOxNKUBjzdL+Fp2Xp53mr5HRwu0IT0EMC1xMXExr46l7loyAuXyvso++naupyNODg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.2000.tgz",
+			"integrity": "sha512-vTY096vLDdZMNIguQGMA1AV2XJye9qCS3x92KGqmFj0788rfeW+8qWDjRYcGALHT4wsunvFxvhy+fqiwgmW84w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -3359,7 +2978,7 @@
 				"@fluidframework/gitresources": "^0.1036.1000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3383,9 +3002,9 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.1000.tgz",
-			"integrity": "sha512-VZtoV+8sEzBtyRbXU6fbaZOxNKUBjzdL+Fp2Xp53mr5HRwu0IT0EMC1xMXExr46l7loyAuXyvso++naupyNODg==",
+			"version": "npm:@fluidframework/driver-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.2000.tgz",
+			"integrity": "sha512-vTY096vLDdZMNIguQGMA1AV2XJye9qCS3x92KGqmFj0788rfeW+8qWDjRYcGALHT4wsunvFxvhy+fqiwgmW84w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -3394,7 +3013,7 @@
 				"@fluidframework/gitresources": "^0.1036.1000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3418,13 +3037,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-0.59.1000.tgz",
-			"integrity": "sha512-9EpaIv0wGt5urRYPk0pjfd0JlkiF6E7WySUe4RzbLwYmyXhX82G0VUjLdYzYhkyihEV0fhveBRlH1sdnqZVZtw==",
+			"version": "npm:@fluidframework/driver-web-cache@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-0.59.2000.tgz",
+			"integrity": "sha512-jt5ZHnf1DbdUvrgraN+X86blId9azxs7Gj+qLXucJCc/dL+OV7B9AKPNmEuuoshx8lXfLF6hiIXtkzUaVdxltA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3473,74 +3092,74 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-0.59.1000.tgz",
-			"integrity": "sha512-It22F5iqqdIJwaJXhmgkkgDyGt7mCB7oVX2AsyaQ5Gs4Z9cdZIUmZVsWOyRLts2PDis+jKx0yxV53lOfw61DPA==",
+			"version": "npm:@fluidframework/file-driver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-0.59.2000.tgz",
+			"integrity": "sha512-zFFJGuHEBj5A/BPBgD0hNcnnkDSCkEPqiDpcFr5SmMO2eVJKRw0n+i+Lar4RDHRBoPQdBzqZcLWNaxd/BK3B7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/replay-driver": "^0.59.1000"
+				"@fluidframework/replay-driver": "^0.59.2000"
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.1000.tgz",
-			"integrity": "sha512-dJbl5QwE6knlVxG5rMPWJX8omkd73y0iGcyCkRX/D6dI8t/78tEPeUckOd0qNBfpLzyGe6h+vsQKGx9C+XokQw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.2000.tgz",
+			"integrity": "sha512-p+pHpXYNvUPemwwYe2B6zgENoCFuq89L4L7nm7KJ9WozBG+nJZ6lltRRCmkUl5tuYB8jiJF1Ar9nAfp+lM3B3A==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/request-handler": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.1000.tgz",
-			"integrity": "sha512-dJbl5QwE6knlVxG5rMPWJX8omkd73y0iGcyCkRX/D6dI8t/78tEPeUckOd0qNBfpLzyGe6h+vsQKGx9C+XokQw==",
+			"version": "npm:@fluidframework/fluid-static@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.2000.tgz",
+			"integrity": "sha512-p+pHpXYNvUPemwwYe2B6zgENoCFuq89L4L7nm7KJ9WozBG+nJZ6lltRRCmkUl5tuYB8jiJF1Ar9nAfp+lM3B3A==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/request-handler": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.1000.tgz",
-			"integrity": "sha512-2F4EIR604W8iZzFyPqDwA19SVqmEyD+3w6TYaLQO9dC9s3Pk00EIGTbc3asIA1x76SEgHC6nFwgVvQ2LuVTwLQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.2000.tgz",
+			"integrity": "sha512-4OSLgAGpU3M7Hzcz8TnxItk6lTibTEmyRLU2l3Zud0qYKJpjZAzd4zAkX619OIpB5sxseNqx7tZ4osekZ9zxPg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.1000.tgz",
-			"integrity": "sha512-2F4EIR604W8iZzFyPqDwA19SVqmEyD+3w6TYaLQO9dC9s3Pk00EIGTbc3asIA1x76SEgHC6nFwgVvQ2LuVTwLQ==",
+			"version": "npm:@fluidframework/garbage-collector@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.2000.tgz",
+			"integrity": "sha512-4OSLgAGpU3M7Hzcz8TnxItk6lTibTEmyRLU2l3Zud0qYKJpjZAzd4zAkX619OIpB5sxseNqx7tZ4osekZ9zxPg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -3549,63 +3168,63 @@
 			"integrity": "sha512-QbfvNPPahZkgyQUgaFcb1ycYdt8i10wa5nhgSqNk/4sXyTa+ESdpHTd7ljEs0X3kx1aW0QOCQTZq2tL8JmZiLQ=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-0.59.1000.tgz",
-			"integrity": "sha512-AT5esBd+bry+Mphq1lQqvmA3ZoHGro14UDLZfBAYuyyuMCYWMU5HW3Av4eFaw6kT9xQOmSpuZ4EmI9bSw8DGTg==",
+			"version": "npm:@fluidframework/iframe-driver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-0.59.2000.tgz",
+			"integrity": "sha512-Y2z5h2SytSUEAdgCCuNRCKfe0D5KXQvJ36H7kSe4rKUPUaXH6rRrR+zgFe15s3GaFJPEu+9sjjWroj28UTZvNg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"comlink": "^4.3.0"
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.1000.tgz",
-			"integrity": "sha512-p5LAM2EuFNrGwLFLr96lUVRAOKoW32ds+1ytBC9ieH2BckFXPPGyjY4+JDKeXcVRt8BWk/Kg0iXx7ss9BcHk8g==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.2000.tgz",
+			"integrity": "sha512-xEFUNFQPtqbVqok88hLV5bEJ3d5jKf1c7wjM2HZwn4fTAsEcshvhMz7PbfjMGxJSHQr/8PekfCJ6RCSFjbNMOA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.1000.tgz",
-			"integrity": "sha512-p5LAM2EuFNrGwLFLr96lUVRAOKoW32ds+1ytBC9ieH2BckFXPPGyjY4+JDKeXcVRt8BWk/Kg0iXx7ss9BcHk8g==",
+			"version": "npm:@fluidframework/ink@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.2000.tgz",
+			"integrity": "sha512-xEFUNFQPtqbVqok88hLV5bEJ3d5jKf1c7wjM2HZwn4fTAsEcshvhMz7PbfjMGxJSHQr/8PekfCJ6RCSFjbNMOA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.1000.tgz",
-			"integrity": "sha512-GFBoMaHA3lWBHi61fATH8SckCLc4dQx6VBffdHMw4IQgnoVbT9eh3YxG/f9xb4VqLRhPQOQVyLpyJgasxePswA==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.2000.tgz",
+			"integrity": "sha512-CNJNeEJR0G4Z3ThJpN/xVa414CXbhCoG3XV5+ySiOHK6eYOTyTXKFx6ACxwrSvlVyb9ag98vYUu5evKOV3PCCQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
 				"@fluidframework/server-local-server": "^0.1036.1000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
 				"@fluidframework/server-services-core": "^0.1036.1000",
@@ -3795,18 +3414,18 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.1000.tgz",
-			"integrity": "sha512-GFBoMaHA3lWBHi61fATH8SckCLc4dQx6VBffdHMw4IQgnoVbT9eh3YxG/f9xb4VqLRhPQOQVyLpyJgasxePswA==",
+			"version": "npm:@fluidframework/local-driver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.2000.tgz",
+			"integrity": "sha512-CNJNeEJR0G4Z3ThJpN/xVa414CXbhCoG3XV5+ySiOHK6eYOTyTXKFx6ACxwrSvlVyb9ag98vYUu5evKOV3PCCQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
 				"@fluidframework/server-local-server": "^0.1036.1000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
 				"@fluidframework/server-services-core": "^0.1036.1000",
@@ -3996,57 +3615,57 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.1000.tgz",
-			"integrity": "sha512-viwpzIFGgQnUgnJ0w7CHdw2KH025AawN6S8fATHg8IvGspJ3Q5ZV8Bw/GH38B6ogTk/jNgYdmeJx+t06IO77kw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.2000.tgz",
+			"integrity": "sha512-jKdBf1v0dFK8m4Q+OVh/RFHUr/1HyS2f0B5P1HtFBPzA6OOf8p6/r3XpAaE86L/NlmXxDHX3doT6Az+7gooSrA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.1000.tgz",
-			"integrity": "sha512-viwpzIFGgQnUgnJ0w7CHdw2KH025AawN6S8fATHg8IvGspJ3Q5ZV8Bw/GH38B6ogTk/jNgYdmeJx+t06IO77kw==",
+			"version": "npm:@fluidframework/map@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.2000.tgz",
+			"integrity": "sha512-jKdBf1v0dFK8m4Q+OVh/RFHUr/1HyS2f0B5P1HtFBPzA6OOf8p6/r3XpAaE86L/NlmXxDHX3doT6Az+7gooSrA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.1000.tgz",
-			"integrity": "sha512-mxFDgAyHLJJ2CDKFL5qRvbW0/k1iWiC1HJOuwm+MvOtipAahXUJgfqcWQDNdJdrswyWHpZLFfEJmtHXzksJ9Qg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.2000.tgz",
+			"integrity": "sha512-FSIyUQZg2UMfqxk7qaGizJc2av03ANLxv3XYcCgJsaCwsyF3+jMVqp7kt6DOLdMdwset5Rh57wQtC8xlQtyfxg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/merge-tree": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4070,21 +3689,21 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.1000.tgz",
-			"integrity": "sha512-mxFDgAyHLJJ2CDKFL5qRvbW0/k1iWiC1HJOuwm+MvOtipAahXUJgfqcWQDNdJdrswyWHpZLFfEJmtHXzksJ9Qg==",
+			"version": "npm:@fluidframework/matrix@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.2000.tgz",
+			"integrity": "sha512-FSIyUQZg2UMfqxk7qaGizJc2av03ANLxv3XYcCgJsaCwsyF3+jMVqp7kt6DOLdMdwset5Rh57wQtC8xlQtyfxg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/merge-tree": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4108,20 +3727,20 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.1000.tgz",
-			"integrity": "sha512-kwcuPbHoexKYxs4rDh32LEl0/AaZFXsxQVui6agRbfCl84sItMkX6KHiibFjSCvfV5MOXwwKwvUZWxIgOmbIAQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.2000.tgz",
+			"integrity": "sha512-J59igU51mqC7yKVksjO+93IGECMBwnYd8HYxKVtDDLJb7o9xLLZxQQGr7cMZ6irE1TcDzsx8xzycW8yQAeC1jA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
@@ -4372,70 +3991,70 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.1000.tgz",
-			"integrity": "sha512-EIdO0cQJmOoD4MZJqSJSoFadzF8HaOa1UPN+TnegCxpiwLTXYshfByCEwTC1YH05iXxEGAXVHcYYentggCwvpQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.2000.tgz",
+			"integrity": "sha512-CqU+9ry9udo82n+MHpFwMDxLn+VU4tqDxTFJ3qcv3qDRY9tqb2RH9YaDXmbjkcCQ0B1/g/1+B2NOH3lZVOGhEg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
+				"@fluidframework/test-driver-definitions": "^0.59.2000",
 				"mocha": "^8.4.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.1000.tgz",
-			"integrity": "sha512-EIdO0cQJmOoD4MZJqSJSoFadzF8HaOa1UPN+TnegCxpiwLTXYshfByCEwTC1YH05iXxEGAXVHcYYentggCwvpQ==",
+			"version": "npm:@fluidframework/mocha-test-setup@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.2000.tgz",
+			"integrity": "sha512-CqU+9ry9udo82n+MHpFwMDxLn+VU4tqDxTFJ3qcv3qDRY9tqb2RH9YaDXmbjkcCQ0B1/g/1+B2NOH3lZVOGhEg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
+				"@fluidframework/test-driver-definitions": "^0.59.2000",
 				"mocha": "^8.4.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.1000.tgz",
-			"integrity": "sha512-Crd9z5tfU07N7WmwtzcqSQUMwzLOizdg/BW4oiMKxDB+s8jNapjGgZaRL2SDeyEiuY5HVnyWzMOOnnefpJ2DGw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.2000.tgz",
+			"integrity": "sha512-Ofn71lsbbFbAD6L1NK8Azf6GnKkTzqNMR6qGiXd/KWAPgzlcOgtjUPp20pYhJc0w7UdN7tBOwqXSDkjVKJbbPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.1000.tgz",
-			"integrity": "sha512-Crd9z5tfU07N7WmwtzcqSQUMwzLOizdg/BW4oiMKxDB+s8jNapjGgZaRL2SDeyEiuY5HVnyWzMOOnnefpJ2DGw==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.2000.tgz",
+			"integrity": "sha512-Ofn71lsbbFbAD6L1NK8Azf6GnKkTzqNMR6qGiXd/KWAPgzlcOgtjUPp20pYhJc0w7UdN7tBOwqXSDkjVKJbbPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.1000.tgz",
-			"integrity": "sha512-GAr4q/9eWNtwpYe3XNgp2B/gFfEQiPLdQlWy3XYspqcxNW1+qbuCN/pZW8SdN2tjTKfbA5S2qOI8snGCaMiWTw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.2000.tgz",
+			"integrity": "sha512-mM341ZBMdKRbVfirTwewtWaPlPLfhOW5BqWgcehOGW2dsJ5T/hNLB2OlNTww899KkHvd28qouKgs0hSjv8miHw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4461,38 +4080,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-rzwpLtUjzoP3DJalwz+pEnTIjuy0WXb1tUMQikMCB3pQMZyoa8AsFLFFgWJVNka1+3vg8xv/k9bfnhGKDyx+6A==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.2000.tgz",
+			"integrity": "sha512-VcUj/dvDAc+KpucDT4NGwDb5mm/HTI0AqWUY7ZPWheDnTE/7UavArsY3zaFfUap6J4XT8Sb6xO4twsxjIAU/tQ==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-rzwpLtUjzoP3DJalwz+pEnTIjuy0WXb1tUMQikMCB3pQMZyoa8AsFLFFgWJVNka1+3vg8xv/k9bfnhGKDyx+6A==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.2000.tgz",
+			"integrity": "sha512-VcUj/dvDAc+KpucDT4NGwDb5mm/HTI0AqWUY7ZPWheDnTE/7UavArsY3zaFfUap6J4XT8Sb6xO4twsxjIAU/tQ==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.1000.tgz",
-			"integrity": "sha512-GAr4q/9eWNtwpYe3XNgp2B/gFfEQiPLdQlWy3XYspqcxNW1+qbuCN/pZW8SdN2tjTKfbA5S2qOI8snGCaMiWTw==",
+			"version": "npm:@fluidframework/odsp-driver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.2000.tgz",
+			"integrity": "sha512-mM341ZBMdKRbVfirTwewtWaPlPLfhOW5BqWgcehOGW2dsJ5T/hNLB2OlNTww899KkHvd28qouKgs0hSjv8miHw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4518,54 +4137,54 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-tcRRvS0kWJLQ1miCGuXMFTO5ELISoFyZpIG12oqnIXrx1wZ0njop5K49+isOO61xngSJ2QQn/kgohvvm4MO2zA==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.2000.tgz",
+			"integrity": "sha512-4UUOfig3a1+QqFeXxR+ncwjEUX/9JEDGyE2mSiNBth0BZgFqJ0dH6u6PfzeLv5GshLUykTDl4AJgF2RHXs3TIQ==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000"
+				"@fluidframework/odsp-driver": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-tcRRvS0kWJLQ1miCGuXMFTO5ELISoFyZpIG12oqnIXrx1wZ0njop5K49+isOO61xngSJ2QQn/kgohvvm4MO2zA==",
+			"version": "npm:@fluidframework/odsp-urlresolver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.2000.tgz",
+			"integrity": "sha512-4UUOfig3a1+QqFeXxR+ncwjEUX/9JEDGyE2mSiNBth0BZgFqJ0dH6u6PfzeLv5GshLUykTDl4AJgF2RHXs3TIQ==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000"
+				"@fluidframework/odsp-driver": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.1000.tgz",
-			"integrity": "sha512-xhZpeN3F9XlyiujcsW0foxG/WPhfw3B5ysUbg7pMoThFxkwqsWcmF18SkO0uiAj9ccnVGvOd7MyAIPxYqu+cFQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.2000.tgz",
+			"integrity": "sha512-FkQE0NaFEMMHLhA0dR1JowymWi1BJpHIg3mrDSncGUWwKpfKnxdPmIEhTuUzkIBsolKEOI193AVjujqTQUwyoA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.1000.tgz",
-			"integrity": "sha512-xhZpeN3F9XlyiujcsW0foxG/WPhfw3B5ysUbg7pMoThFxkwqsWcmF18SkO0uiAj9ccnVGvOd7MyAIPxYqu+cFQ==",
+			"version": "npm:@fluidframework/ordered-collection@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.2000.tgz",
+			"integrity": "sha512-FkQE0NaFEMMHLhA0dR1JowymWi1BJpHIg3mrDSncGUWwKpfKnxdPmIEhTuUzkIBsolKEOI193AVjujqTQUwyoA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4589,17 +4208,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.1000.tgz",
-			"integrity": "sha512-aZL4/apKXW2b8qJO7AAg1fS85IjyiDTMBsLdOs0eC4BJ5ssRbkrHhAolcuEvWr2x6otzr/5ltUzNITbjpfUjWQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.2000.tgz",
+			"integrity": "sha512-ecTfBZJhRbu6IBkc4JzkAn+Zi9UQ5YMP+nls/4Sm/L+n2yXmpoHSpnzxWktajyUR5bRI1l6FOUC6l1gOgj1zIQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4621,17 +4240,17 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.1000.tgz",
-			"integrity": "sha512-aZL4/apKXW2b8qJO7AAg1fS85IjyiDTMBsLdOs0eC4BJ5ssRbkrHhAolcuEvWr2x6otzr/5ltUzNITbjpfUjWQ==",
+			"version": "npm:@fluidframework/register-collection@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.2000.tgz",
+			"integrity": "sha512-ecTfBZJhRbu6IBkc4JzkAn+Zi9UQ5YMP+nls/4Sm/L+n2yXmpoHSpnzxWktajyUR5bRI1l6FOUC6l1gOgj1zIQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4653,70 +4272,70 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.1000.tgz",
-			"integrity": "sha512-65Ud/QfLtXRxg1apxtxVz9A5f4JFFlJ1q+VZBK8GGGGYDDw4h5E838UhHgyN5jgpQUC+/z2Z1RTZoIkjuKXstg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.2000.tgz",
+			"integrity": "sha512-UOrc96+pKg4445YvqNrDUBDxRLMFlPcd5+GG2IIPpCs/yI7vj4hAN+NmJa/redPULUngB3Bmy4IRpiky4239VA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.1000.tgz",
-			"integrity": "sha512-65Ud/QfLtXRxg1apxtxVz9A5f4JFFlJ1q+VZBK8GGGGYDDw4h5E838UhHgyN5jgpQUC+/z2Z1RTZoIkjuKXstg==",
+			"version": "npm:@fluidframework/replay-driver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.2000.tgz",
+			"integrity": "sha512-UOrc96+pKg4445YvqNrDUBDxRLMFlPcd5+GG2IIPpCs/yI7vj4hAN+NmJa/redPULUngB3Bmy4IRpiky4239VA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.1000.tgz",
-			"integrity": "sha512-XQTusnpyTNEvR5tGztN4ZIcG7+tOwh1JDDVJydVdLawOlPD9SASGZBYY3pg4uXs0Pj25u5flXroeM8EcC2AURg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.2000.tgz",
+			"integrity": "sha512-HEbu2hwy89cfz13KiGkYJYDl8FiwZcqNS4C8esNJAh7HMy4NEKlL78FDNqtUrdANRgKC8pJ7UjdTFuZPdnUvEA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.1000.tgz",
-			"integrity": "sha512-XQTusnpyTNEvR5tGztN4ZIcG7+tOwh1JDDVJydVdLawOlPD9SASGZBYY3pg4uXs0Pj25u5flXroeM8EcC2AURg==",
+			"version": "npm:@fluidframework/request-handler@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.2000.tgz",
+			"integrity": "sha512-HEbu2hwy89cfz13KiGkYJYDl8FiwZcqNS4C8esNJAh7HMy4NEKlL78FDNqtUrdANRgKC8pJ7UjdTFuZPdnUvEA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-Jjw894PYVmhcS+KAsW/cQj5unyKRLYGtrhllbUWV37C4AMJ+bWvs11CkMra891I4KloZKoxv6FpyJT6O7Xh02g==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.2000.tgz",
+			"integrity": "sha512-dHTRDsqyrggSUOEHRQEtm0vleQRCSBcf1k8pAQPV8G429zQpVX+xTwkLUxIcwcApj/HLjwYfsmp62TB2UHlb5w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/gitresources": "^0.1036.1000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.4.1",
@@ -4767,20 +4386,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-Jjw894PYVmhcS+KAsW/cQj5unyKRLYGtrhllbUWV37C4AMJ+bWvs11CkMra891I4KloZKoxv6FpyJT6O7Xh02g==",
+			"version": "npm:@fluidframework/routerlicious-driver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.2000.tgz",
+			"integrity": "sha512-dHTRDsqyrggSUOEHRQEtm0vleQRCSBcf1k8pAQPV8G429zQpVX+xTwkLUxIcwcApj/HLjwYfsmp62TB2UHlb5w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/gitresources": "^0.1036.1000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.4.1",
@@ -4831,9 +4450,9 @@
 			}
 		},
 		"@fluidframework/routerlicious-host-previous": {
-			"version": "npm:@fluidframework/routerlicious-host@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-0.59.1000.tgz",
-			"integrity": "sha512-1faWHEtWqyZNr996C1zPWX/is0f08veoKbccwCSBlXBFyjZegRhqKkx786ahpxk54zxVRMuIJV0MuN/8Neia6Q==",
+			"version": "npm:@fluidframework/routerlicious-host@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-0.59.2000.tgz",
+			"integrity": "sha512-tQPYfeq0/aIMOc5jVT8/GAhLJ6X723tnyj3u81dAu/UTQSmQlzY6rkEvvaRfx5brlIh23YHPXQ2FvmKPnm7CJw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -4842,21 +4461,21 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-Fb1fTQH1SLmKz6EobQOrEhMD2EqI06pYHEuH29OaIV+HTAwepCfDS/qr7ImkO2AjEi4ctu24egY/nNl0f+Lc8w==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-0.59.2000.tgz",
+			"integrity": "sha512-Mq2YKNtjWJhwOwsWW18sobZx/wSuTQxJQsGwKvL8e/XBCL1CosEa2YtNwYJWQ/AkxBj/njrV12BmMY5QQhcJyA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"nconf": "^0.11.0"
+				"nconf": "^0.11.4"
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-qqnBhU9x7aPWfGAAOZpoX2zRWvU9WmtdWhpfg6BRW+BgTCmuIb4abMwyqCaJPhew1CZ0TLVv02jTE0mk7lS/jw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.2000.tgz",
+			"integrity": "sha512-nF23aAGSJ5MshYxCyQKdGm/kOSwacJh2VEIukKsRRNxgbVf+rqXXelVWm4BBJQN/zchkbS7jbCtebTD+5yMCUQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -4868,9 +4487,9 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-qqnBhU9x7aPWfGAAOZpoX2zRWvU9WmtdWhpfg6BRW+BgTCmuIb4abMwyqCaJPhew1CZ0TLVv02jTE0mk7lS/jw==",
+			"version": "npm:@fluidframework/runtime-definitions@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.2000.tgz",
+			"integrity": "sha512-nF23aAGSJ5MshYxCyQKdGm/kOSwacJh2VEIukKsRRNxgbVf+rqXXelVWm4BBJQN/zchkbS7jbCtebTD+5yMCUQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -4882,21 +4501,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-ew/I2sOFjc34J73Pn66BLe9JC+koU6P7HAz3hbG+4SDMDgXNxNA4Bp2AzGJPMq0fFzLHpKNcKFnRTIXYI88qOw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.2000.tgz",
+			"integrity": "sha512-gcnduOs3OyPz6Tlbw06QlO2L6BRvbdy7NY/esYdiPnShmdpWuKX9qJpvk7/TlgWoUbjBykQ0Up0eDfRnw1TLjQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/garbage-collector": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4918,21 +4537,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-ew/I2sOFjc34J73Pn66BLe9JC+koU6P7HAz3hbG+4SDMDgXNxNA4Bp2AzGJPMq0fFzLHpKNcKFnRTIXYI88qOw==",
+			"version": "npm:@fluidframework/runtime-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.2000.tgz",
+			"integrity": "sha512-gcnduOs3OyPz6Tlbw06QlO2L6BRvbdy7NY/esYdiPnShmdpWuKX9qJpvk7/TlgWoUbjBykQ0Up0eDfRnw1TLjQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/garbage-collector": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4954,20 +4573,20 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.1000.tgz",
-			"integrity": "sha512-vJ04fhtVk4Lao+yfx68XYp7d6Y8aiByFBemfqL6UGWJehJMUSD3GfEfmkktbsdNxITyy6wphZq+3t5JK2NBQUA==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.2000.tgz",
+			"integrity": "sha512-0ua4LpsauuCtxIE4RJ+T03nse7Yni1uwWZRzfJX43M0mC6AGalt08tDiWbCf4FThMmhOfKMt9apbqRT1eljEFw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/merge-tree": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5979,73 +5598,73 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.1000.tgz",
-			"integrity": "sha512-du8IZ32lzoHBnp5XBBVdaIujex5blGw7B+wMrry2jzw80IgHhN0NjrC496klUktDLe25C6IhxpDA0JfNWZ8Gmw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.2000.tgz",
+			"integrity": "sha512-u8NTbI5M5A9TpSbKqLf3zXjPLHUD3s5To80C4I+NQNsf6R010Ck8F5o+3cwgzLM/+nmPyS7hBPbufUO50AMU1Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime": "^0.59.2000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.1000.tgz",
-			"integrity": "sha512-du8IZ32lzoHBnp5XBBVdaIujex5blGw7B+wMrry2jzw80IgHhN0NjrC496klUktDLe25C6IhxpDA0JfNWZ8Gmw==",
+			"version": "npm:@fluidframework/shared-object-base@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.2000.tgz",
+			"integrity": "sha512-u8NTbI5M5A9TpSbKqLf3zXjPLHUD3s5To80C4I+NQNsf6R010Ck8F5o+3cwgzLM/+nmPyS7hBPbufUO50AMU1Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime": "^0.59.2000",
+				"@fluidframework/container-utils": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-0.59.1000.tgz",
-			"integrity": "sha512-yXtznzCmxnjfOyJtMl9chFQNYnayphkYnwIrhFSHvmH3JuRDST8TtTJaZEqSJERJxtuPm7FqLz4fP2XYcCIpqg==",
+			"version": "npm:@fluidframework/shared-summary-block@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-0.59.2000.tgz",
+			"integrity": "sha512-XABB1wivgWee8blAdSOXmXbrq/kA9eZdknzS/cJTjmG10q61hDxufvAUXIIXKkLZXkOrg4DOUd5mNvvBY2l6Ig==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/shared-object-base": "^0.59.2000"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.1000.tgz",
-			"integrity": "sha512-K6utPbwIoF4NOHlPOJ26xXnDDyysSM4lXnsnVSCMQ29cCTQUhHGg36pjMF+EYhVvbTkDsjRuxt+Y0GyDpoQRYQ=="
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.2000.tgz",
+			"integrity": "sha512-1WJ0LH+28d6jbOC17ZQnwRmmq4KxrrUYNlVLLh8+FQAGGuUIIm83ECkc0I7Rd4LOw30M2zidZ8uXefGKyRpIjg=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.1000.tgz",
-			"integrity": "sha512-K6utPbwIoF4NOHlPOJ26xXnDDyysSM4lXnsnVSCMQ29cCTQUhHGg36pjMF+EYhVvbTkDsjRuxt+Y0GyDpoQRYQ=="
+			"version": "npm:@fluidframework/synthesize@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.2000.tgz",
+			"integrity": "sha512-1WJ0LH+28d6jbOC17ZQnwRmmq4KxrrUYNlVLLh8+FQAGGuUIIm83ECkc0I7Rd4LOw30M2zidZ8uXefGKyRpIjg=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.1000.tgz",
-			"integrity": "sha512-1UwKRq+8+yYriKZo0YqGRSMe5MiNgwJN1mGt2Eaw6k5Fag+2SWSJ2RoYIQnMiPg/IDH1q/vWtr2Bu5QnDo8N6A==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.2000.tgz",
+			"integrity": "sha512-aAqzBaqY9vOqpQNLiwxyQQa5ggVtrG4K1ZK6bqvIbgmvXrHP+viJxkm1wk5xGZI+YfESVZM28sgs3vL9OsUEWw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6055,9 +5674,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.1000.tgz",
-			"integrity": "sha512-1UwKRq+8+yYriKZo0YqGRSMe5MiNgwJN1mGt2Eaw6k5Fag+2SWSJ2RoYIQnMiPg/IDH1q/vWtr2Bu5QnDo8N6A==",
+			"version": "npm:@fluidframework/telemetry-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.2000.tgz",
+			"integrity": "sha512-aAqzBaqY9vOqpQNLiwxyQQa5ggVtrG4K1ZK6bqvIbgmvXrHP+viJxkm1wk5xGZI+YfESVZM28sgs3vL9OsUEWw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6067,19 +5686,19 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-0.59.1000.tgz",
-			"integrity": "sha512-91mlZ21hkUY/l8DqkXNYGLd0fjya0JWiB3hePPJIWy6oKfqHNKPTau61TgJNtKYP0is+LFf/KEMx0KtsMTAjww==",
+			"version": "npm:@fluidframework/test-client-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-0.59.2000.tgz",
+			"integrity": "sha512-wKPYxJI1sHhsVzttkhHe68Rj9X47cCHH4+JhWLLd2RXgD5MZ8gWS5fLif6uquSvmwaTeReU/hyBs+1601HWCfA==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
+				"@fluidframework/test-runtime-utils": "^0.59.2000",
 				"sillyname": "^0.1.0"
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-eh/52XAXGteJSxfxWGKD5BnrYBj9kZf8MJOZgxp1AxqXU0APa02B7ScuI1gvy57luyhsbCxQOm1t2uRXvcm/8w==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.2000.tgz",
+			"integrity": "sha512-moEQLLSA3jISc3AIWuWyB2xO3KWSaNUxjhF/lQ6eZEAT2BZPK0+1jMdACCFDd94FwBoInDC3cV14BScpxmKX7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -6089,9 +5708,9 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "npm:@fluidframework/test-driver-definitions@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-eh/52XAXGteJSxfxWGKD5BnrYBj9kZf8MJOZgxp1AxqXU0APa02B7ScuI1gvy57luyhsbCxQOm1t2uRXvcm/8w==",
+			"version": "npm:@fluidframework/test-driver-definitions@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.2000.tgz",
+			"integrity": "sha512-moEQLLSA3jISc3AIWuWyB2xO3KWSaNUxjhF/lQ6eZEAT2BZPK0+1jMdACCFDd94FwBoInDC3cV14BScpxmKX7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -6101,27 +5720,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.1000.tgz",
-			"integrity": "sha512-OOSqDL6lyN4icxhaW0u+1UZ6jJihce9yVqPjfFW/EM/qOaslK+LeIIwJc0ZioQoH1cmAyD/Lz9le85FbVW9hjQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.2000.tgz",
+			"integrity": "sha512-EHIzotrjIFAxDjcezxPQratxGEosWChhlBqOIWkEZyFDc77oycay1sjhvrbery600j15xeXb39CZ6cYZ92yKSw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/odsp-urlresolver": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/local-driver": "^0.59.2000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2000",
+				"@fluidframework/odsp-driver": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
+				"@fluidframework/odsp-urlresolver": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
 				"@fluidframework/server-local-server": "^0.1036.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-pairwise-generator": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
-				"@fluidframework/tinylicious-driver": "^0.59.1000",
-				"@fluidframework/tool-utils": "^0.59.1000",
+				"@fluidframework/test-driver-definitions": "^0.59.2000",
+				"@fluidframework/test-pairwise-generator": "^0.59.2000",
+				"@fluidframework/test-runtime-utils": "^0.59.2000",
+				"@fluidframework/tinylicious-driver": "^0.59.2000",
+				"@fluidframework/tool-utils": "^0.59.2000",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -6310,27 +5929,27 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.1000.tgz",
-			"integrity": "sha512-OOSqDL6lyN4icxhaW0u+1UZ6jJihce9yVqPjfFW/EM/qOaslK+LeIIwJc0ZioQoH1cmAyD/Lz9le85FbVW9hjQ==",
+			"version": "npm:@fluidframework/test-drivers@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.2000.tgz",
+			"integrity": "sha512-EHIzotrjIFAxDjcezxPQratxGEosWChhlBqOIWkEZyFDc77oycay1sjhvrbery600j15xeXb39CZ6cYZ92yKSw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/odsp-urlresolver": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/local-driver": "^0.59.2000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2000",
+				"@fluidframework/odsp-driver": "^0.59.2000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2000",
+				"@fluidframework/odsp-urlresolver": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
 				"@fluidframework/server-local-server": "^0.1036.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-pairwise-generator": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
-				"@fluidframework/tinylicious-driver": "^0.59.1000",
-				"@fluidframework/tool-utils": "^0.59.1000",
+				"@fluidframework/test-driver-definitions": "^0.59.2000",
+				"@fluidframework/test-pairwise-generator": "^0.59.2000",
+				"@fluidframework/test-runtime-utils": "^0.59.2000",
+				"@fluidframework/tinylicious-driver": "^0.59.2000",
+				"@fluidframework/tool-utils": "^0.59.2000",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -6519,75 +6138,75 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-0.59.1000.tgz",
-			"integrity": "sha512-zVTd5IhAOjrWPFrr955xgqPqApySHRThQ4TDigSsTd170Yjd5PjJlBHmJvO8ibsS8H9WTfFzy19+Oj9bgYxaww==",
+			"version": "npm:@fluidframework/test-loader-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-0.59.2000.tgz",
+			"integrity": "sha512-bNQUbkjJQK+Ac754mD/99eyXWkRTfgW+wbxH0cqNZb6wg0E9EavQnARrmwE/DjLlAxikFo3OxxRUbRa8aXinrg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000"
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.1000.tgz",
-			"integrity": "sha512-/4fyw0zTwaM9SudO9OR1S5DedEuT1N4E2rvg/UFn0CW4PYBi/LK3BCMO9CuK7Y7BI+nOMYD4Ef6GplLX2QnEFQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.2000.tgz",
+			"integrity": "sha512-IZIFrgF/ilPFh+btfI4GkonfYvTBN3Mohrju1iSoC5g813EwsNn6WSi9tg7TNimiDfGPsr3lZfSOBIUB/eg+kQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.1000.tgz",
-			"integrity": "sha512-/4fyw0zTwaM9SudO9OR1S5DedEuT1N4E2rvg/UFn0CW4PYBi/LK3BCMO9CuK7Y7BI+nOMYD4Ef6GplLX2QnEFQ==",
+			"version": "npm:@fluidframework/test-pairwise-generator@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.2000.tgz",
+			"integrity": "sha512-IZIFrgF/ilPFh+btfI4GkonfYvTBN3Mohrju1iSoC5g813EwsNn6WSi9tg7TNimiDfGPsr3lZfSOBIUB/eg+kQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-pgs4aU9g+X84AgCI2GoZynSlMFum3P/aayABxv21i0V7aI5+oRRwlaJXEF4hc1TK63SYS+jW0WUgKvUV0DcQ5w==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.2000.tgz",
+			"integrity": "sha512-Isf7ECYSpCxbrN7oO7w4Usq/SVlzWCsOKq9DV7dl3Q94dlqOOnb0nOVR+d4ACF16KEepL16Thmy5dPhAaZ7JAg==",
 			"requires": {
-				"@fluidframework/azure-service-utils": "^0.59.1000",
+				"@fluidframework/azure-service-utils": "^0.59.2000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-pgs4aU9g+X84AgCI2GoZynSlMFum3P/aayABxv21i0V7aI5+oRRwlaJXEF4hc1TK63SYS+jW0WUgKvUV0DcQ5w==",
+			"version": "npm:@fluidframework/test-runtime-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.2000.tgz",
+			"integrity": "sha512-Isf7ECYSpCxbrN7oO7w4Usq/SVlzWCsOKq9DV7dl3Q94dlqOOnb0nOVR+d4ACF16KEepL16Thmy5dPhAaZ7JAg==",
 			"requires": {
-				"@fluidframework/azure-service-utils": "^0.59.1000",
+				"@fluidframework/azure-service-utils": "^0.59.2000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			}
@@ -6599,131 +6218,131 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.1000.tgz",
-			"integrity": "sha512-zNYhn8NugiGo98lxIPkIa3wfqGo6zWMtv4tV6asPUgR2hasy8Q2VrEkBTmfmmE6HJsiTCNtlEUbxMjz2MzMK+Q==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.2000.tgz",
+			"integrity": "sha512-mSLxWahWpc63lu1pn7VI7aDWbWsP3GeYml+BsYoNQnKvviidUq2iKjt0Tacv4PxOBzV4g5zvyInQJc2QNu4NmQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
+				"@fluidframework/container-runtime": "^0.59.2000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/local-driver": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
+				"@fluidframework/request-handler": "^0.59.2000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
+				"@fluidframework/test-driver-definitions": "^0.59.2000",
+				"@fluidframework/test-runtime-utils": "^0.59.2000",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.1000.tgz",
-			"integrity": "sha512-zNYhn8NugiGo98lxIPkIa3wfqGo6zWMtv4tV6asPUgR2hasy8Q2VrEkBTmfmmE6HJsiTCNtlEUbxMjz2MzMK+Q==",
+			"version": "npm:@fluidframework/test-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.2000.tgz",
+			"integrity": "sha512-mSLxWahWpc63lu1pn7VI7aDWbWsP3GeYml+BsYoNQnKvviidUq2iKjt0Tacv4PxOBzV4g5zvyInQJc2QNu4NmQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
+				"@fluidframework/container-runtime": "^0.59.2000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/local-driver": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
+				"@fluidframework/request-handler": "^0.59.2000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2000",
+				"@fluidframework/test-driver-definitions": "^0.59.2000",
+				"@fluidframework/test-runtime-utils": "^0.59.2000",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-0.59.1000.tgz",
-			"integrity": "sha512-fUvGpKfQu/Aj7ZllUy7fCh1H8EWVq9HBKofMiKcrd4WVfXmrlL//h1lBQkNj0h2onlmlbqSRLPio9z63Lq34OA==",
+			"version": "npm:@fluidframework/test-version-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-0.59.2000.tgz",
+			"integrity": "sha512-OkW+xnS9tmTs+LwiWrvkAQMwP+za507QdSyhX70DE8yC+jCkvnkYMFXUCd91aEd/xDyDN29mbgqFyiSCrV56RQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
-				"@fluidframework/cell": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2000",
+				"@fluidframework/cell": "^0.59.2000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
+				"@fluidframework/container-runtime": "^0.59.2000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/counter": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/counter": "^0.59.2000",
+				"@fluidframework/datastore-definitions": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/ink": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/matrix": "^0.59.1000",
-				"@fluidframework/mocha-test-setup": "^0.59.1000",
-				"@fluidframework/ordered-collection": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/ink": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
+				"@fluidframework/matrix": "^0.59.2000",
+				"@fluidframework/mocha-test-setup": "^0.59.2000",
+				"@fluidframework/ordered-collection": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/register-collection": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/sequence": "^0.59.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-drivers": "^0.59.1000",
-				"@fluidframework/test-utils": "^0.59.1000",
-				"nconf": "^0.11.0",
+				"@fluidframework/register-collection": "^0.59.2000",
+				"@fluidframework/runtime-definitions": "^0.59.2000",
+				"@fluidframework/sequence": "^0.59.2000",
+				"@fluidframework/test-driver-definitions": "^0.59.2000",
+				"@fluidframework/test-drivers": "^0.59.2000",
+				"@fluidframework/test-utils": "^0.59.2000",
+				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.1000.tgz",
-			"integrity": "sha512-JnBmuUEAl9VWPL+C+bc4I1ZHEWSnVDowVUz9x4jj6wjJtkFVYMKxPMfrCnehbLzXPfGG8pcdYjfYoxl6z/xhaQ==",
+			"version": "npm:@fluidframework/tinylicious-client@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.2000.tgz",
+			"integrity": "sha512-11hBfps7mk161z2BDdFGt38Eda7fNPMqHqLXt4kax7ZElF2Vlzt0n2WvoW6QmDahkPRma0kI6SmcrI4xq3i0PQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/fluid-static": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
+				"@fluidframework/fluid-static": "^0.59.2000",
+				"@fluidframework/map": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/tinylicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
+				"@fluidframework/runtime-utils": "^0.59.2000",
+				"@fluidframework/tinylicious-driver": "^0.59.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-9McR39G+CUEdWaVqjNRzyKsOKfwbTPHELQbSmRpiFzWXmh8t9mzoMQV5f2B0wcjPjUkgXlPRPpXqIV9Ffn1Fkg==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.2000.tgz",
+			"integrity": "sha512-7NGqW4b4ii6VlTCmrSt0lncwJdvg4TQzmJUgvILsSGetMKgft0kxzC/A/9l9pXqcV3KQcezRUaDzqvR5xpMCuw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
@@ -6772,15 +6391,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-9McR39G+CUEdWaVqjNRzyKsOKfwbTPHELQbSmRpiFzWXmh8t9mzoMQV5f2B0wcjPjUkgXlPRPpXqIV9Ffn1Fkg==",
+			"version": "npm:@fluidframework/tinylicious-driver@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.2000.tgz",
+			"integrity": "sha512-7NGqW4b4ii6VlTCmrSt0lncwJdvg4TQzmJUgvILsSGetMKgft0kxzC/A/9l9pXqcV3KQcezRUaDzqvR5xpMCuw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2000",
 				"@fluidframework/server-services-client": "^0.1036.1000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
@@ -6829,12 +6448,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.1000.tgz",
-			"integrity": "sha512-aaH+ybxUdzoBWOkbCtpsT8zSllLcm6TbktO93DguSh0WDIHPK5cVl6kzhRE5yAO6sTlT7RHL/1d/CFA+O4zS2w==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.2000.tgz",
+			"integrity": "sha512-pbF3zhfn3TonMa0J1OdN9+uPNsPddlthkBnua1xrilF7TVLhgDKkEJNxF/DZwd8nGPZnCPLBqrZs7LzY6lS1xQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"async-mutex": "^0.3.1",
@@ -6862,12 +6481,12 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.1000.tgz",
-			"integrity": "sha512-aaH+ybxUdzoBWOkbCtpsT8zSllLcm6TbktO93DguSh0WDIHPK5cVl6kzhRE5yAO6sTlT7RHL/1d/CFA+O4zS2w==",
+			"version": "npm:@fluidframework/tool-utils@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.2000.tgz",
+			"integrity": "sha512-pbF3zhfn3TonMa0J1OdN9+uPNsPddlthkBnua1xrilF7TVLhgDKkEJNxF/DZwd8nGPZnCPLBqrZs7LzY6lS1xQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2000",
 				"@fluidframework/protocol-base": "^0.1036.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"async-mutex": "^0.3.1",
@@ -6895,58 +6514,58 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.1000.tgz",
-			"integrity": "sha512-0GamjG54FrXG9QHsSTHEv092VDWf/30sd62p8h0w1zjcoN+r2vGDsztQ6mVcexMB8BnX/pDVd51WvS2o2l4u0g==",
+			"version": "npm:@fluidframework/undo-redo@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.2000.tgz",
+			"integrity": "sha512-CyKXdc6FPOZayrYFTr+YnqkruFZUOqSOc3oDedSF0Jsp48hMza0ZguY3eVLzne97vTIAp/NnZy9kawxnIAn+BQ==",
 			"requires": {
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/matrix": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
-				"@fluidframework/sequence": "^0.59.1000"
+				"@fluidframework/map": "^0.59.2000",
+				"@fluidframework/matrix": "^0.59.2000",
+				"@fluidframework/merge-tree": "^0.59.2000",
+				"@fluidframework/sequence": "^0.59.2000"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.1000.tgz",
-			"integrity": "sha512-s5CV8HS9AWVkpemIXTMAsG32O3QFFsfIiJtu94DpRtslnZDIYNBhyT9oUPPEnVpEkaP+rJGMfAOkdh7ATHwnmQ==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.2000.tgz",
+			"integrity": "sha512-rib3RKBkYnkLpqop2uARgezYihj2ZhKhB/BEyiIxy6Wtq6PT8qh49QKpLoG8LfHVr3b55j0ElENNYpymf9f1Qg==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/view-interfaces": "^0.59.2000",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.1000.tgz",
-			"integrity": "sha512-s5CV8HS9AWVkpemIXTMAsG32O3QFFsfIiJtu94DpRtslnZDIYNBhyT9oUPPEnVpEkaP+rJGMfAOkdh7ATHwnmQ==",
+			"version": "npm:@fluidframework/view-adapters@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.2000.tgz",
+			"integrity": "sha512-rib3RKBkYnkLpqop2uARgezYihj2ZhKhB/BEyiIxy6Wtq6PT8qh49QKpLoG8LfHVr3b55j0ElENNYpymf9f1Qg==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/view-interfaces": "^0.59.2000",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.1000.tgz",
-			"integrity": "sha512-KEv/iccEKfySJetEye8TvdimFj0K1nuADutKkdRAvvcCxXU03DChXVZtjqdHirVBXT9Djvl/lJDVPfeRmGfovw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.2000.tgz",
+			"integrity": "sha512-V3sxv0fBNQwK7QJ8SKb5MfFkRHNiIA04VS4HpNxFO/edaPKZA6b9eeMOB8EMh22QKUIoyXeL7+Hg44UxfvoC0g==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.1000.tgz",
-			"integrity": "sha512-KEv/iccEKfySJetEye8TvdimFj0K1nuADutKkdRAvvcCxXU03DChXVZtjqdHirVBXT9Djvl/lJDVPfeRmGfovw==",
+			"version": "npm:@fluidframework/view-interfaces@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.2000.tgz",
+			"integrity": "sha512-V3sxv0fBNQwK7QJ8SKb5MfFkRHNiIA04VS4HpNxFO/edaPKZA6b9eeMOB8EMh22QKUIoyXeL7+Hg44UxfvoC0g==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.1000.tgz",
-			"integrity": "sha512-W9Z151qbssS5FJNL+BHbjTBwFwX4G537sGK/kjWHPxpSohwXwXMJixZnO77uha7px44PbSwVvkgQhQpot7MhZw==",
+			"version": "0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.2000.tgz",
+			"integrity": "sha512-x+F5WkNz9EzSPY9tBB+qLHFnRyp1GHPG86BXqyG0ZIp3mbzamqxQrUzXEoCSfK7qcOComgg5w6/8eJIBFXNyUg==",
 			"requires": {
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -6954,9 +6573,9 @@
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.1000.tgz",
-			"integrity": "sha512-W9Z151qbssS5FJNL+BHbjTBwFwX4G537sGK/kjWHPxpSohwXwXMJixZnO77uha7px44PbSwVvkgQhQpot7MhZw==",
+			"version": "npm:@fluidframework/web-code-loader@0.59.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.2000.tgz",
+			"integrity": "sha512-x+F5WkNz9EzSPY9tBB+qLHFnRyp1GHPG86BXqyG0ZIp3mbzamqxQrUzXEoCSfK7qcOComgg5w6/8eJIBFXNyUg==",
 			"requires": {
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -18124,7 +17743,8 @@
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"optional": true
 		},
 		"async-hook-jl": {
 			"version": "1.7.6",
@@ -25322,14 +24942,6 @@
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
 		},
-		"eventsource": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-			"integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-			"requires": {
-				"original": "^1.0.0"
-			}
-		},
 		"evp_bytestokey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -32481,11 +32093,6 @@
 				"json-buffer": "3.0.0"
 			}
 		},
-		"killable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
-			"integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="
-		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -33876,11 +33483,6 @@
 				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
 			}
-		},
-		"loglevel": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-			"integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
 		},
 		"lolex": {
 			"version": "4.2.0",
@@ -37794,21 +37396,6 @@
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
 			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="
 		},
-		"opn": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-			"requires": {
-				"is-wsl": "^1.1.0"
-			},
-			"dependencies": {
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-				}
-			}
-		},
 		"optimism": {
 			"version": "0.16.1",
 			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
@@ -37835,14 +37422,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.1.tgz",
 			"integrity": "sha512-3Ux8um0zXbVacKUkcytc0u3HgC0b0bBLT+I60r2J/En72cI0nZffqrA7Xtf2Hqs27j1g82llR5Mhbd0Z1XW4AQ=="
-		},
-		"original": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-			"requires": {
-				"url-parse": "^1.4.3"
-			}
 		},
 		"os-browserify": {
 			"version": "0.3.0",
@@ -38625,14 +38204,6 @@
 			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
-			}
-		},
-		"pkg-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-			"requires": {
-				"find-up": "^3.0.0"
 			}
 		},
 		"pkg-up": {
@@ -42797,28 +42368,6 @@
 				"websocket-driver": "^0.7.4"
 			}
 		},
-		"sockjs-client": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.0.tgz",
-			"integrity": "sha512-qVHJlyfdHFht3eBFZdKEXKTlb7I4IV41xnVNo8yUKA1UHcPJwgW2SvTq9LhnjjCywSkSK7c/e4nghU0GOoMCRQ==",
-			"requires": {
-				"debug": "^3.2.7",
-				"eventsource": "^1.1.0",
-				"faye-websocket": "^0.11.4",
-				"inherits": "^2.0.4",
-				"url-parse": "^1.5.10"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
 		"socks": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
@@ -46525,7 +46074,8 @@
 		"upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+			"optional": true
 		},
 		"update-notifier": {
 			"version": "2.5.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/cell-previous": "npm:@fluidframework/cell@0.59.1000",
+    "@fluidframework/cell-previous": "npm:@fluidframework/cell@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
@@ -101,7 +101,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/counter-previous": "npm:@fluidframework/counter@0.59.1000",
+    "@fluidframework/counter-previous": "npm:@fluidframework/counter@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
@@ -97,7 +97,7 @@
     "typescript": "~4.1.3"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/ink-previous": "npm:@fluidframework/ink@0.59.1000",
+    "@fluidframework/ink-previous": "npm:@fluidframework/ink@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
@@ -100,7 +100,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -76,7 +76,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/map-previous": "npm:@fluidframework/map@0.59.1000",
+    "@fluidframework/map-previous": "npm:@fluidframework/map@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
@@ -105,7 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -77,7 +77,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@0.59.1000",
+    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
@@ -111,7 +111,7 @@
     "uuid": "^8.3.1"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@0.59.1000",
+    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -102,7 +102,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@0.59.1000",
+    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -101,7 +101,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@0.59.1000",
+    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/benchmark": "^2.1.0",
@@ -109,7 +109,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@0.59.1000",
+    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -103,7 +103,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/shared-object-base": "^0.59.3000"
   },
   "devDependencies": {
-    "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@0.59.1000",
+    "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@0.59.2000",
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
@@ -105,7 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@0.59.1000",
+    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -68,7 +68,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@0.59.1000",
+    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -67,7 +67,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@0.59.1000",
+    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -71,7 +71,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@0.59.1000",
+    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
@@ -66,7 +66,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/odsp-driver-definitions": "^0.59.3000"
   },
   "devDependencies": {
-    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.1000",
+    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
@@ -70,7 +70,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@0.59.1000",
+    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -72,7 +72,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@0.59.1000",
+    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -102,7 +102,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@0.59.1000",
+    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@0.59.2000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -65,7 +65,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -81,7 +81,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@0.59.1000",
+    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -110,7 +110,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@0.59.1000",
+    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
@@ -69,7 +69,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@0.59.1000",
+    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -71,7 +71,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@0.59.1000",
+    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -111,7 +111,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
-    "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@0.59.1000",
+    "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",
@@ -66,7 +66,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@0.59.1000",
+    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/nconf": "^0.10.0",
@@ -73,7 +73,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@0.59.1000",
+    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^8.2.2",
@@ -69,7 +69,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -81,7 +81,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@0.59.1000",
+    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
@@ -112,7 +112,7 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.59.3000",
-    "@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@0.59.1000",
+    "@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@0.59.2000",
     "@fluidframework/azure-local-service": "^0.1.38773",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
@@ -80,7 +80,7 @@
     "fluid-framework": "^0.58.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/azure-service-utils/package.json
+++ b/packages/framework/azure-service-utils/package.json
@@ -42,7 +42,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@0.59.1000",
+    "@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.22.2",
@@ -67,7 +67,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@0.59.1000",
+    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
@@ -102,7 +102,7 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@0.59.1000",
+    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
@@ -103,7 +103,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -52,7 +52,7 @@
     "@fluid-experimental/get-container": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@0.59.1000",
+    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
@@ -76,11 +76,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
-    "broken": {
-      "ClassDeclaration_FluidContainer": {
-        "forwardCompat": false
-      }
-    }
+    "version": "0.59.3000",
+    "broken": {}
   }
 }

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.ts
@@ -96,7 +96,6 @@ declare function get_old_ClassDeclaration_FluidContainer():
 declare function use_current_ClassDeclaration_FluidContainer(
     use: TypeOnly<current.FluidContainer>);
 use_current_ClassDeclaration_FluidContainer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidContainer());
 
 /*

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@0.59.1000",
+    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -101,7 +101,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/datastore": "^0.59.3000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@0.59.1000",
+    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -95,7 +95,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@0.59.1000",
+    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
@@ -66,7 +66,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.59.3000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@0.59.1000",
+    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -73,7 +73,7 @@
     "fluid-framework": "^0.50.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
-    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@0.59.1000",
+    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -101,7 +101,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@0.59.1000",
+    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
@@ -63,7 +63,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@0.59.1000",
+    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
@@ -60,7 +60,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@0.59.1000",
+    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-loader-utils": "^0.59.3000",
@@ -112,7 +112,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@0.59.1000",
+    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
@@ -96,7 +96,7 @@
     "typescript": "~4.1.3"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@0.59.1000",
+    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/runtime-utils": "^0.59.3000",
@@ -103,7 +103,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@0.59.1000",
+    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",
@@ -58,7 +58,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
-    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@0.59.1000",
+    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/isomorphic-fetch": "^0.0.35",
@@ -65,7 +65,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -64,7 +64,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@0.59.1000",
+    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@rushstack/eslint-config": "^2.5.1",
@@ -100,7 +100,7 @@
     }
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@0.59.1000",
+    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -64,7 +64,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.63777",
-    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@0.59.1000",
+    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
@@ -116,17 +116,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
-    "broken": {
-      "ClassDeclaration_Summarizer": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_IProvideSummarizer": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_ISummarizer": {
-        "forwardCompat": false
-      }
-    }
+    "version": "0.59.3000",
+    "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -792,7 +792,6 @@ declare function get_old_InterfaceDeclaration_IProvideSummarizer():
 declare function use_current_InterfaceDeclaration_IProvideSummarizer(
     use: TypeOnly<current.IProvideSummarizer>);
 use_current_InterfaceDeclaration_IProvideSummarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideSummarizer());
 
 /*
@@ -961,7 +960,6 @@ declare function get_old_InterfaceDeclaration_ISummarizer():
 declare function use_current_InterfaceDeclaration_ISummarizer(
     use: TypeOnly<current.ISummarizer>);
 use_current_InterfaceDeclaration_ISummarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISummarizer());
 
 /*
@@ -1490,7 +1488,6 @@ declare function get_old_ClassDeclaration_Summarizer():
 declare function use_current_ClassDeclaration_Summarizer(
     use: TypeOnly<current.Summarizer>);
 use_current_ClassDeclaration_Summarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_Summarizer());
 
 /*

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@0.59.1000",
+    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -64,7 +64,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@0.59.1000",
+    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
@@ -111,7 +111,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@0.59.1000",
+    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -98,7 +98,7 @@
     "typescript": "~4.1.3"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@0.59.1000",
+    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
@@ -65,7 +65,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@0.59.1000",
+    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -105,7 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@0.59.1000",
+    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -106,7 +106,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@0.59.1000",
+    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -86,7 +86,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@0.59.1000",
+    "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -89,7 +89,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@0.59.1000",
+    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
@@ -105,7 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@0.59.1000",
+    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",
@@ -81,7 +81,7 @@
     "typescript": "~4.1.3"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@0.59.1000",
+    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -113,7 +113,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
-    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@0.59.1000",
+    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",
@@ -115,7 +115,7 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.ts
+++ b/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.ts
@@ -161,6 +161,30 @@ use_old_VariableDeclaration_ensurePackageInstalled(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ExpectedEvents": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ExpectedEvents():
+    TypeOnly<old.ExpectedEvents>;
+declare function use_current_TypeAliasDeclaration_ExpectedEvents(
+    use: TypeOnly<current.ExpectedEvents>);
+use_current_TypeAliasDeclaration_ExpectedEvents(
+    get_old_TypeAliasDeclaration_ExpectedEvents());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ExpectedEvents": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ExpectedEvents():
+    TypeOnly<current.ExpectedEvents>;
+declare function use_old_TypeAliasDeclaration_ExpectedEvents(
+    use: TypeOnly<old.ExpectedEvents>);
+use_old_TypeAliasDeclaration_ExpectedEvents(
+    get_current_TypeAliasDeclaration_ExpectedEvents());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_ExpectsTest": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_ExpectsTest():

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -92,7 +92,7 @@
     "webpack-dev-server": "4.0.0"
   },
   "devDependencies": {
-    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@0.59.1000",
+    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
@@ -127,7 +127,7 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/tools/webpack-fluid-loader/src/test/types/validateWebpackFluidLoaderPrevious.ts
+++ b/packages/tools/webpack-fluid-loader/src/test/types/validateWebpackFluidLoaderPrevious.ts
@@ -61,3 +61,27 @@ declare function use_old_VariableDeclaration_before(
     use: TypeOnly<typeof old.before>);
 use_old_VariableDeclaration_before(
     get_current_VariableDeclaration_before());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_devServerConfig": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_devServerConfig():
+    TypeOnly<typeof old.devServerConfig>;
+declare function use_current_FunctionDeclaration_devServerConfig(
+    use: TypeOnly<typeof current.devServerConfig>);
+use_current_FunctionDeclaration_devServerConfig(
+    get_old_FunctionDeclaration_devServerConfig());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_devServerConfig": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_devServerConfig():
+    TypeOnly<typeof current.devServerConfig>;
+declare function use_old_FunctionDeclaration_devServerConfig(
+    use: TypeOnly<typeof old.devServerConfig>);
+use_old_FunctionDeclaration_devServerConfig(
+    get_current_FunctionDeclaration_devServerConfig());

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@0.59.1000",
+    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node-fetch": "^2.5.10",
@@ -96,7 +96,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@0.59.1000",
+    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -103,7 +103,7 @@
     "typescript": "~4.1.3"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.1000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
-    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@0.59.1000",
+    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -103,7 +103,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.2000",
+    "version": "0.59.3000",
     "broken": {}
   }
 }


### PR DESCRIPTION
All content is generated via tooling:
1. `npm run typetests:prepare`
2. `npm install`
3. `fluid-build -s build:compile` or  `npm run build:fast`