### PR TITLE
[GitRest] Fixing bugs and UTs

### DIFF
--- a/server/gitrest/README.md
+++ b/server/gitrest/README.md
@@ -81,15 +81,15 @@ curl -H "Content-Type: application/json" -X POST -d '{"content": "Hello, World!"
 curl -H "Content-Type: application/json" -X POST -d '{"tree": [{"path": "file.txt", "mode": "100644", "type": "blob", "sha": "b45ef6fec89518d314f546fd6c3025367b721684"}]}' --verbose localhost:3000/repos/prague/test/git/trees
 curl --verbose localhost:3000/repos/prague/test/git/trees/bf4db183cbd07f48546a5dde098b4510745d79a1
 curl -H "Content-Type: application/json" -X POST -d '{"message": "first commit", "tree": "bf4db183cbd07f48546a5dde098b4510745d79a1", "parents": [], "author": { "name": "Kurt Berglund", "email": "kurtb@microsoft.com", "date": "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)" }}' --verbose localhost:3000/repos/prague/test/git/commits
-curl --verbose localhost:3000/repos/prague/test/git/commits/cf0b592907d683143b28edd64d274ca70f68998e
-curl -H "Content-Type: application/json" -X POST -d '{"ref": "refs/heads/main", "sha": "cf0b592907d683143b28edd64d274ca70f68998e"}' --verbose localhost:3000/repos/prague/test/git/refs
+curl --verbose localhost:3000/repos/prague/test/git/commits/38421e18f9cf4ec024ae98f687e79c0bdf8f3f18
+curl -H "Content-Type: application/json" -X POST -d '{"ref": "refs/heads/main", "sha": "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18"}' --verbose localhost:3000/repos/prague/test/git/refs
 curl --verbose http://localhost:3000/repos/prague/test/git/refs
 ```
 
 Submodule example
 ```
 curl -H "Content-Type: application/json" -X POST -d '{"content": "[submodule \"module\"]\n\tpath = module\n\turl = ssh://git@localhost:3022/home/git/prague/test", "encoding": "utf-8"}' --verbose localhost:3000/repos/prague/test/git/blobs
-curl -H "Content-Type: application/json" -X POST -d '{"tree": [{"path": ".gitmodules", "mode": "100644", "type": "blob", "sha": "54a2d1738d0c62529ada54d32c5d05e1d1ea0fae"},{"path": "file.txt", "mode": "100644", "type": "blob", "sha": "b45ef6fec89518d314f546fd6c3025367b721684"},{"path": "module", "mode": "160000", "type": "commit", "sha": "cf0b592907d683143b28edd64d274ca70f68998e"}]}' --verbose localhost:3000/repos/prague/test/git/trees
+curl -H "Content-Type: application/json" -X POST -d '{"tree": [{"path": ".gitmodules", "mode": "100644", "type": "blob", "sha": "54a2d1738d0c62529ada54d32c5d05e1d1ea0fae"},{"path": "file.txt", "mode": "100644", "type": "blob", "sha": "b45ef6fec89518d314f546fd6c3025367b721684"},{"path": "module", "mode": "160000", "type": "commit", "sha": "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18"}]}' --verbose localhost:3000/repos/prague/test/git/trees
 curl -H "Content-Type: application/json" -X POST -d '{"message": "submodule commit", "tree": "f007d4f4ebe654785e87634a2e8f91d02993361d", "parents": [], "author": { "name": "Kurt Berglund", "email": "kurtb@microsoft.com", "date": "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)" }}' --verbose localhost:3000/repos/prague/test/git/commits
 curl -H "Content-Type: application/json" -X POST -d '{"ref": "refs/heads/modules", "sha": "b02301e7f2a6e1cc0bdb8cb33f4905f7c7b17ecc"}' --verbose localhost:3000/repos/prague/test/git/refs
 ```
@@ -97,12 +97,12 @@ curl -H "Content-Type: application/json" -X POST -d '{"ref": "refs/heads/modules
 Reference deletion and tags
 ```
 curl -X DELETE --verbose http://localhost:3000/repos/prague/test/git/refs/heads/main
-curl -H "Content-Type: application/json" -X POST -d '{"ref": "refs/heads/main", "sha": "cf0b592907d683143b28edd64d274ca70f68998e"}' --verbose localhost:3000/repos/prague/test/git/refs
+curl -H "Content-Type: application/json" -X POST -d '{"ref": "refs/heads/main", "sha": "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18"}' --verbose localhost:3000/repos/prague/test/git/refs
 # first fails - second works
-curl -H "Content-Type: application/json" -X PATCH -d '{"force": false, "sha": "cf0b592907d683143b28edd64d274ca70f68998e"}' --verbose http://localhost:3000/repos/prague/test/git/refs/heads/main
-curl -H "Content-Type: application/json" -X PATCH -d '{"force": true, "sha": "cf0b592907d683143b28edd64d274ca70f68998e"}' --verbose http://localhost:3000/repos/prague/test/git/refs/heads/main
-curl -H "Content-Type: application/json" -X POST -d '{"tag": "v1.0", "message": "Hello, World!", "object": "cf0b592907d683143b28edd64d274ca70f68998e", "type": "commit", "tagger": { "name": "Kurt Berglund", "email": "kurtb@microsoft.com", "date": "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)" }}' --verbose localhost:3000/repos/prague/test/git/tags
-curl --verbose localhost:3000/repos/prague/test/git/tags/a8588b3913aa692c3642697d6f136cec470dd82c
+curl -H "Content-Type: application/json" -X PATCH -d '{"force": false, "sha": "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18"}' --verbose http://localhost:3000/repos/prague/test/git/refs/heads/main
+curl -H "Content-Type: application/json" -X PATCH -d '{"force": true, "sha": "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18"}' --verbose http://localhost:3000/repos/prague/test/git/refs/heads/main
+curl -H "Content-Type: application/json" -X POST -d '{"tag": "v1.0", "message": "Hello, World!", "object": "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18", "type": "commit", "tagger": { "name": "Kurt Berglund", "email": "kurtb@microsoft.com", "date": "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)" }}' --verbose localhost:3000/repos/prague/test/git/tags
+curl --verbose localhost:3000/repos/prague/test/git/tags/2f208d6d4c5698feada2b5dad3886a0ceff4f80b
 ```
 
 ## Trademark

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -47,6 +47,7 @@
     "morgan": "^1.9.1",
     "nconf": "^0.11.4",
     "nodegit": "^0.27.0",
+    "serialize-error": "^8.1.0",
     "split": "^1.0.0",
     "uuid": "^3.3.2",
     "winston": "^3.6.0"

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -47,7 +47,6 @@
     "morgan": "^1.9.1",
     "nconf": "^0.11.4",
     "nodegit": "^0.27.0",
-    "serialize-error": "^8.1.0",
     "split": "^1.0.0",
     "uuid": "^3.3.2",
     "winston": "^3.6.0"

--- a/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
@@ -21,7 +21,7 @@ import sillyname from "sillyname";
 import request from "supertest";
 import * as app from "../app";
 import { ExternalStorageManager } from "../externalStorageManager";
-import { NodeFsManagerFactory, NodegitRepositoryManagerFactory } from "../utils";
+import { IsomorphicGitManagerFactory, NodeFsManagerFactory, NodegitRepositoryManagerFactory } from "../utils";
 import * as testUtils from "./utils";
 
 // TODO: (issue logged): replace email & name
@@ -104,8 +104,33 @@ async function initBaseRepo(
     await createRef(supertest, owner, repoName, testRef);
 }
 
-describe("GitRest", () => {
-    describe("Routes", () => {
+function normalizeMessage(gitLibrary: string, message: string) {
+    // isomorphic-git automatically adds a new line character at the end of commit
+    // messages and tag annotation messages. It's something we cannot control. Because
+    // of that, the SHA/OIDs could be different in nodegit vs isomorphic-git. To counter
+    // that, we "normalize" the message so that those used with nodegit also include
+    // the new line character, making the content exactly the same as for isomorphic-git.
+    if (gitLibrary === "nodegit") {
+        return `${message}\n`;
+    } else if (gitLibrary === "isomorphic-git") {
+        return message;
+    }
+    throw new Error(`Cannot normalize message. Unknown gitLibrary: ${gitLibrary}`);
+}
+
+const testModes: testUtils.ITestMode[] = [
+    {
+        name: "Using NodeGit as RepoManager",
+        gitLibrary: "nodegit",
+    },
+    {
+        name: "Using isomorphic-git as RepoManager",
+        gitLibrary: "isomorphic-git",
+    },
+];
+
+testModes.forEach((mode) => {
+    describe(`GitRest: ${mode.name}`, () => {
         const testOwnerName = "owner";
         const testRepoName = "test";
         const testBlob: ICreateBlobParams = {
@@ -127,13 +152,13 @@ describe("GitRest", () => {
                 email: commitEmail,
                 name: commitName,
             },
-            message: "first commit",
+            message: normalizeMessage(mode.gitLibrary, "first commit"),
             parents: [],
             tree: "bf4db183cbd07f48546a5dde098b4510745d79a1",
         };
         const testRef: ICreateRefParamsExternal = {
             ref: "refs/heads/main",
-            sha: "cf0b592907d683143b28edd64d274ca70f68998e",
+            sha: "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18",
             config: { enabled: true },
         };
 
@@ -143,578 +168,590 @@ describe("GitRest", () => {
 
         const testRefWriteDisabled: ICreateRefParams = {
             ref: "refs/heads/main",
-            sha: "cf0b592907d683143b28edd64d274ca70f68998e",
+            sha: "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18",
         };
 
         const fileSystemManagerFactory = new NodeFsManagerFactory();
         const externalStorageManager = new ExternalStorageManager(testUtils.defaultProvider);
-        const getRepoManagerFactory = () => new NodegitRepositoryManagerFactory(
-            testUtils.defaultProvider.get("storageDir"),
-            fileSystemManagerFactory,
-            externalStorageManager,
-        );
+        const getRepoManagerFactory = (gitLibrary: string) =>
+        {
+            if (gitLibrary === "nodegit") {
+                return new NodegitRepositoryManagerFactory(
+                    testUtils.defaultProvider.get("storageDir"),
+                    fileSystemManagerFactory,
+                    externalStorageManager,
+                );
+            } else if (gitLibrary === "isomorphic-git") {
+                return new IsomorphicGitManagerFactory(
+                    testUtils.defaultProvider.get("storageDir"),
+                    fileSystemManagerFactory,
+                );
+            }
+            throw new Error(`Cannot get RepoManagerFactory. Unknown gitLibrary: ${gitLibrary}`);
+        }
+        describe("Routes", () => {
+            testUtils.initializeBeforeAfterTestHooks(testUtils.defaultProvider);
 
-        testUtils.initializeBeforeAfterTestHooks(testUtils.defaultProvider);
-
-        // Create the git repo before and after each test
-        let supertest: request.SuperTest<request.Test>;
-        beforeEach(() => {
-            const repoManagerFactory = getRepoManagerFactory();
-            const testApp = app.create(testUtils.defaultProvider, fileSystemManagerFactory, repoManagerFactory);
-            supertest = request(testApp);
-        });
-
-        // Git data API tests
-        describe("Git", () => {
-            describe("Repos", () => {
-                it("Can create and get a new repo", async () => {
-                    await createRepo(supertest, testOwnerName, testRepoName);
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}`)
-                        .expect(200);
-                });
-
-                it("Returns 400 for an unknown repo", async () => {
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}`)
-                        .expect(400);
-                });
-
-                it("Rejects invalid repo names", async () => {
-                    return supertest
-                        .post(`/${testOwnerName}/repos`)
-                        .set("Accept", "application/json")
-                        .set("Content-Type", "application/json")
-                        .send({ name: "../evilrepo" })
-                        .expect(400);
-                });
-
-                it("Rejects missing repo names", async () => {
-                    return supertest
-                        .post(`/${testOwnerName}/repos`)
-                        .expect(400);
-                });
+            // Create the git repo before and after each test
+            let supertest: request.SuperTest<request.Test>;
+            beforeEach(() => {
+                const repoManagerFactory = getRepoManagerFactory(mode.gitLibrary);
+                const testApp = app.create(testUtils.defaultProvider, fileSystemManagerFactory, repoManagerFactory);
+                supertest = request(testApp);
             });
 
-            describe("Blobs", () => {
-                it("Can create and retrieve a blob", async () => {
-                    await createRepo(supertest, testOwnerName, testRepoName);
-                    const result = await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                    assert.strictEqual(result.body.sha, "b45ef6fec89518d314f546fd6c3025367b721684");
-
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/blobs/${result.body.sha}`)
-                        .expect(200)
-                        .expect((getResult) => {
-                            assert.strictEqual(getResult.body.sha, result.body.sha);
-                        });
-                });
-
-                it("Can create an existing blob without error", async () => {
-                    await createRepo(supertest, testOwnerName, testRepoName);
-                    await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                    await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                });
-            });
-
-            describe("Trees", () => {
-                it("Can create and retrieve a tree", async () => {
-                    await createRepo(supertest, testOwnerName, testRepoName);
-                    await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                    const tree = await createTree(supertest, testOwnerName, testRepoName, testTree);
-                    assert.strictEqual(tree.body.sha, "bf4db183cbd07f48546a5dde098b4510745d79a1");
-
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/trees/${tree.body.sha}`)
-                        .expect(200)
-                        .expect((getResult) => {
-                            assert.strictEqual(getResult.body.sha, tree.body.sha);
-                        });
-                });
-
-                it("Can recursively retrieve a tree", async () => {
-                    // Create a tree with a single sub directory
-                    await createRepo(supertest, testOwnerName, testRepoName);
-                    await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                    await createTree(supertest, testOwnerName, testRepoName, testTree);
-                    const parentBlob = await createBlob(
-                        supertest,
-                        testOwnerName,
-                        testRepoName,
-                        { content: "Parent", encoding: "utf-8" });
-                    const parentTree = {
-                        tree: [
-                            {
-                                mode: "100644",
-                                path: "parentBlob.txt",
-                                sha: parentBlob.body.sha,
-                                type: "blob",
-                            },
-                            {
-                                mode: "040000",
-                                path: "subdir",
-                                sha: "bf4db183cbd07f48546a5dde098b4510745d79a1",
-                                type: "tree",
-                            }],
-                    };
-                    const tree = await createTree(supertest, testOwnerName, testRepoName, parentTree);
-
-                    // And then a commit to reference it
-                    const treeCommit: ICreateCommitParams = {
-                        author: {
-                            date: "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)",
-                            email: commitEmail,
-                            name: commitName,
-                        },
-                        message: "complex tree",
-                        parents: [],
-                        tree: tree.body.sha,
-                    };
-                    const commit = await createCommit(supertest, testOwnerName, testRepoName, treeCommit);
-
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/trees/${commit.body.tree.sha}?recursive=1`)
-                        .expect(200);
-                });
-            });
-
-            describe("Commits", () => {
-                it("Can create and retrieve a commit", async () => {
-                    await createRepo(supertest, testOwnerName, testRepoName);
-                    await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                    await createTree(supertest, testOwnerName, testRepoName, testTree);
-                    const commit = await createCommit(supertest, testOwnerName, testRepoName, testCommit);
-                    assert.strictEqual(commit.body.sha, "cf0b592907d683143b28edd64d274ca70f68998e");
-
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/commits/${commit.body.sha}`)
-                        .expect(200)
-                        .expect((getResult) => {
-                            assert.strictEqual(getResult.body.sha, commit.body.sha);
-                        });
-                });
-            });
-
-            describe("Refs", () => {
-                it("Can create and retrieve a reference", async () => {
-                    await createRepo(supertest, testOwnerName, testRepoName);
-                    await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                    await createTree(supertest, testOwnerName, testRepoName, testTree);
-                    await createCommit(supertest, testOwnerName, testRepoName, testCommit);
-                    const ref = await createRef(supertest, testOwnerName, testRepoName, testRef);
-                    assert.strictEqual(ref.body.ref, testRef.ref);
-
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`)
-                        .expect(200)
-                        .expect((getResult) => {
-                            assert.strictEqual(getResult.body.ref, ref.body.ref);
-                        });
-                });
-
-                it("Can retrieve all references", async () => {
-                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/refs`)
-                        .expect(200)
-                        .expect((getResult) => {
-                            assert.strictEqual(getResult.body.length, 1);
-                            assert.strictEqual(getResult.body[0].ref, testRef.ref);
-                        });
-                });
-
-                it("Can patch to create a reference", async () => {
-                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                    return supertest
-                        .patch(`/repos/${testOwnerName}/${testRepoName}/git/refs/heads/patch`)
-                        .set("Accept", "application/json")
-                        .set("Content-Type", "application/json")
-                        .send({
-                            force: true,
-                            sha: "cf0b592907d683143b28edd64d274ca70f68998e",
-                            config : { enabled : true },
-                        })
-                        .expect(200);
-                });
-
-                it("Can't patch an existing reference without force flag set", async () => {
-                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                    return supertest
-                        .patch(`/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`)
-                        .set("Accept", "application/json")
-                        .set("Content-Type", "application/json")
-                        .send({
-                            force: false,
-                            sha: "cf0b592907d683143b28edd64d274ca70f68998e",
-                            config : { enabled : true },
-                        })
-                        .expect(400);
-                });
-
-                it("Can patch an existing reference with force flag set", async () => {
-                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                    return supertest
-                        .patch(`/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`)
-                        .set("Accept", "application/json")
-                        .set("Content-Type", "application/json")
-                        .send({
-                            force: true,
-                            sha: "cf0b592907d683143b28edd64d274ca70f68998e",
-                            config : { enabled : true },
-                        })
-                        .expect(200);
-                });
-
-                it("Can delete a reference", async () => {
-                    await initBaseRepo(
-                        supertest,
-                        testOwnerName,
-                        testRepoName,
-                        testBlob,
-                        testTree,
-                        testCommit,
-                        testRefWriteDisabled);
-                    await supertest
-                        .delete(`/repos/${testOwnerName}/${testRepoName}/git/${testRefWriteDisabled.ref}`)
-                        .expect(204);
-
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/${testRefWriteDisabled.ref}`)
-                        .expect(400);
-                });
-            });
-
-            describe("Tags", () => {
-                it("Can create and retrive an annotated tag", async () => {
-                    const tagParams = {
-                        message: "Hello, World!",
-                        object: "cf0b592907d683143b28edd64d274ca70f68998e",
-                        tag: "v1.0",
-                        tagger: {
-                            date: "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)",
-                            email: commitEmail,
-                            name: commitName,
-                        },
-                        type: "commit",
-                    };
-
-                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                    const tag = await supertest
-                        .post(`/repos/${testOwnerName}/${testRepoName}/git/tags`)
-                        .set("Accept", "application/json")
-                        .set("Content-Type", "application/json")
-                        .send(tagParams)
-                        .expect(201);
-                    assert.strictEqual(tag.body.sha, "a8588b3913aa692c3642697d6f136cec470dd82c");
-
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/git/tags/${tag.body.sha}`)
-                        .expect(200)
-                        .expect((result) => {
-                            assert.strictEqual(result.body.sha, tag.body.sha);
-                        });
-                });
-            });
-        });
-
-        describe("Stress", () => {
-            it("Run a long time and break", async () => {
-                const MaxTreeLength = 10;
-                const MaxParagraphs = 200;
-
-                await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                const repoManagerFactory = getRepoManagerFactory();
-                const repoManager = await repoManagerFactory.open({
-                    repoOwner: testOwnerName,
-                    repoName: testRepoName,
-                });
-
-                let lastCommit;
-
-                async function runRound() {
-                    const total = Math.floor(Math.random() * MaxTreeLength);
-                    const blobsP: Promise<ICreateBlobResponse>[] = [];
-                    for (let i = 0; i < total; i++) {
-                        const param: ICreateBlobParams = {
-                            content: lorem({
-                                count: Math.floor(Math.random() * MaxParagraphs),
-                                units: "paragraphs",
-                            }),
-                            encoding: "utf-8",
-                        };
-                        blobsP.push(repoManager.createBlob(param));
-                    }
-
-                    const blobs = await Promise.all(blobsP);
-                    const files = blobs.map((blob) => {
-                        return {
-                            mode: "100644",
-                            path: `${(sillyname() as string).toLowerCase().split(" ").join("-")}.txt`,
-                            sha: blob.sha,
-                            type: "blob",
-                        };
-                    });
-                    const createTreeParams: ICreateTreeParams = {
-                        tree: files,
-                    };
-
-                    const tree = await repoManager.createTree(createTreeParams);
-
-                    const parents: string[] = [];
-                    if (lastCommit) {
-                        const commits = await repoManager.getCommits(
-                            lastCommit,
-                            1,
-                            testReadParams.config);
-                        const parentCommit = commits[0];
-                        assert.ok(parentCommit.commit);
-                        parents.push(parentCommit.sha);
-                    }
-
-                    const commitParams: ICreateCommitParams = {
-                        author: {
-                            date: new Date().toISOString(),
-                            email: commitEmail,
-                            name: commitName,
-                        },
-                        message: lorem({ count: 1, units: "sentences" }),
-                        parents,
-                        tree: tree.sha,
-                    };
-                    const commit = await repoManager.createCommit(commitParams);
-
-                    lastCommit = commit.sha;
-                }
-
-                const queue = async.queue(
-                    (task, callback) => {
-                        runRound().then(() => callback(), (error) => callback(error));
-                    },
-                    5);
-
-                const resultP = new Promise<void>((resolve, reject) => {
-                    queue.drain(() => {
-                        resolve();
-                    });
-
-                    queue.error((error) => {
-                        reject(error);
-                    });
-                });
-
-                for (let i = 0; i < 100; i++) {
-                    void queue.push(i);
-                }
-
-                return resultP;
-            }).timeout(4000);
-        });
-
-        // Higher level repository tests
-        describe("Repository", () => {
-            describe("Commits", () => {
-                it("Can list recent commits", async () => {
-                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                    return supertest
-                        .get(`/repos/${testOwnerName}/${testRepoName}/commits?sha=main`)
-                        .expect(200)
-                        .expect((result) => {
-                            assert.strictEqual(result.body.length, 1);
-                        });
-                });
-            });
-
-            describe("Content", () => {
-                it("Can retrieve a stored object", async () => {
-                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                    const fullRepoPath = `${testOwnerName}/${testRepoName}`;
-                    return supertest
-                        .get(`/repos/${fullRepoPath}/contents/${testTree.tree[0].path}?ref=${testRef.sha}`)
-                        .expect(200);
-                });
-            });
-        });
-
-        describe("CorrelationId", () => {
-            const correlationIdHeaderName = "x-correlation-id";
-            const testCorrelationId = "test-correlation-id";
-
-            const assertCorrelationId =
-                async (url: string, method: "get" | "post" | "patch" | "delete" = "get"): Promise<void> => {
-                    await supertest[method](url)
-                        .set(correlationIdHeaderName, testCorrelationId)
-                        .set("Accept", "application/json")
-                        .set("Content-Type", "application/json")
-                        .then((res) => {
-                            assert.strictEqual(res.headers?.[correlationIdHeaderName], testCorrelationId);
-                    });
-            };
-
+            // Git data API tests
             describe("Git", () => {
-                describe("Blobs", () => {
-                    it("Should have correlation id when creating a blob", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/${testOwnerName}/repos`,
-                            "post",
-                        );
-                    });
-                    it("Should have correlation id when getting a blob", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/blobs/${testTree.tree[0].sha}`,
-                        );
-                    });
-                });
-
-                describe("Commits", () => {
-                    it("Should have correlation id when creating a commit", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/commits`,
-                            "post",
-                        );
-                    });
-                    it("Should have correlation id when getting a commit", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/commits/${testTree.tree[0].sha}`,
-                        );
-                    });
-                });
-
-                describe("Refs", () => {
-                    it("GET /repos/:owner/:repo/git/refs", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`,
-                        );
-                    });
-                    it("GET /repos/:owner/:repo/git/refs/*", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}/*`,
-                        );
-                    });
-                    it("POST /repos/:owner/:repo/git/refs", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/refs`,
-                            "post",
-                        );
-                    });
-                    it("PATCH /repos/:owner/:repo/git/refs/*", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/refs/heads/patch`,
-                            "patch",
-                        );
-                    });
-                    it("DELETE /repos/:owner/:repo/git/refs/*", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/${testRefWriteDisabled.ref}`,
-                            "delete",
-                        );
-                    });
-                });
-
                 describe("Repos", () => {
-                    it("Should have correlation id when creating a repo", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(`/repos/${testOwnerName}/repos`, "post");
+                    it("Can create and get a new repo", async () => {
+                        await createRepo(supertest, testOwnerName, testRepoName);
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}`)
+                            .expect(200);
                     });
-                    it("Should have correlation id when getting a repo", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}`,
-                        );
+
+                    it("Returns 400 for an unknown repo", async () => {
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}`)
+                            .expect(400);
+                    });
+
+                    it("Rejects invalid repo names", async () => {
+                        return supertest
+                            .post(`/${testOwnerName}/repos`)
+                            .set("Accept", "application/json")
+                            .set("Content-Type", "application/json")
+                            .send({ name: "../evilrepo" })
+                            .expect(400);
+                    });
+
+                    it("Rejects missing repo names", async () => {
+                        return supertest
+                            .post(`/${testOwnerName}/repos`)
+                            .expect(400);
                     });
                 });
 
-                describe("Tags", () => {
-                    it("Should have correlation id when creating a tag", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/tags`,
-                            "post",
-                        );
+                describe("Blobs", () => {
+                    it("Can create and retrieve a blob", async () => {
+                        await createRepo(supertest, testOwnerName, testRepoName);
+                        const result = await createBlob(supertest, testOwnerName, testRepoName, testBlob);
+                        assert.strictEqual(result.body.sha, "b45ef6fec89518d314f546fd6c3025367b721684");
+
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/blobs/${result.body.sha}`)
+                            .expect(200)
+                            .expect((getResult) => {
+                                assert.strictEqual(getResult.body.sha, result.body.sha);
+                            });
                     });
-                    it("Should have correlation id when getting a tag", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/tags/${testTree.tree[0].sha}`,
-                        );
+
+                    it("Can create an existing blob without error", async () => {
+                        await createRepo(supertest, testOwnerName, testRepoName);
+                        await createBlob(supertest, testOwnerName, testRepoName, testBlob);
+                        await createBlob(supertest, testOwnerName, testRepoName, testBlob);
                     });
                 });
 
                 describe("Trees", () => {
-                    it("Should have correlation id when creating a tree", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/trees`, "post",
-                        );
+                    it("Can create and retrieve a tree", async () => {
+                        await createRepo(supertest, testOwnerName, testRepoName);
+                        await createBlob(supertest, testOwnerName, testRepoName, testBlob);
+                        const tree = await createTree(supertest, testOwnerName, testRepoName, testTree);
+                        assert.strictEqual(tree.body.sha, "bf4db183cbd07f48546a5dde098b4510745d79a1");
+
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/trees/${tree.body.sha}`)
+                            .expect(200)
+                            .expect((getResult) => {
+                                assert.strictEqual(getResult.body.sha, tree.body.sha);
+                            });
                     });
-                    it("Should have correlation id when getting a tree", async () => {
+
+                    it("Can recursively retrieve a tree", async () => {
+                        // Create a tree with a single sub directory
+                        await createRepo(supertest, testOwnerName, testRepoName);
+                        await createBlob(supertest, testOwnerName, testRepoName, testBlob);
+                        await createTree(supertest, testOwnerName, testRepoName, testTree);
+                        const parentBlob = await createBlob(
+                            supertest,
+                            testOwnerName,
+                            testRepoName,
+                            { content: "Parent", encoding: "utf-8" });
+                        const parentTree = {
+                            tree: [
+                                {
+                                    mode: "100644",
+                                    path: "parentBlob.txt",
+                                    sha: parentBlob.body.sha,
+                                    type: "blob",
+                                },
+                                {
+                                    mode: "040000",
+                                    path: "subdir",
+                                    sha: "bf4db183cbd07f48546a5dde098b4510745d79a1",
+                                    type: "tree",
+                                }],
+                        };
+                        const tree = await createTree(supertest, testOwnerName, testRepoName, parentTree);
+
+                        // And then a commit to reference it
+                        const treeCommit: ICreateCommitParams = {
+                            author: {
+                                date: "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)",
+                                email: commitEmail,
+                                name: commitName,
+                            },
+                            message: normalizeMessage(mode.gitLibrary, "complex tree"),
+                            parents: [],
+                            tree: tree.body.sha,
+                        };
+                        const commit = await createCommit(supertest, testOwnerName, testRepoName, treeCommit);
+
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/trees/${commit.body.tree.sha}?recursive=1`)
+                            .expect(200);
+                    });
+                });
+
+                describe("Commits", () => {
+                    it("Can create and retrieve a commit", async () => {
+                        await createRepo(supertest, testOwnerName, testRepoName);
+                        await createBlob(supertest, testOwnerName, testRepoName, testBlob);
+                        await createTree(supertest, testOwnerName, testRepoName, testTree);
+                        const commit = await createCommit(supertest, testOwnerName, testRepoName, testCommit);
+                        assert.strictEqual(commit.body.sha, "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18");
+
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/commits/${commit.body.sha}`)
+                            .expect(200)
+                            .expect((getResult) => {
+                                assert.strictEqual(getResult.body.sha, commit.body.sha);
+                            });
+                    });
+                });
+
+                describe("Refs", () => {
+                    it("Can create and retrieve a reference", async () => {
+                        await createRepo(supertest, testOwnerName, testRepoName);
+                        await createBlob(supertest, testOwnerName, testRepoName, testBlob);
+                        await createTree(supertest, testOwnerName, testRepoName, testTree);
+                        await createCommit(supertest, testOwnerName, testRepoName, testCommit);
+                        const ref = await createRef(supertest, testOwnerName, testRepoName, testRef);
+                        assert.strictEqual(ref.body.ref, testRef.ref);
+
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`)
+                            .expect(200)
+                            .expect((getResult) => {
+                                assert.strictEqual(getResult.body.ref, ref.body.ref);
+                            });
+                    });
+
+                    it("Can retrieve all references", async () => {
+                        await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/refs`)
+                            .expect(200)
+                            .expect((getResult) => {
+                                assert.strictEqual(getResult.body.length, 1);
+                                assert.strictEqual(getResult.body[0].ref, testRef.ref);
+                            });
+                    });
+
+                    it("Can patch to create a reference", async () => {
+                        await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                        return supertest
+                            .patch(`/repos/${testOwnerName}/${testRepoName}/git/refs/heads/patch`)
+                            .set("Accept", "application/json")
+                            .set("Content-Type", "application/json")
+                            .send({
+                                force: true,
+                                sha: "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18",
+                                config : { enabled : true },
+                            })
+                            .expect(200);
+                    });
+
+                    it("Can't patch an existing reference without force flag set", async () => {
+                        await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                        return supertest
+                            .patch(`/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`)
+                            .set("Accept", "application/json")
+                            .set("Content-Type", "application/json")
+                            .send({
+                                force: false,
+                                sha: "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18",
+                                config : { enabled : true },
+                            })
+                            .expect(400);
+                    });
+
+                    it("Can patch an existing reference with force flag set", async () => {
+                        await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                        return supertest
+                            .patch(`/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`)
+                            .set("Accept", "application/json")
+                            .set("Content-Type", "application/json")
+                            .send({
+                                force: true,
+                                sha: "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18",
+                                config : { enabled : true },
+                            })
+                            .expect(200);
+                    });
+
+                    it("Can delete a reference", async () => {
                         await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/git/trees/${testTree.tree[0].sha}`,
-                        );
+                            supertest,
+                            testOwnerName,
+                            testRepoName,
+                            testBlob,
+                            testTree,
+                            testCommit,
+                            testRefWriteDisabled);
+                        await supertest
+                            .delete(`/repos/${testOwnerName}/${testRepoName}/git/${testRefWriteDisabled.ref}`)
+                            .expect(204);
+
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/${testRefWriteDisabled.ref}`)
+                            .expect(400);
+                    });
+                });
+
+                describe("Tags", () => {
+                    it("Can create and retrieve an annotated tag", async () => {
+                        const tagParams = {
+                            message: normalizeMessage(mode.gitLibrary, "Hello, World!"),
+                            object: "38421e18f9cf4ec024ae98f687e79c0bdf8f3f18",
+                            tag: "v1.0",
+                            tagger: {
+                                date: "Thu Jul 13 2017 20:17:40 GMT-0700 (PDT)",
+                                email: commitEmail,
+                                name: commitName,
+                            },
+                            type: "commit",
+                        };
+
+                        await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                        const tag = await supertest
+                            .post(`/repos/${testOwnerName}/${testRepoName}/git/tags`)
+                            .set("Accept", "application/json")
+                            .set("Content-Type", "application/json")
+                            .send(tagParams)
+                            .expect(201);
+                        assert.strictEqual(tag.body.sha, "2f208d6d4c5698feada2b5dad3886a0ceff4f80b");
+
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/git/tags/${tag.body.sha}`)
+                            .expect(200)
+                            .expect((result) => {
+                                assert.strictEqual(result.body.sha, tag.body.sha);
+                            });
                     });
                 });
             });
 
+            describe("Stress", () => {
+                it("Run a long time and break", async () => {
+                    const MaxTreeLength = 10;
+                    const MaxParagraphs = 200;
+
+                    await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                    const repoManagerFactory = getRepoManagerFactory(mode.gitLibrary);
+                    const repoManager = await repoManagerFactory.open({
+                        repoOwner: testOwnerName,
+                        repoName: testRepoName,
+                    });
+
+                    let lastCommit;
+
+                    async function runRound() {
+                        const total = Math.floor(Math.random() * MaxTreeLength);
+                        const blobsP: Promise<ICreateBlobResponse>[] = [];
+                        for (let i = 0; i < total; i++) {
+                            const param: ICreateBlobParams = {
+                                content: lorem({
+                                    count: Math.floor(Math.random() * MaxParagraphs),
+                                    units: "paragraphs",
+                                }),
+                                encoding: "utf-8",
+                            };
+                            blobsP.push(repoManager.createBlob(param));
+                        }
+
+                        const blobs = await Promise.all(blobsP);
+                        const files = blobs.map((blob) => {
+                            return {
+                                mode: "100644",
+                                path: `${(sillyname() as string).toLowerCase().split(" ").join("-")}.txt`,
+                                sha: blob.sha,
+                                type: "blob",
+                            };
+                        });
+                        const createTreeParams: ICreateTreeParams = {
+                            tree: files,
+                        };
+
+                        const tree = await repoManager.createTree(createTreeParams);
+
+                        const parents: string[] = [];
+                        if (lastCommit) {
+                            const commits = await repoManager.getCommits(
+                                lastCommit,
+                                1,
+                                testReadParams.config);
+                            const parentCommit = commits[0];
+                            assert.ok(parentCommit.commit);
+                            parents.push(parentCommit.sha);
+                        }
+
+                        const commitParams: ICreateCommitParams = {
+                            author: {
+                                date: new Date().toISOString(),
+                                email: commitEmail,
+                                name: commitName,
+                            },
+                            message: normalizeMessage(mode.gitLibrary, lorem({ count: 1, units: "sentences" })),
+                            parents,
+                            tree: tree.sha,
+                        };
+                        const commit = await repoManager.createCommit(commitParams);
+
+                        lastCommit = commit.sha;
+                    }
+
+                    const queue = async.queue(
+                        (task, callback) => {
+                            runRound().then(() => callback(), (error) => callback(error));
+                        },
+                        5);
+
+                    const resultP = new Promise<void>((resolve, reject) => {
+                        queue.drain(() => {
+                            resolve();
+                        });
+
+                        queue.error((error) => {
+                            reject(error);
+                        });
+                    });
+
+                    for (let i = 0; i < 100; i++) {
+                        void queue.push(i);
+                    }
+
+                    return resultP;
+                }).timeout(4000);
+            });
+
+            // Higher level repository tests
             describe("Repository", () => {
                 describe("Commits", () => {
-                    it("Should have correlation id when listing recent commits", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
-                        await assertCorrelationId(
-                            `/repos/${testOwnerName}/${testRepoName}/commits?sha=main`,
-                        );
+                    it("Can list recent commits", async () => {
+                        await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                        return supertest
+                            .get(`/repos/${testOwnerName}/${testRepoName}/commits?sha=main`)
+                            .expect(200)
+                            .expect((result) => {
+                                assert.strictEqual(result.body.length, 1);
+                            });
                     });
                 });
 
                 describe("Content", () => {
-                    it("Should have correlation id when retrieving a stored object", async () => {
-                        await initBaseRepo(
-                            supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
-                        );
+                    it("Can retrieve a stored object", async () => {
+                        await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
                         const fullRepoPath = `${testOwnerName}/${testRepoName}`;
-                        await assertCorrelationId(
-                            `/repos/${fullRepoPath}/contents/${testTree.tree[0].path}?ref=${testRef.sha}`,
-                        );
+                        return supertest
+                            .get(`/repos/${fullRepoPath}/contents/${testTree.tree[0].path}?ref=${testRef.sha}`)
+                            .expect(200);
+                    });
+                });
+            });
+
+            describe("CorrelationId", () => {
+                const correlationIdHeaderName = "x-correlation-id";
+                const testCorrelationId = "test-correlation-id";
+
+                const assertCorrelationId =
+                    async (url: string, method: "get" | "post" | "patch" | "delete" = "get"): Promise<void> => {
+                        await supertest[method](url)
+                            .set(correlationIdHeaderName, testCorrelationId)
+                            .set("Accept", "application/json")
+                            .set("Content-Type", "application/json")
+                            .then((res) => {
+                                assert.strictEqual(res.headers?.[correlationIdHeaderName], testCorrelationId);
+                        });
+                };
+
+                describe("Git", () => {
+                    describe("Blobs", () => {
+                        it("Should have correlation id when creating a blob", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/${testOwnerName}/repos`,
+                                "post",
+                            );
+                        });
+                        it("Should have correlation id when getting a blob", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/blobs/${testTree.tree[0].sha}`,
+                            );
+                        });
+                    });
+
+                    describe("Commits", () => {
+                        it("Should have correlation id when creating a commit", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/commits`,
+                                "post",
+                            );
+                        });
+                        it("Should have correlation id when getting a commit", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/commits/${testTree.tree[0].sha}`,
+                            );
+                        });
+                    });
+
+                    describe("Refs", () => {
+                        it("GET /repos/:owner/:repo/git/refs", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}`,
+                            );
+                        });
+                        it("GET /repos/:owner/:repo/git/refs/*", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/${testRef.ref}/*`,
+                            );
+                        });
+                        it("POST /repos/:owner/:repo/git/refs", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/refs`,
+                                "post",
+                            );
+                        });
+                        it("PATCH /repos/:owner/:repo/git/refs/*", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/refs/heads/patch`,
+                                "patch",
+                            );
+                        });
+                        it("DELETE /repos/:owner/:repo/git/refs/*", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/${testRefWriteDisabled.ref}`,
+                                "delete",
+                            );
+                        });
+                    });
+
+                    describe("Repos", () => {
+                        it("Should have correlation id when creating a repo", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(`/repos/${testOwnerName}/repos`, "post");
+                        });
+                        it("Should have correlation id when getting a repo", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}`,
+                            );
+                        });
+                    });
+
+                    describe("Tags", () => {
+                        it("Should have correlation id when creating a tag", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/tags`,
+                                "post",
+                            );
+                        });
+                        it("Should have correlation id when getting a tag", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/tags/${testTree.tree[0].sha}`,
+                            );
+                        });
+                    });
+
+                    describe("Trees", () => {
+                        it("Should have correlation id when creating a tree", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/trees`, "post",
+                            );
+                        });
+                        it("Should have correlation id when getting a tree", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/git/trees/${testTree.tree[0].sha}`,
+                            );
+                        });
+                    });
+                });
+
+                describe("Repository", () => {
+                    describe("Commits", () => {
+                        it("Should have correlation id when listing recent commits", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            await assertCorrelationId(
+                                `/repos/${testOwnerName}/${testRepoName}/commits?sha=main`,
+                            );
+                        });
+                    });
+
+                    describe("Content", () => {
+                        it("Should have correlation id when retrieving a stored object", async () => {
+                            await initBaseRepo(
+                                supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef,
+                            );
+                            const fullRepoPath = `${testOwnerName}/${testRepoName}`;
+                            await assertCorrelationId(
+                                `/repos/${fullRepoPath}/contents/${testTree.tree[0].path}?ref=${testRef.sha}`,
+                            );
+                        });
                     });
                 });
             });

--- a/server/gitrest/packages/gitrest-base/src/test/utils.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/utils.ts
@@ -8,9 +8,10 @@ import nconf from "nconf";
 import rimrafCallback from "rimraf";
 import { IStorageDirectoryConfig } from "../utils";
 
+export type gitLibType = "nodegit" | "isomorphic-git";
 export interface ITestMode {
     name: string;
-    gitLibrary: string;
+    gitLibrary: gitLibType;
 }
 
 export const defaultProvider = new nconf.Provider({}).defaults({

--- a/server/gitrest/packages/gitrest-base/src/test/utils.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/utils.ts
@@ -8,6 +8,11 @@ import nconf from "nconf";
 import rimrafCallback from "rimraf";
 import { IStorageDirectoryConfig } from "../utils";
 
+export interface ITestMode {
+    name: string;
+    gitLibrary: string;
+}
+
 export const defaultProvider = new nconf.Provider({}).defaults({
     logger: {
         colorize: true,

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -178,5 +178,5 @@ export function logAndThrowApiError(error: any, request: Request, params: IRepoM
     // 400 by default, using something different here would override the expected behavior and cause issues. Because
     // of that, for now, we use 400 here. But ideally, we would revisit every RepoManager API and make sure that API
     // is actively throwing NetworkErrors with appropriate status codes according to what the protocols expect.
-    throw new NetworkError(error?.code ?? 400, `Error when processing ${request.method} request to ${request.url}`);
+    throw new NetworkError(400, `Error when processing ${request.method} request to ${request.url}`);
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -291,6 +291,8 @@ export class IsomorphicGitRepositoryManager implements IRepositoryManager {
                     [BaseGitRestTelemetryProperties.ref]: refId,
                 },
                 err);
+            // `GitManager.getRef` relies on a 404 || 400 error code to return null.
+            // That is expected by some components like Scribe.
             throw new NetworkError(400, "Unable to get ref.");
         }
     }

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -291,7 +291,7 @@ export class IsomorphicGitRepositoryManager implements IRepositoryManager {
                     [BaseGitRestTelemetryProperties.ref]: refId,
                 },
                 err);
-            throw new NetworkError(500, "Unable to get ref.");
+            throw new NetworkError(400, "Unable to get ref.");
         }
     }
 
@@ -318,7 +318,7 @@ export class IsomorphicGitRepositoryManager implements IRepositoryManager {
             gitdir: this.directory,
             ref: refId,
             value: patchRefParams.sha,
-            force: true, // Isomorphic-Git requires force to be always true if we want to overwrite a ref.
+            force: patchRefParams.force,
         });
         return conversions.refToIRef(patchRefParams.sha, refId);
     }

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -193,7 +193,11 @@ export class NodegitRepositoryManager implements IRepositoryManager {
             throw new NetworkError(400, "Invalid input");
         }
 
-        const signature = nodegit.Signature.create(commit.author.name, commit.author.email, Math.floor(date), 0);
+        const signature = nodegit.Signature.create(
+            commit.author.name,
+            commit.author.email,
+            Math.floor(date / 1000),
+            0);
         const parents = commit.parents && commit.parents.length > 0 ? commit.parents : null;
         const commitOid = await this.repo.createCommit(
             null,
@@ -323,7 +327,11 @@ export class NodegitRepositoryManager implements IRepositoryManager {
             throw new NetworkError(400, "Invalid input");
         }
 
-        const signature = nodegit.Signature.create(tagParams.tagger.name, tagParams.tagger.email, Math.floor(date), 0);
+        const signature = nodegit.Signature.create(
+            tagParams.tagger.name,
+            tagParams.tagger.email,
+            Math.floor(date / 1000),
+            0);
         const object = await nodegit.Object.lookup(
             this.repo,
             nodegit.Oid.fromString(tagParams.object),

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -196,7 +196,7 @@ export class NodegitRepositoryManager implements IRepositoryManager {
         const signature = nodegit.Signature.create(
             commit.author.name,
             commit.author.email,
-            Math.floor(date / 1000),
+            Math.floor(date / 1000), // date represents time in milliseconds. NodeGit expects a timestamp in seconds.
             0);
         const parents = commit.parents && commit.parents.length > 0 ? commit.parents : null;
         const commitOid = await this.repo.createCommit(
@@ -330,7 +330,7 @@ export class NodegitRepositoryManager implements IRepositoryManager {
         const signature = nodegit.Signature.create(
             tagParams.tagger.name,
             tagParams.tagger.email,
-            Math.floor(date / 1000),
+            Math.floor(date / 1000), // date represents time in milliseconds. NodeGit expects a timestamp in seconds.
             0);
         const object = await nodegit.Object.lookup(
             this.repo,


### PR DESCRIPTION
1. Fixing bug in `NodegitRepositoryManager` where we would use a wrong date/timestamp when creating a commit or tag. The date paramater would be in POSIX time (milliseconds) while [NodeGit expects a timestamp in seconds](https://www.nodegit.org/api/signature/). This is the reason why summary and commit data in r11s/GitRest seemed to provide weird dates, years ahead of our current time 😄 
2. Fixed a bug in `logAndThrowApiError ` introduced in https://github.com/microsoft/FluidFramework/pull/10083. When creating a new `NetworkError` to throw, we were trying to reuse the current `error?.code`, and passing it to `NetworkError`'s constructor, which expects a `number`. But if `error` was internally thrown by `isomorphic-git`, for example, `code` could be a `string`. That would mess things up, including making UTs hang and fail with timeouts. Here, I fix that by always using a 400 response code, since the caller is not interested in knowing specific error codes internal to GitRest.
3. Fixed unit tests that relied on specific SHAs. Since Git is content-addressable, the SHAs are computed from the content (e.g. commit and tag content). As we changed the date calculation format, I had to update the SHAs.
4. Updated UTs to run both when using `NodegitRepositoryManager` as well as `IsomorphicGitRepositoryManager`. Updated `IsomorphicGitRepositoryManager` to match the behavior of `NodegitRepositoryManager` in some specific situations (like force patching refs)