### PR TITLE
[server]: fixing Kubernetes files by using string env variable values

### DIFF
--- a/server/charts/fluid-metrics/templates/metrics-deployment.yaml
+++ b/server/charts/fluid-metrics/templates/metrics-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: DEBUG
           value: "routerlicious:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/charts/fluid-metrics/templates/metrics-deployment.yaml
+++ b/server/charts/fluid-metrics/templates/metrics-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /home/node/server/config.json

--- a/server/charts/historian/templates/gitrest-deployment.yaml
+++ b/server/charts/historian/templates/gitrest-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           containerPort: 3000
         env:
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/charts/historian/templates/gitrest-deployment.yaml
+++ b/server/charts/historian/templates/gitrest-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: data
           mountPath: /home/node/documents

--- a/server/charts/historian/templates/historian-deployment.yaml
+++ b/server/charts/historian/templates/historian-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: DEBUG
           value: "routerlicious:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/charts/historian/templates/historian-deployment.yaml
+++ b/server/charts/historian/templates/historian-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /home/node/server/packages/historian/config.json

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/functions/deli/config.json

--- a/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/functions/deli/config.json

--- a/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/functions/deli/config.json

--- a/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/deli-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:

--- a/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: NODE_ENV
           value: production
         - name: IS_FLUID_SERVER
-          value: true
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /usr/src/server/packages/routerlicious/config/config.json

--- a/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: DEBUG
           value: "fluid:*"
         - name: NODE_ENV
-          value: production
+          value: "production"
         - name: IS_FLUID_SERVER
           value: "true"
         volumeMounts:


### PR DESCRIPTION
Kubernetes environment variables are specified via `name` and `value` pairs. `value` expects string types. In https://github.com/microsoft/FluidFramework/pull/9973, a new environment variable was introduced: `IS_FLUID_SERVER`. But the values I provided were simply `true`. YAML would interpret those values as boolean instead of string, which would make Kubernetes deployments fail. I'm fixing that in this PR, and also making sure NODE_ENV are considered properly as string (I believe using values like `production` would be considered as string by YAML, but it does not hurt to make that explicit).