### PR TITLE
[GitRest] Allowing asyncLocalStorage to be passed as a parameter

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/app.ts
+++ b/server/gitrest/packages/gitrest-base/src/app.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { AsyncLocalStorage } from "async_hooks";
 import { json, urlencoded } from "body-parser";
 import cors from "cors";
 import express, { Express } from "express";
@@ -31,6 +32,7 @@ export function create(
     store: nconf.Provider,
     fileSystemManagerFactory: IFileSystemManagerFactory,
     repositoryManagerFactory: IRepositoryManagerFactory,
+    asyncLocalStorage?: AsyncLocalStorage<string>,
 ) {
     // Express app configuration
     const app: Express = express();
@@ -63,7 +65,7 @@ export function create(
     app.use(json({ limit: requestSize }));
     app.use(urlencoded({ limit: requestSize, extended: false }));
 
-    app.use(bindCorrelationId());
+    app.use(bindCorrelationId(asyncLocalStorage));
 
     app.use(cors());
 

--- a/server/gitrest/packages/gitrest-base/src/runner.ts
+++ b/server/gitrest/packages/gitrest-base/src/runner.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { AsyncLocalStorage } from "async_hooks";
 import { Deferred } from "@fluidframework/common-utils";
 import { IWebServer, IWebServerFactory, IRunner } from "@fluidframework/server-services-core";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
@@ -19,13 +20,18 @@ export class GitrestRunner implements IRunner {
         private readonly config: Provider,
         private readonly port: string | number,
         private readonly fileSystemManagerFactory: IFileSystemManagerFactory,
-        private readonly repositoryManagerFactory: IRepositoryManagerFactory) {
+        private readonly repositoryManagerFactory: IRepositoryManagerFactory,
+        private readonly asyncLocalStorage?: AsyncLocalStorage<string>) {
     }
 
     public async start(): Promise<void> {
         this.runningDeferred = new Deferred<void>();
         // Create the gitrest app
-        const gitrest = app.create(this.config, this.fileSystemManagerFactory, this.repositoryManagerFactory);
+        const gitrest = app.create(
+            this.config,
+            this.fileSystemManagerFactory,
+            this.repositoryManagerFactory,
+            this.asyncLocalStorage);
         gitrest.set("port", this.port);
 
         this.server = this.serverFactory.create(gitrest);

--- a/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { AsyncLocalStorage } from "async_hooks";
 import { Provider } from "nconf";
 import * as services from "@fluidframework/server-services-shared";
 import * as core from "@fluidframework/server-services-core";
@@ -25,7 +26,8 @@ export class GitrestResources implements core.IResources {
         public readonly config: Provider,
         public readonly port: string | number,
         public readonly fileSystemManagerFactory: IFileSystemManagerFactory,
-        public readonly repositoryManagerFactory: IRepositoryManagerFactory) {
+        public readonly repositoryManagerFactory: IRepositoryManagerFactory,
+        public readonly asyncLocalStorage?: AsyncLocalStorage<string>) {
         this.webServerFactory = new services.BasicWebServerFactory();
     }
 
@@ -57,8 +59,14 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
             throw new Error("Invalid git library name.");
         };
         const repositoryManagerFactory = getRepositoryManagerFactory();
+        const asyncLocalStorage = config.get("asyncLocalStorageInstance")?.[0];
 
-        return new GitrestResources(config, port, fileSystemManagerFactory, repositoryManagerFactory);
+        return new GitrestResources(
+            config,
+            port,
+            fileSystemManagerFactory,
+            repositoryManagerFactory,
+            asyncLocalStorage);
     }
 }
 
@@ -69,6 +77,7 @@ export class GitrestRunnerFactory implements core.IRunnerFactory<GitrestResource
             resources.config,
             resources.port,
             resources.fileSystemManagerFactory,
-            resources.repositoryManagerFactory);
+            resources.repositoryManagerFactory,
+            resources.asyncLocalStorage);
     }
 }


### PR DESCRIPTION
GitRest logs were not working properly with respect to `correlationId`. It turns out that's because GitRest was using the default `AsyncLocalStorage` instance every time. In this PR, I am updating GitRest to accept an `AsyncLocalStorage` parameter, similar to what is done in Historian.