### PR TITLE
Fix handling of removed segments when calculating interval position

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -1002,7 +1002,7 @@ export class Client {
         let clientId: number;
         if (op) {
             clientId = this.getOrAddShortClientId(op.clientId);
-            seq = op.sequenceNumber;
+            seq = op.referenceSequenceNumber;
         } else {
             const segWindow = this.mergeTree.getCollabWindow();
             seq = segWindow.currentSeq;

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -10,6 +10,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { UnassignedSequenceNumber } from "../constants";
 import { SegmentGroup } from "../mergeTree";
 import { MergeTreeDeltaType } from "../ops";
+import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
 import { TestClientLogger } from "./testClientLogger";
 
@@ -425,5 +426,33 @@ describe("client.applyMsg", () => {
         const regeneratedOp = clientA.regeneratePendingOp(annotateOp, seg);
         assert(regeneratedOp.type === MergeTreeDeltaType.GROUP);
         assert.strictEqual(regeneratedOp.ops.length, 0);
+    });
+
+    it("getContainingSegment with op", () => {
+        const clientA = new TestClient();
+        clientA.startOrUpdateCollaboration("A");
+        const clientB = new TestClient();
+        clientB.startOrUpdateCollaboration("B");
+
+        let seq = 0;
+        const insertOp1 = clientA.makeOpMessage(clientA.insertTextLocal(0, "ABC"), ++seq);
+        [clientA, clientB].map((c) => c.applyMsg(insertOp1));
+
+        const removeOp = clientA.removeRangeLocal(0, 2);
+        const removeSequence = ++seq;
+        clientA.applyMsg(clientA.makeOpMessage(removeOp, removeSequence));
+
+        const insertOp2 = clientB.insertTextLocal(2, "X");
+
+        // op with no reference sequence should count removed segment
+        const insertMessage2 = clientB.makeOpMessage(insertOp2, ++seq);
+        let seg = clientA.getContainingSegment(2, insertMessage2);
+        assert.notStrictEqual(seg.segment, undefined);
+        assert.strictEqual((seg.segment as TextSegment).text, "C");
+
+        // op with reference sequence >= remove op sequence should not count removed segment
+        const insertMessage3 = clientB.makeOpMessage(insertOp2, seq, removeSequence);
+        seg = clientA.getContainingSegment(2, insertMessage3);
+        assert.strictEqual(seg.segment, undefined);
     });
 });

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -395,7 +395,7 @@ describe("SharedString", () => {
             ]);
         });
 
-        it.only("can slide intervals on create conflict with remove range", () => {
+        it("can slide intervals on create conflict with remove range", () => {
             const collection1 = sharedString.getIntervalCollection("test");
             sharedString.insertText(0, "ABCD");
             containerRuntimeFactory.processAllMessages();

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -395,6 +395,26 @@ describe("SharedString", () => {
             ]);
         });
 
+        it.only("can slide intervals on create conflict with remove range", () => {
+            const collection1 = sharedString.getIntervalCollection("test");
+            sharedString.insertText(0, "ABCD");
+            containerRuntimeFactory.processAllMessages();
+            const collection2 = sharedString2.getIntervalCollection("test");
+
+            sharedString.removeRange(1, 3);
+
+            collection2.add(1, 3, IntervalType.SlideOnRemove);
+
+            containerRuntimeFactory.processAllMessages();
+
+            assertIntervals(sharedString2, collection2, [
+                { start: 1, end: 1 },
+            ]);
+            assertIntervals(sharedString, collection1, [
+                { start: 1, end: 1 },
+            ]);
+        });
+
         it("can maintain consistency of LocalReference's when segments are packed", async () => {
             // sharedString.insertMarker(0, ReferenceType.Tile, { nodeType: "Paragraph" });
 


### PR DESCRIPTION
When finding the containing segment for an interval the code was using the op sequenceNumber as the reference sequence number. This caused it to ignore removed segments in calculating the position. This fixes getContainingSegment to use the correct reference sequence. It also adds a unit test which reproduced the problem and verifies the fix. Based on a code search, the interval collections is the only code that uses the op parameter, so this bug only impacted interval collections and the fix will only change the behavior of interval collections.
