### PR TITLE
Allow Quorum propose() promises to remain unsettled until reconnect after disconnect

### DIFF
--- a/server/routerlicious/packages/protocol-base/README.md
+++ b/server/routerlicious/packages/protocol-base/README.md
@@ -5,15 +5,9 @@ consistent across client and service. It also provides utilities for facilitatin
 
 ## Quorum and Proposal
 
-A quorum proposal transitions between four possible states: propose, accept, reject, and commit.
+A quorum proposal transitions between two states: propose and accept.
 
 A proposal begins in the propose state. The proposal is sent to the server and receives a sequence number which is
 used to uniquely identify it. Clients within the collaboration window accept the proposal by allowing their
-reference sequence number to go above the sequence number for the proposal. They reject it by submitting a reject
-message prior to sending a reference sequence number above the proposal number. Once the minimum sequence number
-goes above the sequence number for the proposal without any rejections it is considered accepted.
-
-The proposal enters the commit state when the minimum sequence number goes above the sequence number at which it
-became accepted. In the commit state all subsequent messages are guaranteed to have been sent with knowledge of
-the proposal. Between the accept and commit state there may be messages with reference sequence numbers prior to
-the proposal being accepted.
+reference sequence number to go above the sequence number for the proposal. Once the minimum sequence number
+goes above the sequence number for the proposal without it is considered accepted.

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -217,7 +217,9 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     }
 
     /**
-     * Proposes a new value. Returns a promise that will resolve when the proposal is either accepted or rejected.
+     * Proposes a new value. Returns a promise that will either:
+     * - Resolve when the proposal is accepted
+     * - Reject if the proposal fails to send or if the QuorumProposals is disposed
      */
     public async propose(key: string, value: any): Promise<void> {
         const clientSequenceNumber = this.sendProposal(key, value);

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -256,8 +256,10 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
 
             // There are two error flows we consider:  disconnect and disposal.
             // If we get disconnected before the proposal is sequenced, it has one of two possible futures:
-            // 1. We reconnect and see the proposal was sequenced in the meantime.  The promise resolves.
-            // 2. We reconnect and see the proposal was not sequenced in the meantime.  The promise rejects.
+            // 1. We reconnect and see the proposal was sequenced in the meantime.
+            //    -> The promise can still resolve, once it is approved.
+            // 2. We reconnect and see the proposal was not sequenced in the meantime, so it will never sequence.
+            //    -> The promise rejects.
             const disconnectedHandler = () => {
                 // If we haven't seen the ack by the time we disconnect, we hope to see it by the time we reconnect.
                 if (thisProposalSequenceNumber === undefined) {

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -204,11 +204,7 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
      * Returns the consensus value for the given key
      */
     public get(key: string): any {
-        const keyMap = this.values.get(key);
-        if (keyMap !== undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            return keyMap.value;
-        }
+        return this.values.get(key)?.value;
     }
 
     /**

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -304,9 +304,8 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
         );
         this.proposals.set(sequenceNumber, proposal);
 
-        // Emit the event - which will also provide clients an opportunity to reject the proposal. We require
-        // clients to make a rejection decision at the time of receiving the proposal and so disable rejecting it
-        // after we have emitted the event.
+        // Legacy event, from rejection support.  May still have some use for clients to learn that a proposal is
+        // likely to be approved soon.
         this.emit("addProposal", proposal);
 
         if (local) {

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -254,9 +254,14 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
             // 1. We reconnect and see the proposal was sequenced in the meantime.  The promise resolves.
             // 2. We reconnect and see the proposal was not sequenced in the meantime.  The promise rejects.
             const disconnectedHandler = () => {
+                // If we haven't seen the ack by the time we disconnect, we hope to see it by the time we reconnect.
                 if (targetSequenceNumber === undefined) {
                     this.stateEvents.once("connected", () => {
-                        reject(new Error("Client disconnected without successfully sending proposal"));
+                        // If we don't see the ack by the time reconnection finishes, it failed to send.
+                        if (targetSequenceNumber === undefined) {
+                            reject(new Error("Client disconnected without successfully sending proposal"));
+                            removeListeners();
+                        }
                     });
                 }
             };

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -23,8 +23,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 
 /**
- * Appends a deferred and rejection count to a sequenced proposal. For locally generated promises this allows us to
- * attach a Deferred which we will resolve once the proposal is either accepted or rejected.
+ * Structure for tracking proposals that have been sequenced but not approved yet.
  */
 class PendingProposal implements ISequencedProposal {
     constructor(
@@ -329,7 +328,7 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): void {
         const msn = message.minimumSequenceNumber;
 
-        // Accept proposals and reject proposals whose sequenceNumber is <= the minimumSequenceNumber
+        // Accept proposals proposals whose sequenceNumber is <= the minimumSequenceNumber
 
         // Return a sorted list of approved proposals. We sort so that we apply them in their sequence number order
         // TODO this can be optimized if necessary to avoid the linear search+sort
@@ -495,7 +494,8 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     }
 
     /**
-     * Proposes a new value. Returns a promise that will resolve when the proposal is either accepted or rejected.
+     * Proposes a new value. Returns a promise that will resolve when the proposal is either accepted, or reject if
+     * the proposal fails to send.
      */
     public async propose(key: string, value: any): Promise<void> {
         return this.quorumProposals.propose(key, value);

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -87,7 +87,7 @@ describe("Quorum", () => {
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 3");
 
             // Wait to see if the proposal promise resolved.
-            await Promise.resolve().then(() => {});
+            await Promise.resolve().then(() => { });
 
             assert.strictEqual(evented, false, "Should not have evented yet 2");
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 4");
@@ -100,9 +100,9 @@ describe("Quorum", () => {
             assert.strictEqual(quorum.get(proposalKey), proposalValue, "Should have the proposal value");
 
             // Wait to see if the proposal promise resolved.
-            await Promise.resolve().then(() => {});
+            await Promise.resolve().then(() => { });
             // Due to the composition of Quorum -> QuorumProposals, we require one more microtask deferral to resolve.
-            await Promise.resolve().then(() => {});
+            await Promise.resolve().then(() => { });
 
             // Acceptance should have happened before the above await resolves.
             acceptanceState = "too late";
@@ -167,7 +167,7 @@ describe("Quorum", () => {
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 2");
 
             // Wait to see if any async stuff is waiting (shouldn't be).
-            await Promise.resolve().then(() => {});
+            await Promise.resolve().then(() => { });
 
             assert.strictEqual(evented, false, "Should not have evented yet 2");
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 3");
@@ -178,7 +178,150 @@ describe("Quorum", () => {
             assert.strictEqual(quorum.get(proposalKey), proposalValue, "Should have the proposal value");
 
             // Wait to see if any async stuff is waiting (shouldn't be).
-            await Promise.resolve().then(() => {});
+            await Promise.resolve().then(() => { });
+        });
+
+        describe("Disconnected handling", () => {
+            it("Settling propose() promise after disconnect/reconnect", async () => {
+                const proposal1 = {
+                    key: "one",
+                    value: "uno",
+                    sequenceNumber: 53,
+                    resolved: false,
+                    rejected: false,
+                };
+                const proposal2 = {
+                    key: "two",
+                    value: "dos",
+                    sequenceNumber: 68,
+                    resolved: false,
+                    rejected: false,
+                };
+                const proposal3 = {
+                    key: "three",
+                    value: "tres",
+                    sequenceNumber: 92,
+                    resolved: false,
+                    rejected: false,
+                };
+
+                const messageApproving1 = {
+                    minimumSequenceNumber: 61,
+                    sequenceNumber: 64,
+                } as ISequencedDocumentMessage;
+                const messageApproving2 = {
+                    minimumSequenceNumber: 77,
+                    sequenceNumber: 82,
+                } as ISequencedDocumentMessage;
+                // Proposal 3 shouldn't actually get approved, but we will test that.
+                const messageApproving3 = {
+                    minimumSequenceNumber: 98,
+                    sequenceNumber: 107,
+                } as ISequencedDocumentMessage;
+
+                // Testing three scenarios:
+                // - Proposal 1 will be ack'd and approved before reconnection
+                // - Proposal 2 will be ack'd before reconnection, and then approved after reconnection
+                // - Proposal 3 will not be ack'd before reconnection, and so should reject.
+                const proposal1P = assert.doesNotReject(
+                    quorum.propose(proposal1.key, proposal1.value)
+                        .then(() => { proposal1.resolved = true; })
+                        .catch(() => { proposal1.rejected = true; }),
+                );
+                const proposal2P = assert.doesNotReject(
+                    quorum.propose(proposal2.key, proposal2.value)
+                        .then(() => { proposal2.resolved = true; })
+                        .catch(() => { proposal2.rejected = true; }),
+                );
+                const proposal3P = assert.rejects(
+                    quorum.propose(proposal3.key, proposal3.value)
+                        .then(() => { proposal3.resolved = true; })
+                        .catch(() => { proposal3.rejected = true; }),
+                );
+
+                quorum.setConnectionState(false);
+
+                // Wait to make sure the proposal promises have not settled from the disconnect.
+                await Promise.resolve().then(() => { });
+                // Due to the composition of Quorum -> QuorumProposals,
+                // we require one more microtask deferral to resolve.
+                await Promise.resolve().then(() => { });
+                assert.strictEqual(proposal1.resolved, false, "Stage 1, Prop 1, Resolved");
+                assert.strictEqual(proposal1.rejected, false, "Stage 1, Prop 1, Rejected");
+                assert.strictEqual(proposal2.resolved, false, "Stage 1, Prop 2, Resolved");
+                assert.strictEqual(proposal2.rejected, false, "Stage 1, Prop 2, Rejected");
+                assert.strictEqual(proposal3.resolved, false, "Stage 1, Prop 3, Resolved");
+                assert.strictEqual(proposal3.rejected, false, "Stage 1, Prop 3, Rejected");
+
+                // Now we're simulating "connecting" state, where we will see the ack's for proposals 1 and 2
+                // And also we'll advance the MSN past proposal 1
+                quorum.addProposal(proposal1.key, proposal1.value, proposal1.sequenceNumber, true, 1);
+                quorum.updateMinimumSequenceNumber(messageApproving1);
+                quorum.addProposal(proposal2.key, proposal2.value, proposal2.sequenceNumber, true, 2);
+
+                // Now we'll simulate the transition to connected state
+                quorum.setConnectionState(true);
+
+                // Wait to make sure the proposal promises have settled in the manner we expect.
+                await Promise.resolve().then(() => { });
+                // Due to the composition of Quorum -> QuorumProposals,
+                // we require one more microtask deferral to resolve.
+                await Promise.resolve().then(() => { });
+                assert.strictEqual(proposal1.resolved, true, "Stage 2, Prop 1, Resolved");
+                assert.strictEqual(proposal1.rejected, false, "Stage 2, Prop 1, Rejected");
+                assert.strictEqual(proposal2.resolved, false, "Stage 2, Prop 2, Resolved");
+                assert.strictEqual(proposal2.rejected, false, "Stage 2, Prop 2, Rejected");
+                assert.strictEqual(proposal3.resolved, false, "Stage 2, Prop 3, Resolved");
+                assert.strictEqual(proposal3.rejected, true, "Stage 2, Prop 3, Rejected");
+
+                // Verify the quorum holds the data we expect.
+                assert.strictEqual(quorum.get(proposal1.key), proposal1.value, "Value 1 missing");
+                assert.strictEqual(quorum.get(proposal2.key), undefined, "Unexpected value 2");
+                assert.strictEqual(quorum.get(proposal3.key), undefined, "Unexpected value 3");
+
+                // Now advance the MSN past proposal 2
+                quorum.updateMinimumSequenceNumber(messageApproving2);
+
+                // Wait to make sure the proposal promises have settled in the manner we expect.
+                await Promise.resolve().then(() => { });
+                // Due to the composition of Quorum -> QuorumProposals,
+                // we require one more microtask deferral to resolve.
+                await Promise.resolve().then(() => { });
+                assert.strictEqual(proposal1.resolved, true, "Stage 3, Prop 1, Resolved");
+                assert.strictEqual(proposal1.rejected, false, "Stage 3, Prop 1, Rejected");
+                assert.strictEqual(proposal2.resolved, true, "Stage 3, Prop 2, Resolved");
+                assert.strictEqual(proposal2.rejected, false, "Stage 3, Prop 2, Rejected");
+                assert.strictEqual(proposal3.resolved, false, "Stage 3, Prop 3, Resolved");
+                assert.strictEqual(proposal3.rejected, true, "Stage 3, Prop 3, Rejected");
+
+                // Verify the quorum holds the data we expect.
+                assert.strictEqual(quorum.get(proposal1.key), proposal1.value, "Value 1 missing");
+                assert.strictEqual(quorum.get(proposal2.key), proposal2.value, "Value 2 missing");
+                assert.strictEqual(quorum.get(proposal3.key), undefined, "Unexpected value 3");
+
+                // Now advance the MSN past proposal 3 (this should have no real effect)
+                quorum.updateMinimumSequenceNumber(messageApproving3);
+
+                // Wait to make sure the proposal promises have settled in the manner we expect.
+                await Promise.resolve().then(() => { });
+                // Due to the composition of Quorum -> QuorumProposals,
+                // we require one more microtask deferral to resolve.
+                await Promise.resolve().then(() => { });
+                assert.strictEqual(proposal1.resolved, true, "Stage 4, Prop 1, Resolved");
+                assert.strictEqual(proposal1.rejected, false, "Stage 4, Prop 1, Rejected");
+                assert.strictEqual(proposal2.resolved, true, "Stage 4, Prop 2, Resolved");
+                assert.strictEqual(proposal2.rejected, false, "Stage 4, Prop 2, Rejected");
+                assert.strictEqual(proposal3.resolved, false, "Stage 4, Prop 3, Resolved");
+                assert.strictEqual(proposal3.rejected, true, "Stage 4, Prop 3, Rejected");
+
+                // Verify the quorum holds the data we expect.
+                assert.strictEqual(quorum.get(proposal1.key), proposal1.value, "Value 1 missing");
+                assert.strictEqual(quorum.get(proposal2.key), proposal2.value, "Value 2 missing");
+                assert.strictEqual(quorum.get(proposal3.key), undefined, "Unexpected value 3");
+
+                // Backstop to ensure the doesNotReject/rejects promises are complete.
+                await Promise.all([proposal1P, proposal2P, proposal3P]).catch(() => { });
+            });
         });
     });
 


### PR DESCRIPTION
Related to #10191 

When we get disconnected, it's possible our outstanding proposal actually _was_ sequenced and we just didn't see the ack before disconnecting.  In this case, we'll see the ack on reconnect and hit the 0x1d1 assert.

This change restructures the handling of local proposal promises and permits them to remain unsettled until the reconnect completes -- this is when we learn whether our outstanding proposals were seen by the server or got vanished.