### PR TITLE
Improve property-binder test setup

### DIFF
--- a/experimental/PropertyDDS/packages/property-binder/jest.config.js
+++ b/experimental/PropertyDDS/packages/property-binder/jest.config.js
@@ -4,13 +4,6 @@
  */
 // jest.config.js
 module.exports = {
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/src/test/tsconfig.json'
-    }
-  },
-  preset: "ts-jest",
-
   // The glob patterns Jest uses to detect test files
   testMatch: [
     "/**/dist/test/*.spec.js"
@@ -19,13 +12,5 @@ module.exports = {
   testEnvironment: "jsdom",
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: ['/node_modules/'],
-
-  // A map from regular expressions to paths to transformers
-  transform: {
-    "^.+\\.(t|j)sx?$": "ts-jest"
-  }
-
-  // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  //   setupFilesAfterEnv: ['<rootDir>/test/setup.ts']
+  testPathIgnorePatterns: ['/node_modules/']
 };

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -101,9 +101,6 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "source-map-support": "^0.5.16",
-    "ts-jest": "^26.4.4",
-    "ts-loader": "^6.1.2",
-    "ts-node": "^7.0.1",
     "typedoc": "^0.12.0",
     "typescript": "~4.1.3"
   },

--- a/experimental/PropertyDDS/packages/property-binder/src/test/activation_tests.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/activation_tests.spec.js
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 /* globals expect */
-import { DataBinder } from '../../src/data_binder/dataBinder';
+import { DataBinder } from '../data_binder/dataBinder';
 
 import { catchConsoleErrors } from './catchConsoleError';
 
-import { DataBinding } from '../../src/data_binder/dataBinding';
+import { DataBinding } from '../data_binder/dataBinding';
 import { PropertyFactory } from '@fluid-experimental/property-properties';
-import { ActivationQueryCacheHelper } from '../../src/internal/activationQueryCacheHelper';
+import { ActivationQueryCacheHelper } from '../internal/activationQueryCacheHelper';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree'
 
 /**

--- a/experimental/PropertyDDS/packages/property-binder/src/test/data_binder.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/data_binder.spec.js
@@ -16,8 +16,8 @@
  *
  */
 import _ from 'lodash';
-import { DataBinder } from '../../src/data_binder/dataBinder';
-import { ModificationContext } from '../../src/data_binder/modificationContext';
+import { DataBinder } from '../data_binder/dataBinder';
+import { ModificationContext } from '../data_binder/modificationContext';
 import {
   registerTestTemplates, ParentTemplate, ChildTemplate,
   PrimitiveChildrenTemplate, ArrayContainerTemplate, SetContainerTemplate,
@@ -26,7 +26,7 @@ import {
   positionTemplate, ReferenceParentTemplate,
   EscapingTestTemplate
 } from './testTemplates';
-import { DataBinding } from '../../src/data_binder/dataBinding';
+import { DataBinding } from '../data_binder/dataBinding';
 
 import {
   ParentDataBinding,
@@ -38,9 +38,9 @@ import {
 import {
   catchConsoleErrors, hadConsoleError, clearConsoleError
 } from './catchConsoleError';
-import { unregisterAllOnPathListeners } from '../../src/data_binder/internalUtils';
+import { unregisterAllOnPathListeners } from '../data_binder/internalUtils';
 import { PropertyFactory } from '@fluid-experimental/property-properties';
-import { RESOLVE_NEVER } from '../../src/internal/constants';
+import { RESOLVE_NEVER } from '../internal/constants';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree'
 
 const cleanupClasses = function() {

--- a/experimental/PropertyDDS/packages/property-binder/src/test/data_binding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/data_binding.spec.js
@@ -14,11 +14,11 @@
  *
  */
 import _ from 'lodash';
-import { DataBinder } from '../../src/data_binder/dataBinder';
+import { DataBinder } from '../data_binder/dataBinder';
 import {
   onValuesChanged, onPropertyChanged, onPathChanged, DataBinding
-} from '../../src/data_binder/dataBinding';
-import { unregisterAllOnPathListeners } from '../../src/data_binder/internalUtils';
+} from '../data_binder/dataBinding';
+import { unregisterAllOnPathListeners } from '../data_binder/internalUtils';
 import {
   registerTestTemplates, ParentTemplate, ChildTemplate, ReferenceParentTemplate,
   PrimitiveChildrenTemplate, NodeContainerTemplate, ArrayContainerTemplate,
@@ -31,9 +31,9 @@ import {
   DerivedDataBinding, DerivedDerivedDataBinding
 } from './testDataBindings';
 import { catchConsoleErrors } from './catchConsoleError';
-import { RESOLVE_NO_LEAFS } from '../../src/internal/constants';
+import { RESOLVE_NO_LEAFS } from '../internal/constants';
 import { BaseProperty, PropertyFactory } from '@fluid-experimental/property-properties';
-import { ModificationContext } from '../../src/data_binder/modificationContext';
+import { ModificationContext } from '../data_binder/modificationContext';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 
 // Create a mock THREE.Object3D

--- a/experimental/PropertyDDS/packages/property-binder/src/test/data_binding_tree.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/data_binding_tree.spec.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 /* globals should, expect */
-import { DataBindingTree } from '../../src/data_binder/dataBindingTree';
+import { DataBindingTree } from '../data_binder/dataBindingTree';
 import { catchConsoleErrors } from './catchConsoleError';
 
 describe('DataBindingTree', function() {

--- a/experimental/PropertyDDS/packages/property-binder/src/test/es6_data_binding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/es6_data_binding.spec.js
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 /* globals should, sinon, expect */
-import { DataBinder } from '../../src/data_binder/dataBinder';
-import { DataBinding } from '../../src/data_binder/dataBinding';
+import { DataBinder } from '../data_binder/dataBinder';
+import { DataBinding } from '../data_binder/dataBinding';
 import { catchConsoleErrors } from './catchConsoleError';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 import { BaseProperty, PropertyFactory } from '@fluid-experimental/property-properties';

--- a/experimental/PropertyDDS/packages/property-binder/src/test/es6_decorator_data_binding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/es6_decorator_data_binding.spec.js
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 /* globals should, sinon, expect */
-import { DataBinder } from '../../src/data_binder/dataBinder';
+import { DataBinder } from '../data_binder/dataBinder';
 import {
   DataBinding,
   onValuesChanged,
   onPathChanged,
   onPropertyChanged
-} from '../../src/data_binder/dataBinding';
+} from '../data_binder/dataBinding';
 import { catchConsoleErrors } from './catchConsoleError';
-import { ModificationContext } from '../../src/data_binder/modificationContext';
+import { ModificationContext } from '../data_binder/modificationContext';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 import { BaseProperty, PropertyFactory } from '@fluid-experimental/property-properties';
 

--- a/experimental/PropertyDDS/packages/property-binder/src/test/internal_utils.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/internal_utils.spec.js
@@ -4,7 +4,7 @@
  */
 import { BaseProperty, PropertyFactory } from '@fluid-experimental/property-properties';
 /* globals expect, sinon  */
-import { forEachProperty, minimalRootPaths, visitTypeHierarchy } from '../../src/data_binder/internalUtils';
+import { forEachProperty, minimalRootPaths, visitTypeHierarchy } from '../data_binder/internalUtils';
 import { catchConsoleErrors } from './catchConsoleError';
 import { PrimitiveChildrenTemplate, AnimalSchema, registerTestTemplates } from './testTemplates';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
@@ -209,7 +209,7 @@ describe('forEachProperty', () => {
   });
 });
 
-describe('visitTypeHierarchy', async () => {
+describe('visitTypeHierarchy', () => {
   let workspace;
   const callbackSpy = jest.fn();
   beforeAll(async () => {

--- a/experimental/PropertyDDS/packages/property-binder/src/test/onDemandDataBinding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/onDemandDataBinding.spec.js
@@ -12,9 +12,9 @@
  *
  */
 import _ from 'lodash';
-import { DataBinding } from '../../src/data_binder/dataBinding';
-import { DataBinder } from '../../src/data_binder/dataBinder';
-import { unregisterAllOnPathListeners } from '../../src/data_binder/internalUtils';
+import { DataBinding } from '../data_binder/dataBinding';
+import { DataBinder } from '../data_binder/dataBinder';
+import { unregisterAllOnPathListeners } from '../data_binder/internalUtils';
 import {
   registerTestTemplates, ParentTemplate, ChildTemplate,
   InheritedChildTemplate,

--- a/experimental/PropertyDDS/packages/property-binder/src/test/property_element.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/property_element.spec.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 /* globals expect, should  */
-import { DataBinder } from '../../src/data_binder/dataBinder';
+import { DataBinder } from '../data_binder/dataBinder';
 
 import {
   catchConsoleErrors
@@ -16,9 +16,9 @@ import {
 
 import * as _ from 'underscore';
 
-import { PropertyElement } from '../../src/internal/propertyElement';
+import { PropertyElement } from '../internal/propertyElement';
 import { PropertyFactory } from '@fluid-experimental/property-properties';
-import { RESOLVE_NEVER, RESOLVE_NO_LEAFS, RESOLVE_ALWAYS } from '../../src/internal/constants';
+import { RESOLVE_NEVER, RESOLVE_NO_LEAFS, RESOLVE_ALWAYS } from '../internal/constants';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 
 describe('Property element', function() {

--- a/experimental/PropertyDDS/packages/property-binder/src/test/references.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/references.spec.js
@@ -11,11 +11,11 @@
 /* eslint max-nested-callbacks: ["warn", 5] */
 
 import _ from 'lodash';
-import { DataBinder } from '../../src/data_binder/dataBinder';
+import { DataBinder } from '../data_binder/dataBinder';
 import {
   DataBinding
-} from '../../src/data_binder/dataBinding';
-import { ModificationContext } from '../../src/data_binder/modificationContext';
+} from '../data_binder/dataBinding';
+import { ModificationContext } from '../data_binder/modificationContext';
 import {
   registerTestTemplates, ParentTemplate, ChildTemplate,
   PrimitiveChildrenTemplate, ArrayContainerTemplate,
@@ -30,8 +30,8 @@ import {
   InheritedChildDataBinding
 } from './testDataBindings';
 import { catchConsoleErrors } from './catchConsoleError';
-import { unregisterAllOnPathListeners } from '../../src/data_binder/internalUtils';
-import { RESOLVE_NO_LEAFS, RESOLVE_NEVER } from '../../src/internal/constants';
+import { unregisterAllOnPathListeners } from '../data_binder/internalUtils';
+import { RESOLVE_NO_LEAFS, RESOLVE_NEVER } from '../internal/constants';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 import { PropertyFactory } from '@fluid-experimental/property-properties';
 

--- a/experimental/PropertyDDS/packages/property-binder/src/test/runtime_models.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/runtime_models.spec.js
@@ -6,10 +6,10 @@
 /* eslint-disable require-jsdoc */
 
 import { registerTestTemplates } from './testTemplates';
-import { DataBinding } from '../../src/data_binder/dataBinding';
+import { DataBinding } from '../data_binder/dataBinding';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 import { PropertyFactory } from '@fluid-experimental/property-properties';
-import { DataBinder } from '../../src';
+import { DataBinder } from '..';
 
 class AnimalRepresentation {
 }

--- a/experimental/PropertyDDS/packages/property-binder/src/test/semver_bindings.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/semver_bindings.spec.js
@@ -5,15 +5,15 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable require-jsdoc */
 /* globals expect */
-import { DataBinder } from '../../src/data_binder/dataBinder';
+import { DataBinder } from '../data_binder/dataBinder';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 import {
   catchConsoleErrors
 } from './catchConsoleError';
 
-import { DataBinding } from '../../src/data_binder/dataBinding';
+import { DataBinding } from '../data_binder/dataBinding';
 import { PropertyFactory } from '@fluid-experimental/property-properties';
-import { UpgradeType } from '../../src';
+import { UpgradeType } from '..';
 
 const versions = [
   'test1:mytype-0.0.9',

--- a/experimental/PropertyDDS/packages/property-binder/src/test/semver_reps.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/semver_reps.spec.js
@@ -7,7 +7,7 @@
 /* eslint-disable require-jsdoc */
 
 import { registerTestTemplates } from './testTemplates';
-import { DataBinder, UpgradeType } from '../../src/index';
+import { DataBinder, UpgradeType } from '../index';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 import { PropertyFactory } from '@fluid-experimental/property-properties';
 class VersionedRepresentation100 {

--- a/experimental/PropertyDDS/packages/property-binder/src/test/stateless_binding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/stateless_binding.spec.js
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 /* globals sinon, expect, should */
-import { DataBinder } from '../../src/data_binder/dataBinder';
-import { SingletonDataBinding, StatelessDataBinding } from '../../src/data_binder/statelessDataBinding';
+import { DataBinder } from '../data_binder/dataBinder';
+import { SingletonDataBinding, StatelessDataBinding } from '../data_binder/statelessDataBinding';
 import { catchConsoleErrors } from './catchConsoleError';
 import { MockSharedPropertyTree } from './mockSharedPropertyTree';
 

--- a/experimental/PropertyDDS/packages/property-binder/src/test/testDataBindings.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/testDataBindings.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 /* globals sinon */
-import { DataBinding } from '../../src/data_binder/dataBinding';
+import { DataBinding } from '../data_binder/dataBinding';
 
 // Define the DataBinding classes. Must be done here due to the inheritance
 


### PR DESCRIPTION
This fixes 3 issues in the property-binder tests:
1. Remove unused async in describe which causes jest to skip running all tests in that describe block (and print a warning about this)
2. Normalize the import paths to skip unneeded ../src
3. Stop using ts-jest to compile the already compiled javascript in dist

Fix # 2 is needed for # 3 to work, since without it the javascript ends up importing some of the typescript files from src.

An alternative to # 3 would be to remove the first tsc step and point ts-jest at the src/test directory. I was unable to get that to work. 

This change is needed to make property-binder tests work with the new version of typescript in #10039