### PR TITLE
`fluid-build`: update repo dep version and add dep for type validator

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -42,7 +42,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -456,9 +456,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@^0.32.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@0.48.1000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@0.43.1000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@0.46.1000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@0.1028.1000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2159,9 +2159,9 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.64540",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-			"integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+			"version": "0.2.65117",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+			"integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -9864,33 +9864,11 @@
 						"whatwg-url": "^5.0.0"
 					}
 				},
-				"tr46": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-					"dev": true
-				},
 				"universal-user-agent": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
 					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
 					"dev": true
-				},
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-					"dev": true
-				},
-				"whatwg-url": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-					"dev": true,
-					"requires": {
-						"tr46": "~0.0.3",
-						"webidl-conversions": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -20246,28 +20224,6 @@
 					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
-					}
-				},
-				"tr46": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-					"dev": true
-				},
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-					"dev": true
-				},
-				"whatwg-url": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-					"dev": true,
-					"requires": {
-						"tr46": "~0.0.3",
-						"webidl-conversions": "^3.0.0"
 					}
 				}
 			}
@@ -42568,13 +42524,10 @@
 			}
 		},
 		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"traverse": {
 			"version": "0.6.6",
@@ -43355,6 +43308,28 @@
 			"requires": {
 				"hasurl": "^1.0.0",
 				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"universal-user-agent": {
@@ -44936,14 +44911,21 @@
 			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
 		},
 		"whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
+				}
 			}
 		},
 		"when": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -6079,6 +6079,15 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
@@ -6905,23 +6914,49 @@
           }
         },
         "string.prototype.trimend": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         },
         "string.prototype.trimstart": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         }
       }
@@ -11110,23 +11145,49 @@
           }
         },
         "string.prototype.trimend": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         },
         "string.prototype.trimstart": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/test-tools": "^0.2.3074",
     "@microsoft/api-documenter": "^7.17.9",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/cell-previous": "npm:@fluidframework/cell@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/counter-previous": "npm:@fluidframework/counter@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/ink-previous": "npm:@fluidframework/ink@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -74,8 +74,8 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
-    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/map-previous": "npm:@fluidframework/map@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/map-previous": "npm:@fluidframework/map@0.59.2000",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@0.59.2000",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@0.59.2000",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -77,6 +77,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/gitresources": "^0.1036.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@0.59.2000",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@0.59.2000",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -75,6 +75,7 @@
     "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@0.59.2000",
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@0.59.2000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@0.59.2000",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@0.59.2000",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@0.59.2000",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@0.59.2000",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@0.59.2000",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@0.59.2000",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -83,6 +83,7 @@
   "devDependencies": {
     "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -62,6 +62,7 @@
     "@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@0.59.2000",
     "@fluidframework/azure-local-service": "^0.1.38773",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/test-client-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/azure-service-utils/package.json
+++ b/packages/framework/azure-service-utils/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -69,6 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@0.59.2000",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.3000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.59.3000",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -80,6 +80,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@0.59.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@0.59.2000",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -76,6 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@0.59.2000",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -82,6 +82,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -82,6 +82,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -94,6 +94,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -69,6 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@0.59.2000",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@0.59.2000",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@0.59.2000",

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/eslint-config-fluid": "^0.28.1000-61189",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/compression": "0.0.36",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -340,9 +340,9 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.64540",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-			"integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+			"version": "0.2.65117",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+			"integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -278,9 +278,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@microsoft/api-documenter": "^7.17.9",
     "@microsoft/api-extractor": "^7.22.2",
     "concurrently": "^6.2.0",


### PR DESCRIPTION
`fluid-build` trigger commands with only the `node_module` of the package added to the executable path env.
If invoked outside of `npm run build:fast`, `fluid-type-validator` command will fail because these packages didn't include the dependencies for `built-tools` package.