### PR TITLE
Update container defs to latest pre-release 

### DIFF
--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/ink": "^0.60.1000",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/ink": "^0.60.1000",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/ink": "^0.60.1000",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/merge-tree": "^0.60.1000",
     "@fluidframework/runtime-definitions": "^0.60.1000",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/merge-tree": "^0.60.1000",
     "@fluidframework/runtime-definitions": "^0.60.1000",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/merge-tree": "^0.60.1000",
     "@fluidframework/runtime-definitions": "^0.60.1000",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -45,7 +45,7 @@
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -45,7 +45,7 @@
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -45,7 +45,7 @@
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -44,7 +44,7 @@
     "@fluid-example/table-document": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/matrix": "^0.60.1000",
     "@fluidframework/runtime-utils": "^0.60.1000",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -44,7 +44,7 @@
     "@fluid-example/table-document": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/matrix": "^0.60.1000",
     "@fluidframework/runtime-utils": "^0.60.1000",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -44,7 +44,7 @@
     "@fluid-example/table-document": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/matrix": "^0.60.1000",
     "@fluidframework/runtime-utils": "^0.60.1000",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/request-handler": "^0.60.1000",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/request-handler": "^0.60.1000",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/request-handler": "^0.60.1000",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -39,7 +39,7 @@
     "@fluid-experimental/get-container": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -39,7 +39,7 @@
     "@fluid-experimental/get-container": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -39,7 +39,7 @@
     "@fluid-experimental/get-container": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000"
   },
   "devDependencies": {

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000"
   },
   "devDependencies": {

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000"
   },
   "devDependencies": {

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-utils": "^0.60.1000",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-utils": "^0.60.1000",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-utils": "^0.60.1000",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-example/todo": "^0.60.1000",
     "@fluid-experimental/get-container": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-example/todo": "^0.60.1000",
     "@fluid-experimental/get-container": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-example/todo": "^0.60.1000",
     "@fluid-experimental/get-container": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluid-example/key-value-cache": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluid-example/key-value-cache": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluid-example/key-value-cache": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -38,7 +38,7 @@
     "@fluid-experimental/property-changeset": "^0.60.1000",
     "@fluid-experimental/property-properties": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -38,7 +38,7 @@
     "@fluid-experimental/property-changeset": "^0.60.1000",
     "@fluid-experimental/property-properties": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -38,7 +38,7 @@
     "@fluid-experimental/property-changeset": "^0.60.1000",
     "@fluid-experimental/property-properties": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -45,7 +45,7 @@
     "@fluid-experimental/bubblebench-common": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -45,7 +45,7 @@
     "@fluid-experimental/bubblebench-common": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -45,7 +45,7 @@
     "@fluid-experimental/bubblebench-common": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/sharejs-json1": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/sharejs-json1": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/sharejs-json1": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/tree": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/tree": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/tree": "^0.60.1000",
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -30,7 +30,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -30,7 +30,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -30,7 +30,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1966,20 +1966,20 @@
 			}
 		},
 		"@fluid-experimental/task-manager-previous": {
-			"version": "npm:@fluid-experimental/task-manager-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-0.59.1000.tgz",
-			"integrity": "sha512-14U5Fumd4UjBHBXsgclXzRo6+GLUGzp2l1CXN6olKufCuKCRpgLwFMpYUk0FcJmabwxkRg2c8+rg5MBw3TdpXg==",
+			"version": "npm:@fluid-experimental/task-manager@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-0.59.2001.tgz",
+			"integrity": "sha512-XD4ubrdNJYX8AtIUQE4A7AHRpsrTV16Sbmoan/Rjf8uz7RtEKmA3xh3+tSZayiRf2mPASn0LbT78F4Vr4PzYdw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -2017,15 +2017,15 @@
 			}
 		},
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-g+T8MGBeIl92LMKddok6tev9rKWZ528sYVLhGUnp102nYWztbCmOEAslAXjO0oSzJXjIfowwI4+IJo+j2yx3jQ==",
+			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-0.59.2001.tgz",
+			"integrity": "sha512-ol2MrMs3mW7aYj0Ol23GdkZ7hzCve5zmH9dPTRMd0GVjR/G6L+uc4pi3vtsoSrD4flSrGXcJTNFJvL72MhhM6w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000"
+				"@fluidframework/odsp-driver": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -2041,38 +2041,38 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-0.59.1000.tgz",
-			"integrity": "sha512-sihDV79PZ9nivswV9UfPb0aLq9e+Q16ieGRKtzQUkKRvNmDAt2Ru8lm7xeoJpLgVlOYwUiL0CW244WVCyx4pBg==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-0.59.2001.tgz",
+			"integrity": "sha512-Fl73oUf4x7/Ioxyt0X2W7cy479iLx97igADKOyrsjmqMGlXJgegb0OKKOxfhrnMtd7SwQLItsH1TVHG/gk+oCQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2001",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/local-driver": "^0.59.2001",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2001",
+				"@fluidframework/odsp-driver": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/server-local-server": "^0.1036.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
-				"@fluidframework/tool-utils": "^0.59.1000",
-				"@fluidframework/view-adapters": "^0.59.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
-				"@fluidframework/web-code-loader": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/server-local-server": "^0.1036.2000",
+				"@fluidframework/server-services-client": "^0.1036.2000",
+				"@fluidframework/test-runtime-utils": "^0.59.2001",
+				"@fluidframework/tool-utils": "^0.59.2001",
+				"@fluidframework/view-adapters": "^0.59.2001",
+				"@fluidframework/view-interfaces": "^0.59.2001",
+				"@fluidframework/web-code-loader": "^0.59.2001",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
-				"nconf": "^0.11.0",
+				"nconf": "^0.11.4",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1",
-				"webpack-dev-server": "^3.8.0"
+				"webpack-dev-server": "4.0.0"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -2097,90 +2097,90 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.1000.tgz",
-					"integrity": "sha512-nf2H38+U0S5amvuyC3JZrPbaqD0VQmgeHsRNx6ecOLeNlsZCA4lL2US89s17aa4g6N8y1RNUQs/Rcs0Wu2g9qw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.2000.tgz",
+					"integrity": "sha512-P+ICmd+gEUBquv0JOFPDWNblZ/znzwAVfwUb8zwhNXVkx6GUWlr0P6fkDrgnk+Hb3vQ/g97pBg3VKlCLx3k6qA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas-driver": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas-driver": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/semver": "^6.0.1",
-						"async": "^3.2.0",
+						"async": "^3.2.2",
 						"axios": "^0.26.0",
 						"double-ended-queue": "^2.1.0-0",
 						"json-stringify-safe": "^5.0.1",
 						"lodash": "^4.17.21",
-						"nconf": "^0.11.0",
+						"nconf": "^0.11.4",
 						"semver": "^6.3.0",
 						"sha.js": "^2.4.11",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-lambdas-driver": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.1000.tgz",
-					"integrity": "sha512-8Q+4+FitbHJea7uMwfIvHrxEdOtxZOsQWlCenm/siEYjCo34JMxCSaO9BJX7REN4j644C3c3a0R/xAEM5ak4iw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.2000.tgz",
+					"integrity": "sha512-ELqQbGag580dh21vmR+r5BQ0d3pxDwpxQMr1Yb7ojQr4lJillgu8CcLwZOJTXy6ar5mn6aA4NP1OQ8+OrPDF1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"async": "^3.2.0",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"async": "^3.2.2",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.1000.tgz",
-					"integrity": "sha512-laLvpTNEBusrSa+fox02SdUpZQZ2VhRhIeos+AuQFw8bVIRStBfFFRqqu7ADcckqz/xeXX7+evX1EFN1QHYWmA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.2000.tgz",
+					"integrity": "sha512-9laj7b2Fxf/eyKT6Fd/8N7c61XXG3l+5EwepeVVQaSs8eh3mYLUTKKq3v+hD4PV7vVRWEiKZUq4Mw/Bu3MET7w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-memory-orderer": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"@fluidframework/server-test-utils": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-memory-orderer": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"@fluidframework/server-test-utils": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.1000.tgz",
-					"integrity": "sha512-pTN7xXU/akNlczupyxZBl2IdJS9r8ygka/BEbzSYAYmCg2URBBVFbsmxUtQhd1NRxu3Ft8nhETmOxrIQK5duAA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.2000.tgz",
+					"integrity": "sha512-dX7/SrNGC18Xj3UxeXPrepxURi/klLmu82oa2UWthkXOJkA1HnbbDfGPUigTC4RLewJFVBUBu7tSNjp2ACwL1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -2195,13 +2195,13 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -2214,25 +2214,25 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.1000.tgz",
-					"integrity": "sha512-IhLvveSmswFSp5TgiJgFnDt0bAJhq4XvSgKv9V+xl+5GwxPgvFuSLE/uZJkCbiGlGWs3VO+3SfUZkbmvVBYEkA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.2000.tgz",
+					"integrity": "sha512-rxV2lwUBiWATxNK3ai9w7D0PfJB3QVkgyE6Jmmd/dtG33wkYJhJK6XhLddtyxcV3xjyNLSBMPD9ZBUFkA7Uk8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/nconf": "^0.10.0",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
+						"nconf": "^0.11.4"
 					}
 				},
 				"@fluidframework/server-services-telemetry": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.1000.tgz",
-					"integrity": "sha512-iUa7Ux3zvj+9NswrFTdslxW2jm4II/3g94+tDNFdXpy5316XmlEKfLHgOuQbSPDC2T++oPqiJuy9Y4CLAVDvEQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.2000.tgz",
+					"integrity": "sha512-3MluWe1wlFWP2UZ2hrfhSlH9s6IJs9O1dKZxRmjczCVv1KW0SQtlc0+zjYBTeXg0Nk0qWCQfpFSOYMyT4OWPAQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"json-stringify-safe": "^5.0.1",
@@ -2242,17 +2242,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.1000.tgz",
-					"integrity": "sha512-DqykRhXh9WZ4s2iWD2qzAjozNei+HPP6AzFyuba6PKXLKNhQjiTK+k7g4BxdKUI0Uu+ZJeZEptoipy1xTNpsjQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.2000.tgz",
+					"integrity": "sha512-A0mO+quijpJZFji9/aQvMJ9n3Sg90CDACrm4Ohbl9UeCVN1OLie/8DILryFD5c62/3xXiaYla8IwSikUUFtwgg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -2264,414 +2264,38 @@
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
 				},
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						}
-					}
-				},
-				"binary-extensions": {
-					"version": "1.13.1",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-				},
-				"chokidar": {
-					"version": "2.1.8",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-					"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"default-gateway": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
-					"integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
-					"requires": {
-						"execa": "^1.0.0",
-						"ip-regex": "^2.1.0"
-					}
-				},
-				"fsevents": {
-					"version": "1.2.13",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-					"optional": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"nan": "^2.12.1"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"html-entities": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-					"integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA=="
-				},
-				"http-proxy-middleware": {
-					"version": "0.19.1",
-					"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-					"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
-					"requires": {
-						"http-proxy": "^1.17.0",
-						"is-glob": "^4.0.0",
-						"lodash": "^4.17.11",
-						"micromatch": "^3.1.10"
-					}
-				},
-				"import-local": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
-					}
-				},
-				"internal-ip": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
-					"integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
-					"requires": {
-						"default-gateway": "^4.2.0",
-						"ipaddr.js": "^1.9.0"
-					}
-				},
-				"ip-regex": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-				},
-				"is-binary-path": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-					"requires": {
-						"binary-extensions": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				"async": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
 					"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
 				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-				},
-				"p-retry": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-					"integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
-					"requires": {
-						"retry": "^0.12.0"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"resolve-cwd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-					"requires": {
-						"resolve-from": "^3.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"webpack-dev-server": {
-					"version": "3.11.3",
-					"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
-					"integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
-					"requires": {
-						"ansi-html-community": "0.0.8",
-						"bonjour": "^3.5.0",
-						"chokidar": "^2.1.8",
-						"compression": "^1.7.4",
-						"connect-history-api-fallback": "^1.6.0",
-						"debug": "^4.1.1",
-						"del": "^4.1.1",
-						"express": "^4.17.1",
-						"html-entities": "^1.3.1",
-						"http-proxy-middleware": "0.19.1",
-						"import-local": "^2.0.0",
-						"internal-ip": "^4.3.0",
-						"ip": "^1.1.5",
-						"is-absolute-url": "^3.0.3",
-						"killable": "^1.0.1",
-						"loglevel": "^1.6.8",
-						"opn": "^5.5.0",
-						"p-retry": "^3.0.1",
-						"portfinder": "^1.0.26",
-						"schema-utils": "^1.0.0",
-						"selfsigned": "^1.10.8",
-						"semver": "^6.3.0",
-						"serve-index": "^1.9.1",
-						"sockjs": "^0.3.21",
-						"sockjs-client": "^1.5.0",
-						"spdy": "^4.0.2",
-						"strip-ansi": "^3.0.1",
-						"supports-color": "^6.1.0",
-						"url": "^0.11.0",
-						"webpack-dev-middleware": "^3.7.2",
-						"webpack-log": "^2.0.0",
-						"ws": "^6.2.1",
-						"yargs": "^13.3.2"
-					},
-					"dependencies": {
-						"ws": {
-							"version": "6.2.2",
-							"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-							"integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-							"requires": {
-								"async-limiter": "~1.0.0"
-							}
-						}
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
 				}
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.59.1000.tgz",
-			"integrity": "sha512-2Vvr2Ofl+1yfPLal/kkwQyfatx2Q7sP+VbwvUIi3sAe8M86+e6Enk+cv8hddtk3GhtmycqhKvDcOeepXc8JB3w==",
+			"version": "npm:@fluidframework/agent-scheduler@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.59.2001.tgz",
+			"integrity": "sha512-oJGpPn/ViZ7S3YTeQqNtYCz7GndV81kB6mSbxzKwIIILEKEyHnFOV18GrWgmyGJ8y0iTbqQmwsyAAkMyUFSjwA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/register-collection": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
+				"@fluidframework/register-collection": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2699,25 +2323,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.1000.tgz",
-			"integrity": "sha512-mzYuHMt2ww3ZfG0SpwFLRekqn4xYybikHxuJSTaejijSYZSZxuU8ZZO3juZRM8/p/pGdJQac9dnqHMVY38xt/Q==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.2001.tgz",
+			"integrity": "sha512-VRsJCYbVB1WOYBTZVWDrBZTsj+L8cChEzAODbLDuo2rkQ0Y4RrJWzMBUB+aqG59cjdolca9/QHbbDQJvdfKJsw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
+				"@fluidframework/container-runtime": "^0.59.2001",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/synthesize": "^0.59.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
+				"@fluidframework/request-handler": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/synthesize": "^0.59.2001",
+				"@fluidframework/view-interfaces": "^0.59.2001",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2745,25 +2369,25 @@
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.1000.tgz",
-			"integrity": "sha512-mzYuHMt2ww3ZfG0SpwFLRekqn4xYybikHxuJSTaejijSYZSZxuU8ZZO3juZRM8/p/pGdJQac9dnqHMVY38xt/Q==",
+			"version": "npm:@fluidframework/aqueduct@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.2001.tgz",
+			"integrity": "sha512-VRsJCYbVB1WOYBTZVWDrBZTsj+L8cChEzAODbLDuo2rkQ0Y4RrJWzMBUB+aqG59cjdolca9/QHbbDQJvdfKJsw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
+				"@fluidframework/container-runtime": "^0.59.2001",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/synthesize": "^0.59.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
+				"@fluidframework/request-handler": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/synthesize": "^0.59.2001",
+				"@fluidframework/view-interfaces": "^0.59.2001",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2791,22 +2415,22 @@
 			}
 		},
 		"@fluidframework/azure-client-previous": {
-			"version": "npm:@fluidframework/azure-client-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-0.59.1000.tgz",
-			"integrity": "sha512-AzWMorHSjvKr8rOU/8Qu/04t+PeSqMgClusNh3y2lLzmijLZvyFQ1QrMk62ki8cMPgztSZUyl49LwObEywWKYQ==",
+			"version": "npm:@fluidframework/azure-client@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-0.59.2001.tgz",
+			"integrity": "sha512-erFRfYNfRbAZMd2C+R31GqrlTchTOty2PEYZQQqZqyMcTpv6CnuG0/x8CzRYq/129VYYYx2OvqNB07zsRQfPdg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/fluid-static": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/fluid-static": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/server-services-client": "^0.1036.2000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -2833,29 +2457,29 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -2883,9 +2507,9 @@
 			}
 		},
 		"@fluidframework/azure-service-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.1000.tgz",
-			"integrity": "sha512-GBKZ/l+nJHigo7LsSQwj3WFBm33WNd2N4ivR5jjlGSjvixz1C/Am9w517WdlV2l1T6sLFZp2prwHbWJIsngOvA==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.2001.tgz",
+			"integrity": "sha512-gpySsbyInZBGdqWc/js66NlhLe4GHmumPEsR7GGeoUvlDg/HrcXvq+h6DItYzXW3ioQ09MyXvrNY2p4b5LyT7w==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"jsrsasign": "^10.2.0",
@@ -2893,9 +2517,9 @@
 			}
 		},
 		"@fluidframework/azure-service-utils-previous": {
-			"version": "npm:@fluidframework/azure-service-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.1000.tgz",
-			"integrity": "sha512-GBKZ/l+nJHigo7LsSQwj3WFBm33WNd2N4ivR5jjlGSjvixz1C/Am9w517WdlV2l1T6sLFZp2prwHbWJIsngOvA==",
+			"version": "npm:@fluidframework/azure-service-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.2001.tgz",
+			"integrity": "sha512-gpySsbyInZBGdqWc/js66NlhLe4GHmumPEsR7GGeoUvlDg/HrcXvq+h6DItYzXW3ioQ09MyXvrNY2p4b5LyT7w==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"jsrsasign": "^10.2.0",
@@ -2994,31 +2618,31 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.1000.tgz",
-			"integrity": "sha512-gR/TbtAg1OLMSh1cAdpJpPtlCPlEkcROqvozmBsXVRNiZAncDvMGolmJSgjjC4E2+dVcQHtbPOZwf9ezV0m5pg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.2001.tgz",
+			"integrity": "sha512-SbPNQBEfHy3v2ZxsR42akVZPqMrWztgd7Sxb3Y4+N8sjaqVZNV7VTg1ZVdNWjahh5bzxGpJjnnloN6ZpbT6kPw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.1000.tgz",
-			"integrity": "sha512-gR/TbtAg1OLMSh1cAdpJpPtlCPlEkcROqvozmBsXVRNiZAncDvMGolmJSgjjC4E2+dVcQHtbPOZwf9ezV0m5pg==",
+			"version": "npm:@fluidframework/cell@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.2001.tgz",
+			"integrity": "sha512-SbPNQBEfHy3v2ZxsR42akVZPqMrWztgd7Sxb3Y4+N8sjaqVZNV7VTg1ZVdNWjahh5bzxGpJjnnloN6ZpbT6kPw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -3047,9 +2671,9 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.49.1000-63433",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.49.1000-63433.tgz",
-			"integrity": "sha512-oY+HopWUYe3ijR5ihOygPc7r8RhXsTNZFCX/xo5JldsHoClTCgmfcu7u92Y/6IUzadNOFGy+mdd3pJRqfmhnlg==",
+			"version": "0.49.1000-64278",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.49.1000-64278.tgz",
+			"integrity": "sha512-c6LeOZewp+hJvJVn3z5tgHmXm3Ina61gvPGQuLIuDfnAl7FZ+HMiMXPLVhdLqxeZIrtiMVyO8ebK8vjvK/uPcQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -3058,20 +2682,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.1000.tgz",
-			"integrity": "sha512-xK6jqL9ZBmVpJlCcCZ4MhO4GIhFgE4W07ZHZ8Dubq6Mtusi6wJ/knpiGRmHoNmPQCx2ZKi8SNy+LPTzH0HdzXg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.2001.tgz",
+			"integrity": "sha512-aGrytr/jH+MYqyoc3VboZDL4/d6jKo6M+YeU4XuC8U/ZeBmVNI9rH3EEWJQmTSXlo/eaxXvyqC/sS48hIvi1zA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -3100,17 +2724,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3118,20 +2742,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.1000.tgz",
-			"integrity": "sha512-xK6jqL9ZBmVpJlCcCZ4MhO4GIhFgE4W07ZHZ8Dubq6Mtusi6wJ/knpiGRmHoNmPQCx2ZKi8SNy+LPTzH0HdzXg==",
+			"version": "npm:@fluidframework/container-loader@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.2001.tgz",
+			"integrity": "sha512-aGrytr/jH+MYqyoc3VboZDL4/d6jKo6M+YeU4XuC8U/ZeBmVNI9rH3EEWJQmTSXlo/eaxXvyqC/sS48hIvi1zA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -3160,17 +2784,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3178,25 +2802,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.1000.tgz",
-			"integrity": "sha512-AGNUBNrrfINALPd6DcgJMZg6TGkRvjWYjpoE73GwhYfFwBOs0ClRbt2ErJtjV+fOa3+2p2iGCnKJlLwQ+zAnvA==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.2001.tgz",
+			"integrity": "sha512-Qh+QpdRInnhQMmpMIdzD3gpU4h1DFyXXhGsrNTm89Tc7N3qRaafJCFozD2uU2+nCctLEyuUmHYoGfYRL+xC40g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/garbage-collector": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -3223,17 +2847,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3241,16 +2865,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-OUACev+V9UWQfO7oQ8GLN8vPwCKoMp9FrTKvzHXxBLVK/+RiXaKS0yOtPlskLkhdDLid1SzDslHsRoLq6VCjeA==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.2001.tgz",
+			"integrity": "sha512-4Ia2wC4+93+F0oBKmBFAv823hRCHuY4Bf2bbJM3fv3Ee//uH73uzv1Jk0Z8SJRtQiBaUfELmGKoVowQyjRHnoA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3278,16 +2902,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-OUACev+V9UWQfO7oQ8GLN8vPwCKoMp9FrTKvzHXxBLVK/+RiXaKS0yOtPlskLkhdDLid1SzDslHsRoLq6VCjeA==",
+			"version": "npm:@fluidframework/container-runtime-definitions@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.2001.tgz",
+			"integrity": "sha512-4Ia2wC4+93+F0oBKmBFAv823hRCHuY4Bf2bbJM3fv3Ee//uH73uzv1Jk0Z8SJRtQiBaUfELmGKoVowQyjRHnoA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3315,25 +2939,25 @@
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.1000.tgz",
-			"integrity": "sha512-AGNUBNrrfINALPd6DcgJMZg6TGkRvjWYjpoE73GwhYfFwBOs0ClRbt2ErJtjV+fOa3+2p2iGCnKJlLwQ+zAnvA==",
+			"version": "npm:@fluidframework/container-runtime@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.2001.tgz",
+			"integrity": "sha512-Qh+QpdRInnhQMmpMIdzD3gpU4h1DFyXXhGsrNTm89Tc7N3qRaafJCFozD2uU2+nCctLEyuUmHYoGfYRL+xC40g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/garbage-collector": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -3360,17 +2984,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3378,15 +3002,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.1000.tgz",
-			"integrity": "sha512-ChBj7qam/xyBVvsSxjmcBi0R9XVnvOJfw4Tb991S2qJDi5XFPSVImk1PQd1f5SzmAfC2O9Vasm8uqoYeMCUKyQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.2001.tgz",
+			"integrity": "sha512-IHrXXri3bFdgf60mqTlgQTy/WWP2jCivQsVbR8Dx+xjyIHUxczp+bq9E3FZbAq0KgsLANlnYU689K3fSuDNt2g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3413,15 +3037,15 @@
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.1000.tgz",
-			"integrity": "sha512-ChBj7qam/xyBVvsSxjmcBi0R9XVnvOJfw4Tb991S2qJDi5XFPSVImk1PQd1f5SzmAfC2O9Vasm8uqoYeMCUKyQ==",
+			"version": "npm:@fluidframework/container-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.2001.tgz",
+			"integrity": "sha512-IHrXXri3bFdgf60mqTlgQTy/WWP2jCivQsVbR8Dx+xjyIHUxczp+bq9E3FZbAq0KgsLANlnYU689K3fSuDNt2g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3453,49 +3077,49 @@
 			"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
 		},
 		"@fluidframework/counter": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.1000.tgz",
-			"integrity": "sha512-T+8rYBdXd7EQTvO4N0l+ISlY2zo0+Yf/yjDXC0pAPCtbAaMCrWPUblRUemHgKtCNlfYrO05GVflkYWq/FLi1zg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.2001.tgz",
+			"integrity": "sha512-FO2DAbaO1rJrA08X+o4hRTWB3qmRhvVLlt9xo7ZkC5Iyrtq1AacEgh64J6uMaJkIEZshtxJS6f9dt2/dm7XHNg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.1000.tgz",
-			"integrity": "sha512-T+8rYBdXd7EQTvO4N0l+ISlY2zo0+Yf/yjDXC0pAPCtbAaMCrWPUblRUemHgKtCNlfYrO05GVflkYWq/FLi1zg==",
+			"version": "npm:@fluidframework/counter@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.2001.tgz",
+			"integrity": "sha512-FO2DAbaO1rJrA08X+o4hRTWB3qmRhvVLlt9xo7ZkC5Iyrtq1AacEgh64J6uMaJkIEZshtxJS6f9dt2/dm7XHNg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-0.59.1000.tgz",
-			"integrity": "sha512-F7SuZHcowq5rhhS95G8gEn1GERNfrCErIfVgtFiuyCFF2uAsvaW0GHSIIi6Dv3Em0dagVZtCZOTfCtsAolTK6Q==",
+			"version": "npm:@fluidframework/data-object-base@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-0.59.2001.tgz",
+			"integrity": "sha512-KQXILC/thIzw5BzeYzARexIRYIpWi3tr3TPkpb1dwDyjeiMjx+P71R3G/zdFJitoGUjiKkCYs+cIRcVlBMh1Uw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
+				"@fluidframework/container-runtime": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/request-handler": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3522,24 +3146,24 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.1000.tgz",
-			"integrity": "sha512-C/2uXuy8wHXv98fRQeAsA7Cww8n4JA0yjsjMXIesJCRsj93XMAGyqzN+PPXTsLF2gu5I06PcKF2BB19WjUQYBQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.2001.tgz",
+			"integrity": "sha512-fmFNHNYQhMyxGVzSH5zxHd11EDC4RlqL+TB4KcojqFbWUOJXOc062+aH+prycZ4lcStRDCWyu2GgiJ9VNQFwdA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/garbage-collector": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3566,17 +3190,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3584,16 +3208,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.1000.tgz",
-			"integrity": "sha512-/YMoDxDp1CX8YtvnCiu3ndbPgpOg5MrKAANF/0vSAbPTODM1PGxnOTsXW8zKbjY9CstM4jbIGpx0oq6JKJIJKQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.2001.tgz",
+			"integrity": "sha512-VDIcQsb7oTzTCXBfhcM+4pyMPm621wjVHdH3wyjDmgZ1YusvmTa4O4dQQGoA4sJcSVbs4yRllMR/eZ0w2VYTWQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3621,16 +3245,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.1000.tgz",
-			"integrity": "sha512-/YMoDxDp1CX8YtvnCiu3ndbPgpOg5MrKAANF/0vSAbPTODM1PGxnOTsXW8zKbjY9CstM4jbIGpx0oq6JKJIJKQ==",
+			"version": "npm:@fluidframework/datastore-definitions@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.2001.tgz",
+			"integrity": "sha512-VDIcQsb7oTzTCXBfhcM+4pyMPm621wjVHdH3wyjDmgZ1YusvmTa4O4dQQGoA4sJcSVbs4yRllMR/eZ0w2VYTWQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3658,24 +3282,24 @@
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.1000.tgz",
-			"integrity": "sha512-C/2uXuy8wHXv98fRQeAsA7Cww8n4JA0yjsjMXIesJCRsj93XMAGyqzN+PPXTsLF2gu5I06PcKF2BB19WjUQYBQ==",
+			"version": "npm:@fluidframework/datastore@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.2001.tgz",
+			"integrity": "sha512-fmFNHNYQhMyxGVzSH5zxHd11EDC4RlqL+TB4KcojqFbWUOJXOc062+aH+prycZ4lcStRDCWyu2GgiJ9VNQFwdA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/garbage-collector": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3702,17 +3326,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3720,27 +3344,27 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-0.59.1000.tgz",
-			"integrity": "sha512-IqMJjbrgS8bGXq1v1wXJ5O/W+lufn8e9NGcNxTjYpg1IA5rHDT01FaaDhEylR/7Jx5LGFPhryBw/W0kh5XRSzw==",
+			"version": "npm:@fluidframework/dds-interceptions@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-0.59.2001.tgz",
+			"integrity": "sha512-TBnRuJxy6HVggVmSX+oh5vEVhvXW8nD2WSWWdDdA/raO5vP5uwAXFrVsv9sea5nyEMRREe6tZt81jEEiEUSc5A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/sequence": "^0.59.1000"
+				"@fluidframework/map": "^0.59.2001",
+				"@fluidframework/merge-tree": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/sequence": "^0.59.2001"
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-0.59.1000.tgz",
-			"integrity": "sha512-cukrgsdo0wJBiNyDXY1ghE/5oNoF6prZO4Vj0x8lfAKGU3fCnsH1rcBKrLj1abSlEMC+DNNSbrtkJK2szXsn1g==",
+			"version": "npm:@fluidframework/debugger@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-0.59.2001.tgz",
+			"integrity": "sha512-Bfc923fYjZnXOuzdDqaLTsvfP+dEAsYcYdh7gxejExqGQlqsHoaOxkZQzHSmiWjqVXlLbUOF+xthEfHdQrqHoQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/replay-driver": "^0.59.1000",
+				"@fluidframework/replay-driver": "^0.59.2001",
 				"jsonschema": "^1.2.6"
 			},
 			"dependencies": {
@@ -3757,16 +3381,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.1000.tgz",
-			"integrity": "sha512-C3J7L1vZfw1/nqV8erGIxHJ0sA2j2uIvIV/bEePW5fyP55GBSJKXOkuNFVbgYKjFJiykpLHIjMMfZCrLnY/VwA==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.2001.tgz",
+			"integrity": "sha512-H8NYa9kPO80fsWrJfd/IIFisb5ScrjqU8slN1qYP+Qy57jOPMvlOMdBOSlHuSRNnebFKPUO/Urg74pf4uEGMcg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -3782,16 +3406,16 @@
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.1000.tgz",
-			"integrity": "sha512-C3J7L1vZfw1/nqV8erGIxHJ0sA2j2uIvIV/bEePW5fyP55GBSJKXOkuNFVbgYKjFJiykpLHIjMMfZCrLnY/VwA==",
+			"version": "npm:@fluidframework/driver-base@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.2001.tgz",
+			"integrity": "sha512-H8NYa9kPO80fsWrJfd/IIFisb5ScrjqU8slN1qYP+Qy57jOPMvlOMdBOSlHuSRNnebFKPUO/Urg74pf4uEGMcg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -3817,18 +3441,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.1000.tgz",
-			"integrity": "sha512-VZtoV+8sEzBtyRbXU6fbaZOxNKUBjzdL+Fp2Xp53mr5HRwu0IT0EMC1xMXExr46l7loyAuXyvso++naupyNODg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.2001.tgz",
+			"integrity": "sha512-pjNLWiX/5W+VkQRp32NLZ0VSpzvDC1ZsXxp2J1NO5igmGlVL3yD+NfSKyRi7wnpl+ZTAzXPdfa8zrAFJCfru3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/gitresources": "^0.1036.2000",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3844,17 +3468,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3862,18 +3486,18 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.1000.tgz",
-			"integrity": "sha512-VZtoV+8sEzBtyRbXU6fbaZOxNKUBjzdL+Fp2Xp53mr5HRwu0IT0EMC1xMXExr46l7loyAuXyvso++naupyNODg==",
+			"version": "npm:@fluidframework/driver-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.2001.tgz",
+			"integrity": "sha512-pjNLWiX/5W+VkQRp32NLZ0VSpzvDC1ZsXxp2J1NO5igmGlVL3yD+NfSKyRi7wnpl+ZTAzXPdfa8zrAFJCfru3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/gitresources": "^0.1036.2000",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3889,17 +3513,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -3907,13 +3531,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-0.59.1000.tgz",
-			"integrity": "sha512-9EpaIv0wGt5urRYPk0pjfd0JlkiF6E7WySUe4RzbLwYmyXhX82G0VUjLdYzYhkyihEV0fhveBRlH1sdnqZVZtw==",
+			"version": "npm:@fluidframework/driver-web-cache@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-0.59.2001.tgz",
+			"integrity": "sha512-ZSHTKQGb+1330+2CMDB9QTDON0KF2vZmu3wkkUIjJ8X1e3v94KZwf4Ol5AnA+YsOnJS6dEzRV2UtIBQZAxpnrA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3962,16 +3586,16 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-0.59.1000.tgz",
-			"integrity": "sha512-It22F5iqqdIJwaJXhmgkkgDyGt7mCB7oVX2AsyaQ5Gs4Z9cdZIUmZVsWOyRLts2PDis+jKx0yxV53lOfw61DPA==",
+			"version": "npm:@fluidframework/file-driver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-0.59.2001.tgz",
+			"integrity": "sha512-jYJifMsLyztJydsplIoCJkMvm/r2RZjsuQT6MQyJ2TYKQ3sNVThgLIoa02BhN5Nk/SSvkJUM03kx8Q6QIyIVPg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/replay-driver": "^0.59.1000"
+				"@fluidframework/replay-driver": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -3987,22 +3611,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.1000.tgz",
-			"integrity": "sha512-dJbl5QwE6knlVxG5rMPWJX8omkd73y0iGcyCkRX/D6dI8t/78tEPeUckOd0qNBfpLzyGe6h+vsQKGx9C+XokQw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.2001.tgz",
+			"integrity": "sha512-5Kz5A9wrc8ymwyOEwjd6uuS1AuUFuoZ4p62fyWUbKCVMvDtP/DerRArhx/jXu9ZfpbCDe7f7hjBHNF2FUCP3lQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2001",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/request-handler": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -4029,22 +3653,22 @@
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.1000.tgz",
-			"integrity": "sha512-dJbl5QwE6knlVxG5rMPWJX8omkd73y0iGcyCkRX/D6dI8t/78tEPeUckOd0qNBfpLzyGe6h+vsQKGx9C+XokQw==",
+			"version": "npm:@fluidframework/fluid-static@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.2001.tgz",
+			"integrity": "sha512-5Kz5A9wrc8ymwyOEwjd6uuS1AuUFuoZ4p62fyWUbKCVMvDtP/DerRArhx/jXu9ZfpbCDe7f7hjBHNF2FUCP3lQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2001",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/request-handler": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -4071,23 +3695,23 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.1000.tgz",
-			"integrity": "sha512-2F4EIR604W8iZzFyPqDwA19SVqmEyD+3w6TYaLQO9dC9s3Pk00EIGTbc3asIA1x76SEgHC6nFwgVvQ2LuVTwLQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.2001.tgz",
+			"integrity": "sha512-G5/AGDXOU365od96rO/3D3xJQ6rgVl0R9dbIDaON3JQOgLuSdgV3m3fl7Fu5wQ4WBy4VAO72X1xxTYUF8+M6FQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.1000.tgz",
-			"integrity": "sha512-2F4EIR604W8iZzFyPqDwA19SVqmEyD+3w6TYaLQO9dC9s3Pk00EIGTbc3asIA1x76SEgHC6nFwgVvQ2LuVTwLQ==",
+			"version": "npm:@fluidframework/garbage-collector@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.2001.tgz",
+			"integrity": "sha512-G5/AGDXOU365od96rO/3D3xJQ6rgVl0R9dbIDaON3JQOgLuSdgV3m3fl7Fu5wQ4WBy4VAO72X1xxTYUF8+M6FQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -4096,17 +3720,17 @@
 			"integrity": "sha512-QbfvNPPahZkgyQUgaFcb1ycYdt8i10wa5nhgSqNk/4sXyTa+ESdpHTd7ljEs0X3kx1aW0QOCQTZq2tL8JmZiLQ=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-0.59.1000.tgz",
-			"integrity": "sha512-AT5esBd+bry+Mphq1lQqvmA3ZoHGro14UDLZfBAYuyyuMCYWMU5HW3Av4eFaw6kT9xQOmSpuZ4EmI9bSw8DGTg==",
+			"version": "npm:@fluidframework/iframe-driver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-0.59.2001.tgz",
+			"integrity": "sha512-tGDd3HO780MfRIAh+4eX+OgDNcTdxLh/A5WEEq2NRZrojhEp3XpK8SBCWIt7YAx/sDLexD1i3mV6/fiL8lLfEg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"comlink": "^4.3.0"
 			},
 			"dependencies": {
@@ -4123,52 +3747,52 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.1000.tgz",
-			"integrity": "sha512-p5LAM2EuFNrGwLFLr96lUVRAOKoW32ds+1ytBC9ieH2BckFXPPGyjY4+JDKeXcVRt8BWk/Kg0iXx7ss9BcHk8g==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.2001.tgz",
+			"integrity": "sha512-FZX1uGxtG3IplDVhST2oWRjTx/zdxbbNZf2lpZaMu5S13V+cMGanzlIPVAt/usaiORRDIXOODiH6/a0Ue0MWEA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.1000.tgz",
-			"integrity": "sha512-p5LAM2EuFNrGwLFLr96lUVRAOKoW32ds+1ytBC9ieH2BckFXPPGyjY4+JDKeXcVRt8BWk/Kg0iXx7ss9BcHk8g==",
+			"version": "npm:@fluidframework/ink@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.2001.tgz",
+			"integrity": "sha512-FZX1uGxtG3IplDVhST2oWRjTx/zdxbbNZf2lpZaMu5S13V+cMGanzlIPVAt/usaiORRDIXOODiH6/a0Ue0MWEA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.1000.tgz",
-			"integrity": "sha512-GFBoMaHA3lWBHi61fATH8SckCLc4dQx6VBffdHMw4IQgnoVbT9eh3YxG/f9xb4VqLRhPQOQVyLpyJgasxePswA==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.2001.tgz",
+			"integrity": "sha512-9KuUYJQKL0T1gbJNQCDHoTGXaF+/wwKg4ol3OON+c+FzN5voL7gfsu9A1dqECCrzTyxRDtoxxKrIf3z83mLHNg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/server-local-server": "^0.1036.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/server-services-core": "^0.1036.1000",
-				"@fluidframework/server-test-utils": "^0.1036.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/server-local-server": "^0.1036.2000",
+				"@fluidframework/server-services-client": "^0.1036.2000",
+				"@fluidframework/server-services-core": "^0.1036.2000",
+				"@fluidframework/server-test-utils": "^0.1036.2000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -4184,90 +3808,90 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.1000.tgz",
-					"integrity": "sha512-nf2H38+U0S5amvuyC3JZrPbaqD0VQmgeHsRNx6ecOLeNlsZCA4lL2US89s17aa4g6N8y1RNUQs/Rcs0Wu2g9qw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.2000.tgz",
+					"integrity": "sha512-P+ICmd+gEUBquv0JOFPDWNblZ/znzwAVfwUb8zwhNXVkx6GUWlr0P6fkDrgnk+Hb3vQ/g97pBg3VKlCLx3k6qA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas-driver": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas-driver": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/semver": "^6.0.1",
-						"async": "^3.2.0",
+						"async": "^3.2.2",
 						"axios": "^0.26.0",
 						"double-ended-queue": "^2.1.0-0",
 						"json-stringify-safe": "^5.0.1",
 						"lodash": "^4.17.21",
-						"nconf": "^0.11.0",
+						"nconf": "^0.11.4",
 						"semver": "^6.3.0",
 						"sha.js": "^2.4.11",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-lambdas-driver": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.1000.tgz",
-					"integrity": "sha512-8Q+4+FitbHJea7uMwfIvHrxEdOtxZOsQWlCenm/siEYjCo34JMxCSaO9BJX7REN4j644C3c3a0R/xAEM5ak4iw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.2000.tgz",
+					"integrity": "sha512-ELqQbGag580dh21vmR+r5BQ0d3pxDwpxQMr1Yb7ojQr4lJillgu8CcLwZOJTXy6ar5mn6aA4NP1OQ8+OrPDF1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"async": "^3.2.0",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"async": "^3.2.2",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.1000.tgz",
-					"integrity": "sha512-laLvpTNEBusrSa+fox02SdUpZQZ2VhRhIeos+AuQFw8bVIRStBfFFRqqu7ADcckqz/xeXX7+evX1EFN1QHYWmA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.2000.tgz",
+					"integrity": "sha512-9laj7b2Fxf/eyKT6Fd/8N7c61XXG3l+5EwepeVVQaSs8eh3mYLUTKKq3v+hD4PV7vVRWEiKZUq4Mw/Bu3MET7w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-memory-orderer": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"@fluidframework/server-test-utils": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-memory-orderer": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"@fluidframework/server-test-utils": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.1000.tgz",
-					"integrity": "sha512-pTN7xXU/akNlczupyxZBl2IdJS9r8ygka/BEbzSYAYmCg2URBBVFbsmxUtQhd1NRxu3Ft8nhETmOxrIQK5duAA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.2000.tgz",
+					"integrity": "sha512-dX7/SrNGC18Xj3UxeXPrepxURi/klLmu82oa2UWthkXOJkA1HnbbDfGPUigTC4RLewJFVBUBu7tSNjp2ACwL1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -4282,13 +3906,13 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -4301,25 +3925,25 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.1000.tgz",
-					"integrity": "sha512-IhLvveSmswFSp5TgiJgFnDt0bAJhq4XvSgKv9V+xl+5GwxPgvFuSLE/uZJkCbiGlGWs3VO+3SfUZkbmvVBYEkA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.2000.tgz",
+					"integrity": "sha512-rxV2lwUBiWATxNK3ai9w7D0PfJB3QVkgyE6Jmmd/dtG33wkYJhJK6XhLddtyxcV3xjyNLSBMPD9ZBUFkA7Uk8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/nconf": "^0.10.0",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
+						"nconf": "^0.11.4"
 					}
 				},
 				"@fluidframework/server-services-telemetry": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.1000.tgz",
-					"integrity": "sha512-iUa7Ux3zvj+9NswrFTdslxW2jm4II/3g94+tDNFdXpy5316XmlEKfLHgOuQbSPDC2T++oPqiJuy9Y4CLAVDvEQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.2000.tgz",
+					"integrity": "sha512-3MluWe1wlFWP2UZ2hrfhSlH9s6IJs9O1dKZxRmjczCVv1KW0SQtlc0+zjYBTeXg0Nk0qWCQfpFSOYMyT4OWPAQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"json-stringify-safe": "^5.0.1",
@@ -4329,17 +3953,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.1000.tgz",
-					"integrity": "sha512-DqykRhXh9WZ4s2iWD2qzAjozNei+HPP6AzFyuba6PKXLKNhQjiTK+k7g4BxdKUI0Uu+ZJeZEptoipy1xTNpsjQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.2000.tgz",
+					"integrity": "sha512-A0mO+quijpJZFji9/aQvMJ9n3Sg90CDACrm4Ohbl9UeCVN1OLie/8DILryFD5c62/3xXiaYla8IwSikUUFtwgg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -4350,6 +3974,11 @@
 					"version": "6.2.3",
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
+				},
+				"async": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -4364,22 +3993,22 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.1000.tgz",
-			"integrity": "sha512-GFBoMaHA3lWBHi61fATH8SckCLc4dQx6VBffdHMw4IQgnoVbT9eh3YxG/f9xb4VqLRhPQOQVyLpyJgasxePswA==",
+			"version": "npm:@fluidframework/local-driver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.2001.tgz",
+			"integrity": "sha512-9KuUYJQKL0T1gbJNQCDHoTGXaF+/wwKg4ol3OON+c+FzN5voL7gfsu9A1dqECCrzTyxRDtoxxKrIf3z83mLHNg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/server-local-server": "^0.1036.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/server-services-core": "^0.1036.1000",
-				"@fluidframework/server-test-utils": "^0.1036.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/server-local-server": "^0.1036.2000",
+				"@fluidframework/server-services-client": "^0.1036.2000",
+				"@fluidframework/server-services-core": "^0.1036.2000",
+				"@fluidframework/server-test-utils": "^0.1036.2000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -4395,90 +4024,90 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.1000.tgz",
-					"integrity": "sha512-nf2H38+U0S5amvuyC3JZrPbaqD0VQmgeHsRNx6ecOLeNlsZCA4lL2US89s17aa4g6N8y1RNUQs/Rcs0Wu2g9qw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.2000.tgz",
+					"integrity": "sha512-P+ICmd+gEUBquv0JOFPDWNblZ/znzwAVfwUb8zwhNXVkx6GUWlr0P6fkDrgnk+Hb3vQ/g97pBg3VKlCLx3k6qA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas-driver": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas-driver": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/semver": "^6.0.1",
-						"async": "^3.2.0",
+						"async": "^3.2.2",
 						"axios": "^0.26.0",
 						"double-ended-queue": "^2.1.0-0",
 						"json-stringify-safe": "^5.0.1",
 						"lodash": "^4.17.21",
-						"nconf": "^0.11.0",
+						"nconf": "^0.11.4",
 						"semver": "^6.3.0",
 						"sha.js": "^2.4.11",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-lambdas-driver": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.1000.tgz",
-					"integrity": "sha512-8Q+4+FitbHJea7uMwfIvHrxEdOtxZOsQWlCenm/siEYjCo34JMxCSaO9BJX7REN4j644C3c3a0R/xAEM5ak4iw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.2000.tgz",
+					"integrity": "sha512-ELqQbGag580dh21vmR+r5BQ0d3pxDwpxQMr1Yb7ojQr4lJillgu8CcLwZOJTXy6ar5mn6aA4NP1OQ8+OrPDF1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"async": "^3.2.0",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"async": "^3.2.2",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.1000.tgz",
-					"integrity": "sha512-laLvpTNEBusrSa+fox02SdUpZQZ2VhRhIeos+AuQFw8bVIRStBfFFRqqu7ADcckqz/xeXX7+evX1EFN1QHYWmA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.2000.tgz",
+					"integrity": "sha512-9laj7b2Fxf/eyKT6Fd/8N7c61XXG3l+5EwepeVVQaSs8eh3mYLUTKKq3v+hD4PV7vVRWEiKZUq4Mw/Bu3MET7w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-memory-orderer": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"@fluidframework/server-test-utils": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-memory-orderer": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"@fluidframework/server-test-utils": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.1000.tgz",
-					"integrity": "sha512-pTN7xXU/akNlczupyxZBl2IdJS9r8ygka/BEbzSYAYmCg2URBBVFbsmxUtQhd1NRxu3Ft8nhETmOxrIQK5duAA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.2000.tgz",
+					"integrity": "sha512-dX7/SrNGC18Xj3UxeXPrepxURi/klLmu82oa2UWthkXOJkA1HnbbDfGPUigTC4RLewJFVBUBu7tSNjp2ACwL1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -4493,13 +4122,13 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -4512,25 +4141,25 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.1000.tgz",
-					"integrity": "sha512-IhLvveSmswFSp5TgiJgFnDt0bAJhq4XvSgKv9V+xl+5GwxPgvFuSLE/uZJkCbiGlGWs3VO+3SfUZkbmvVBYEkA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.2000.tgz",
+					"integrity": "sha512-rxV2lwUBiWATxNK3ai9w7D0PfJB3QVkgyE6Jmmd/dtG33wkYJhJK6XhLddtyxcV3xjyNLSBMPD9ZBUFkA7Uk8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/nconf": "^0.10.0",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
+						"nconf": "^0.11.4"
 					}
 				},
 				"@fluidframework/server-services-telemetry": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.1000.tgz",
-					"integrity": "sha512-iUa7Ux3zvj+9NswrFTdslxW2jm4II/3g94+tDNFdXpy5316XmlEKfLHgOuQbSPDC2T++oPqiJuy9Y4CLAVDvEQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.2000.tgz",
+					"integrity": "sha512-3MluWe1wlFWP2UZ2hrfhSlH9s6IJs9O1dKZxRmjczCVv1KW0SQtlc0+zjYBTeXg0Nk0qWCQfpFSOYMyT4OWPAQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"json-stringify-safe": "^5.0.1",
@@ -4540,17 +4169,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.1000.tgz",
-					"integrity": "sha512-DqykRhXh9WZ4s2iWD2qzAjozNei+HPP6AzFyuba6PKXLKNhQjiTK+k7g4BxdKUI0Uu+ZJeZEptoipy1xTNpsjQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.2000.tgz",
+					"integrity": "sha512-A0mO+quijpJZFji9/aQvMJ9n3Sg90CDACrm4Ohbl9UeCVN1OLie/8DILryFD5c62/3xXiaYla8IwSikUUFtwgg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -4561,6 +4190,11 @@
 					"version": "6.2.3",
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
+				},
+				"async": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -4575,73 +4209,73 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.1000.tgz",
-			"integrity": "sha512-viwpzIFGgQnUgnJ0w7CHdw2KH025AawN6S8fATHg8IvGspJ3Q5ZV8Bw/GH38B6ogTk/jNgYdmeJx+t06IO77kw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.2001.tgz",
+			"integrity": "sha512-JJ3U+4JP+7IZbfkQA9AQhtsmf/6v1tMFPVgMO9rUPfN3zsE3WcxwTrLfbEyy/kJ0pVF7kOUF5ov3QBuimTpUuQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.1000.tgz",
-			"integrity": "sha512-viwpzIFGgQnUgnJ0w7CHdw2KH025AawN6S8fATHg8IvGspJ3Q5ZV8Bw/GH38B6ogTk/jNgYdmeJx+t06IO77kw==",
+			"version": "npm:@fluidframework/map@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.2001.tgz",
+			"integrity": "sha512-JJ3U+4JP+7IZbfkQA9AQhtsmf/6v1tMFPVgMO9rUPfN3zsE3WcxwTrLfbEyy/kJ0pVF7kOUF5ov3QBuimTpUuQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.1000.tgz",
-			"integrity": "sha512-mxFDgAyHLJJ2CDKFL5qRvbW0/k1iWiC1HJOuwm+MvOtipAahXUJgfqcWQDNdJdrswyWHpZLFfEJmtHXzksJ9Qg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.2001.tgz",
+			"integrity": "sha512-dKzUeXi22dyiw5eek1M7oBYom01hsbXmETDrSYMCFNJlH7TjiE4DWCTUWS9xPXPobofqZ2KycxMOpstCIg1gew==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/merge-tree": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -4649,37 +4283,37 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.1000.tgz",
-			"integrity": "sha512-mxFDgAyHLJJ2CDKFL5qRvbW0/k1iWiC1HJOuwm+MvOtipAahXUJgfqcWQDNdJdrswyWHpZLFfEJmtHXzksJ9Qg==",
+			"version": "npm:@fluidframework/matrix@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.2001.tgz",
+			"integrity": "sha512-dKzUeXi22dyiw5eek1M7oBYom01hsbXmETDrSYMCFNJlH7TjiE4DWCTUWS9xPXPobofqZ2KycxMOpstCIg1gew==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/merge-tree": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -4687,20 +4321,20 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.1000.tgz",
-			"integrity": "sha512-kwcuPbHoexKYxs4rDh32LEl0/AaZFXsxQVui6agRbfCl84sItMkX6KHiibFjSCvfV5MOXwwKwvUZWxIgOmbIAQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.2001.tgz",
+			"integrity": "sha512-hG8wHCdraCrfXQy2VfWX+Uf86KMJL5HBfLVygQmDXmttubE2h54bDckxxkjzTLqM6S9veJOiZbMh7JTzm0AWBQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -4727,7 +4361,7 @@
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree-previous@0.58.2002",
+			"version": "npm:@fluidframework/merge-tree@0.58.2002",
 			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.58.2002.tgz",
 			"integrity": "sha512-phVUFtfDSo0z3xU5wQCYhZ9/DdFR/38kQYaiYRGa8SEb4rbWOOBq15FcXDs7omrJEff+JeWw7EjK0gI5W5P9YA==",
 			"requires": {
@@ -4974,36 +4608,36 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.1000.tgz",
-			"integrity": "sha512-EIdO0cQJmOoD4MZJqSJSoFadzF8HaOa1UPN+TnegCxpiwLTXYshfByCEwTC1YH05iXxEGAXVHcYYentggCwvpQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.2001.tgz",
+			"integrity": "sha512-ckr03bhhLoYDBUq3BzL+SWz9eRbTnmHdHSVrsfvlVWRJ8++bIS9fzLN5HFruAjU67+bbB/1TNqrFy7xDEGTG4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
+				"@fluidframework/test-driver-definitions": "^0.59.2001",
 				"mocha": "^8.4.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.1000.tgz",
-			"integrity": "sha512-EIdO0cQJmOoD4MZJqSJSoFadzF8HaOa1UPN+TnegCxpiwLTXYshfByCEwTC1YH05iXxEGAXVHcYYentggCwvpQ==",
+			"version": "npm:@fluidframework/mocha-test-setup@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.2001.tgz",
+			"integrity": "sha512-ckr03bhhLoYDBUq3BzL+SWz9eRbTnmHdHSVrsfvlVWRJ8++bIS9fzLN5HFruAjU67+bbB/1TNqrFy7xDEGTG4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
+				"@fluidframework/test-driver-definitions": "^0.59.2001",
 				"mocha": "^8.4.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.1000.tgz",
-			"integrity": "sha512-Crd9z5tfU07N7WmwtzcqSQUMwzLOizdg/BW4oiMKxDB+s8jNapjGgZaRL2SDeyEiuY5HVnyWzMOOnnefpJ2DGw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.2001.tgz",
+			"integrity": "sha512-+3sVgNf8t8NFtKxmfgtsSa+frDcOUyKm/CfXTegX1U16AYGuGBOTRf3ML4kvLC1+orsxwZ0H8RUWlClIWZiyqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -5020,16 +4654,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.1000.tgz",
-			"integrity": "sha512-Crd9z5tfU07N7WmwtzcqSQUMwzLOizdg/BW4oiMKxDB+s8jNapjGgZaRL2SDeyEiuY5HVnyWzMOOnnefpJ2DGw==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.2001.tgz",
+			"integrity": "sha512-+3sVgNf8t8NFtKxmfgtsSa+frDcOUyKm/CfXTegX1U16AYGuGBOTRf3ML4kvLC1+orsxwZ0H8RUWlClIWZiyqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -5046,22 +4680,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.1000.tgz",
-			"integrity": "sha512-GAr4q/9eWNtwpYe3XNgp2B/gFfEQiPLdQlWy3XYspqcxNW1+qbuCN/pZW8SdN2tjTKfbA5S2qOI8snGCaMiWTw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.2001.tgz",
+			"integrity": "sha512-3eBJ/SAoAEvowkbfBXUsOdQ9RYe3T0ITwv9oHnUWPdMzOBx3qnCVnQkdazAwRvDuPdTE1xLx9pJbVQc1RTyQ4g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/gitresources": "^0.1036.2000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -5079,17 +4713,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -5097,9 +4731,9 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-rzwpLtUjzoP3DJalwz+pEnTIjuy0WXb1tUMQikMCB3pQMZyoa8AsFLFFgWJVNka1+3vg8xv/k9bfnhGKDyx+6A==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.2001.tgz",
+			"integrity": "sha512-OqM8CqqCEyc00yAhSxA8qHnUhSnHYw8Ww7icgBk0yop57+KKogEyHgk/+KHdZQbjPOr6+wVCybiuBQGDLxwoBg==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
 			},
@@ -5117,9 +4751,9 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-rzwpLtUjzoP3DJalwz+pEnTIjuy0WXb1tUMQikMCB3pQMZyoa8AsFLFFgWJVNka1+3vg8xv/k9bfnhGKDyx+6A==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.2001.tgz",
+			"integrity": "sha512-OqM8CqqCEyc00yAhSxA8qHnUhSnHYw8Ww7icgBk0yop57+KKogEyHgk/+KHdZQbjPOr6+wVCybiuBQGDLxwoBg==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
 			},
@@ -5137,22 +4771,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.1000.tgz",
-			"integrity": "sha512-GAr4q/9eWNtwpYe3XNgp2B/gFfEQiPLdQlWy3XYspqcxNW1+qbuCN/pZW8SdN2tjTKfbA5S2qOI8snGCaMiWTw==",
+			"version": "npm:@fluidframework/odsp-driver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.2001.tgz",
+			"integrity": "sha512-3eBJ/SAoAEvowkbfBXUsOdQ9RYe3T0ITwv9oHnUWPdMzOBx3qnCVnQkdazAwRvDuPdTE1xLx9pJbVQc1RTyQ4g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/gitresources": "^0.1036.2000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -5170,17 +4804,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -5188,14 +4822,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-tcRRvS0kWJLQ1miCGuXMFTO5ELISoFyZpIG12oqnIXrx1wZ0njop5K49+isOO61xngSJ2QQn/kgohvvm4MO2zA==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.2001.tgz",
+			"integrity": "sha512-XNafkgCHMt/UsVSjJD4K3booQZA6QdTN1oMHj+H2MkpFyp+PRJ2f8BjA/KJpfr1t9tOdA9dCMkB8ZckfsMJTOw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000"
+				"@fluidframework/odsp-driver": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -5211,14 +4845,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-tcRRvS0kWJLQ1miCGuXMFTO5ELISoFyZpIG12oqnIXrx1wZ0njop5K49+isOO61xngSJ2QQn/kgohvvm4MO2zA==",
+			"version": "npm:@fluidframework/odsp-urlresolver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.2001.tgz",
+			"integrity": "sha512-XNafkgCHMt/UsVSjJD4K3booQZA6QdTN1oMHj+H2MkpFyp+PRJ2f8BjA/KJpfr1t9tOdA9dCMkB8ZckfsMJTOw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000"
+				"@fluidframework/odsp-driver": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -5234,32 +4868,32 @@
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.1000.tgz",
-			"integrity": "sha512-xhZpeN3F9XlyiujcsW0foxG/WPhfw3B5ysUbg7pMoThFxkwqsWcmF18SkO0uiAj9ccnVGvOd7MyAIPxYqu+cFQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.2001.tgz",
+			"integrity": "sha512-NaXp6A3Pl1fH/JVRqsVpLAzYliZdrf603paG7hoA2BfZNywv2lme1P2lU65+rINu+oX5GdzZB8rTg2tbEkBuaA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.1000.tgz",
-			"integrity": "sha512-xhZpeN3F9XlyiujcsW0foxG/WPhfw3B5ysUbg7pMoThFxkwqsWcmF18SkO0uiAj9ccnVGvOd7MyAIPxYqu+cFQ==",
+			"version": "npm:@fluidframework/ordered-collection@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.2001.tgz",
+			"integrity": "sha512-NaXp6A3Pl1fH/JVRqsVpLAzYliZdrf603paG7hoA2BfZNywv2lme1P2lU65+rINu+oX5GdzZB8rTg2tbEkBuaA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5283,31 +4917,31 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.1000.tgz",
-			"integrity": "sha512-aZL4/apKXW2b8qJO7AAg1fS85IjyiDTMBsLdOs0eC4BJ5ssRbkrHhAolcuEvWr2x6otzr/5ltUzNITbjpfUjWQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.2001.tgz",
+			"integrity": "sha512-0ioj+sh2v7J8qN+pW0e5fB0bhvZc3N4W3gkmmgvjsC8St3hOVd2M1M4YhnvpaJLoGagHfxDUsUkRm/tokkBcNA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -5315,31 +4949,31 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.1000.tgz",
-			"integrity": "sha512-aZL4/apKXW2b8qJO7AAg1fS85IjyiDTMBsLdOs0eC4BJ5ssRbkrHhAolcuEvWr2x6otzr/5ltUzNITbjpfUjWQ==",
+			"version": "npm:@fluidframework/register-collection@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.2001.tgz",
+			"integrity": "sha512-0ioj+sh2v7J8qN+pW0e5fB0bhvZc3N4W3gkmmgvjsC8St3hOVd2M1M4YhnvpaJLoGagHfxDUsUkRm/tokkBcNA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -5347,16 +4981,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.1000.tgz",
-			"integrity": "sha512-65Ud/QfLtXRxg1apxtxVz9A5f4JFFlJ1q+VZBK8GGGGYDDw4h5E838UhHgyN5jgpQUC+/z2Z1RTZoIkjuKXstg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.2001.tgz",
+			"integrity": "sha512-OjdXWW6yDpgFM0YkmaY2IPjF2wtjVwsDkjl2NbHW/6nvz3MZtp26C7RIohKYBcPgZu31GpYHJIbSJlxECa9pRA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -5372,16 +5006,16 @@
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.1000.tgz",
-			"integrity": "sha512-65Ud/QfLtXRxg1apxtxVz9A5f4JFFlJ1q+VZBK8GGGGYDDw4h5E838UhHgyN5jgpQUC+/z2Z1RTZoIkjuKXstg==",
+			"version": "npm:@fluidframework/replay-driver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.2001.tgz",
+			"integrity": "sha512-OjdXWW6yDpgFM0YkmaY2IPjF2wtjVwsDkjl2NbHW/6nvz3MZtp26C7RIohKYBcPgZu31GpYHJIbSJlxECa9pRA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -5397,44 +5031,44 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.1000.tgz",
-			"integrity": "sha512-XQTusnpyTNEvR5tGztN4ZIcG7+tOwh1JDDVJydVdLawOlPD9SASGZBYY3pg4uXs0Pj25u5flXroeM8EcC2AURg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.2001.tgz",
+			"integrity": "sha512-vrrUnv0kF8UaRpTko2Lwn2BmgX5Jd947QshK0agIzBSlTnaSRyP+BIwNFx+LJQFWJP/Bl1vjcOt071waCIc6eg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.1000.tgz",
-			"integrity": "sha512-XQTusnpyTNEvR5tGztN4ZIcG7+tOwh1JDDVJydVdLawOlPD9SASGZBYY3pg4uXs0Pj25u5flXroeM8EcC2AURg==",
+			"version": "npm:@fluidframework/request-handler@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.2001.tgz",
+			"integrity": "sha512-vrrUnv0kF8UaRpTko2Lwn2BmgX5Jd947QshK0agIzBSlTnaSRyP+BIwNFx+LJQFWJP/Bl1vjcOt071waCIc6eg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-Jjw894PYVmhcS+KAsW/cQj5unyKRLYGtrhllbUWV37C4AMJ+bWvs11CkMra891I4KloZKoxv6FpyJT6O7Xh02g==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.2001.tgz",
+			"integrity": "sha512-MwnoImDJ8BqqLDY0zIQhye0NzCmZxum0Vt+ya/EyHZiY6gFHjQtb5+vqxlLGdWsqbfPFMh0IvlBWVQAotsTc1Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/gitresources": "^0.1036.2000",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/server-services-client": "^0.1036.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.4.1",
@@ -5453,29 +5087,29 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -5495,20 +5129,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-Jjw894PYVmhcS+KAsW/cQj5unyKRLYGtrhllbUWV37C4AMJ+bWvs11CkMra891I4KloZKoxv6FpyJT6O7Xh02g==",
+			"version": "npm:@fluidframework/routerlicious-driver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.2001.tgz",
+			"integrity": "sha512-MwnoImDJ8BqqLDY0zIQhye0NzCmZxum0Vt+ya/EyHZiY6gFHjQtb5+vqxlLGdWsqbfPFMh0IvlBWVQAotsTc1Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^0.59.1000",
+				"@fluidframework/driver-base": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/gitresources": "^0.1036.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/gitresources": "^0.1036.2000",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/server-services-client": "^0.1036.2000",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.4.1",
@@ -5527,29 +5161,29 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -5569,9 +5203,9 @@
 			}
 		},
 		"@fluidframework/routerlicious-host-previous": {
-			"version": "npm:@fluidframework/routerlicious-host-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-0.59.1000.tgz",
-			"integrity": "sha512-1faWHEtWqyZNr996C1zPWX/is0f08veoKbccwCSBlXBFyjZegRhqKkx786ahpxk54zxVRMuIJV0MuN/8Neia6Q==",
+			"version": "npm:@fluidframework/routerlicious-host@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-0.59.2001.tgz",
+			"integrity": "sha512-YhCeyurcjfhrnhCrfvlRt7tnygYfDevZcHz7u9EDOtwhB127LprnBCpetHdofcGcjTWd5k6m+qG+UKfJ4OduWA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -5592,15 +5226,15 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-0.59.1000.tgz",
-			"integrity": "sha512-Fb1fTQH1SLmKz6EobQOrEhMD2EqI06pYHEuH29OaIV+HTAwepCfDS/qr7ImkO2AjEi4ctu24egY/nNl0f+Lc8w==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-0.59.2001.tgz",
+			"integrity": "sha512-kTzpET5shmQ4UAzDyqneSOwfswUFqyjoroltDaHCyU05HjfnjAadGnnAUJaCriAeS61y3CzSRjzKup6gSwl6wg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"nconf": "^0.11.0"
+				"nconf": "^0.11.4"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -5616,9 +5250,9 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-qqnBhU9x7aPWfGAAOZpoX2zRWvU9WmtdWhpfg6BRW+BgTCmuIb4abMwyqCaJPhew1CZ0TLVv02jTE0mk7lS/jw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.2001.tgz",
+			"integrity": "sha512-S5MN4HEHhonAFZP9QYmQoOt44+CfyzCOzfO5lB4dP2dcxtnKZ/VuJJbNs4Nr0Dj7EVed/l8s9qPI0YvATDq/Qg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -5653,9 +5287,9 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.1000.tgz",
-			"integrity": "sha512-qqnBhU9x7aPWfGAAOZpoX2zRWvU9WmtdWhpfg6BRW+BgTCmuIb4abMwyqCaJPhew1CZ0TLVv02jTE0mk7lS/jw==",
+			"version": "npm:@fluidframework/runtime-definitions@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.2001.tgz",
+			"integrity": "sha512-S5MN4HEHhonAFZP9QYmQoOt44+CfyzCOzfO5lB4dP2dcxtnKZ/VuJJbNs4Nr0Dj7EVed/l8s9qPI0YvATDq/Qg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -5690,21 +5324,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-ew/I2sOFjc34J73Pn66BLe9JC+koU6P7HAz3hbG+4SDMDgXNxNA4Bp2AzGJPMq0fFzLHpKNcKFnRTIXYI88qOw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.2001.tgz",
+			"integrity": "sha512-8gvyULPhg6u4gF5GtixGs3Tot+le76uYa45qTkSq4bjw8E5I1nSkUc6syeNk3YtchXb59oO/uj9TSEZUrPjcuA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/garbage-collector": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -5729,17 +5363,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -5747,21 +5381,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-ew/I2sOFjc34J73Pn66BLe9JC+koU6P7HAz3hbG+4SDMDgXNxNA4Bp2AzGJPMq0fFzLHpKNcKFnRTIXYI88qOw==",
+			"version": "npm:@fluidframework/runtime-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.2001.tgz",
+			"integrity": "sha512-8gvyULPhg6u4gF5GtixGs3Tot+le76uYa45qTkSq4bjw8E5I1nSkUc6syeNk3YtchXb59oO/uj9TSEZUrPjcuA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/garbage-collector": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/garbage-collector": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -5786,17 +5420,17 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -5804,25 +5438,25 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.1000.tgz",
-			"integrity": "sha512-vJ04fhtVk4Lao+yfx68XYp7d6Y8aiByFBemfqL6UGWJehJMUSD3GfEfmkktbsdNxITyy6wphZq+3t5JK2NBQUA==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.2001.tgz",
+			"integrity": "sha512-Hg6Pl12ueuDoIG+8lOr7r58a3EG508nuCW5pFQ9FHF4Eltae0G/l5/63sZukf9FlMEjeNjKAI01wGSQfvNLgaQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/merge-tree": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence-previous@0.58.2002",
+			"version": "npm:@fluidframework/sequence@0.58.2002",
 			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.58.2002.tgz",
 			"integrity": "sha512-pOGvIRy1zQr9wtX60QUbwsxNiXnkWql4hVyBHVbv7JBbJD8vSfmyblVyD+ddUm2VPXyAaKLOQFWRpngTQBzUgw==",
 			"requires": {
@@ -6829,22 +6463,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.1000.tgz",
-			"integrity": "sha512-du8IZ32lzoHBnp5XBBVdaIujex5blGw7B+wMrry2jzw80IgHhN0NjrC496klUktDLe25C6IhxpDA0JfNWZ8Gmw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.2001.tgz",
+			"integrity": "sha512-U5TT/ipCCRhDm+fdYWcQhBB87li61RJMoTGl4lpTe1WgA1i53h/OvSW/bZw5zdTA2wJGTJYJbnzm48s5F1EQCw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime": "^0.59.2001",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6872,22 +6506,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.1000.tgz",
-			"integrity": "sha512-du8IZ32lzoHBnp5XBBVdaIujex5blGw7B+wMrry2jzw80IgHhN0NjrC496klUktDLe25C6IhxpDA0JfNWZ8Gmw==",
+			"version": "npm:@fluidframework/shared-object-base@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.2001.tgz",
+			"integrity": "sha512-U5TT/ipCCRhDm+fdYWcQhBB87li61RJMoTGl4lpTe1WgA1i53h/OvSW/bZw5zdTA2wJGTJYJbnzm48s5F1EQCw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-utils": "^0.59.1000",
+				"@fluidframework/container-runtime": "^0.59.2001",
+				"@fluidframework/container-utils": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6915,33 +6549,33 @@
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-0.59.1000.tgz",
-			"integrity": "sha512-yXtznzCmxnjfOyJtMl9chFQNYnayphkYnwIrhFSHvmH3JuRDST8TtTJaZEqSJERJxtuPm7FqLz4fP2XYcCIpqg==",
+			"version": "npm:@fluidframework/shared-summary-block@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-0.59.2001.tgz",
+			"integrity": "sha512-eRBTHzRTDy/n6jGiA5iCX7peQCPZZYyJCaO/YlECDfYwiLy0oMWcoOAhxBg1joaysXSuEWNKzXYM/j8MIiaURA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/shared-object-base": "^0.59.1000"
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/shared-object-base": "^0.59.2001"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.1000.tgz",
-			"integrity": "sha512-K6utPbwIoF4NOHlPOJ26xXnDDyysSM4lXnsnVSCMQ29cCTQUhHGg36pjMF+EYhVvbTkDsjRuxt+Y0GyDpoQRYQ=="
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.2001.tgz",
+			"integrity": "sha512-HuDuZvZtNrt7D4gYmEdBohPI1aAlV7Nhas+dlXg5cSg1eGSzGddhzYo6JC2AIuDyTQp6L29NzA+aJ8fHHzYYEA=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.1000.tgz",
-			"integrity": "sha512-K6utPbwIoF4NOHlPOJ26xXnDDyysSM4lXnsnVSCMQ29cCTQUhHGg36pjMF+EYhVvbTkDsjRuxt+Y0GyDpoQRYQ=="
+			"version": "npm:@fluidframework/synthesize@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.2001.tgz",
+			"integrity": "sha512-HuDuZvZtNrt7D4gYmEdBohPI1aAlV7Nhas+dlXg5cSg1eGSzGddhzYo6JC2AIuDyTQp6L29NzA+aJ8fHHzYYEA=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.1000.tgz",
-			"integrity": "sha512-1UwKRq+8+yYriKZo0YqGRSMe5MiNgwJN1mGt2Eaw6k5Fag+2SWSJ2RoYIQnMiPg/IDH1q/vWtr2Bu5QnDo8N6A==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.2001.tgz",
+			"integrity": "sha512-CBKYx9HydIQvNU3jZMgZZL6YykklvhJieg8GnwF7AFiU8Gy5gxi/p5jY6xheNXgQPKBwxInWdvvxyXJ9LAxYIw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6951,9 +6585,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.1000.tgz",
-			"integrity": "sha512-1UwKRq+8+yYriKZo0YqGRSMe5MiNgwJN1mGt2Eaw6k5Fag+2SWSJ2RoYIQnMiPg/IDH1q/vWtr2Bu5QnDo8N6A==",
+			"version": "npm:@fluidframework/telemetry-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.2001.tgz",
+			"integrity": "sha512-CBKYx9HydIQvNU3jZMgZZL6YykklvhJieg8GnwF7AFiU8Gy5gxi/p5jY6xheNXgQPKBwxInWdvvxyXJ9LAxYIw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6963,19 +6597,19 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-0.59.1000.tgz",
-			"integrity": "sha512-91mlZ21hkUY/l8DqkXNYGLd0fjya0JWiB3hePPJIWy6oKfqHNKPTau61TgJNtKYP0is+LFf/KEMx0KtsMTAjww==",
+			"version": "npm:@fluidframework/test-client-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-0.59.2001.tgz",
+			"integrity": "sha512-oMaMne6VUgCzAOV+sPQlhZjmGFjI3xuYxmiiB7hR1MNvv8WqidArYlE+wM2tXkDqgdNhLWCfr7VcdlEZbO4KxQ==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
+				"@fluidframework/test-runtime-utils": "^0.59.2001",
 				"sillyname": "^0.1.0"
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-eh/52XAXGteJSxfxWGKD5BnrYBj9kZf8MJOZgxp1AxqXU0APa02B7ScuI1gvy57luyhsbCxQOm1t2uRXvcm/8w==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.2001.tgz",
+			"integrity": "sha512-dMNnpZW1jik2DRt8wy06dkO7i6guth4fhstlBJvHTRdj5BdPIw8DAM7pCMFM8nqU/hc+98FLz+/IZWuL1ywSJQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -6997,9 +6631,9 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "npm:@fluidframework/test-driver-definitions-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.1000.tgz",
-			"integrity": "sha512-eh/52XAXGteJSxfxWGKD5BnrYBj9kZf8MJOZgxp1AxqXU0APa02B7ScuI1gvy57luyhsbCxQOm1t2uRXvcm/8w==",
+			"version": "npm:@fluidframework/test-driver-definitions@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.2001.tgz",
+			"integrity": "sha512-dMNnpZW1jik2DRt8wy06dkO7i6guth4fhstlBJvHTRdj5BdPIw8DAM7pCMFM8nqU/hc+98FLz+/IZWuL1ywSJQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -7021,27 +6655,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.1000.tgz",
-			"integrity": "sha512-OOSqDL6lyN4icxhaW0u+1UZ6jJihce9yVqPjfFW/EM/qOaslK+LeIIwJc0ZioQoH1cmAyD/Lz9le85FbVW9hjQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.2001.tgz",
+			"integrity": "sha512-KSm6CbRdwtxdFN+JOH+mvvn2+jihiY5JOUb5gwVsQ30SivQUz3Mkc+b9vl/4BWuckMWSkY5Cu30kiHntg4mhRQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/odsp-urlresolver": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/local-driver": "^0.59.2001",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2001",
+				"@fluidframework/odsp-driver": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
+				"@fluidframework/odsp-urlresolver": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/server-local-server": "^0.1036.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-pairwise-generator": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
-				"@fluidframework/tinylicious-driver": "^0.59.1000",
-				"@fluidframework/tool-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/server-local-server": "^0.1036.2000",
+				"@fluidframework/test-driver-definitions": "^0.59.2001",
+				"@fluidframework/test-pairwise-generator": "^0.59.2001",
+				"@fluidframework/test-runtime-utils": "^0.59.2001",
+				"@fluidframework/tinylicious-driver": "^0.59.2001",
+				"@fluidframework/tool-utils": "^0.59.2001",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -7058,42 +6692,42 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.1000.tgz",
-					"integrity": "sha512-nf2H38+U0S5amvuyC3JZrPbaqD0VQmgeHsRNx6ecOLeNlsZCA4lL2US89s17aa4g6N8y1RNUQs/Rcs0Wu2g9qw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.2000.tgz",
+					"integrity": "sha512-P+ICmd+gEUBquv0JOFPDWNblZ/znzwAVfwUb8zwhNXVkx6GUWlr0P6fkDrgnk+Hb3vQ/g97pBg3VKlCLx3k6qA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas-driver": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas-driver": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/semver": "^6.0.1",
-						"async": "^3.2.0",
+						"async": "^3.2.2",
 						"axios": "^0.26.0",
 						"double-ended-queue": "^2.1.0-0",
 						"json-stringify-safe": "^5.0.1",
 						"lodash": "^4.17.21",
-						"nconf": "^0.11.0",
+						"nconf": "^0.11.4",
 						"semver": "^6.3.0",
 						"sha.js": "^2.4.11",
 						"uuid": "^8.3.1"
@@ -7107,48 +6741,48 @@
 					}
 				},
 				"@fluidframework/server-lambdas-driver": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.1000.tgz",
-					"integrity": "sha512-8Q+4+FitbHJea7uMwfIvHrxEdOtxZOsQWlCenm/siEYjCo34JMxCSaO9BJX7REN4j644C3c3a0R/xAEM5ak4iw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.2000.tgz",
+					"integrity": "sha512-ELqQbGag580dh21vmR+r5BQ0d3pxDwpxQMr1Yb7ojQr4lJillgu8CcLwZOJTXy6ar5mn6aA4NP1OQ8+OrPDF1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"async": "^3.2.0",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"async": "^3.2.2",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.1000.tgz",
-					"integrity": "sha512-laLvpTNEBusrSa+fox02SdUpZQZ2VhRhIeos+AuQFw8bVIRStBfFFRqqu7ADcckqz/xeXX7+evX1EFN1QHYWmA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.2000.tgz",
+					"integrity": "sha512-9laj7b2Fxf/eyKT6Fd/8N7c61XXG3l+5EwepeVVQaSs8eh3mYLUTKKq3v+hD4PV7vVRWEiKZUq4Mw/Bu3MET7w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-memory-orderer": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"@fluidframework/server-test-utils": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-memory-orderer": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"@fluidframework/server-test-utils": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.1000.tgz",
-					"integrity": "sha512-pTN7xXU/akNlczupyxZBl2IdJS9r8ygka/BEbzSYAYmCg2URBBVFbsmxUtQhd1NRxu3Ft8nhETmOxrIQK5duAA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.2000.tgz",
+					"integrity": "sha512-dX7/SrNGC18Xj3UxeXPrepxURi/klLmu82oa2UWthkXOJkA1HnbbDfGPUigTC4RLewJFVBUBu7tSNjp2ACwL1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -7163,13 +6797,13 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -7182,25 +6816,25 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.1000.tgz",
-					"integrity": "sha512-IhLvveSmswFSp5TgiJgFnDt0bAJhq4XvSgKv9V+xl+5GwxPgvFuSLE/uZJkCbiGlGWs3VO+3SfUZkbmvVBYEkA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.2000.tgz",
+					"integrity": "sha512-rxV2lwUBiWATxNK3ai9w7D0PfJB3QVkgyE6Jmmd/dtG33wkYJhJK6XhLddtyxcV3xjyNLSBMPD9ZBUFkA7Uk8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/nconf": "^0.10.0",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
+						"nconf": "^0.11.4"
 					}
 				},
 				"@fluidframework/server-services-telemetry": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.1000.tgz",
-					"integrity": "sha512-iUa7Ux3zvj+9NswrFTdslxW2jm4II/3g94+tDNFdXpy5316XmlEKfLHgOuQbSPDC2T++oPqiJuy9Y4CLAVDvEQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.2000.tgz",
+					"integrity": "sha512-3MluWe1wlFWP2UZ2hrfhSlH9s6IJs9O1dKZxRmjczCVv1KW0SQtlc0+zjYBTeXg0Nk0qWCQfpFSOYMyT4OWPAQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"json-stringify-safe": "^5.0.1",
@@ -7210,17 +6844,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.1000.tgz",
-					"integrity": "sha512-DqykRhXh9WZ4s2iWD2qzAjozNei+HPP6AzFyuba6PKXLKNhQjiTK+k7g4BxdKUI0Uu+ZJeZEptoipy1xTNpsjQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.2000.tgz",
+					"integrity": "sha512-A0mO+quijpJZFji9/aQvMJ9n3Sg90CDACrm4Ohbl9UeCVN1OLie/8DILryFD5c62/3xXiaYla8IwSikUUFtwgg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -7231,6 +6865,11 @@
 					"version": "6.2.3",
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
+				},
+				"async": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -7240,27 +6879,27 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.1000.tgz",
-			"integrity": "sha512-OOSqDL6lyN4icxhaW0u+1UZ6jJihce9yVqPjfFW/EM/qOaslK+LeIIwJc0ZioQoH1cmAyD/Lz9le85FbVW9hjQ==",
+			"version": "npm:@fluidframework/test-drivers@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.2001.tgz",
+			"integrity": "sha512-KSm6CbRdwtxdFN+JOH+mvvn2+jihiY5JOUb5gwVsQ30SivQUz3Mkc+b9vl/4BWuckMWSkY5Cu30kiHntg4mhRQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/odsp-driver": "^0.59.1000",
-				"@fluidframework/odsp-driver-definitions": "^0.59.1000",
-				"@fluidframework/odsp-urlresolver": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/local-driver": "^0.59.2001",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2001",
+				"@fluidframework/odsp-driver": "^0.59.2001",
+				"@fluidframework/odsp-driver-definitions": "^0.59.2001",
+				"@fluidframework/odsp-urlresolver": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/server-local-server": "^0.1036.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-pairwise-generator": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
-				"@fluidframework/tinylicious-driver": "^0.59.1000",
-				"@fluidframework/tool-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/server-local-server": "^0.1036.2000",
+				"@fluidframework/test-driver-definitions": "^0.59.2001",
+				"@fluidframework/test-pairwise-generator": "^0.59.2001",
+				"@fluidframework/test-runtime-utils": "^0.59.2001",
+				"@fluidframework/tinylicious-driver": "^0.59.2001",
+				"@fluidframework/tool-utils": "^0.59.2001",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -7277,42 +6916,42 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.1000.tgz",
-					"integrity": "sha512-nf2H38+U0S5amvuyC3JZrPbaqD0VQmgeHsRNx6ecOLeNlsZCA4lL2US89s17aa4g6N8y1RNUQs/Rcs0Wu2g9qw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.2000.tgz",
+					"integrity": "sha512-P+ICmd+gEUBquv0JOFPDWNblZ/znzwAVfwUb8zwhNXVkx6GUWlr0P6fkDrgnk+Hb3vQ/g97pBg3VKlCLx3k6qA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas-driver": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas-driver": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/semver": "^6.0.1",
-						"async": "^3.2.0",
+						"async": "^3.2.2",
 						"axios": "^0.26.0",
 						"double-ended-queue": "^2.1.0-0",
 						"json-stringify-safe": "^5.0.1",
 						"lodash": "^4.17.21",
-						"nconf": "^0.11.0",
+						"nconf": "^0.11.4",
 						"semver": "^6.3.0",
 						"sha.js": "^2.4.11",
 						"uuid": "^8.3.1"
@@ -7326,48 +6965,48 @@
 					}
 				},
 				"@fluidframework/server-lambdas-driver": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.1000.tgz",
-					"integrity": "sha512-8Q+4+FitbHJea7uMwfIvHrxEdOtxZOsQWlCenm/siEYjCo34JMxCSaO9BJX7REN4j644C3c3a0R/xAEM5ak4iw==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.2000.tgz",
+					"integrity": "sha512-ELqQbGag580dh21vmR+r5BQ0d3pxDwpxQMr1Yb7ojQr4lJillgu8CcLwZOJTXy6ar5mn6aA4NP1OQ8+OrPDF1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"async": "^3.2.0",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"async": "^3.2.2",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.1000.tgz",
-					"integrity": "sha512-laLvpTNEBusrSa+fox02SdUpZQZ2VhRhIeos+AuQFw8bVIRStBfFFRqqu7ADcckqz/xeXX7+evX1EFN1QHYWmA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.2000.tgz",
+					"integrity": "sha512-9laj7b2Fxf/eyKT6Fd/8N7c61XXG3l+5EwepeVVQaSs8eh3mYLUTKKq3v+hD4PV7vVRWEiKZUq4Mw/Bu3MET7w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-memory-orderer": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
-						"@fluidframework/server-test-utils": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-memory-orderer": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
+						"@fluidframework/server-test-utils": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.1000.tgz",
-					"integrity": "sha512-pTN7xXU/akNlczupyxZBl2IdJS9r8ygka/BEbzSYAYmCg2URBBVFbsmxUtQhd1NRxu3Ft8nhETmOxrIQK5duAA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.2000.tgz",
+					"integrity": "sha512-dX7/SrNGC18Xj3UxeXPrepxURi/klLmu82oa2UWthkXOJkA1HnbbDfGPUigTC4RLewJFVBUBu7tSNjp2ACwL1Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-lambdas": "^0.1036.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-lambdas": "^0.1036.2000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -7382,13 +7021,13 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -7401,25 +7040,25 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.1000.tgz",
-					"integrity": "sha512-IhLvveSmswFSp5TgiJgFnDt0bAJhq4XvSgKv9V+xl+5GwxPgvFuSLE/uZJkCbiGlGWs3VO+3SfUZkbmvVBYEkA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.2000.tgz",
+					"integrity": "sha512-rxV2lwUBiWATxNK3ai9w7D0PfJB3QVkgyE6Jmmd/dtG33wkYJhJK6XhLddtyxcV3xjyNLSBMPD9ZBUFkA7Uk8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"@types/nconf": "^0.10.0",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
+						"nconf": "^0.11.4"
 					}
 				},
 				"@fluidframework/server-services-telemetry": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.1000.tgz",
-					"integrity": "sha512-iUa7Ux3zvj+9NswrFTdslxW2jm4II/3g94+tDNFdXpy5316XmlEKfLHgOuQbSPDC2T++oPqiJuy9Y4CLAVDvEQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.2000.tgz",
+					"integrity": "sha512-3MluWe1wlFWP2UZ2hrfhSlH9s6IJs9O1dKZxRmjczCVv1KW0SQtlc0+zjYBTeXg0Nk0qWCQfpFSOYMyT4OWPAQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"json-stringify-safe": "^5.0.1",
@@ -7429,17 +7068,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.1000.tgz",
-					"integrity": "sha512-DqykRhXh9WZ4s2iWD2qzAjozNei+HPP6AzFyuba6PKXLKNhQjiTK+k7g4BxdKUI0Uu+ZJeZEptoipy1xTNpsjQ==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.2000.tgz",
+					"integrity": "sha512-A0mO+quijpJZFji9/aQvMJ9n3Sg90CDACrm4Ohbl9UeCVN1OLie/8DILryFD5c62/3xXiaYla8IwSikUUFtwgg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
-						"@fluidframework/server-services-client": "^0.1036.1000",
-						"@fluidframework/server-services-core": "^0.1036.1000",
-						"@fluidframework/server-services-telemetry": "^0.1036.1000",
+						"@fluidframework/server-services-client": "^0.1036.2000",
+						"@fluidframework/server-services-core": "^0.1036.2000",
+						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -7451,6 +7090,11 @@
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
 				},
+				"async": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+				},
 				"jwt-decode": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -7459,14 +7103,14 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-0.59.1000.tgz",
-			"integrity": "sha512-zVTd5IhAOjrWPFrr955xgqPqApySHRThQ4TDigSsTd170Yjd5PjJlBHmJvO8ibsS8H9WTfFzy19+Oj9bgYxaww==",
+			"version": "npm:@fluidframework/test-loader-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-0.59.2001.tgz",
+			"integrity": "sha512-iuNrUhL1gTJAczEzRS/G7iuUOhcgSSfQB+s5C99JAGOOqAcLVrmio3PmoCNYni7J+dC3e+nn/2+oTObT3GlF0Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000"
 			},
 			"dependencies": {
@@ -7483,41 +7127,41 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.1000.tgz",
-			"integrity": "sha512-/4fyw0zTwaM9SudO9OR1S5DedEuT1N4E2rvg/UFn0CW4PYBi/LK3BCMO9CuK7Y7BI+nOMYD4Ef6GplLX2QnEFQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.2001.tgz",
+			"integrity": "sha512-B19LEhOlRA/Sla2bq0K+9F0MgbC71ljj33I3LbD0eE0mKkAMk+T1yyjW1xdymHYAE5KAyVl5HOdT2/hGFS8VtQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.1000.tgz",
-			"integrity": "sha512-/4fyw0zTwaM9SudO9OR1S5DedEuT1N4E2rvg/UFn0CW4PYBi/LK3BCMO9CuK7Y7BI+nOMYD4Ef6GplLX2QnEFQ==",
+			"version": "npm:@fluidframework/test-pairwise-generator@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.2001.tgz",
+			"integrity": "sha512-B19LEhOlRA/Sla2bq0K+9F0MgbC71ljj33I3LbD0eE0mKkAMk+T1yyjW1xdymHYAE5KAyVl5HOdT2/hGFS8VtQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-pgs4aU9g+X84AgCI2GoZynSlMFum3P/aayABxv21i0V7aI5+oRRwlaJXEF4hc1TK63SYS+jW0WUgKvUV0DcQ5w==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.2001.tgz",
+			"integrity": "sha512-bpfctgVAEtRftjlejRCjxzZlgkXAU1xAR2gm7DA6rS8C9tEZJexmrZCX+//sIOtLpUFkqqi1SMVucvK/9oCoew==",
 			"requires": {
-				"@fluidframework/azure-service-utils": "^0.59.1000",
+				"@fluidframework/azure-service-utils": "^0.59.2001",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -7546,23 +7190,23 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.1000.tgz",
-			"integrity": "sha512-pgs4aU9g+X84AgCI2GoZynSlMFum3P/aayABxv21i0V7aI5+oRRwlaJXEF4hc1TK63SYS+jW0WUgKvUV0DcQ5w==",
+			"version": "npm:@fluidframework/test-runtime-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.2001.tgz",
+			"integrity": "sha512-bpfctgVAEtRftjlejRCjxzZlgkXAU1xAR2gm7DA6rS8C9tEZJexmrZCX+//sIOtLpUFkqqi1SMVucvK/9oCoew==",
 			"requires": {
-				"@fluidframework/azure-service-utils": "^0.59.1000",
+				"@fluidframework/azure-service-utils": "^0.59.2001",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -7597,32 +7241,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.1000.tgz",
-			"integrity": "sha512-zNYhn8NugiGo98lxIPkIa3wfqGo6zWMtv4tV6asPUgR2hasy8Q2VrEkBTmfmmE6HJsiTCNtlEUbxMjz2MzMK+Q==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.2001.tgz",
+			"integrity": "sha512-nOJa5JO5M5oqBVKsCSL0Uile45J2SQ/LZDf+oaK24HYprwt2mAVL8VNRh8yBLVCbReSrswkij0B4ukCtEWvEHQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2001",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
+				"@fluidframework/container-runtime": "^0.59.2001",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/local-driver": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
+				"@fluidframework/request-handler": "^0.59.2001",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
+				"@fluidframework/test-driver-definitions": "^0.59.2001",
+				"@fluidframework/test-runtime-utils": "^0.59.2001",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -7651,32 +7295,32 @@
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.1000.tgz",
-			"integrity": "sha512-zNYhn8NugiGo98lxIPkIa3wfqGo6zWMtv4tV6asPUgR2hasy8Q2VrEkBTmfmmE6HJsiTCNtlEUbxMjz2MzMK+Q==",
+			"version": "npm:@fluidframework/test-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.2001.tgz",
+			"integrity": "sha512-nOJa5JO5M5oqBVKsCSL0Uile45J2SQ/LZDf+oaK24HYprwt2mAVL8VNRh8yBLVCbReSrswkij0B4ukCtEWvEHQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2001",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
+				"@fluidframework/container-runtime": "^0.59.2001",
+				"@fluidframework/container-runtime-definitions": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/datastore": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/local-driver": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/local-driver": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/telemetry-utils": "^0.59.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.1000",
+				"@fluidframework/request-handler": "^0.59.2001",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/telemetry-utils": "^0.59.2001",
+				"@fluidframework/test-driver-definitions": "^0.59.2001",
+				"@fluidframework/test-runtime-utils": "^0.59.2001",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -7705,35 +7349,35 @@
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-0.59.1000.tgz",
-			"integrity": "sha512-fUvGpKfQu/Aj7ZllUy7fCh1H8EWVq9HBKofMiKcrd4WVfXmrlL//h1lBQkNj0h2onlmlbqSRLPio9z63Lq34OA==",
+			"version": "npm:@fluidframework/test-version-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-0.59.2001.tgz",
+			"integrity": "sha512-Z4KHGohux2PUSq+E2iT0c+ucDuDuldcJtYhEEpTqde7ovjndP99oBRbjWrfIa3sNnvxLF3iau6bm47Vw1VUpgA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.1000",
-				"@fluidframework/cell": "^0.59.1000",
+				"@fluidframework/aqueduct": "^0.59.2001",
+				"@fluidframework/cell": "^0.59.2001",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
-				"@fluidframework/container-runtime": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
+				"@fluidframework/container-runtime": "^0.59.2001",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/counter": "^0.59.1000",
-				"@fluidframework/datastore-definitions": "^0.59.1000",
+				"@fluidframework/counter": "^0.59.2001",
+				"@fluidframework/datastore-definitions": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/ink": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/matrix": "^0.59.1000",
-				"@fluidframework/mocha-test-setup": "^0.59.1000",
-				"@fluidframework/ordered-collection": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/ink": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
+				"@fluidframework/matrix": "^0.59.2001",
+				"@fluidframework/mocha-test-setup": "^0.59.2001",
+				"@fluidframework/ordered-collection": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/register-collection": "^0.59.1000",
-				"@fluidframework/runtime-definitions": "^0.59.1000",
-				"@fluidframework/sequence": "^0.59.1000",
-				"@fluidframework/test-driver-definitions": "^0.59.1000",
-				"@fluidframework/test-drivers": "^0.59.1000",
-				"@fluidframework/test-utils": "^0.59.1000",
-				"nconf": "^0.11.0",
+				"@fluidframework/register-collection": "^0.59.2001",
+				"@fluidframework/runtime-definitions": "^0.59.2001",
+				"@fluidframework/sequence": "^0.59.2001",
+				"@fluidframework/test-driver-definitions": "^0.59.2001",
+				"@fluidframework/test-drivers": "^0.59.2001",
+				"@fluidframework/test-utils": "^0.59.2001",
+				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
 			},
@@ -7762,22 +7406,22 @@
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.1000.tgz",
-			"integrity": "sha512-JnBmuUEAl9VWPL+C+bc4I1ZHEWSnVDowVUz9x4jj6wjJtkFVYMKxPMfrCnehbLzXPfGG8pcdYjfYoxl6z/xhaQ==",
+			"version": "npm:@fluidframework/tinylicious-client@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.2001.tgz",
+			"integrity": "sha512-gwYFS+1YxB9SRQAni2HDa1QQ9jZsqu0hn3zNCMxYCDvD4XYnjh7eiTLAj1kjNMEgL3zZHL6OOE+Fs6cZ1QSbqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.1000",
+				"@fluidframework/container-loader": "^0.59.2001",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
-				"@fluidframework/fluid-static": "^0.59.1000",
-				"@fluidframework/map": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
+				"@fluidframework/fluid-static": "^0.59.2001",
+				"@fluidframework/map": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/runtime-utils": "^0.59.1000",
-				"@fluidframework/tinylicious-driver": "^0.59.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/runtime-utils": "^0.59.2001",
+				"@fluidframework/tinylicious-driver": "^0.59.2001",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7805,16 +7449,16 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-9McR39G+CUEdWaVqjNRzyKsOKfwbTPHELQbSmRpiFzWXmh8t9mzoMQV5f2B0wcjPjUkgXlPRPpXqIV9Ffn1Fkg==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.2001.tgz",
+			"integrity": "sha512-vEu0ucOimkthUiK6zGCYIcKbEXTLtoMWcGugwVmdNqa+W3FK2N6BhATr1jkMu4SKgrVVaZAEKOMI4ebGoFE7uQ==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/server-services-client": "^0.1036.2000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -7830,29 +7474,29 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -7872,16 +7516,16 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.1000.tgz",
-			"integrity": "sha512-9McR39G+CUEdWaVqjNRzyKsOKfwbTPHELQbSmRpiFzWXmh8t9mzoMQV5f2B0wcjPjUkgXlPRPpXqIV9Ffn1Fkg==",
+			"version": "npm:@fluidframework/tinylicious-driver@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.2001.tgz",
+			"integrity": "sha512-vEu0ucOimkthUiK6zGCYIcKbEXTLtoMWcGugwVmdNqa+W3FK2N6BhATr1jkMu4SKgrVVaZAEKOMI4ebGoFE7uQ==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.1000",
+				"@fluidframework/driver-utils": "^0.59.2001",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.1000",
-				"@fluidframework/server-services-client": "^0.1036.1000",
+				"@fluidframework/routerlicious-driver": "^0.59.2001",
+				"@fluidframework/server-services-client": "^0.1036.2000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -7897,29 +7541,29 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.1000.tgz",
-					"integrity": "sha512-3FSBzwxXZ89IRJ8TshNMCepawVBve+4PAq8ZAVxph9k/2tViXHlRz+kK+yHpyZl3EFTPlsR1YrGdnm/s+b7I0A==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
-						"@fluidframework/protocol-base": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -7939,13 +7583,13 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.1000.tgz",
-			"integrity": "sha512-aaH+ybxUdzoBWOkbCtpsT8zSllLcm6TbktO93DguSh0WDIHPK5cVl6kzhRE5yAO6sTlT7RHL/1d/CFA+O4zS2w==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.2001.tgz",
+			"integrity": "sha512-TjMhr7fMTf3h3Z1q6uQ9tb8AloF6xGRDQ2rFL50ZK3clxxF4iaORyB2Y7bvVuBRl6rSgYcLdd8t59GPBvVKerw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"async-mutex": "^0.3.1",
 				"debug": "^4.1.1",
@@ -7954,17 +7598,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -7972,13 +7616,13 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.1000.tgz",
-			"integrity": "sha512-aaH+ybxUdzoBWOkbCtpsT8zSllLcm6TbktO93DguSh0WDIHPK5cVl6kzhRE5yAO6sTlT7RHL/1d/CFA+O4zS2w==",
+			"version": "npm:@fluidframework/tool-utils@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.2001.tgz",
+			"integrity": "sha512-TjMhr7fMTf3h3Z1q6uQ9tb8AloF6xGRDQ2rFL50ZK3clxxF4iaORyB2Y7bvVuBRl6rSgYcLdd8t59GPBvVKerw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^0.59.1000",
-				"@fluidframework/protocol-base": "^0.1036.1000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.2001",
+				"@fluidframework/protocol-base": "^0.1036.2000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"async-mutex": "^0.3.1",
 				"debug": "^4.1.1",
@@ -7987,17 +7631,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.1000.tgz",
-					"integrity": "sha512-C8I5cKNpE/EPSMbgiPk/ZE2tI2Jjk5hUonXBBlMWE73K4HowrRnpmXbDLGTSd/imFtpkh2t5NNm2LqcjZc2kyw=="
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000.tgz",
+					"integrity": "sha512-7SlrPGLQaHufbsF6Vze8FvzgvcaN8wGPHYcIq0KpUh5LINPq1EeYh44gpRv6yjImIH9X0+WIQUS3T+jK9tf0dQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.1000.tgz",
-					"integrity": "sha512-FBlCK7w+pT8X6d9nxL0TIalVmMjuKaZ3e6gXHGx2CBiqEVMVgh3f7VFtXRoEAVCJItU/Kh0I49v58BabAiMRhA==",
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000.tgz",
+					"integrity": "sha512-S+Q778dZSStNIbxrEwDbuzn+n/COZzZ9EQnF5Kl8Bq9BdpaYRv4KKN697U4Kmob3+FYeBN+yg7smEtHaDSNoRw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.1000",
+						"@fluidframework/gitresources": "^0.1036.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
@@ -8005,58 +7649,58 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.1000.tgz",
-			"integrity": "sha512-0GamjG54FrXG9QHsSTHEv092VDWf/30sd62p8h0w1zjcoN+r2vGDsztQ6mVcexMB8BnX/pDVd51WvS2o2l4u0g==",
+			"version": "npm:@fluidframework/undo-redo@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.2001.tgz",
+			"integrity": "sha512-AeA8IH2R15zehwPD2njnvWxaTuQaUOfPoYbalhABvrEYmsLD9qCKbsn0OOIGNRka+zEUP0imjzjlET3EerZw9Q==",
 			"requires": {
-				"@fluidframework/map": "^0.59.1000",
-				"@fluidframework/matrix": "^0.59.1000",
-				"@fluidframework/merge-tree": "^0.59.1000",
-				"@fluidframework/sequence": "^0.59.1000"
+				"@fluidframework/map": "^0.59.2001",
+				"@fluidframework/matrix": "^0.59.2001",
+				"@fluidframework/merge-tree": "^0.59.2001",
+				"@fluidframework/sequence": "^0.59.2001"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.1000.tgz",
-			"integrity": "sha512-s5CV8HS9AWVkpemIXTMAsG32O3QFFsfIiJtu94DpRtslnZDIYNBhyT9oUPPEnVpEkaP+rJGMfAOkdh7ATHwnmQ==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.2001.tgz",
+			"integrity": "sha512-73VVSRJq8sQwcLxMwg9GDkO+QlT4rYLhgu6c2rU0Y1Id/xpwg38UX9bkzun13et4Bts0CNaRC56B1CQfy6YzQw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/view-interfaces": "^0.59.2001",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.1000.tgz",
-			"integrity": "sha512-s5CV8HS9AWVkpemIXTMAsG32O3QFFsfIiJtu94DpRtslnZDIYNBhyT9oUPPEnVpEkaP+rJGMfAOkdh7ATHwnmQ==",
+			"version": "npm:@fluidframework/view-adapters@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.2001.tgz",
+			"integrity": "sha512-73VVSRJq8sQwcLxMwg9GDkO+QlT4rYLhgu6c2rU0Y1Id/xpwg38UX9bkzun13et4Bts0CNaRC56B1CQfy6YzQw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/view-interfaces": "^0.59.1000",
+				"@fluidframework/view-interfaces": "^0.59.2001",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.1000.tgz",
-			"integrity": "sha512-KEv/iccEKfySJetEye8TvdimFj0K1nuADutKkdRAvvcCxXU03DChXVZtjqdHirVBXT9Djvl/lJDVPfeRmGfovw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.2001.tgz",
+			"integrity": "sha512-tEq89TygBAJS1ZfRkhRAGqE0ubHxRxzgxhnzFg43zhUHZFGEUXojIDVIsoerVIT3wZW5f1ckwP1Jn5sw85LHfw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.1000.tgz",
-			"integrity": "sha512-KEv/iccEKfySJetEye8TvdimFj0K1nuADutKkdRAvvcCxXU03DChXVZtjqdHirVBXT9Djvl/lJDVPfeRmGfovw==",
+			"version": "npm:@fluidframework/view-interfaces@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.2001.tgz",
+			"integrity": "sha512-tEq89TygBAJS1ZfRkhRAGqE0ubHxRxzgxhnzFg43zhUHZFGEUXojIDVIsoerVIT3wZW5f1ckwP1Jn5sw85LHfw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.1000.tgz",
-			"integrity": "sha512-W9Z151qbssS5FJNL+BHbjTBwFwX4G537sGK/kjWHPxpSohwXwXMJixZnO77uha7px44PbSwVvkgQhQpot7MhZw==",
+			"version": "0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.2001.tgz",
+			"integrity": "sha512-patko6ZahWZOmkU5gUd7zEgFEDwfzgSEEYlECyeAZ1LH0em/AT3fJeSbl8TGg+GN3uqEgl/xUoZDw7emA2E/gg==",
 			"requires": {
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -8087,9 +7731,9 @@
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader-previous@0.59.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.1000.tgz",
-			"integrity": "sha512-W9Z151qbssS5FJNL+BHbjTBwFwX4G537sGK/kjWHPxpSohwXwXMJixZnO77uha7px44PbSwVvkgQhQpot7MhZw==",
+			"version": "npm:@fluidframework/web-code-loader@0.59.2001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.2001.tgz",
+			"integrity": "sha512-patko6ZahWZOmkU5gUd7zEgFEDwfzgSEEYlECyeAZ1LH0em/AT3fJeSbl8TGg+GN3uqEgl/xUoZDw7emA2E/gg==",
 			"requires": {
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -19199,7 +18843,8 @@
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"optional": true
 		},
 		"async-hook-jl": {
 			"version": "1.7.6",
@@ -26373,14 +26018,6 @@
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
 		},
-		"eventsource": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-			"integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-			"requires": {
-				"original": "^1.0.0"
-			}
-		},
 		"evp_bytestokey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -27245,7 +26882,7 @@
 			"integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA="
 		},
 		"fluid-framework-previous": {
-			"version": "npm:fluid-framework-previous@0.58.2002",
+			"version": "npm:fluid-framework@0.58.2002",
 			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-0.58.2002.tgz",
 			"integrity": "sha512-5neTvjQJ/Xg9LNhGf6qgqOnqayVFSqaqDkBXNBJ3fDiU2f07lN8C2s9dAzsVQEJ71hFGkmigGs4cYty0z0ku3Q==",
 			"requires": {
@@ -33532,11 +33169,6 @@
 				"json-buffer": "3.0.0"
 			}
 		},
-		"killable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
-			"integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="
-		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -34927,11 +34559,6 @@
 				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
 			}
-		},
-		"loglevel": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-			"integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
 		},
 		"lolex": {
 			"version": "4.2.0",
@@ -38845,21 +38472,6 @@
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
 			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="
 		},
-		"opn": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-			"requires": {
-				"is-wsl": "^1.1.0"
-			},
-			"dependencies": {
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-				}
-			}
-		},
 		"optimism": {
 			"version": "0.16.1",
 			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
@@ -38886,14 +38498,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.1.tgz",
 			"integrity": "sha512-3Ux8um0zXbVacKUkcytc0u3HgC0b0bBLT+I60r2J/En72cI0nZffqrA7Xtf2Hqs27j1g82llR5Mhbd0Z1XW4AQ=="
-		},
-		"original": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-			"requires": {
-				"url-parse": "^1.4.3"
-			}
 		},
 		"os-browserify": {
 			"version": "0.3.0",
@@ -39676,14 +39280,6 @@
 			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
-			}
-		},
-		"pkg-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-			"requires": {
-				"find-up": "^3.0.0"
 			}
 		},
 		"pkg-up": {
@@ -43848,28 +43444,6 @@
 				"websocket-driver": "^0.7.4"
 			}
 		},
-		"sockjs-client": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.0.tgz",
-			"integrity": "sha512-qVHJlyfdHFht3eBFZdKEXKTlb7I4IV41xnVNo8yUKA1UHcPJwgW2SvTq9LhnjjCywSkSK7c/e4nghU0GOoMCRQ==",
-			"requires": {
-				"debug": "^3.2.7",
-				"eventsource": "^1.1.0",
-				"faye-websocket": "^0.11.4",
-				"inherits": "^2.0.4",
-				"url-parse": "^1.5.10"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
 		"socks": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
@@ -47576,7 +47150,8 @@
 		"upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+			"optional": true
 		},
 		"update-notifier": {
 			"version": "2.5.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1966,7 +1966,7 @@
 			}
 		},
 		"@fluid-experimental/task-manager-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluid-experimental/task-manager-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-0.59.1000.tgz",
 			"integrity": "sha512-14U5Fumd4UjBHBXsgclXzRo6+GLUGzp2l1CXN6olKufCuKCRpgLwFMpYUk0FcJmabwxkRg2c8+rg5MBw3TdpXg==",
 			"requires": {
@@ -2017,7 +2017,7 @@
 			}
 		},
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-0.59.1000.tgz",
 			"integrity": "sha512-g+T8MGBeIl92LMKddok6tev9rKWZ528sYVLhGUnp102nYWztbCmOEAslAXjO0oSzJXjIfowwI4+IJo+j2yx3jQ==",
 			"requires": {
@@ -2041,7 +2041,7 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluid-tools/webpack-fluid-loader-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-0.59.1000.tgz",
 			"integrity": "sha512-sihDV79PZ9nivswV9UfPb0aLq9e+Q16ieGRKtzQUkKRvNmDAt2Ru8lm7xeoJpLgVlOYwUiL0CW244WVCyx4pBg==",
 			"requires": {
@@ -2658,7 +2658,7 @@
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/agent-scheduler-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.59.1000.tgz",
 			"integrity": "sha512-2Vvr2Ofl+1yfPLal/kkwQyfatx2Q7sP+VbwvUIi3sAe8M86+e6Enk+cv8hddtk3GhtmycqhKvDcOeepXc8JB3w==",
 			"requires": {
@@ -2745,7 +2745,7 @@
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/aqueduct-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.1000.tgz",
 			"integrity": "sha512-mzYuHMt2ww3ZfG0SpwFLRekqn4xYybikHxuJSTaejijSYZSZxuU8ZZO3juZRM8/p/pGdJQac9dnqHMVY38xt/Q==",
 			"requires": {
@@ -2791,7 +2791,7 @@
 			}
 		},
 		"@fluidframework/azure-client-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/azure-client-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-0.59.1000.tgz",
 			"integrity": "sha512-AzWMorHSjvKr8rOU/8Qu/04t+PeSqMgClusNh3y2lLzmijLZvyFQ1QrMk62ki8cMPgztSZUyl49LwObEywWKYQ==",
 			"requires": {
@@ -2893,7 +2893,7 @@
 			}
 		},
 		"@fluidframework/azure-service-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/azure-service-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.1000.tgz",
 			"integrity": "sha512-GBKZ/l+nJHigo7LsSQwj3WFBm33WNd2N4ivR5jjlGSjvixz1C/Am9w517WdlV2l1T6sLFZp2prwHbWJIsngOvA==",
 			"requires": {
@@ -3008,7 +3008,7 @@
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/cell-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.1000.tgz",
 			"integrity": "sha512-gR/TbtAg1OLMSh1cAdpJpPtlCPlEkcROqvozmBsXVRNiZAncDvMGolmJSgjjC4E2+dVcQHtbPOZwf9ezV0m5pg==",
 			"requires": {
@@ -3118,7 +3118,7 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/container-loader-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.1000.tgz",
 			"integrity": "sha512-xK6jqL9ZBmVpJlCcCZ4MhO4GIhFgE4W07ZHZ8Dubq6Mtusi6wJ/knpiGRmHoNmPQCx2ZKi8SNy+LPTzH0HdzXg==",
 			"requires": {
@@ -3278,7 +3278,7 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/container-runtime-definitions-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.1000.tgz",
 			"integrity": "sha512-OUACev+V9UWQfO7oQ8GLN8vPwCKoMp9FrTKvzHXxBLVK/+RiXaKS0yOtPlskLkhdDLid1SzDslHsRoLq6VCjeA==",
 			"requires": {
@@ -3315,7 +3315,7 @@
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/container-runtime-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.1000.tgz",
 			"integrity": "sha512-AGNUBNrrfINALPd6DcgJMZg6TGkRvjWYjpoE73GwhYfFwBOs0ClRbt2ErJtjV+fOa3+2p2iGCnKJlLwQ+zAnvA==",
 			"requires": {
@@ -3413,7 +3413,7 @@
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/container-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.1000.tgz",
 			"integrity": "sha512-ChBj7qam/xyBVvsSxjmcBi0R9XVnvOJfw4Tb991S2qJDi5XFPSVImk1PQd1f5SzmAfC2O9Vasm8uqoYeMCUKyQ==",
 			"requires": {
@@ -3467,7 +3467,7 @@
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/counter-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.1000.tgz",
 			"integrity": "sha512-T+8rYBdXd7EQTvO4N0l+ISlY2zo0+Yf/yjDXC0pAPCtbAaMCrWPUblRUemHgKtCNlfYrO05GVflkYWq/FLi1zg==",
 			"requires": {
@@ -3481,7 +3481,7 @@
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/data-object-base-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-0.59.1000.tgz",
 			"integrity": "sha512-F7SuZHcowq5rhhS95G8gEn1GERNfrCErIfVgtFiuyCFF2uAsvaW0GHSIIi6Dv3Em0dagVZtCZOTfCtsAolTK6Q==",
 			"requires": {
@@ -3621,7 +3621,7 @@
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/datastore-definitions-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.1000.tgz",
 			"integrity": "sha512-/YMoDxDp1CX8YtvnCiu3ndbPgpOg5MrKAANF/0vSAbPTODM1PGxnOTsXW8zKbjY9CstM4jbIGpx0oq6JKJIJKQ==",
 			"requires": {
@@ -3658,7 +3658,7 @@
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/datastore-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.1000.tgz",
 			"integrity": "sha512-C/2uXuy8wHXv98fRQeAsA7Cww8n4JA0yjsjMXIesJCRsj93XMAGyqzN+PPXTsLF2gu5I06PcKF2BB19WjUQYBQ==",
 			"requires": {
@@ -3720,7 +3720,7 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/dds-interceptions-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-0.59.1000.tgz",
 			"integrity": "sha512-IqMJjbrgS8bGXq1v1wXJ5O/W+lufn8e9NGcNxTjYpg1IA5rHDT01FaaDhEylR/7Jx5LGFPhryBw/W0kh5XRSzw==",
 			"requires": {
@@ -3732,7 +3732,7 @@
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/debugger-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-0.59.1000.tgz",
 			"integrity": "sha512-cukrgsdo0wJBiNyDXY1ghE/5oNoF6prZO4Vj0x8lfAKGU3fCnsH1rcBKrLj1abSlEMC+DNNSbrtkJK2szXsn1g==",
 			"requires": {
@@ -3782,7 +3782,7 @@
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/driver-base-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.1000.tgz",
 			"integrity": "sha512-C3J7L1vZfw1/nqV8erGIxHJ0sA2j2uIvIV/bEePW5fyP55GBSJKXOkuNFVbgYKjFJiykpLHIjMMfZCrLnY/VwA==",
 			"requires": {
@@ -3862,7 +3862,7 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/driver-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.1000.tgz",
 			"integrity": "sha512-VZtoV+8sEzBtyRbXU6fbaZOxNKUBjzdL+Fp2Xp53mr5HRwu0IT0EMC1xMXExr46l7loyAuXyvso++naupyNODg==",
 			"requires": {
@@ -3907,7 +3907,7 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/driver-web-cache-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-0.59.1000.tgz",
 			"integrity": "sha512-9EpaIv0wGt5urRYPk0pjfd0JlkiF6E7WySUe4RzbLwYmyXhX82G0VUjLdYzYhkyihEV0fhveBRlH1sdnqZVZtw==",
 			"requires": {
@@ -3962,7 +3962,7 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/file-driver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-0.59.1000.tgz",
 			"integrity": "sha512-It22F5iqqdIJwaJXhmgkkgDyGt7mCB7oVX2AsyaQ5Gs4Z9cdZIUmZVsWOyRLts2PDis+jKx0yxV53lOfw61DPA==",
 			"requires": {
@@ -4029,7 +4029,7 @@
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/fluid-static-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.1000.tgz",
 			"integrity": "sha512-dJbl5QwE6knlVxG5rMPWJX8omkd73y0iGcyCkRX/D6dI8t/78tEPeUckOd0qNBfpLzyGe6h+vsQKGx9C+XokQw==",
 			"requires": {
@@ -4081,7 +4081,7 @@
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/garbage-collector-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.1000.tgz",
 			"integrity": "sha512-2F4EIR604W8iZzFyPqDwA19SVqmEyD+3w6TYaLQO9dC9s3Pk00EIGTbc3asIA1x76SEgHC6nFwgVvQ2LuVTwLQ==",
 			"requires": {
@@ -4096,7 +4096,7 @@
 			"integrity": "sha512-QbfvNPPahZkgyQUgaFcb1ycYdt8i10wa5nhgSqNk/4sXyTa+ESdpHTd7ljEs0X3kx1aW0QOCQTZq2tL8JmZiLQ=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/iframe-driver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-0.59.1000.tgz",
 			"integrity": "sha512-AT5esBd+bry+Mphq1lQqvmA3ZoHGro14UDLZfBAYuyyuMCYWMU5HW3Av4eFaw6kT9xQOmSpuZ4EmI9bSw8DGTg==",
 			"requires": {
@@ -4138,7 +4138,7 @@
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/ink-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.1000.tgz",
 			"integrity": "sha512-p5LAM2EuFNrGwLFLr96lUVRAOKoW32ds+1ytBC9ieH2BckFXPPGyjY4+JDKeXcVRt8BWk/Kg0iXx7ss9BcHk8g==",
 			"requires": {
@@ -4364,7 +4364,7 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/local-driver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.1000.tgz",
 			"integrity": "sha512-GFBoMaHA3lWBHi61fATH8SckCLc4dQx6VBffdHMw4IQgnoVbT9eh3YxG/f9xb4VqLRhPQOQVyLpyJgasxePswA==",
 			"requires": {
@@ -4593,7 +4593,7 @@
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/map-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.1000.tgz",
 			"integrity": "sha512-viwpzIFGgQnUgnJ0w7CHdw2KH025AawN6S8fATHg8IvGspJ3Q5ZV8Bw/GH38B6ogTk/jNgYdmeJx+t06IO77kw==",
 			"requires": {
@@ -4649,7 +4649,7 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/matrix-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.1000.tgz",
 			"integrity": "sha512-mxFDgAyHLJJ2CDKFL5qRvbW0/k1iWiC1HJOuwm+MvOtipAahXUJgfqcWQDNdJdrswyWHpZLFfEJmtHXzksJ9Qg==",
 			"requires": {
@@ -4727,7 +4727,7 @@
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "0.58.2002",
+			"version": "npm:@fluidframework/merge-tree-previous@0.58.2002",
 			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.58.2002.tgz",
 			"integrity": "sha512-phVUFtfDSo0z3xU5wQCYhZ9/DdFR/38kQYaiYRGa8SEb4rbWOOBq15FcXDs7omrJEff+JeWw7EjK0gI5W5P9YA==",
 			"requires": {
@@ -4984,7 +4984,7 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/mocha-test-setup-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.1000.tgz",
 			"integrity": "sha512-EIdO0cQJmOoD4MZJqSJSoFadzF8HaOa1UPN+TnegCxpiwLTXYshfByCEwTC1YH05iXxEGAXVHcYYentggCwvpQ==",
 			"requires": {
@@ -5020,7 +5020,7 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/odsp-doclib-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.1000.tgz",
 			"integrity": "sha512-Crd9z5tfU07N7WmwtzcqSQUMwzLOizdg/BW4oiMKxDB+s8jNapjGgZaRL2SDeyEiuY5HVnyWzMOOnnefpJ2DGw==",
 			"requires": {
@@ -5117,7 +5117,7 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/odsp-driver-definitions-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.1000.tgz",
 			"integrity": "sha512-rzwpLtUjzoP3DJalwz+pEnTIjuy0WXb1tUMQikMCB3pQMZyoa8AsFLFFgWJVNka1+3vg8xv/k9bfnhGKDyx+6A==",
 			"requires": {
@@ -5137,7 +5137,7 @@
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/odsp-driver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.1000.tgz",
 			"integrity": "sha512-GAr4q/9eWNtwpYe3XNgp2B/gFfEQiPLdQlWy3XYspqcxNW1+qbuCN/pZW8SdN2tjTKfbA5S2qOI8snGCaMiWTw==",
 			"requires": {
@@ -5211,7 +5211,7 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/odsp-urlresolver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.1000.tgz",
 			"integrity": "sha512-tcRRvS0kWJLQ1miCGuXMFTO5ELISoFyZpIG12oqnIXrx1wZ0njop5K49+isOO61xngSJ2QQn/kgohvvm4MO2zA==",
 			"requires": {
@@ -5249,7 +5249,7 @@
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/ordered-collection-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.1000.tgz",
 			"integrity": "sha512-xhZpeN3F9XlyiujcsW0foxG/WPhfw3B5ysUbg7pMoThFxkwqsWcmF18SkO0uiAj9ccnVGvOd7MyAIPxYqu+cFQ==",
 			"requires": {
@@ -5315,7 +5315,7 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/register-collection-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.1000.tgz",
 			"integrity": "sha512-aZL4/apKXW2b8qJO7AAg1fS85IjyiDTMBsLdOs0eC4BJ5ssRbkrHhAolcuEvWr2x6otzr/5ltUzNITbjpfUjWQ==",
 			"requires": {
@@ -5372,7 +5372,7 @@
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/replay-driver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.1000.tgz",
 			"integrity": "sha512-65Ud/QfLtXRxg1apxtxVz9A5f4JFFlJ1q+VZBK8GGGGYDDw4h5E838UhHgyN5jgpQUC+/z2Z1RTZoIkjuKXstg==",
 			"requires": {
@@ -5409,7 +5409,7 @@
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/request-handler-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.1000.tgz",
 			"integrity": "sha512-XQTusnpyTNEvR5tGztN4ZIcG7+tOwh1JDDVJydVdLawOlPD9SASGZBYY3pg4uXs0Pj25u5flXroeM8EcC2AURg==",
 			"requires": {
@@ -5495,7 +5495,7 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/routerlicious-driver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.1000.tgz",
 			"integrity": "sha512-Jjw894PYVmhcS+KAsW/cQj5unyKRLYGtrhllbUWV37C4AMJ+bWvs11CkMra891I4KloZKoxv6FpyJT6O7Xh02g==",
 			"requires": {
@@ -5569,7 +5569,7 @@
 			}
 		},
 		"@fluidframework/routerlicious-host-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/routerlicious-host-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-0.59.1000.tgz",
 			"integrity": "sha512-1faWHEtWqyZNr996C1zPWX/is0f08veoKbccwCSBlXBFyjZegRhqKkx786ahpxk54zxVRMuIJV0MuN/8Neia6Q==",
 			"requires": {
@@ -5592,7 +5592,7 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/routerlicious-urlresolver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-0.59.1000.tgz",
 			"integrity": "sha512-Fb1fTQH1SLmKz6EobQOrEhMD2EqI06pYHEuH29OaIV+HTAwepCfDS/qr7ImkO2AjEi4ctu24egY/nNl0f+Lc8w==",
 			"requires": {
@@ -5653,7 +5653,7 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/runtime-definitions-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.1000.tgz",
 			"integrity": "sha512-qqnBhU9x7aPWfGAAOZpoX2zRWvU9WmtdWhpfg6BRW+BgTCmuIb4abMwyqCaJPhew1CZ0TLVv02jTE0mk7lS/jw==",
 			"requires": {
@@ -5747,7 +5747,7 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/runtime-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.1000.tgz",
 			"integrity": "sha512-ew/I2sOFjc34J73Pn66BLe9JC+koU6P7HAz3hbG+4SDMDgXNxNA4Bp2AzGJPMq0fFzLHpKNcKFnRTIXYI88qOw==",
 			"requires": {
@@ -5822,7 +5822,7 @@
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "0.58.2002",
+			"version": "npm:@fluidframework/sequence-previous@0.58.2002",
 			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.58.2002.tgz",
 			"integrity": "sha512-pOGvIRy1zQr9wtX60QUbwsxNiXnkWql4hVyBHVbv7JBbJD8vSfmyblVyD+ddUm2VPXyAaKLOQFWRpngTQBzUgw==",
 			"requires": {
@@ -6872,7 +6872,7 @@
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/shared-object-base-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.1000.tgz",
 			"integrity": "sha512-du8IZ32lzoHBnp5XBBVdaIujex5blGw7B+wMrry2jzw80IgHhN0NjrC496klUktDLe25C6IhxpDA0JfNWZ8Gmw==",
 			"requires": {
@@ -6915,7 +6915,7 @@
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/shared-summary-block-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-0.59.1000.tgz",
 			"integrity": "sha512-yXtznzCmxnjfOyJtMl9chFQNYnayphkYnwIrhFSHvmH3JuRDST8TtTJaZEqSJERJxtuPm7FqLz4fP2XYcCIpqg==",
 			"requires": {
@@ -6934,7 +6934,7 @@
 			"integrity": "sha512-K6utPbwIoF4NOHlPOJ26xXnDDyysSM4lXnsnVSCMQ29cCTQUhHGg36pjMF+EYhVvbTkDsjRuxt+Y0GyDpoQRYQ=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/synthesize-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.1000.tgz",
 			"integrity": "sha512-K6utPbwIoF4NOHlPOJ26xXnDDyysSM4lXnsnVSCMQ29cCTQUhHGg36pjMF+EYhVvbTkDsjRuxt+Y0GyDpoQRYQ=="
 		},
@@ -6951,7 +6951,7 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/telemetry-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.1000.tgz",
 			"integrity": "sha512-1UwKRq+8+yYriKZo0YqGRSMe5MiNgwJN1mGt2Eaw6k5Fag+2SWSJ2RoYIQnMiPg/IDH1q/vWtr2Bu5QnDo8N6A==",
 			"requires": {
@@ -6963,7 +6963,7 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-client-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-0.59.1000.tgz",
 			"integrity": "sha512-91mlZ21hkUY/l8DqkXNYGLd0fjya0JWiB3hePPJIWy6oKfqHNKPTau61TgJNtKYP0is+LFf/KEMx0KtsMTAjww==",
 			"requires": {
@@ -6997,7 +6997,7 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-driver-definitions-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.1000.tgz",
 			"integrity": "sha512-eh/52XAXGteJSxfxWGKD5BnrYBj9kZf8MJOZgxp1AxqXU0APa02B7ScuI1gvy57luyhsbCxQOm1t2uRXvcm/8w==",
 			"requires": {
@@ -7240,7 +7240,7 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-drivers-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.1000.tgz",
 			"integrity": "sha512-OOSqDL6lyN4icxhaW0u+1UZ6jJihce9yVqPjfFW/EM/qOaslK+LeIIwJc0ZioQoH1cmAyD/Lz9le85FbVW9hjQ==",
 			"requires": {
@@ -7459,7 +7459,7 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-loader-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-0.59.1000.tgz",
 			"integrity": "sha512-zVTd5IhAOjrWPFrr955xgqPqApySHRThQ4TDigSsTd170Yjd5PjJlBHmJvO8ibsS8H9WTfFzy19+Oj9bgYxaww==",
 			"requires": {
@@ -7492,7 +7492,7 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-pairwise-generator-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.1000.tgz",
 			"integrity": "sha512-/4fyw0zTwaM9SudO9OR1S5DedEuT1N4E2rvg/UFn0CW4PYBi/LK3BCMO9CuK7Y7BI+nOMYD4Ef6GplLX2QnEFQ==",
 			"requires": {
@@ -7546,7 +7546,7 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-runtime-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.1000.tgz",
 			"integrity": "sha512-pgs4aU9g+X84AgCI2GoZynSlMFum3P/aayABxv21i0V7aI5+oRRwlaJXEF4hc1TK63SYS+jW0WUgKvUV0DcQ5w==",
 			"requires": {
@@ -7651,7 +7651,7 @@
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.1000.tgz",
 			"integrity": "sha512-zNYhn8NugiGo98lxIPkIa3wfqGo6zWMtv4tV6asPUgR2hasy8Q2VrEkBTmfmmE6HJsiTCNtlEUbxMjz2MzMK+Q==",
 			"requires": {
@@ -7705,7 +7705,7 @@
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/test-version-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-0.59.1000.tgz",
 			"integrity": "sha512-fUvGpKfQu/Aj7ZllUy7fCh1H8EWVq9HBKofMiKcrd4WVfXmrlL//h1lBQkNj0h2onlmlbqSRLPio9z63Lq34OA==",
 			"requires": {
@@ -7762,7 +7762,7 @@
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/tinylicious-client-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.1000.tgz",
 			"integrity": "sha512-JnBmuUEAl9VWPL+C+bc4I1ZHEWSnVDowVUz9x4jj6wjJtkFVYMKxPMfrCnehbLzXPfGG8pcdYjfYoxl6z/xhaQ==",
 			"requires": {
@@ -7872,7 +7872,7 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/tinylicious-driver-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.1000.tgz",
 			"integrity": "sha512-9McR39G+CUEdWaVqjNRzyKsOKfwbTPHELQbSmRpiFzWXmh8t9mzoMQV5f2B0wcjPjUkgXlPRPpXqIV9Ffn1Fkg==",
 			"requires": {
@@ -7972,7 +7972,7 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/tool-utils-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.1000.tgz",
 			"integrity": "sha512-aaH+ybxUdzoBWOkbCtpsT8zSllLcm6TbktO93DguSh0WDIHPK5cVl6kzhRE5yAO6sTlT7RHL/1d/CFA+O4zS2w==",
 			"requires": {
@@ -8005,7 +8005,7 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/undo-redo-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.1000.tgz",
 			"integrity": "sha512-0GamjG54FrXG9QHsSTHEv092VDWf/30sd62p8h0w1zjcoN+r2vGDsztQ6mVcexMB8BnX/pDVd51WvS2o2l4u0g==",
 			"requires": {
@@ -8027,7 +8027,7 @@
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/view-adapters-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.1000.tgz",
 			"integrity": "sha512-s5CV8HS9AWVkpemIXTMAsG32O3QFFsfIiJtu94DpRtslnZDIYNBhyT9oUPPEnVpEkaP+rJGMfAOkdh7ATHwnmQ==",
 			"requires": {
@@ -8046,7 +8046,7 @@
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/view-interfaces-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.1000.tgz",
 			"integrity": "sha512-KEv/iccEKfySJetEye8TvdimFj0K1nuADutKkdRAvvcCxXU03DChXVZtjqdHirVBXT9Djvl/lJDVPfeRmGfovw==",
 			"requires": {
@@ -8087,7 +8087,7 @@
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "0.59.1000",
+			"version": "npm:@fluidframework/web-code-loader-previous@0.59.1000",
 			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.1000.tgz",
 			"integrity": "sha512-W9Z151qbssS5FJNL+BHbjTBwFwX4G537sGK/kjWHPxpSohwXwXMJixZnO77uha7px44PbSwVvkgQhQpot7MhZw==",
 			"requires": {
@@ -27245,7 +27245,7 @@
 			"integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA="
 		},
 		"fluid-framework-previous": {
-			"version": "0.58.2002",
+			"version": "npm:fluid-framework-previous@0.58.2002",
 			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-0.58.2002.tgz",
 			"integrity": "sha512-5neTvjQJ/Xg9LNhGf6qgqOnqayVFSqaqDkBXNBJ3fDiU2f07lN8C2s9dAzsVQEJ71hFGkmigGs4cYty0z0ku3Q==",
 			"requires": {

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/fluid-static": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",
     "@fluidframework/sequence": "^0.60.1000"

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/fluid-static": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",
     "@fluidframework/sequence": "^0.60.1000"

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/fluid-static": "^0.60.1000",
     "@fluidframework/map": "^0.60.1000",
     "@fluidframework/sequence": "^0.60.1000"

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -75,7 +75,6 @@
   "typeValidation": {
     "version": "0.60.1000",
     "broken": {
-      "ClassDeclaration_FluidContainer": {"forwardCompat": false},
       "InterfaceDeclaration_IFluidContainer": {"forwardCompat": false}
     }
   }

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.ts
@@ -96,7 +96,6 @@ declare function get_old_ClassDeclaration_FluidContainer():
 declare function use_current_ClassDeclaration_FluidContainer(
     use: TypeOnly<current.FluidContainer>);
 use_current_ClassDeclaration_FluidContainer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidContainer());
 
 /*

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/driver-utils": "^0.60.1000",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/driver-utils": "^0.60.1000",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/driver-utils": "^0.60.1000",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -148,10 +148,6 @@ export class DeltaManagerProxy
         super.dispose();
     }
 
-    public close(): void {
-        return this.deltaManager.close();
-    }
-
     public submitSignal(content: any): void {
         return this.deltaManager.submitSignal(content);
     }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/telemetry-utils": "^0.60.1000"
   },

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/telemetry-utils": "^0.60.1000"
   },

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/telemetry-utils": "^0.60.1000"
   },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.60.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -115,15 +115,6 @@
   "typeValidation": {
     "version": "0.60.1000",
     "broken": {
-      "ClassDeclaration_Summarizer": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_ISummarizer": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_IProvideSummarizer": {
-        "forwardCompat": false
-      },
       "ClassDeclaration_ContainerRuntime": {
         "forwardCompat": false,
         "backCompat": false
@@ -146,7 +137,9 @@
       "InterfaceDeclaration_ITestContainerConfig": {
         "forwardCompat": false,
         "backCompat": false
-      }
+      },
+      "InterfaceDeclaration_IConnectableRuntime": {"backCompat": false},
+      "InterfaceDeclaration_ISummarizerRuntime": {"backCompat": false}
     }
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -446,6 +446,7 @@ declare function get_current_InterfaceDeclaration_IConnectableRuntime():
 declare function use_old_InterfaceDeclaration_IConnectableRuntime(
     use: TypeOnly<old.IConnectableRuntime>);
 use_old_InterfaceDeclaration_IConnectableRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnectableRuntime());
 
 /*
@@ -796,7 +797,6 @@ declare function get_old_InterfaceDeclaration_IProvideSummarizer():
 declare function use_current_InterfaceDeclaration_IProvideSummarizer(
     use: TypeOnly<current.IProvideSummarizer>);
 use_current_InterfaceDeclaration_IProvideSummarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideSummarizer());
 
 /*
@@ -965,7 +965,6 @@ declare function get_old_InterfaceDeclaration_ISummarizer():
 declare function use_current_InterfaceDeclaration_ISummarizer(
     use: TypeOnly<current.ISummarizer>);
 use_current_InterfaceDeclaration_ISummarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISummarizer());
 
 /*
@@ -1100,6 +1099,7 @@ declare function get_current_InterfaceDeclaration_ISummarizerRuntime():
 declare function use_old_InterfaceDeclaration_ISummarizerRuntime(
     use: TypeOnly<old.ISummarizerRuntime>);
 use_old_InterfaceDeclaration_ISummarizerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummarizerRuntime());
 
 /*
@@ -1498,7 +1498,6 @@ declare function get_old_ClassDeclaration_Summarizer():
 declare function use_current_ClassDeclaration_Summarizer(
     use: TypeOnly<current.Summarizer>);
 use_current_ClassDeclaration_Summarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_Summarizer());
 
 /*

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/runtime-definitions": "^0.60.1000",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/runtime-definitions": "^0.60.1000",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -62,6 +62,10 @@
   },
   "typeValidation": {
     "version": "0.60.1000",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_IFluidDataStoreRuntime": {
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/runtime-definitions": "^0.60.1000",

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.ts
@@ -204,6 +204,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: TypeOnly<old.IFluidDataStoreRuntime>);
 use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-utils": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -109,6 +109,10 @@
   },
   "typeValidation": {
     "version": "0.60.1000",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_FluidDataStoreRuntime": {
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.ts
@@ -60,6 +60,7 @@ declare function get_current_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_old_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<old.FluidDataStoreRuntime>);
 use_old_ClassDeclaration_FluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.1000",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/azure-service-utils": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/azure-service-utils": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/azure-service-utils": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.60.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -60,7 +60,7 @@
     "@fluid-internal/replay-tool": "^0.60.1000",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.60.1000",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -60,7 +60,7 @@
     "@fluid-internal/replay-tool": "^0.60.1000",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.60.1000",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -60,7 +60,7 @@
     "@fluid-internal/replay-tool": "^0.60.1000",
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.60.1000",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
@@ -23,7 +22,6 @@ import {
     ITestObjectProvider,
     DataObjectFactoryType,
 } from "@fluidframework/test-utils";
-import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
 
 interface ISharedObjectConstructor<T> {
@@ -50,7 +48,7 @@ function generate(
         });
         let dataStore1: ITestFluidObject;
         let dataStore2: ITestFluidObject;
-        let deltaManager2: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+        let closeContainer2: () => void;
         let sharedMap1: ISharedMap;
         let sharedMap2: ISharedMap;
         let sharedMap3: ISharedMap;
@@ -65,7 +63,7 @@ function generate(
             const container2 = await provider.loadTestContainer(testContainerConfig);
             dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
             sharedMap2 = await dataStore2.getSharedObject<SharedMap>(mapId);
-            deltaManager2 = container2.deltaManager;
+            closeContainer2 = () => container2.close();
 
             // Load the Container that was created by the first client.
             const container3 = await provider.loadTestContainer(testContainerConfig);
@@ -272,7 +270,7 @@ function generate(
             let waitRejected = false;
             waitAcquireAndComplete(collection2)
                 .catch(() => { waitRejected = true; });
-            deltaManager2.close();
+            closeContainer2();
 
             await collection1.add("testValue");
 

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.ts
+++ b/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.ts
@@ -161,6 +161,30 @@ use_old_VariableDeclaration_ensurePackageInstalled(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ExpectedEvents": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ExpectedEvents():
+    TypeOnly<old.ExpectedEvents>;
+declare function use_current_TypeAliasDeclaration_ExpectedEvents(
+    use: TypeOnly<current.ExpectedEvents>);
+use_current_TypeAliasDeclaration_ExpectedEvents(
+    get_old_TypeAliasDeclaration_ExpectedEvents());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ExpectedEvents": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ExpectedEvents():
+    TypeOnly<current.ExpectedEvents>;
+declare function use_old_TypeAliasDeclaration_ExpectedEvents(
+    use: TypeOnly<old.ExpectedEvents>);
+use_old_TypeAliasDeclaration_ExpectedEvents(
+    get_current_TypeAliasDeclaration_ExpectedEvents());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_ExpectsTest": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_ExpectsTest():

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/cell": "^0.60.1000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/container-runtime": "^0.60.1000",
     "@fluidframework/container-runtime-definitions": "^0.60.1000",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-64278",
+    "@fluidframework/container-definitions": "^0.49.1000-0",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-63433",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.60.1000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.49.1000-0",
+    "@fluidframework/container-definitions": "^0.49.1000-64278",
     "@fluidframework/container-loader": "^0.60.1000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.47.1000-0",

--- a/packages/tools/webpack-fluid-loader/src/test/types/validateWebpackFluidLoaderPrevious.ts
+++ b/packages/tools/webpack-fluid-loader/src/test/types/validateWebpackFluidLoaderPrevious.ts
@@ -61,3 +61,27 @@ declare function use_old_VariableDeclaration_before(
     use: TypeOnly<typeof old.before>);
 use_old_VariableDeclaration_before(
     get_current_VariableDeclaration_before());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_devServerConfig": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_devServerConfig():
+    TypeOnly<typeof old.devServerConfig>;
+declare function use_current_FunctionDeclaration_devServerConfig(
+    use: TypeOnly<typeof current.devServerConfig>);
+use_current_FunctionDeclaration_devServerConfig(
+    get_old_FunctionDeclaration_devServerConfig());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_devServerConfig": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_devServerConfig():
+    TypeOnly<typeof current.devServerConfig>;
+declare function use_old_FunctionDeclaration_devServerConfig(
+    use: TypeOnly<typeof old.devServerConfig>);
+use_old_FunctionDeclaration_devServerConfig(
+    get_current_FunctionDeclaration_devServerConfig());


### PR DESCRIPTION
This picks up #10048

Got 0.49.1000-64278 in the lock file, ~and updated package.json back to simply 0.49.1000-0 (I think this is required for our release tooling to work properly, FYI @kian-thompson and @wes-carlson - or maybe I'm wrong! I prefer the explicit version in package.json personally)~