### PR TITLE
`fluid-build`: Fix incremental build after typescript update

### DIFF
--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -15,7 +15,8 @@ const isEqual = require("lodash.isequal");
 
 interface ITsBuildInfo {
     program: {
-        fileInfos: { [key: string]: { version: string, signature: string } },
+        fileNames: string[],
+        fileInfos: (string | { version: string, affectsGlobalScope: true })[],
         semanticDiagnosticsPerFile?: any[],
         options: any
     }
@@ -104,23 +105,27 @@ export class TscTask extends LeafTask {
             return false;
         }
         // Check dependencies file hashes
+        const fileNames = tsBuildInfo.program.fileNames;
         const fileInfos = tsBuildInfo.program.fileInfos;
-        for (const key of Object.keys(fileInfos)) {
+        for (let i = 0; i < fileNames.length; i++) {
+            const fileName = fileNames[i];
             try {
                 // Resolve relative path based on the directory of the tsBuildInfo file
-                let fullPath = path.resolve(tsBuildInfoFileDirectory, key);
+                let fullPath = path.resolve(tsBuildInfoFileDirectory, fileName);
 
                 // If we have project reference, see if this is in reference to one of the file, and map it to the d.ts file instead
                 if (this._projectReference) {
                     fullPath = this._projectReference.remapSrcDeclFile(fullPath);
                 }
                 const hash = await this.node.buildContext.fileHashCache.getFileHash(fullPath);
-                if (hash !== fileInfos[key].version) {
-                    this.logVerboseTrigger(`version mismatch for ${key}, ${hash}, ${fileInfos[key].version}`);
+                const fileInfo = fileInfos[i];
+                const version = typeof fileInfo === "string" ? fileInfo : fileInfo.version;
+                if (hash !== version) {
+                    this.logVerboseTrigger(`version mismatch for ${fileName}, ${hash}, ${version}`);
                     return false;
                 }
             } catch (e: any) {
-                this.logVerboseTrigger(`exception generating hash for ${key}`);
+                this.logVerboseTrigger(`exception generating hash for ${fileName}`);
                 logVerbose(e.stack);
                 return false;
             }
@@ -155,8 +160,8 @@ export class TscTask extends LeafTask {
         if (!configFileFullPath) { assert.fail(); };
 
         // Patch relative path based on the file directory where the config comes from
-        const configOptions =
-            TscUtils.convertToOptionsWithAbsolutePath(options.options, path.dirname(configFileFullPath));
+        const configOptions = TscUtils.filterIncrementalOptions(
+            TscUtils.convertToOptionsWithAbsolutePath(options.options, path.dirname(configFileFullPath)));
         const tsBuildInfoOptions =
             TscUtils.convertToOptionsWithAbsolutePath(tsBuildInfo.program.options, tsBuildInfoFileDirectory);
 
@@ -301,10 +306,10 @@ export class TscTask extends LeafTask {
             if (tsBuildInfoFileFullPath && existsSync(tsBuildInfoFileFullPath)) {
                 try {
                     const tsBuildInfo = JSON.parse(await readFileAsync(tsBuildInfoFileFullPath, "utf8"));
-                    if (tsBuildInfo.program) {
+                    if (tsBuildInfo.program && tsBuildInfo.program.fileNames) {
                         this._tsBuildInfo = tsBuildInfo;
                     } else {
-                        logVerbose(`${this.node.pkg.nameColored}: Missing program property ${tsBuildInfoFileFullPath}`);
+                        logVerbose(`${this.node.pkg.nameColored}: Missing program or fileNames property ${tsBuildInfoFileFullPath}`);
                     }
                 } catch {
                     logVerbose(`${this.node.pkg.nameColored}: Unable to load ${tsBuildInfoFileFullPath}`);

--- a/tools/build-tools/src/fluidBuild/tscUtils.ts
+++ b/tools/build-tools/src/fluidBuild/tscUtils.ts
@@ -11,6 +11,86 @@ export const parseCommandLine = defaultTscUtil.parseCommandLine;
 export const findConfigFile = defaultTscUtil.findConfigFile;
 export const readConfigFile = defaultTscUtil.readConfigFile;
 
+// See convertToProgramBuildInfoCompilerOptions in typescript src/compiler/builder.ts
+const incrementalOptions = [
+    // affectsEmit === true
+    "assumeChangesOnlyAffectDirectDependencies",
+    "target",
+    "listFilesOnly",
+    "module",
+    "jsx",
+    "declaration",
+    "declarationMap",
+    "emitDeclarationOnly",
+    "sourceMap",
+    "outFile",
+    "outDir",
+    "rootDir",
+    "composite",
+    "tsBuildInfoFile",
+    "removeComments",
+    "importHelpers",
+    "importsNotUsedAsValues",
+    "downlevelIteration",
+    "esModuleInterop",
+    "sourceRoot",
+    "mapRoot",
+    "inlineSourceMap",
+    "inlineSources",
+    "emitDecoratorMetadata",
+    "jsxImportSource",
+    "out",
+    "reactNamespace",
+    "emitBOM",
+    "newLine",
+    "stripInternal",
+    "noEmitHelpers",
+    "noEmitOnError",
+    "preserveConstEnums",
+    "declarationDir",
+    "useDefineForClassFields",
+    "preserveValueImports",
+
+    // affectsSemanticDiagnostics === true
+    "noImplicitAny",
+    "strictNullChecks",
+    "strictPropertyInitialization",
+    "noImplicitThis",
+    "useUnknownInCatchVariables",
+    "noUnusedLocals",
+    "noUnusedParameters",
+    "exactOptionalPropertyTypes",
+    "noImplicitReturns",
+    "noFallthroughCasesInSwitch",
+    "noUncheckedIndexedAccess",
+    "noImplicitOverride",
+    "allowSyntheticDefaultImports",
+    "allowUmdGlobalAccess",
+    "experimentalDecorators",
+    "noErrorTruncation",
+    "noImplicitUseStrict",
+    "allowUnusedLabels",
+    "allowUnreachableCode",
+    "suppressExcessPropertyErrors",
+    "suppressImplicitAnyIndexErrors",
+    "noStrictGenericChecks",
+    "useDefineForClassFields",
+
+    "skipLibCheck",
+    "skipdefaultlibcheck",
+    "strict",
+].sort();  // sort it so that the result of the filter is sorted as well.
+
+export function filterIncrementalOptions(options: any) {
+    const newOptions: any = {};
+    for (const key of incrementalOptions) {
+        if (options[key] !== undefined) {
+            newOptions[key] = options[key];
+        }
+    }
+    return newOptions;
+}
+
 export function convertToOptionsWithAbsolutePath(options: ts.CompilerOptions, cwd: string) {
     // Shallow clone 'CompilerOptions' before modifying.
     const result = { ...options };


### PR DESCRIPTION
Recent update to Typescript 4.5.5 brought in some optimization to `tsbuildinfo` file size that changes its format.

- Filenames are hoisted to a separate array, data now uses the array index to refer to those file names
- Compiler options saved in the file are filtered to ones affects the incremental build.

`fluid-build` needs to be updated to read the new format and filter the options before comparison.