### PR TITLE
Switch to running fullGC as false

### DIFF
--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -159,7 +159,7 @@ export async function uploadSummary(container: IContainer) {
     const summaryResult = await runtime.summarize({
         fullTree: true,
         trackState: false,
-        fullGC: true,
+        fullGC: false,
     });
     return runtime.storage.uploadSummaryWithContext(summaryResult.summary, {
         referenceSequenceNumber: 0,


### PR DESCRIPTION
[AB#189](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/189)
Resolves #10015 

There's a buggy version of snapshots right now where we have duplicate GC outbound routes in the GC blob. Create a snapshot test for this scenario, as we are making a snapshot level change.

Setting `fullGC = false` will already generate these issues for existing snapshots. 

Point at the commit that has these duplicate route issues.