### PR TITLE
update monaco and webpack plugins

### DIFF
--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-tsdoc": "~0.2.14",
     "eslint-plugin-unicorn": "~40.0.0",
-    "html-loader": "^0.5.5",
+    "html-loader": "^3.1.0",
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",
     "jest-junit": "^10.0.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/runtime-definitions": "^0.59.3000",
     "@fluidframework/sequence": "^0.59.3000",
     "@types/node": "^14.18.0",
-    "monaco-editor": "^0.15.6",
+    "monaco-editor": "^0.30.0",
     "react": "^16.10.2"
   },
   "devDependencies": {
@@ -71,9 +71,9 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-tsdoc": "~0.2.14",
     "eslint-plugin-unicorn": "~40.0.0",
-    "html-loader": "^0.5.5",
+    "html-loader": "^3.1.0",
     "loader-utils": "^1.1.0",
-    "monaco-editor-webpack-plugin": "~1.7.0",
+    "monaco-editor-webpack-plugin": "^6.0.0",
     "rimraf": "^2.6.2",
     "sass": "^1.42.1",
     "sass-loader": "^7.1.0",

--- a/examples/data-objects/monaco/src/view.tsx
+++ b/examples/data-objects/monaco/src/view.tsx
@@ -75,9 +75,9 @@ export const MonacoView: React.FC<IMonacoViewProps> = (props: IMonacoViewProps) 
         let ignoreModelContentChanges: boolean = false;
         codeEditor.onDidChangeModelContent((e) => {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            monaco.languages.typescript.getTypeScriptWorker().then((worker) => {
-                worker(codeModel.uri.toString()).then((client) => {
-                    client.getEmitOutput(codeModel.uri.toString()).then((r) => {
+            monaco.languages.typescript.getTypeScriptWorker().then(async (worker) => {
+                await worker(codeModel.uri).then(async (client) => {
+                    await client.getEmitOutput(codeModel.uri.toString()).then((r) => {
                         outputModel.setValue(r.outputFiles[0].text);
                     });
                 });

--- a/examples/data-objects/monaco/webpack.config.js
+++ b/examples/data-objects/monaco/webpack.config.js
@@ -6,7 +6,7 @@
 const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require('path');
 const { merge } = require("webpack-merge");
-// const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 module.exports = env => {
     const isProduction = env && env.production;
@@ -94,7 +94,7 @@ module.exports = env => {
             ignored: "**/node_modules/**",
         },
         plugins: [
-            // new MonacoWebpackPlugin()
+            new MonacoWebpackPlugin()
             // new BundleAnalyzerPlugin()
         ]
     }, isProduction

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-tsdoc": "~0.2.14",
     "eslint-plugin-unicorn": "~40.0.0",
-    "html-loader": "^0.5.5",
+    "html-loader": "^3.1.0",
     "jest": "^26.6.3",
     "jest-junit": "^10.0.0",
     "jest-puppeteer": "^4.3.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-tsdoc": "~0.2.14",
     "eslint-plugin-unicorn": "~40.0.0",
     "file-loader": "^3.0.1",
-    "html-loader": "^0.5.5",
+    "html-loader": "^3.1.0",
     "ignore-styles": "^5.0.1",
     "jsdom": "^16.7.0",
     "jsdom-global": "^3.0.2",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -23209,15 +23209,6 @@
 			"resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
 			"integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA=="
 		},
-		"es6-templates": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
-			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-			"requires": {
-				"recast": "~0.11.12",
-				"through": "~2.3.6"
-			}
-		},
 		"escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -26789,15 +26780,90 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
 		},
 		"html-loader": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz",
-			"integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/html-loader/-/html-loader-3.1.0.tgz",
+			"integrity": "sha512-ycMYFRiCF7YANcLDNP72kh3Po5pTcH+bROzdDwh00iVOAY/BwvpuZ1BKPziQ35Dk9D+UD84VGX1Lu/H4HpO4fw==",
 			"requires": {
-				"es6-templates": "^0.2.3",
-				"fastparse": "^1.1.1",
-				"html-minifier": "^3.5.8",
-				"loader-utils": "^1.1.0",
-				"object-assign": "^4.1.1"
+				"html-minifier-terser": "^6.0.2",
+				"parse5": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.7.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
+				},
+				"clean-css": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
+					"integrity": "sha512-YYuuxv4H/iNb1Z/5IbMRoxgrzjWGhOEFfd+groZ5dMCVkpENiMZmwspdrzBo9286JjM1gZJPAyL7ZIdzuvu2AQ==",
+					"requires": {
+						"source-map": "~0.6.0"
+					}
+				},
+				"commander": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+					"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+				},
+				"html-minifier-terser": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+					"integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
+					"requires": {
+						"camel-case": "^4.1.2",
+						"clean-css": "^5.2.2",
+						"commander": "^8.3.0",
+						"he": "^1.2.0",
+						"param-case": "^3.0.4",
+						"relateurl": "^0.2.7",
+						"terser": "^5.10.0"
+					}
+				},
+				"terser": {
+					"version": "5.13.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
+					"integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+					"requires": {
+						"acorn": "^8.5.0",
+						"commander": "^2.20.0",
+						"source-map": "~0.8.0-beta.0",
+						"source-map-support": "~0.5.20"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+						},
+						"source-map": {
+							"version": "0.8.0-beta.0",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+							"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+							"requires": {
+								"whatwg-url": "^7.0.0"
+							}
+						}
+					}
+				},
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"html-minifier": {
@@ -32367,8 +32433,7 @@
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.template": {
 			"version": "4.5.0",
@@ -34286,16 +34351,28 @@
 			"dev": true
 		},
 		"monaco-editor": {
-			"version": "0.15.6",
-			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.15.6.tgz",
-			"integrity": "sha512-JoU9V9k6KqT9R9Tiw1RTU8ohZ+Xnf9DMg6Ktqqw5hILumwmq7xqa/KLXw513uTUsWbhtnHoSJYYR++u3pkyxJg=="
+			"version": "0.30.1",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
+			"integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
 		},
 		"monaco-editor-webpack-plugin": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.7.0.tgz",
-			"integrity": "sha512-oItymcnlL14Sjd7EF7q+CMhucfwR/2BxsqrXIBrWL6LQplFfAfV+grLEQRmVHeGSBZ/Gk9ptzfueXnWcoEcFuA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-6.0.0.tgz",
+			"integrity": "sha512-vC886Mzpd2AkSM35XLkfQMjH+Ohz6RISVwhAejDUzZDheJAiz6G34lky1vyO8fZ702v7IrcKmsGwL1rRFnwvUA==",
 			"requires": {
-				"@types/webpack": "^4.4.19"
+				"loader-utils": "^2.0.0"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+					"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				}
 			}
 		},
 		"moo": {
@@ -37697,11 +37774,6 @@
 			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
 			"integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
 		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
-		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -39277,34 +39349,6 @@
 					"requires": {
 						"webidl-conversions": "^4.0.2"
 					}
-				}
-			}
-		},
-		"recast": {
-			"version": "0.11.23",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-			"requires": {
-				"ast-types": "0.9.6",
-				"esprima": "~3.1.0",
-				"private": "~0.1.5",
-				"source-map": "~0.5.0"
-			},
-			"dependencies": {
-				"ast-types": {
-					"version": "0.9.6",
-					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-					"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
-				},
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},


### PR DESCRIPTION
Update some webpack plugins. Hopefully this will ease the change to webpack 5 by reducing the number of plugins that are likely to break.

This focuses on the monaco example, which uses a plugin specific to loading monaco in webpack. As this plugin has its versions work with specific versions of monaco, I updated monaco as well. I did not update to the latest version because doing so introduces syntax in the javascript files that error (es6 classes, "?." and "??" operators) which would require additional webpack plugins to make work.

As I have previously discovered, this example does not have automated tests that make sure it loads correctly, so I have manually confirmed that it works with these changes.

The html-loader webpack plugins was also updated.