### PR TITLE
Start SharedTree workspace VSCode terminals in root directory

### DIFF
--- a/experimental/dds/tree/.vscode/SharedTree.code-workspace
+++ b/experimental/dds/tree/.vscode/SharedTree.code-workspace
@@ -9,4 +9,7 @@
         "path": ".."
       }
     ],
+    "settings": {
+      "terminal.integrated.cwd": "../../.."
+    }
   }


### PR DESCRIPTION
This is for convenience since command line tools (`npm i`, `lerna`) are generally invoked from the root of the FluidFramework package.

Newly created terminals in VSCode will start in `FluidFramework` rather than `FluidFramework/experimental/dds/tree`