### PR TITLE
Adjustments applied on fix from 8995 - Added Reference to the code and telemetry for when cache is not reset

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -154,6 +154,10 @@ class BlobCache {
     }
 }
 
+interface GetVersionsTelemetryProps {
+    cacheEntryAge?: number;
+    cacheSummarizerExpired?: boolean;
+}
 export class OdspDocumentStorageService implements IDocumentStorageService {
     readonly policies = {
         // By default, ODSP tells the container not to prefetch/cache.
@@ -403,7 +407,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 this.logger,
                 { eventName: "ObtainSnapshot" },
                 async (event: PerformanceEvent) => {
-                    const props = {};
+                    const props: GetVersionsTelemetryProps = {};
                     let retrievedSnapshot: ISnapshotContents | undefined;
                     // Here's the logic to grab the persistent cache snapshot implemented by the host
                     // Epoch tracker is responsible for communicating with the persistent cache, handling epochs and cache versions
@@ -421,18 +425,15 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                     // See: https://github.com/microsoft/FluidFramework/issues/8995 for additional information.
                                     if (this.hostPolicy.summarizerClient) {
                                         if (age > defaultSummarizerCacheExpiryTimeout) {
-                                            // eslint-disable-next-line @typescript-eslint/dot-notation
-                                            props["cacheSummarizerExpired"] = true;
+                                            props.cacheSummarizerExpired = true;
                                             return undefined;
                                         } else {
-                                            // eslint-disable-next-line @typescript-eslint/dot-notation
-                                            props["cacheSummarizerExpired"] = false;
+                                            props.cacheSummarizerExpired = false;
                                         }
                                     }
 
                                     // Record the cache age
-                                    // eslint-disable-next-line @typescript-eslint/dot-notation
-                                    props["cacheEntryAge"] = age;
+                                    props.cacheEntryAge = age;
                                 }
 
                                 return snapshotCachedEntry;
@@ -481,8 +482,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         }
                     }
                     if (method === "network") {
-                        // eslint-disable-next-line @typescript-eslint/dot-notation
-                        props["cacheEntryAge"] = undefined;
+                        props.cacheEntryAge = undefined;
                     }
                     event.end({ ...props, method });
                     return retrievedSnapshot;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -418,11 +418,16 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                     // In order to decrease the number of times we have to execute a snapshot refresh,
                                     // if this is the summarizer and we have a cache entry but it is past the defaultSummarizerCacheExpiryTimeout,
                                     // force the network retrieval instead as there might be a more recent snapshot available.
-                                    if (this.hostPolicy.summarizerClient &&
-                                        age > defaultSummarizerCacheExpiryTimeout) {
-                                        // eslint-disable-next-line @typescript-eslint/dot-notation
-                                        props["cacheSummarizerExpired"] = true;
-                                        return undefined;
+                                    // See: https://github.com/microsoft/FluidFramework/issues/8995 for additional information.
+                                    if (this.hostPolicy.summarizerClient) {
+                                        if (age > defaultSummarizerCacheExpiryTimeout) {
+                                            // eslint-disable-next-line @typescript-eslint/dot-notation
+                                            props["cacheSummarizerExpired"] = true;
+                                            return undefined;
+                                        } else {
+                                            // eslint-disable-next-line @typescript-eslint/dot-notation
+                                            props["cacheSummarizerExpired"] = false;
+                                        }
                                     }
 
                                     // Record the cache age


### PR DESCRIPTION
Applying feedback from Vlad that I saw after merging the PR: 

1) It's useful to put issue references in the code, as they have way more data about reasoning, stats, etc. Something that comes handy next time when we need to change it or question the decision
2) It would be great to have telemetry when we reject it, to be able to assess if we should tune the number upwards.