### PR TITLE
Fixed summary count in container runtime

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -377,6 +377,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly nonSystemOpsSinceLastSummary: number;
     readonly opsSizesSinceLastSummary: number;
     readonly summarizedDataStoreCount: number;
+    readonly summaryNumber: number;
 }
 
 // @public

--- a/api-report/tool-utils.api.md
+++ b/api-report/tool-utils.api.md
@@ -8,7 +8,7 @@ import { IClientConfig } from '@fluidframework/odsp-doclib-utils';
 import { IOdspTokens } from '@fluidframework/odsp-doclib-utils';
 import { ITree } from '@fluidframework/protocol-definitions';
 
-// @public (undocumented)
+// @public
 export const gcBlobPrefix = "__gc";
 
 // @public (undocumented)
@@ -82,14 +82,13 @@ export class OdspTokenManager {
     getPushTokens(server: string, clientConfig: IClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
     // (undocumented)
     updateTokensCache(key: IOdspTokenManagerCacheKey, value: IOdspTokens): Promise<void>;
-    }
+}
 
 // @public (undocumented)
 export const odspTokensCache: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens>;
 
 // @public (undocumented)
 export function saveRC(rc: IResources): Promise<void>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -117,6 +117,22 @@
   },
   "typeValidation": {
     "version": "0.59.3000",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_IGeneratedSummaryStats": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IGenerateSummaryTreeResult": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_ISubmitSummaryOpResult": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IUploadSummaryResult": {
+        "forwardCompat": false
+      },
+      "TypeAliasDeclaration_SubmitSummaryResult": {
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -629,11 +629,11 @@ export class GarbageCollector implements IGarbageCollector {
                 ["/"],
                 logger,
             );
-            const gcStats = this.generateStatsAndLogEvents(gcResult);
+            const gcStats = this.generateStatsAndLogEvents(gcResult, logger);
 
             // Update the state since the last GC run. There can be nodes that were referenced between the last and
             // the current run. We need to identify than and update their unreferenced state if needed.
-            this.updateStateSinceLastRun(gcData);
+            this.updateStateSinceLastRun(gcData, logger);
 
             // Update the current state of the system based on the GC run.
             const currentReferenceTimestampMs = this.runtime.getCurrentReferenceTimestampMs();
@@ -850,7 +850,7 @@ export class GarbageCollector implements IGarbageCollector {
      * This function identifies nodes that were referenced since last run and removes their unreferenced state, if any.
      * If these nodes are currently unreferenced, they will be assigned new unreferenced state by the current run.
      */
-    private updateStateSinceLastRun(currentGCData: IGarbageCollectionData) {
+    private updateStateSinceLastRun(currentGCData: IGarbageCollectionData, logger: ITelemetryLogger) {
         // If we haven't run GC before there is nothing to do.
         if (this.previousGCDataFromLastRun === undefined) {
             return;
@@ -873,7 +873,7 @@ export class GarbageCollector implements IGarbageCollector {
                     gcNodeId: missingExplicitReference[0],
                     gcRoutes: JSON.stringify(missingExplicitReference[1]),
                 };
-                this.mc.logger.sendPerformanceEvent(event);
+                logger.sendPerformanceEvent(event);
             });
         }
 
@@ -912,7 +912,7 @@ export class GarbageCollector implements IGarbageCollector {
          * unreferenced, stop tracking them and remove from unreferenced list.
          * Some of these nodes may be unreferenced now and if so, the current run will add unreferenced state for them.
          */
-        const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, ["/"], this.mc.logger);
+        const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, ["/"], logger);
         for (const nodeId of gcResult.referencedNodeIds) {
             const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
             if (nodeStateTracker !== undefined) {
@@ -983,13 +983,13 @@ export class GarbageCollector implements IGarbageCollector {
      * @param gcResult - The result of a GC run.
      * @returns the GC stats of the GC run.
      */
-    private generateStatsAndLogEvents(gcResult: IGCResult): IGCStats {
+    private generateStatsAndLogEvents(gcResult: IGCResult, logger: ITelemetryLogger): IGCStats {
         // Log pending events for unreferenced nodes after GC has run. We should have the package data available for
         // them now since the GC run should have loaded these nodes.
         let event = this.pendingEventsQueue.shift();
         while (event !== undefined) {
             const pkg = this.getNodePackagePath(event.id);
-            this.mc.logger.sendErrorEvent({
+            logger.sendErrorEvent({
                 ...event,
                 pkg: pkg ? { value: `/${pkg.join("/")}`, tag: TelemetryDataTag.PackageData } : undefined,
             });

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -152,6 +152,8 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly opsSizesSinceLastSummary: number;
     /** Number of non-system ops since the last summary @see isSystemMessage */
     readonly nonSystemOpsSinceLastSummary: number;
+    /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
+    readonly summaryNumber: number;
 }
 
 /** Base results for all submitSummary attempts. */

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -77,16 +77,21 @@ export function hasIsolatedChannels(attributes: ReadFluidDataStoreAttributes): b
 export type GCVersion = number;
 export interface IContainerRuntimeMetadata extends ICreateContainerMetadata {
     readonly summaryFormatVersion: 1;
-    /** The last message processed at the time of summary. Only primitive propertiy types are added to the summary. */
+    /** The last message processed at the time of summary. Only primitive property types are added to the summary. */
     readonly message: ISummaryMetadataMessage | undefined;
     /** True if channels are not isolated in .channels subtrees, otherwise isolated. */
     readonly disableIsolatedChannels?: true;
     /** 0 to disable GC, \> 0 to enable GC, undefined defaults to disabled. */
     readonly gcFeature?: GCVersion;
-    /** Counter of the last summary happened, increments every time we summarize */
-    readonly summaryCount?: number;
+    /** Represents the summary number for a document. Incremented on summary throughout a document's lifetime. */
+    readonly summaryNumber?: number;
     /** If this is present, the session for this container will expire after this time and the container will close */
     readonly sessionExpiryTimeoutMs?: number;
+    /**
+     * @deprecated - User summaryNumber instead.
+     * Counter of the last summary happened, increments every time we summarize
+     * */
+    readonly summaryCount?: number;
 }
 
 export interface ICreateContainerMetadata {

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -83,7 +83,7 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata {
     readonly disableIsolatedChannels?: true;
     /** 0 to disable GC, \> 0 to enable GC, undefined defaults to disabled. */
     readonly gcFeature?: GCVersion;
-    /** Represents the summary number for a document. Incremented on summary throughout a document's lifetime. */
+    /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
     readonly summaryNumber?: number;
     /** If this is present, the session for this container will expire after this time and the container will close */
     readonly sessionExpiryTimeoutMs?: number;

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -170,6 +170,7 @@ describe("Runtime", () => {
                                 unreferencedBlobSize: 0,
                                 opsSizesSinceLastSummary: 0,
                                 nonSystemOpsSinceLastSummary: 0,
+                                summaryNumber: 0,
                             },
                             handle: "test-handle",
                             clientSequenceNumber: lastClientSeq,

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -576,6 +576,7 @@ declare function get_old_InterfaceDeclaration_IGeneratedSummaryStats():
 declare function use_current_InterfaceDeclaration_IGeneratedSummaryStats(
     use: TypeOnly<current.IGeneratedSummaryStats>);
 use_current_InterfaceDeclaration_IGeneratedSummaryStats(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IGeneratedSummaryStats());
 
 /*
@@ -600,6 +601,7 @@ declare function get_old_InterfaceDeclaration_IGenerateSummaryTreeResult():
 declare function use_current_InterfaceDeclaration_IGenerateSummaryTreeResult(
     use: TypeOnly<current.IGenerateSummaryTreeResult>);
 use_current_InterfaceDeclaration_IGenerateSummaryTreeResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IGenerateSummaryTreeResult());
 
 /*
@@ -864,6 +866,7 @@ declare function get_old_InterfaceDeclaration_ISubmitSummaryOpResult():
 declare function use_current_InterfaceDeclaration_ISubmitSummaryOpResult(
     use: TypeOnly<current.ISubmitSummaryOpResult>);
 use_current_InterfaceDeclaration_ISubmitSummaryOpResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISubmitSummaryOpResult());
 
 /*
@@ -1296,6 +1299,7 @@ declare function get_old_InterfaceDeclaration_IUploadSummaryResult():
 declare function use_current_InterfaceDeclaration_IUploadSummaryResult(
     use: TypeOnly<current.IUploadSummaryResult>);
 use_current_InterfaceDeclaration_IUploadSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IUploadSummaryResult());
 
 /*
@@ -1464,6 +1468,7 @@ declare function get_old_TypeAliasDeclaration_SubmitSummaryResult():
 declare function use_current_TypeAliasDeclaration_SubmitSummaryResult(
     use: TypeOnly<current.SubmitSummaryResult>);
 use_current_TypeAliasDeclaration_SubmitSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_SubmitSummaryResult());
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -10,13 +10,12 @@ import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
-import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
-import { IContainer } from "@fluidframework/container-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { IContainerRuntimeOptions, SummaryCollection } from "@fluidframework/container-runtime";
+import { IAckedSummary, IContainerRuntimeOptions, SummaryCollection } from "@fluidframework/container-runtime";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -25,9 +24,13 @@ class TestDataObject extends DataObject {
     public get _root() {
         return this.root;
     }
+
+    public get containerRuntime() {
+        return this.context.containerRuntime;
+    }
 }
 
-describeNoCompat("Generate Summary Stats", (getTestObjectProvider) => {
+describeNoCompat.only("Generate Summary Stats", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const dataObjectFactory = new DataObjectFactory(
         "TestDataObject",
@@ -64,93 +67,129 @@ describeNoCompat("Generate Summary Stats", (getTestObjectProvider) => {
 
     let mainContainer: IContainer;
     let mainDataStore: TestDataObject;
+    let createContainerTimestamp: number;
+    let createContainerRuntimeVersion: number;
     let summaryCollection: SummaryCollection;
-    const mockLogger: MockLogger = new MockLogger();
-    let containerStatsEvents: ITelemetryBaseEvent[];
+    let mockLogger: MockLogger;
+
+    const loadContainer = async (summaryVersion?: string): Promise<IContainer> => {
+        const requestHeader = {
+            [LoaderHeader.version]: summaryVersion,
+        };
+        return provider.loadContainer(runtimeFactory, { logger: mockLogger }, requestHeader);
+    };
 
     /**
      * Waits for a summary with the current state of the document (including all in-flight changes). It basically
      * synchronizes all containers and waits for a summary that contains the last processed sequence number.
-     * @returns the sequence number of the summary
+     * @returns the version of this summary. This version can be used to load a Container with the summary associated
+     * with it.
      */
-     async function waitForSummary(): Promise<number> {
+    async function waitForSummary(): Promise<string> {
+        // Send an op which should trigger a summary.
+        mainDataStore._root.set("test", "value");
         await provider.ensureSynchronized();
-        const sequenceNumber = mainContainer.deltaManager.lastSequenceNumber;
-        await summaryCollection.waitSummaryAck(sequenceNumber);
-        return sequenceNumber;
+        const ackedSummary: IAckedSummary =
+            await summaryCollection.waitSummaryAck(mainContainer.deltaManager.lastSequenceNumber);
+        return ackedSummary.summaryAck.contents.handle;
     }
 
-    const getContainerLoadStatsEvents = (): ITelemetryBaseEvent[] =>
-        mockLogger.events.filter((event) => event.eventName === "fluid:telemetry:ContainerLoadStats");
+    function validateLoadStats(
+        summaryNumber: number,
+        containerLoadDataStoreCount: number,
+        referencedDataStoreCount: number,
+        message: string,
+        summarizer: boolean = false,
+    ) {
+        mockLogger.assertMatch([
+            {
+                eventName: "fluid:telemetry:ContainerLoadStats",
+                summaryNumber,
+                containerLoadDataStoreCount,
+                referencedDataStoreCount,
+                createContainerTimestamp,
+                createContainerRuntimeVersion,
+                clientType: summarizer ? "noninteractive/summarizer" : "interactive",
+            },
+        ], message);
+    }
 
-    const createContainer = async (logger): Promise<IContainer> => provider.createContainer(runtimeFactory, { logger });
-
-    beforeEach(async () => {
-    });
-
-    it("should generate correct container load stats with two summarizer containers", async function() {
+    beforeEach(async function() {
         provider = getTestObjectProvider();
-        // GitHub issue: #9534
         if (provider.driver.type === "odsp") {
             this.skip();
         }
 
-        // Create a Container for the first client.
-        mainContainer = await createContainer(mockLogger);
+        mockLogger = new MockLogger();
 
-        // Set an initial key. The Container is in read-only mode so the first op it sends will get nack'd and is
-        // re-sent. Do it here so that the extra events don't mess with rest of the test.
+        // Create and set up a container for the first client.
+        mainContainer = await provider.createContainer(runtimeFactory, { logger: mockLogger });
         mainDataStore = await requestFluidObject<TestDataObject>(mainContainer, "default");
-        mainDataStore._root.set("test", "value");
-
         // Create and setup a summary collection that will be used to track and wait for summaries.
         summaryCollection = new SummaryCollection(mainContainer.deltaManager, new TelemetryNullLogger());
 
-        // Wait for summary that contains the above set.
+        const loadStatEvents =
+            mockLogger.events.filter((event) => event.eventName === "fluid:telemetry:ContainerLoadStats");
+        assert(loadStatEvents.length === 1, "There should only be one event for the created container");
+        createContainerTimestamp = loadStatEvents[0].createContainerTimestamp as number;
+        createContainerRuntimeVersion = loadStatEvents[0].createContainerRuntimeVersion as number;
+
+        // Validate that the first container's stats are correct. It should load from summaryNumber 0 because it was
+        // just created and it shouldn't have loaded any data stores.
+        validateLoadStats(0, 0, 0, "First container stats incorrect");
+    });
+
+    it("should load summarizer with correct create stats", async function() {
+        // Wait for summarizer to load and submit a summary. Validate that it loads from summaryNumber 1 and has
+        // 1 data store which is referenced.
         await waitForSummary();
+        validateLoadStats(1, 1, 1, "Summarizer should load with correct create stats", true /* summarizer */);
+    });
 
-        // Trigger the telemetry event so it logs the new summary count
-        await provider.loadContainer(runtimeFactory, { logger: mockLogger });
-        await provider.ensureSynchronized();
+    it("should load container with correct create stats", async function() {
+        // Wait for summarizer to load and submit a summary. Validate that it loads from summaryNumber 1 and has
+        // 1 data store which is referenced.
+        const summaryVersion = await waitForSummary();
+        validateLoadStats(1, 1, 1, "Summarizer should load with correct create stats", true /* summarizer */);
 
-        // Get all the containerLoadStats events
-        containerStatsEvents = getContainerLoadStatsEvents();
-        assert(containerStatsEvents !== undefined, "container load stats event is undefined");
+        // Load a new container with the above summary and validate that it loads from summaryNumber 2.
+        await loadContainer(summaryVersion);
+        validateLoadStats(2, 1, 1, "Second container should load with correct create stats");
+    });
 
-        // Checking all the stats
-        assert.strictEqual(containerStatsEvents.length, 3, "wrong number of containerLoadStats events");
-        assert.strictEqual(containerStatsEvents[0].containerLoadDataStoreCount, 0, "dataStore count should be 0");
-        assert.strictEqual(containerStatsEvents[0].referencedDataStoreCount, 0,
-            "summarized dataStore count should be 0");
-        assert.strictEqual(containerStatsEvents[2].containerLoadDataStoreCount, 1, "data store count should be 1");
-        assert.strictEqual(containerStatsEvents[2].referencedDataStoreCount, 1,
-            "summarized data store count should be 1");
-        assert.strictEqual(containerStatsEvents[1].summaryCount, undefined, "summary count should be 0");
-        assert.strictEqual(containerStatsEvents[2].summaryCount, 1, "summary count should be 1");
+    it("should load container with correct data store load stats", async function() {
+        // Create another data store so that the data store stats are updated.
+        const dataStore2 = await dataObjectFactory.createInstance(mainDataStore.containerRuntime);
+        mainDataStore._root.set("dataStore2", dataStore2.handle);
 
-        // close the current summarizer and start a new summarizer container
-        // this is to test summaryCount will still increment instead of reset
+        // Wait for summarizer to load and submit a summary. Validate that it loads from summaryNumber 1. It loads
+        // from the first summary which does not have the newly created data store.
+        const summaryVersion = await waitForSummary();
+        validateLoadStats(1, 1, 1, "Summarizer should load with correct data store stats", true /* summarizer */);
+
+        // Load a new container with the above summary and validate that it loads with summaryNumber 2, has 2 data
+        // stores and both are referenced.
+        await loadContainer(summaryVersion);
+        validateLoadStats(2, 2, 2, "Second container should load with correct data store stats");
+    });
+
+    it("should load second summarizer with correct stats", async function() {
+        // Wait for summarizer to load and submit a summary. Validate that it loads from summaryNumber 1.
+        const summaryVersion = await waitForSummary();
+        validateLoadStats(1, 1, 1, "Summarizer should load with correct data store stats", true /* summarizer */);
+
+        // Close the main container which should also close the summarizer.
         mainContainer.close();
-        mainContainer = await provider.loadContainer(runtimeFactory, { logger: mockLogger });
+
+        // Load and set up a new main container with the above summary and validate that it loads with summaryNumber 2.
+        mainContainer = await loadContainer(summaryVersion);
         mainDataStore = await requestFluidObject<TestDataObject>(mainContainer, "default");
-        mainDataStore._root.set("test", "value");
+        // Create and setup a summary collection that will be used to track and wait for summaries.
         summaryCollection = new SummaryCollection(mainContainer.deltaManager, new TelemetryNullLogger());
+        validateLoadStats(2, 1, 1, "Second container should load with correct data store stats");
+
+        // Wait for summary and validate that the new summarizer loads from summary number 2 as well.
         await waitForSummary();
-        await provider.loadContainer(runtimeFactory, { logger: mockLogger });
-
-        containerStatsEvents = getContainerLoadStatsEvents();
-        assert.strictEqual(containerStatsEvents.length, 6, "wrong number of containerLoadStats events");
-
-        // createContainerTimestamp and runtimeVersio should be consistent
-        assert(containerStatsEvents.every((event) =>
-            event.createContainerTimestamp === containerStatsEvents[0].createContainerTimestamp),
-            "create container timestamp is inconsistent");
-        assert(containerStatsEvents.every((event) =>
-            event.createContainerRuntimeVersion === containerStatsEvents[0].createContainerRuntimeVersion),
-            "create container runtime version is inconsistent");
-
-        // summary count should increment instead of reset to 0
-        assert.strictEqual(containerStatsEvents[4].summaryCount, 1, "summary count should still be 1");
-        assert.strictEqual(containerStatsEvents[5].summaryCount, 2, "summary count should be 2");
+        validateLoadStats(2, 1, 1, "Summarizer should load with correct data store stats", true /* summarizer */);
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -30,7 +30,7 @@ class TestDataObject extends DataObject {
     }
 }
 
-describeNoCompat.only("Generate Summary Stats", (getTestObjectProvider) => {
+describeNoCompat("Generate Summary Stats", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const dataObjectFactory = new DataObjectFactory(
         "TestDataObject",

--- a/packages/utils/tool-utils/src/snapshotNormalizer.ts
+++ b/packages/utils/tool-utils/src/snapshotNormalizer.ts
@@ -10,9 +10,9 @@ import {
     ITreeEntry,
 } from "@fluidframework/protocol-definitions";
 
-// The name of the metadata blob added to the root of the container runtime.
+/** The name of the metadata blob added to the root of the container runtime. */
 const metadataBlobName = ".metadata";
-// The prefix that all GC blob names start with.
+/** The prefix that all GC blob names start with. */
 export const gcBlobPrefix = "__gc";
 
 export interface ISnapshotNormalizerConfig {
@@ -95,14 +95,19 @@ function getNormalizedBlobContent(blobContent: string, blobName: string): string
     }
 
     /**
-      * The metadata blob has "summaryNumber" that tells which summary this is for a container. This can be different in
-      * summaries of two clients even if they are generated at the same sequence number. For instance, at seq# 1000, if
-      * one client has summarized 10 times and other has summarizer 15 times, summaryNumber will be different for them.
-      * So, update "summaryNumber" to 0 for purposes of comparing snapshots.
+      * The metadata blob has "summaryNumber" or "summaryCount" that tells which summary this is for a container. It can
+      * be different in summaries of two clients even if they are generated at the same sequence#. For instance, at seq#
+      * 1000, if one client has summarized 10 times and other has summarizer 15 times, summaryNumber will be different
+      * for them. So, update "summaryNumber" to 0 for purposes of comparing snapshots.
       */
     if (blobName === metadataBlobName) {
         const metadata = JSON.parse(content);
-        metadata.summaryNumber = 0;
+        if (metadata.summaryNumber !== undefined) {
+            metadata.summaryNumber = 0;
+        }
+        if (metadata.summaryCount !== undefined) {
+            metadata.summaryCount = 0;
+        }
         content = JSON.stringify(metadata);
     }
 


### PR DESCRIPTION
`summaryCount` in container runtime was not correct for the first couple of summaries:
- The first container's load event logs `summaryCount` as  undefined.
- The first summarizer's load event also logs `summaryCount` as undefined. It initializes this count to 1 which is added to the summary and it incremented for each summary after this.
When looking at telemetry, its hard to determine which were the first few summaries. Having this information is helpful in certain situations.

Also, its name is easy to confuse with `summarizeCount` in Summarizer which has a different meaning.

This PR does the following:
- Renames `summaryCount` to `summaryNumber` in summary and in logs.
- The first container's load event now logs `summaryNumber` as 0.
- The first summarizer's load event now logs `summaryNumber` as 1.
- All summaries that are successfully generated increment this number.
- All events logged during summary (including the ones in SummaryGenerator) will have this `summaryNumber` which can help correlate them throughout the lifetime of a document.

The test snapshots need to be updated to include `summaryNumber` - https://github.com/microsoft/FluidFrameworkTestData/pull/45