### PR TITLE
Throw error instead of assert in createContainer paths where empty summary tree is unsupported

### DIFF
--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -4,7 +4,6 @@
  */
 
 import { parse } from "url";
-import { assert } from "@fluidframework/common-utils";
 import {
     IDocumentService,
     IDocumentServiceFactory,
@@ -48,7 +47,9 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
         clientIsSummarizer?: boolean,
     ): Promise<IDocumentService> {
         ensureFluidResolvedUrl(resolvedUrl);
-        assert(!!createNewSummary, 0x202 /* "create empty file not supported" */);
+        if (createNewSummary === undefined) {
+            throw new Error("Empty file summary creation isn't supported in this driver.");
+        }
         const pathName = new URL(resolvedUrl.url).pathname;
         const pathArr = pathName.split("/");
         const tenantId = pathArr[pathArr.length - 2];

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -66,7 +66,9 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         clientIsSummarizer?: boolean,
     ): Promise<IDocumentService> {
         ensureFluidResolvedUrl(resolvedUrl);
-        assert(!!createNewSummary, 0x204 /* "create empty file not supported" */);
+        if (createNewSummary === undefined) {
+            throw new Error("Empty file summary creation isn't supported in this driver.");
+        }
         assert(!!resolvedUrl.endpoints.ordererUrl, 0x0b2 /* "Missing orderer URL!" */);
         let parsedUrl = parseFluidUrl(resolvedUrl.url);
         if (!parsedUrl.pathname) {

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -268,7 +268,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage);
         }
         await attachP;
 
@@ -319,7 +319,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage);
         }
         await attachP;
         detachedBlobStorage.blobs.clear();
@@ -349,7 +349,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage);
         }
         await attachP;
 
@@ -380,7 +380,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage);
         }
         await attachP;
 

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -57,10 +57,12 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
     }
 }
 
-const ContainerClose0x202ExpectedDrivers: ExpectedEvents = {
-    local: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: "0x202" }],
-    routerlicious: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: "0x204" }],
-    tinylicious: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: "0x204" }],
+const usageErrorMessage = "Empty file summary creation isn't supported in this driver.";
+
+const ContainerCloseUsageError: ExpectedEvents = {
+    local: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage }],
+    routerlicious: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage }],
+    tinylicious: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage }],
 };
 
 describeFullCompat("blobs", (getTestObjectProvider) => {
@@ -249,7 +251,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
     });
 
-    itExpects("works in detached container", ContainerClose0x202ExpectedDrivers, async function() {
+    itExpects("works in detached container", ContainerCloseUsageError, async function() {
         const detachedBlobStorage = new MockDetachedBlobStorage();
         const loader = provider.makeTestLoader({ ...testContainerConfig, loaderProps: { detachedBlobStorage } });
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -266,7 +268,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
         }
         await attachP;
 
@@ -298,7 +300,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await rehydratedDataStore._root.get("my blob").get(), "utf-8"), text);
     });
 
-    itExpects("redirect table saved in snapshot", ContainerClose0x202ExpectedDrivers, async function() {
+    itExpects("redirect table saved in snapshot", ContainerCloseUsageError, async function() {
         const detachedBlobStorage = new MockDetachedBlobStorage();
         const loader = provider.makeTestLoader({ ...testContainerConfig, loaderProps: { detachedBlobStorage } });
         const detachedContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -317,7 +319,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
         }
         await attachP;
         detachedBlobStorage.blobs.clear();
@@ -330,7 +332,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
     });
 
-    itExpects("serialize/rehydrate then attach", ContainerClose0x202ExpectedDrivers, async function() {
+    itExpects("serialize/rehydrate then attach", ContainerCloseUsageError, async function() {
         const loader = provider.makeTestLoader(
             { ...testContainerConfig, loaderProps: { detachedBlobStorage: new MockDetachedBlobStorage() } });
         const serializeContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -347,7 +349,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
         }
         await attachP;
 
@@ -358,7 +360,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(bufferToString(await (attachedDataStore._root.get("my blob")).get(), "utf-8"), text);
     });
 
-    itExpects("serialize/rehydrate multiple times then attach", ContainerClose0x202ExpectedDrivers, async function() {
+    itExpects("serialize/rehydrate multiple times then attach", ContainerCloseUsageError, async function() {
         const loader = provider.makeTestLoader(
             { ...testContainerConfig, loaderProps: { detachedBlobStorage: new MockDetachedBlobStorage() } });
         let container = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -378,7 +380,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
             return assert.rejects(attachP,
-                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
+                (err) => err.message === usageErrorMessage /* "create empty file not supported" */);
         }
         await attachP;
 


### PR DESCRIPTION
This throws an error instead of an assert in the case where an undefined summary tree is passed to drivers that don't support it. 

Fixes #9039