### PR TITLE
Add optional constructor param to Deferred to ensure rejections are handled

### DIFF
--- a/common/lib/common-utils/src/promises.ts
+++ b/common/lib/common-utils/src/promises.ts
@@ -12,12 +12,25 @@ export class Deferred<T> {
     private rej: ((reason?: any) => void) | undefined;
     private completed: boolean = false;
 
-    constructor() {
+    /**
+     * Create the Deferred, initializing the backing Promise
+     * If there may be a case where reject is called but no one awaits or .catch's the Promise,
+     * pass onRejection to avoid triggering an unhandledRejection.
+     * @param onRejection - (Optional) callback to pass to .catch on the Promise to ensure it isn't left floating.
+     */
+    constructor(onRejection?: (e: any) => void) {
         this.p = new Promise<T>((resolve, reject) => {
             this.res = resolve;
             this.rej = reject;
         });
+
+        // This guards against the case where reject is called but no one properly handles this.p,
+        // which results in an unhandledRejection event on the process/window.
+        if (onRejection !== undefined) {
+            this.p.catch(onRejection);
+        }
     }
+
     /**
      * Returns whether the underlying promise has been completed
      */

--- a/common/lib/common-utils/src/test/mocha/promises.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/promises.spec.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { Deferred } from "../..";
+
+describe.only("Deferred", () => {
+    it("reject rejects", async () => {
+        const deferred = new Deferred();
+        deferred.reject(new Error("Oh no!"));
+        await assert.rejects(deferred.promise);
+    });
+    it("unhandledRejection protection", async () => {
+        let rejectedWith: Error | undefined;
+
+        // Passing this callback is required to avoid an unhandledRejection,
+        // since the test doesn't await or .catch the promise
+        const deferred = new Deferred((e) => { rejectedWith = e; });
+        deferred.reject(new Error("Oh no!"));
+
+        await Promise.resolve();
+        assert(rejectedWith !== undefined && rejectedWith.message === "Oh no!");
+    });
+});


### PR DESCRIPTION
There are cases where Deferred is used in such a way that `reject(...)` is called but then no one ever follows up on the rejected promise.  This results in an unhandled rejection event on the process/window.  This change highlights the need to think through floating promises with Deferred, and provides a way to easily protect against this.