### PR TITLE
Deprecate IProxyLoaderFactory

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -19,12 +19,16 @@ There are a few steps you can take to write a good change note and avoid needing
 ## 0.59 Upcoming changes
 - [Remove ICodeLoader interface](#Remove-ICodeLoader-interface)
 - [IFluidContainer.connect() and IFluidContainer.disconnect() will be made mandatory in future major release](#ifluidcontainer-connect-and-ifluidcontainer-disconnect-will-be-made-mandatory-in-future-major-release)
+- [proxyLoaderFactories members to be removed from ILoaderProps and ILoaderServices](#proxyLoaderFactories-members-to-be-removed-from-ILoaderProps-and-ILoaderServices)
 
 ### Remove ICodeLoader interface
 ICodeLoader interface was deprecated a while ago and will be removed in the next release. Please refer to [replace ICodeLoader with ICodeDetailsLoader interface](#Replace-ICodeLoader-with-ICodeDetailsLoader-interface) for more details.
 
 ### IFluidContainer.connect() and IFluidContainer.disconnect() will be made mandatory in future major release
 In major release 1.0, the optional functions `IFluidContainer.connect()` and `IFluidContainer.disconnect()` will be made mandatory functions.
+
+### proxyLoaderFactories members to be removed from ILoaderProps and ILoaderServices
+The `proxyLoaderFactories` member on `ILoaderProps` and `ILoaderServices` has been deprecated in 0.59 and will be removed in an upcoming release.
 
 ## 0.59 Breaking changes
 - [Removing Commit from TreeEntry and commits from SnapShotTree](#Removing-Commit-from-TreeEntry-and-commits-from-SnapShotTree)

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -114,7 +114,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     subLogger: TelemetryLogger;
     // (undocumented)
     static version: string;
-    }
+}
 
 // @public @deprecated (undocumented)
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
@@ -166,6 +166,7 @@ export interface ILoaderProps {
     readonly documentServiceFactory: IDocumentServiceFactory;
     readonly logger?: ITelemetryBaseLogger;
     readonly options?: ILoaderOptions;
+    // @deprecated
     readonly proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
     readonly scope?: FluidObject;
     readonly urlResolver: IUrlResolver;
@@ -177,6 +178,7 @@ export interface ILoaderServices {
     readonly detachedBlobStorage?: IDetachedBlobStorage;
     readonly documentServiceFactory: IDocumentServiceFactory;
     readonly options: ILoaderOptions;
+    // @deprecated
     readonly proxyLoaderFactories: Map<string, IProxyLoaderFactory>;
     readonly scope: FluidObject;
     readonly subLogger: ITelemetryLogger;
@@ -213,7 +215,6 @@ export class RelativeLoader implements ILoader {
 
 // @public
 export function waitContainerToCatchUp(container: IContainer): Promise<boolean>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/lib/container-definitions/BREAKING.md
+++ b/common/lib/container-definitions/BREAKING.md
@@ -1,3 +1,15 @@
+## 0.48 Upcoming changes
+- [IProxyLoader interface to be removed](#IProxyLoader-interface-to-be-removed)
+
+### IProxyLoader interface to be removed
+The `IProxyLoader` interface has been deprecated in 0.48 and will be removed in an upcoming release.
+
+## 0.45 Breaking changes
+- [ContainerErrorType.clientSessionExpiredError added](#ContainerErrorType.clientSessionExpiredError-added)
+
+### ContainerErrorType.clientSessionExpiredError added
+We have session expiry for GC purposes. Once the session has expired, we want to throw this new clientSessionExpiredError to clear out any stale in-memory data that may still be on the container.
+
 ## 0.40 Breaking changes
 
 - [IErrorBase.sequenceNumber removed](#IErrorBase.sequenceNumber-removed)
@@ -12,9 +24,3 @@ but a large number of useful properties off the offending message, via `CreatePr
 Use `IContainerContext.taggedLogger` instead if present. If it's missing and you must use `logger`,
 be sure to handle tagged data before sending events to it.
 `logger` won't be removed for a very long time since old loaders could remain in production for quite some time.
-
-## 0.45 Breaking changes
-- [ContainerErrorType.clientSessionExpiredError added](#ContainerErrorType.clientSessionExpiredError-added)
-
-### ContainerErrorType.clientSessionExpiredError added
-We have session expiry for GC purposes. Once the session has expired, we want to throw this new clientSessionExpiredError to clear out any stale in-memory data that may still be on the container.

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -488,9 +488,11 @@ export interface IProvideRuntimeFactory {
     readonly IRuntimeFactory: IRuntimeFactory;
 }
 
-// @public
+// @public @deprecated
 export interface IProxyLoaderFactory {
+    // @deprecated
     createProxyLoader(id: string, options: ILoaderOptions, resolved: IFluidResolvedUrl, fromSequenceNumber: number): Promise<ILoader>;
+    // @deprecated
     environment: string;
 }
 

--- a/common/lib/container-definitions/src/proxyLoader.ts
+++ b/common/lib/container-definitions/src/proxyLoader.ts
@@ -8,15 +8,18 @@ import { ILoader, ILoaderOptions } from "./loader";
 
 /**
  * Abstraction layer to support different Loaders in different Node execution contexts
+ * @deprecated Not recommended for general use and will be removed in an upcoming release.
  */
 export interface IProxyLoaderFactory {
     /**
      * Loader environment
+     * @deprecated Not recommended for general use and will be removed in an upcoming release.
      */
     environment: string;
 
     /**
      * Returns an instance of ILoader loaded inside an execution context.
+     * @deprecated Not recommended for general use and will be removed in an upcoming release.
      */
     createProxyLoader(
         id: string,

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -8,7 +8,6 @@ import {
     AttachState,
     IContainerContext,
     IRuntime,
-    IProxyLoaderFactory,
     ILoaderOptions,
     IContainer,
     ICodeDetailsLoader,
@@ -63,8 +62,6 @@ export interface IFrameOuterHostConfig {
     // A Fluid object that gives host provided capabilities/configurations
     // to the Fluid object in the container(such as auth).
     scope?: FluidObject;
-
-    proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
 }
 
 class ProxyRuntime implements IRuntime {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -203,6 +203,7 @@ export interface ILoaderProps {
     /**
      * Proxy loader factories for loading containers via proxy in other contexts,
      * like web workers, or worker threads.
+     * @deprecated Not recommended for general use and will be removed in an upcoming release.
      */
     readonly proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
 
@@ -259,6 +260,7 @@ export interface ILoaderServices {
     /**
      * Proxy loader factories for loading containers via proxy in other contexts,
      * like web workers, or worker threads.
+     * @deprecated Not recommended for general use and will be removed in an upcoming release.
      */
     readonly proxyLoaderFactories: Map<string, IProxyLoaderFactory>;
 


### PR DESCRIPTION
Aligning with #8094, this change marks `IProxyLoaderFactory` and associated members as deprecated in anticipation of future removal.  No known customers, this used to be intended for the web worker loader that we never really got working - should be safe to remove across a major version.