### PR TITLE
Make `connect()` and `disconnect()` mandatory on `IContainer` and `IFluidContainer`

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Remove IFluidSerializer from IFluidObject](#Remove-IFluidSerializer-from-IFluidObject)
 - [Remove write method from IDocumentStorageService](#Remove-Write-Method-from-IDocumentStorageService)
 - [Remove IDeltaManager.close()](#remove-ideltamanagerclose)
+- [connect() and disconnect() made mandatory on IContainer and IFluidContainer](#connect-and-disconnect-made-mandatory-on-icontainer-and-ifluidcontainer)
 
 ### Remove IFluidSerializer from core-interfaces
 `IFluidSerializer` was deprecated from core-interfaces in 0.55 and is now removed. Use `IFluidSerializer` in shared-object-base instead.
@@ -40,6 +41,9 @@ Use IContainer.close() or IContainerContext.closeFn() instead, and pass an error
 ### Require enableOfflineLoad to use IContainer.closeAndGetPendingLocalState()
 Offline load functionality has been placed behind a feature flag as part of [ongoing offline work](https://github.com/microsoft/FluidFramework/pull/9557).
 In order to use `IContainer.closeAndGetPendingLocalState`, pass a set of options to the container runtime including `{ enableOfflineLoad: true }`.
+
+### connect() and disconnect() made mandatory on IContainer and IFluidContainer
+The functions `IContainer.connect()`, `IContainer.disconnect()`, `IFluidContainer.connect()`, and `IFluidContainer.disconnect()` have all been changed from optional to mandatory functions.
 
 # 0.59
 

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -35,7 +35,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
     constructor(schema: ContainerSchema);
     // (undocumented)
     protected containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void>;
-    }
+}
 
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
@@ -51,7 +51,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     get disposed(): boolean;
     get initialObjects(): Record<string, IFluidLoadable>;
     get isDirty(): boolean;
-    }
+}
 
 // @public
 export interface IConnection {
@@ -63,12 +63,12 @@ export interface IConnection {
 export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
     attach(): Promise<string>;
     readonly attachState: AttachState;
-    connect?(): void;
+    connect(): void;
     // @deprecated
     readonly connected: boolean;
     readonly connectionState: ConnectionState;
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
-    disconnect?(): void;
+    disconnect(): void;
     dispose(): void;
     readonly disposed: boolean;
     readonly initialObjects: LoadableObjectRecord;
@@ -125,7 +125,7 @@ export class RootDataObject extends DataObject<{
     protected initializingFirstTime(props: RootDataObjectProps): Promise<void>;
     // (undocumented)
     get initialObjects(): LoadableObjectRecord;
-    }
+}
 
 // @public (undocumented)
 export interface RootDataObjectProps {
@@ -153,7 +153,6 @@ export abstract class ServiceAudience<M extends IMember = IMember> extends Typed
 export type SharedObjectClass<T extends IFluidLoadable> = {
     readonly getFactory: () => IChannelFactory;
 } & LoadableObjectCtor<T>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -131,12 +131,12 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     close(error?: ICriticalContainerError): void;
     closeAndGetPendingLocalState(): string;
     readonly closed: boolean;
-    connect?(): void;
+    connect(): void;
     // @deprecated
     readonly connected: boolean;
     readonly connectionState: ConnectionState;
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    disconnect?(): void;
+    disconnect(): void;
     // @alpha
     forceReadonly?(readonly: boolean): any;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -82,6 +82,7 @@
         "backCompat": false
       },
       "InterfaceDeclaration_IContainer": {
+        "forwardCompat": false,
         "backCompat": false
       },
       "InterfaceDeclaration_IDeltaManager": {

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -264,12 +264,12 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     /**
      * Attempts to connect the container to the delta stream and process ops
      */
-    connect?(): void;
+    connect(): void;
 
     /**
      * Disconnects the container from the delta stream and stops processing ops
      */
-    disconnect?(): void;
+    disconnect(): void;
 
     /**
      * Dictates whether or not the current container will automatically attempt to reconnect to the delta stream

--- a/common/lib/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/common/lib/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -336,6 +336,7 @@ declare function get_old_InterfaceDeclaration_IContainer():
 declare function use_current_InterfaceDeclaration_IContainer(
     use: TypeOnly<current.IContainer>);
 use_current_InterfaceDeclaration_IContainer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainer());
 
 /*

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -75,7 +75,8 @@
   "typeValidation": {
     "version": "0.60.1000",
     "broken": {
-      "ClassDeclaration_FluidContainer": {"forwardCompat": false}
+      "ClassDeclaration_FluidContainer": {"forwardCompat": false},
+      "InterfaceDeclaration_IFluidContainer": {"forwardCompat": false}
     }
   }
 }

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -131,12 +131,12 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
     /**
      * Attempts to connect the container to the delta stream and process ops
      */
-    connect?(): void;
+    connect(): void;
 
     /**
      * Disconnects the container from the delta stream and stops processing ops
      */
-    disconnect?(): void;
+    disconnect(): void;
 
     /**
      * Create a new data object or DDS of the specified type.  In order to share the data object or DDS with other

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.ts
@@ -145,6 +145,7 @@ declare function get_old_InterfaceDeclaration_IFluidContainer():
 declare function use_current_InterfaceDeclaration_IFluidContainer(
     use: TypeOnly<current.IFluidContainer>);
 use_current_InterfaceDeclaration_IFluidContainer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidContainer());
 
 /*


### PR DESCRIPTION
This PR changes `IContainer.connect()`, `IContainer.disconnect()`, `IFluidContainer.connect()`, and `IFluidContainer.disconnect()` from optional to mandatory functions.

Closes #9945