### PR TITLE
Pipeline config updates.

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -115,7 +115,7 @@ jobs:
           pipeline: Build - client packages
           preferTriggeringPipeline: true
           allowPartiallySucceededBuilds: true
-          runVersion: specific
+          runVersion: latestFromBranch
           runBranch: $(Build.SourceBranch)
           artifact: pack
           patterns: "**/${{ variables.testPackageFilePattern }}"
@@ -192,7 +192,7 @@ jobs:
             pipeline: Build - client packages
             preferTriggeringPipeline: true
             allowPartiallySucceededBuilds: true
-            runVersion: specific
+            runVersion: latestFromBranch
             runBranch: $(Build.SourceBranch)
             artifact: test-files
             path: $(Pipeline.Workspace)/test-files

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -114,7 +114,8 @@ jobs:
           project: internal
           pipeline: Build - client packages
           preferTriggeringPipeline: true
-          runVersion: latestFromBranch
+          allowPartiallySucceededBuilds: true
+          runVersion: specific
           runBranch: $(Build.SourceBranch)
           artifact: pack
           patterns: "**/${{ variables.testPackageFilePattern }}"
@@ -190,7 +191,8 @@ jobs:
             project: internal
             pipeline: Build - client packages
             preferTriggeringPipeline: true
-            runVersion: latestFromBranch
+            allowPartiallySucceededBuilds: true
+            runVersion: specific
             runBranch: $(Build.SourceBranch)
             artifact: test-files
             path: $(Pipeline.Workspace)/test-files


### PR DESCRIPTION
Our E2E pipelines were not able to download test artifacts that were generated with warnings. This PR should enable us to bypass that restriction.