### PR TITLE
Merge Tree: const enums to const objects

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,11 +14,11 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
-# 1.0
+# 0.60
 
-## 1.0 Upcoming changes
+## 0.60 Upcoming changes
 
-## 1.0 Breaking changes
+## 0.60 Breaking changes
 - [Remove IFluidSerializer from core-interfaces](#Remove-IFluidSerializer-from-core-interfaces)
 - [Remove IFluidSerializer from IFluidObject](#Remove-IFluidSerializer-from-IFluidObject)
 - [Deprecate TelemetryDataTag.PackageData](#Deprecate-TelemetryDataTagPackageData)
@@ -27,6 +27,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Deprecated Fields from ISummaryRuntimeOptions](#Deprecated-fields-from-ISummaryRuntimeOptions)
 - [`ISummarizerOptions` is deprecated](#isummarizerOptions-is-deprecated)
 - [connect() and disconnect() made mandatory on IContainer and IFluidContainer](#connect-and-disconnect-made-mandatory-on-icontainer-and-ifluidcontainer)
+- [Remove Const Enums from Merge Tree, Sequence, and Shared String](#Remove-Const-Enums-from-Merge-Tree-Sequence-and-Shared-String)
 
 ### Remove IFluidSerializer from core-interfaces
 `IFluidSerializer` was deprecated from core-interfaces in 0.55 and is now removed. Use `IFluidSerializer` in shared-object-base instead.
@@ -65,6 +66,15 @@ Options that control the behavior of a running summarizer will be moved to the `
 
 ### connect() and disconnect() made mandatory on IContainer and IFluidContainer
 The functions `IContainer.connect()`, `IContainer.disconnect()`, `IFluidContainer.connect()`, and `IFluidContainer.disconnect()` have all been changed from optional to mandatory functions.
+
+### Remove Const Enums from Merge Tree, Sequence, and Shared String
+
+The types RBColor, MergeTreeMaintenanceType, and MergeTreeDeltaType are no longer const enums they are now const objects with a union type. In general there should be no change necessary for consumer, unless you are using a specific value as a type. When using a specific value as a type, it is now necessary to prefix with typeof. This scenario is uncommon in consuming code. Example:
+``` diff
+export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
+-    type: MergeTreeDeltaType.INSERT;
++    type: typeof MergeTreeDeltaType.INSERT;
+```
 
 # 0.59
 

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -461,7 +461,7 @@ export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
     // (undocumented)
     relativePos2?: IRelativePosition;
     // (undocumented)
-    type: MergeTreeDeltaType.ANNOTATE;
+    type: typeof MergeTreeDeltaType.ANNOTATE;
 }
 
 // @public (undocumented)
@@ -502,7 +502,7 @@ export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
     // (undocumented)
     ops: IMergeTreeDeltaOp[];
     // (undocumented)
-    type: MergeTreeDeltaType.GROUP;
+    type: typeof MergeTreeDeltaType.GROUP;
 }
 
 // @public (undocumented)
@@ -518,7 +518,7 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
     // (undocumented)
     seg?: any;
     // (undocumented)
-    type: MergeTreeDeltaType.INSERT;
+    type: typeof MergeTreeDeltaType.INSERT;
 }
 
 // @public (undocumented)
@@ -539,7 +539,7 @@ export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
     // (undocumented)
     relativePos2?: IRelativePosition;
     // (undocumented)
-    type: MergeTreeDeltaType.REMOVE;
+    type: typeof MergeTreeDeltaType.REMOVE;
 }
 
 // @public (undocumented)
@@ -1056,35 +1056,35 @@ export class MergeTree {
 export type MergeTreeDeltaCallback = (opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs) => void;
 
 // @public (undocumented)
-export type MergeTreeDeltaOperationType = MergeTreeDeltaType.ANNOTATE | MergeTreeDeltaType.INSERT | MergeTreeDeltaType.REMOVE;
+export type MergeTreeDeltaOperationType = typeof MergeTreeDeltaType.ANNOTATE | typeof MergeTreeDeltaType.INSERT | typeof MergeTreeDeltaType.REMOVE;
 
 // @public (undocumented)
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
 
 // @public (undocumented)
-export const enum MergeTreeDeltaType {
-    // (undocumented)
-    ANNOTATE = 2,
-    // (undocumented)
-    GROUP = 3,
-    // (undocumented)
-    INSERT = 0,
-    // (undocumented)
-    REMOVE = 1
-}
+export const MergeTreeDeltaType: {
+    readonly INSERT: 0;
+    readonly REMOVE: 1;
+    readonly ANNOTATE: 2;
+    readonly GROUP: 3;
+};
+
+// @public (undocumented)
+export type MergeTreeDeltaType = typeof MergeTreeDeltaType[keyof typeof MergeTreeDeltaType];
 
 // @public (undocumented)
 export type MergeTreeMaintenanceCallback = (MaintenanceArgs: IMergeTreeMaintenanceCallbackArgs, opArgs: IMergeTreeDeltaOpArgs | undefined) => void;
 
 // @public (undocumented)
-export const enum MergeTreeMaintenanceType {
-    ACKNOWLEDGED = -4,
-    // (undocumented)
-    APPEND = -1,
-    // (undocumented)
-    SPLIT = -2,
-    UNLINK = -3
-}
+export const MergeTreeMaintenanceType: {
+    readonly APPEND: -1;
+    readonly SPLIT: -2;
+    readonly UNLINK: -3;
+    readonly ACKNOWLEDGED: -4;
+};
+
+// @public (undocumented)
+export type MergeTreeMaintenanceType = typeof MergeTreeMaintenanceType[keyof typeof MergeTreeMaintenanceType];
 
 // @public (undocumented)
 export interface MergeTreeStats {
@@ -1194,12 +1194,13 @@ export interface QProperty<TKey, TData> {
 export type RangeStackMap = MapLike<Stack<ReferencePosition>>;
 
 // @public (undocumented)
-export const enum RBColor {
-    // (undocumented)
-    BLACK = 1,
-    // (undocumented)
-    RED = 0
-}
+export const RBColor: {
+    readonly RED: 0;
+    readonly BLACK: 1;
+};
+
+// @public (undocumented)
+export type RBColor = typeof RBColor[keyof typeof RBColor];
 
 // @public (undocumented)
 export interface RBNode<TKey, TData> {

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -220,10 +220,11 @@ export class Heap<T> {
     /* eslint-enable no-bitwise */
 }
 
-export const enum RBColor {
-    RED,
-    BLACK,
-}
+export const RBColor = {
+    RED: 0,
+    BLACK: 1,
+} as const;
+export type RBColor = typeof RBColor[keyof typeof RBColor];
 
 export interface RBNode<TKey, TData> {
     key: TKey;

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -13,28 +13,26 @@ import { PropertySet } from "./properties";
 import { ISegment } from "./mergeTree";
 
 export type MergeTreeDeltaOperationType =
-    MergeTreeDeltaType.ANNOTATE | MergeTreeDeltaType.INSERT | MergeTreeDeltaType.REMOVE;
+    typeof MergeTreeDeltaType.ANNOTATE | typeof MergeTreeDeltaType.INSERT | typeof MergeTreeDeltaType.REMOVE;
 
 // Note: Assigned negative integers to avoid clashing with MergeTreeDeltaType
-export const enum MergeTreeMaintenanceType {
-    APPEND = -1,
-    SPLIT = -2,
+export const MergeTreeMaintenanceType = {
+    APPEND: -1,
+    SPLIT: -2,
     /**
      * Notification that a segment has been unlinked from the MergeTree.  This occurs during
      * Zamboni when:
      *
-     *    a) The minSeq has moved past the segment's removeSeq, in which case the segment
-     *       can no longer be referenced by incoming remote ops, and...
-     *
      *    b) The segment's tracking collection is empty (e.g., not being tracked for undo/redo).
      */
-    UNLINK = -3,
+    UNLINK: -3,
     /**
      * Notification that a local change has been acknowledged by the server.
      * This means that it has made the round trip to the server and has had a sequence number assigned.
      */
-    ACKNOWLEDGED = -4,
-}
+    ACKNOWLEDGED: -4,
+} as const;
+export type MergeTreeMaintenanceType = typeof MergeTreeMaintenanceType[keyof typeof MergeTreeMaintenanceType];
 
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
 

--- a/packages/dds/merge-tree/src/ops.ts
+++ b/packages/dds/merge-tree/src/ops.ts
@@ -19,12 +19,14 @@ export interface IMarkerDef {
 }
 
 // Note: Assigned positive integers to avoid clashing with MergeTreeMaintenanceType
-export const enum MergeTreeDeltaType {
-    INSERT = 0,
-    REMOVE = 1,
-    ANNOTATE = 2,
-    GROUP = 3,
-}
+export const MergeTreeDeltaType = {
+    INSERT: 0,
+    REMOVE: 1,
+    ANNOTATE: 2,
+    GROUP: 3,
+} as const;
+
+export type MergeTreeDeltaType = typeof MergeTreeDeltaType[keyof typeof MergeTreeDeltaType];
 
 export interface IMergeTreeDelta {
     /**
@@ -54,7 +56,7 @@ export interface IRelativePosition {
 }
 
 export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
-    type: MergeTreeDeltaType.INSERT;
+    type: typeof MergeTreeDeltaType.INSERT;
     pos1?: number;
     relativePos1?: IRelativePosition;
     pos2?: number;
@@ -63,7 +65,7 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
 }
 
 export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
-    type: MergeTreeDeltaType.REMOVE;
+    type: typeof MergeTreeDeltaType.REMOVE;
     pos1?: number;
     relativePos1?: IRelativePosition;
     pos2?: number;
@@ -78,7 +80,7 @@ export interface ICombiningOp {
 }
 
 export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
-    type: MergeTreeDeltaType.ANNOTATE;
+    type: typeof MergeTreeDeltaType.ANNOTATE;
     pos1?: number;
     relativePos1?: IRelativePosition;
     pos2?: number;
@@ -88,7 +90,7 @@ export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
 }
 
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
-    type: MergeTreeDeltaType.GROUP;
+    type: typeof MergeTreeDeltaType.GROUP;
     ops: IMergeTreeDeltaOp[];
 }
 


### PR DESCRIPTION
This change moves from const enums to const objects in the merge tree package. This will fix #8142 and is related to #10147.

I also fixed the breaking.md version, which does not match the package versions.