### PR TITLE
Use pipeline for aggregate instead of just group

### DIFF
--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -17,7 +17,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
         this.collectionName = `${namespace}-${name}`;
     }
 
-    public aggregate(group: any, options?: any): any {
+    public aggregate(pipeline: any, options?: any): any {
         throw new Error("Method Not Implemented");
     }
 

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -45,7 +45,7 @@ export interface ICollection<T> {
      * @param options - optional settings
      * @returns - cursor you can use to iterate over aggregated results
      */
-    aggregate(group: any, options?: any): any;
+    aggregate(pipeline: any, options?: any): any;
     /**
      * Finds queries in the database
      *

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -21,9 +21,9 @@ export async function deleteSummarizedOps(
             return Promise.reject(error);
         }
 
-        const uniqueDocuments = await documentsCollection.aggregate(
-            { _id: { documentId: "$documentId", tenantId: "$tenantId" } },
-        ).toArray();
+        const uniqueDocuments = await documentsCollection.aggregate([
+            { $group: { _id: { documentId: "$documentId", tenantId: "$tenantId" } } },
+        ]).toArray();
 
         const currentEpochTime = new Date().getTime();
         const epochTimeBeforeOfflineWindow = currentEpochTime - offlineWindowMs;

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -14,9 +14,7 @@ export class MongoCollection<T> implements core.ICollection<T> {
     constructor(private readonly collection: Collection<T>) {
     }
 
-    public aggregate(group: any, options?: any): AggregationCursor<T> {
-        const pipeline: any = [];
-        pipeline.$group = group;
+    public aggregate(pipeline: any, options?: any): AggregationCursor<T> {
         return this.collection.aggregate(pipeline, options);
     }
 

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -11,7 +11,7 @@ export class TestCollection implements ICollection<any> {
     constructor(public collection: any[]) {
     }
 
-    public async aggregate(group: any, options?: any) {
+    public async aggregate(pipeline: any, options?: any) {
         throw new Error("Method not implemented.");
     }
 

--- a/server/tinylicious/src/services/inMemorycollection.ts
+++ b/server/tinylicious/src/services/inMemorycollection.ts
@@ -14,7 +14,7 @@ export class Collection<T> implements ICollection<T> {
     constructor() {
     }
 
-    public aggregate(group: any, options?: any): any {
+    public aggregate(pipeline: any, options?: any): any {
         throw new Error("Method Not Implemented");
     }
 

--- a/server/tinylicious/src/services/levelDbCollection.ts
+++ b/server/tinylicious/src/services/levelDbCollection.ts
@@ -40,7 +40,7 @@ export class Collection<T> implements ICollection<T> {
                 private readonly property: ICollectionProperty) {
     }
 
-    public aggregate(group: any, options?: any): any {
+    public aggregate(pipeline: any, options?: any): any {
         throw new Error("Method Not Implemented");
     }
 


### PR DESCRIPTION
The aggregate for mongo uses an array as a pipeline. Previous implementation limited it only to group. Now extend it to take the array instead.