### PR TITLE
GC: Add TestOverride.SessionExpiryMs config

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -42,7 +42,7 @@ export class DebugLogger extends TelemetryLogger {
     static create(namespace: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
     static mixinDebugLogger(namespace: string, baseLogger?: ITelemetryBaseLogger, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
     send(event: ITelemetryBaseEvent): void;
-    }
+}
 
 // @public (undocumented)
 export const disconnectedEventName = "disconnected";
@@ -52,7 +52,7 @@ export class EventEmitterWithErrorHandling<TEvent extends IEvent = IEvent> exten
     constructor(errorHandler: (eventName: EventEmitterEventType, error: any) => void);
     // (undocumented)
     emit(event: EventEmitterEventType, ...args: any[]): boolean;
-    }
+}
 
 // @public
 export function extractLogSafeErrorProperties(error: any, sanitizeStack: boolean): {
@@ -177,6 +177,8 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     constructor();
     assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string): void;
     assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string): void;
+    // (undocumented)
+    clear(): void;
     // (undocumented)
     events: ITelemetryBaseEvent[];
     matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): boolean;
@@ -304,14 +306,13 @@ export class ThresholdCounter {
     constructor(threshold: number, logger: ITelemetryLogger, thresholdMultiple?: number);
     send(eventName: string, value: number): void;
     sendIfMultiple(eventName: string, value: number): void;
-    }
+}
 
 // @public
 export function wrapError<T extends LoggingError>(innerError: unknown, newErrorFn: (message: string) => T): T;
 
 // @public
 export function wrapErrorAndLog<T extends LoggingError>(innerError: unknown, newErrorFn: (message: string) => T, logger: ITelemetryLogger): T;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -65,7 +65,7 @@ const runSweepKey = "Fluid.GarbageCollection.RunSweep";
 // Feature gate key to write GC data at the root of the summary tree.
 const writeAtRootKey = "Fluid.GarbageCollection.WriteDataAtRoot";
 // Feature gate key to expire a session after a set period of time.
-const runSessionExpiry = "Fluid.GarbageCollection.RunSessionExpiry";
+const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
 // Feature gate key to log error messages if GC reference validation fails.
 const logUnknownOutboundReferencesKey = "Fluid.GarbageCollection.LogUnknownOutboundReferences";
 
@@ -390,7 +390,7 @@ export class GarbageCollector implements IGarbageCollector {
             // For new documents, GC has to be explicitly enabled via the gcAllowed flag in GC options.
             this.gcEnabled = gcOptions.gcAllowed === true;
             // Set the Session Expiry only if the flag is enabled or the test option is set.
-            if (this.mc.config.getBoolean(runSessionExpiry) && this.gcEnabled) {
+            if (this.mc.config.getBoolean(runSessionExpiryKey) && this.gcEnabled) {
                 this.sessionExpiryTimeoutMs = defaultSessionExpiryDurationMs;
             }
         }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -398,10 +398,10 @@ export class GarbageCollector implements IGarbageCollector {
         // If session expiry is enabled, we need to close the container when the timeout expires
         if (this.sessionExpiryTimeoutMs !== undefined) {
             // If Test Override config is set, override Session Expiry timeout
-            const sessionExpiryTimeoutDays =
-                this.mc.config.getNumber("Fluid.GarbageCollection.TestOverride.SessionExpiryDays");
-            if (sessionExpiryTimeoutDays !== undefined) {
-                this.sessionExpiryTimeoutMs = sessionExpiryTimeoutDays * 24 * 60 * 60 * 1000;
+            const overrideSessionExpiryTimeoutMs =
+                this.mc.config.getNumber("Fluid.GarbageCollection.TestOverride.SessionExpiryMs");
+            if (overrideSessionExpiryTimeoutMs !== undefined) {
+                this.sessionExpiryTimeoutMs = overrideSessionExpiryTimeoutMs;
             }
 
             const timeoutMs = this.sessionExpiryTimeoutMs;

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -66,6 +66,8 @@ const runSweepKey = "Fluid.GarbageCollection.RunSweep";
 const writeAtRootKey = "Fluid.GarbageCollection.WriteDataAtRoot";
 // Feature gate key to expire a session after a set period of time.
 const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
+// Feature gate key to disable expiring session after a set period of time, even if expiry value is present
+const disableSessionExpiryKey = "Fluid.GarbageCollection.DisableSessionExpiry";
 // Feature gate key to log error messages if GC reference validation fails.
 const logUnknownOutboundReferencesKey = "Fluid.GarbageCollection.LogUnknownOutboundReferences";
 
@@ -396,7 +398,8 @@ export class GarbageCollector implements IGarbageCollector {
         }
 
         // If session expiry is enabled, we need to close the container when the timeout expires
-        if (this.sessionExpiryTimeoutMs !== undefined) {
+        if (this.sessionExpiryTimeoutMs !== undefined
+            && this.mc.config.getBoolean(disableSessionExpiryKey) !== true) {
             // If Test Override config is set, override Session Expiry timeout
             const overrideSessionExpiryTimeoutMs =
                 this.mc.config.getNumber("Fluid.GarbageCollection.TestOverride.SessionExpiryMs");

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -397,6 +397,13 @@ export class GarbageCollector implements IGarbageCollector {
 
         // If session expiry is enabled, we need to close the container when the timeout expires
         if (this.sessionExpiryTimeoutMs !== undefined) {
+            // If Test Override config is set, override Session Expiry timeout
+            const sessionExpiryTimeoutDays =
+                this.mc.config.getNumber("Fluid.GarbageCollection.TestOverride.SessionExpiryDays");
+            if (sessionExpiryTimeoutDays !== undefined) {
+                this.sessionExpiryTimeoutMs = sessionExpiryTimeoutDays * 24 * 60 * 60 * 1000;
+            }
+
             const timeoutMs = this.sessionExpiryTimeoutMs;
             setLongTimeout(timeoutMs,
                 () => {

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -161,7 +161,7 @@ describe("Garbage Collection Tests", () => {
             assert(customExpiryMs, "setting not found!");
 
             const metadata: IContainerRuntimeMetadata =
-                { summaryFormatVersion: 1, message: undefined, sessionExpiryTimeoutMs: 10};
+                { summaryFormatVersion: 1, message: undefined, sessionExpiryTimeoutMs: 10 };
             createGarbageCollector(undefined, undefined, metadata);
             assert(closeCalledAfterExactTicks(customExpiryMs), "Close should have been called at exact expiry.");
         });

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -105,7 +105,7 @@ describe("Garbage Collection Tests", () => {
         const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
         const injectedSettings = {};
         const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
-        const testOverrideSessionExpiryDaysKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryDays";
+        const testOverrideSessionExpiryMsKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
         before(() => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
@@ -140,10 +140,10 @@ describe("Garbage Collection Tests", () => {
         });
 
         it("Session expiry overridden via TestOverride setting (existing container)", async () => {
-            // Override expiry to 2 days
-            injectedSettings[testOverrideSessionExpiryDaysKey] = "2";
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const customExpiryMs = mc.config.getNumber(testOverrideSessionExpiryDaysKey)! * (24 * 60 * 60 * 1000);
+            // Override expiry to 2 seconds
+            injectedSettings[testOverrideSessionExpiryMsKey] = "2000";
+            const customExpiryMs = mc.config.getNumber(testOverrideSessionExpiryMsKey);
+            assert(customExpiryMs, "setting not found!");
 
             const metadata: IContainerRuntimeMetadata =
                 { summaryFormatVersion: 1, message: undefined, sessionExpiryTimeoutMs: 10};
@@ -152,10 +152,10 @@ describe("Garbage Collection Tests", () => {
         });
 
         it("Session expiry overridden via TestOverride setting (new container)", async () => {
-            // Override expiry to 2 days
-            injectedSettings[testOverrideSessionExpiryDaysKey] = "2";
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const customExpiryMs = mc.config.getNumber(testOverrideSessionExpiryDaysKey)! * (24 * 60 * 60 * 1000);
+            // Override expiry to 2 seconds
+            injectedSettings[testOverrideSessionExpiryMsKey] = "2000";
+            const customExpiryMs = mc.config.getNumber(testOverrideSessionExpiryMsKey);
+            assert(customExpiryMs, "setting not found!");
 
             createGarbageCollector();
             assert(closeCalledAfterExactTicks(customExpiryMs), "Close should have been called at exact expiry.");
@@ -163,9 +163,9 @@ describe("Garbage Collection Tests", () => {
 
         it("Session expiry override ignored if RunSessionExpiry setting disabled", async () => {
             injectedSettings[runSessionExpiryKey] = "false";
-            injectedSettings[testOverrideSessionExpiryDaysKey] = "2";
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const customExpiryMs = mc.config.getNumber(testOverrideSessionExpiryDaysKey)! * (24 * 60 * 60 * 1000);
+            injectedSettings[testOverrideSessionExpiryMsKey] = "2000";
+            const customExpiryMs = mc.config.getNumber(testOverrideSessionExpiryMsKey);
+            assert(customExpiryMs, "setting not found!");
 
             createGarbageCollector();
 

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -104,6 +104,8 @@
   },
   "typeValidation": {
     "version": "0.59.3000",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_MockLogger": {"forwardCompat": false}
+    }
   }
 }

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -15,6 +15,10 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
 
     constructor() { super(); }
 
+    clear() {
+        this.events = [];
+    }
+
     send(event: ITelemetryBaseEvent): void {
         this.events.push(event);
     }

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
@@ -672,6 +672,7 @@ declare function get_old_ClassDeclaration_MockLogger():
 declare function use_current_ClassDeclaration_MockLogger(
     use: TypeOnly<current.MockLogger>);
 use_current_ClassDeclaration_MockLogger(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockLogger());
 
 /*


### PR DESCRIPTION
Add a new number config `Fluid.GarbageCollection.TestOverride.SessionExpiryDays` which will override session expiry, but only if it's set.

I don't want this numerical value to have the power to suddenly enable session expiry where it wasn't already.  This makes using it for testing a little more difficult (you have to set `Fluid.GarbageCollection.RunSessionExpiry` and create new documents), but this seems fine.

This way in an emergency it could be used to _reduce_ the session expiry to 20 days or whatever to provide a way to rescue 0.56 and below clients (but it's awkward - the doc has to be summarized by a client with this code, and then the 0.56 client needs to refresh hard enough to load from a new summary).  So kind of low-value, but gives some peace of mind if it's within the realm of possibility.

I'm open to changing the semantics if we discuss and agree on a different choice.

Also, decided against adding an "escape hatch" to disable setting of the sessionExpiry timeout itself, because Tyler and I didn't feel there was really much risk for this code at this point and it's just another line of code that adds complexity.  @agarwal-navin what are your thoughts on this?

Thanks @tyler-cai-microsoft for pairing on this!