### PR TITLE
Stress: Stop registering faultInjectionNack as error

### DIFF
--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -62,6 +62,9 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
             event.category = event.testCategoryOverride;
         }
 
+        if (typeof event.message === "string" && event.message.indexOf("FaultInjectionNack") > -1) {
+            event.category = "generic";
+        }
         this.baseLogger?.send({ ...event, hostName: pkgName });
 
         event.Event_Time = Date.now();

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -60,9 +60,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
     send(event: ITelemetryBaseEvent): void {
         if (typeof event.testCategoryOverride === "string") {
             event.category = event.testCategoryOverride;
-        }
-
-        if (typeof event.message === "string" && event.message.indexOf("FaultInjectionNack") > -1) {
+        } else if (typeof event.message === "string" && event.message.indexOf("FaultInjectionNack") > -1) {
             event.category = "generic";
         }
         this.baseLogger?.send({ ...event, hostName: pkgName });


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/9407
Log injected nack as generic to keep error category clean of expected errors. 
