### PR TITLE
Pipeline config updates. (#10157)

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -114,6 +114,7 @@ jobs:
           project: internal
           pipeline: Build - client packages
           preferTriggeringPipeline: true
+          allowPartiallySucceededBuilds: true
           runVersion: latestFromBranch
           runBranch: $(Build.SourceBranch)
           artifact: pack
@@ -190,6 +191,7 @@ jobs:
             project: internal
             pipeline: Build - client packages
             preferTriggeringPipeline: true
+            allowPartiallySucceededBuilds: true
             runVersion: latestFromBranch
             runBranch: $(Build.SourceBranch)
             artifact: test-files


### PR DESCRIPTION
Cherry pick commit from https://github.com/microsoft/FluidFramework/pull/10157:

Our E2E pipelines were not able to download test artifacts that were generated with warnings. This PR should enable us to bypass that restriction.