### PR TITLE
Fix dependency and lint issues in azure monorepo

### DIFF
--- a/azure/lerna-package-lock.json
+++ b/azure/lerna-package-lock.json
@@ -396,19 +396,6 @@
 				"strip-json-comments": "^3.1.1"
 			}
 		},
-		"@fluid-experimental/data-objects": {
-			"version": "0.59.2001",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/data-objects/-/data-objects-0.59.2001.tgz",
-			"integrity": "sha512-JS2UVPMZ4TXW2qQSgyLCKy4WclM1zua1wQtyp5ICM02jC2Ut1BOMo9fwBnqxrpoSkm9FEqYkRV2mPBt+Eutcsg==",
-			"requires": {
-				"@fluidframework/aqueduct": "^0.59.2001",
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/datastore-definitions": "^0.59.2001",
-				"@fluidframework/map": "^0.59.2001",
-				"@fluidframework/runtime-definitions": "^0.59.2001"
-			}
-		},
 		"@fluid-experimental/get-container": {
 			"version": "0.59.2001",
 			"resolved": "https://registry.npmjs.org/@fluid-experimental/get-container/-/get-container-0.59.2001.tgz",
@@ -452,6 +439,27 @@
 						"semver": "^6.3.0",
 						"sha.js": "^2.4.11",
 						"uuid": "^8.3.1"
+					},
+					"dependencies": {
+						"@fluidframework/server-services-client": {
+							"version": "0.1036.2000",
+							"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+							"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+							"requires": {
+								"@fluidframework/common-utils": "^0.32.1",
+								"@fluidframework/gitresources": "^0.1036.2000",
+								"@fluidframework/protocol-base": "^0.1036.2000",
+								"@fluidframework/protocol-definitions": "^0.1028.1000",
+								"axios": "^0.26.0",
+								"crc-32": "1.2.0",
+								"debug": "^4.1.1",
+								"json-stringify-safe": "^5.0.1",
+								"jsrsasign": "^10.2.0",
+								"jwt-decode": "^3.0.0",
+								"sillyname": "^0.1.0",
+								"uuid": "^8.3.1"
+							}
+						}
 					}
 				},
 				"@fluidframework/server-lambdas-driver": {
@@ -465,6 +473,27 @@
 						"@fluidframework/server-services-telemetry": "^0.1036.2000",
 						"async": "^3.2.2",
 						"lodash": "^4.17.21"
+					},
+					"dependencies": {
+						"@fluidframework/server-services-client": {
+							"version": "0.1036.2000",
+							"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+							"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+							"requires": {
+								"@fluidframework/common-utils": "^0.32.1",
+								"@fluidframework/gitresources": "^0.1036.2000",
+								"@fluidframework/protocol-base": "^0.1036.2000",
+								"@fluidframework/protocol-definitions": "^0.1028.1000",
+								"axios": "^0.26.0",
+								"crc-32": "1.2.0",
+								"debug": "^4.1.1",
+								"json-stringify-safe": "^5.0.1",
+								"jsrsasign": "^10.2.0",
+								"jwt-decode": "^3.0.0",
+								"sillyname": "^0.1.0",
+								"uuid": "^8.3.1"
+							}
+						}
 					}
 				},
 				"@fluidframework/server-local-server": {
@@ -483,6 +512,27 @@
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
+					},
+					"dependencies": {
+						"@fluidframework/server-services-client": {
+							"version": "0.1036.2000",
+							"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+							"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+							"requires": {
+								"@fluidframework/common-utils": "^0.32.1",
+								"@fluidframework/gitresources": "^0.1036.2000",
+								"@fluidframework/protocol-base": "^0.1036.2000",
+								"@fluidframework/protocol-definitions": "^0.1028.1000",
+								"axios": "^0.26.0",
+								"crc-32": "1.2.0",
+								"debug": "^4.1.1",
+								"json-stringify-safe": "^5.0.1",
+								"jsrsasign": "^10.2.0",
+								"jwt-decode": "^3.0.0",
+								"sillyname": "^0.1.0",
+								"uuid": "^8.3.1"
+							}
+						}
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
@@ -508,6 +558,27 @@
 						"sillyname": "^0.1.0",
 						"uuid": "^8.3.1",
 						"ws": "^7.4.6"
+					},
+					"dependencies": {
+						"@fluidframework/server-services-client": {
+							"version": "0.1036.2000",
+							"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+							"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+							"requires": {
+								"@fluidframework/common-utils": "^0.32.1",
+								"@fluidframework/gitresources": "^0.1036.2000",
+								"@fluidframework/protocol-base": "^0.1036.2000",
+								"@fluidframework/protocol-definitions": "^0.1028.1000",
+								"axios": "^0.26.0",
+								"crc-32": "1.2.0",
+								"debug": "^4.1.1",
+								"json-stringify-safe": "^5.0.1",
+								"jsrsasign": "^10.2.0",
+								"jwt-decode": "^3.0.0",
+								"sillyname": "^0.1.0",
+								"uuid": "^8.3.1"
+							}
+						}
 					}
 				},
 				"@fluidframework/server-services-core": {
@@ -524,6 +595,27 @@
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
 						"nconf": "^0.11.4"
+					},
+					"dependencies": {
+						"@fluidframework/server-services-client": {
+							"version": "0.1036.2000",
+							"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+							"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+							"requires": {
+								"@fluidframework/common-utils": "^0.32.1",
+								"@fluidframework/gitresources": "^0.1036.2000",
+								"@fluidframework/protocol-base": "^0.1036.2000",
+								"@fluidframework/protocol-definitions": "^0.1028.1000",
+								"axios": "^0.26.0",
+								"crc-32": "1.2.0",
+								"debug": "^4.1.1",
+								"json-stringify-safe": "^5.0.1",
+								"jsrsasign": "^10.2.0",
+								"jwt-decode": "^3.0.0",
+								"sillyname": "^0.1.0",
+								"uuid": "^8.3.1"
+							}
+						}
 					}
 				},
 				"@fluidframework/server-services-telemetry": {
@@ -554,6 +646,27 @@
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
 						"uuid": "^8.3.1"
+					},
+					"dependencies": {
+						"@fluidframework/server-services-client": {
+							"version": "0.1036.2000",
+							"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+							"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+							"requires": {
+								"@fluidframework/common-utils": "^0.32.1",
+								"@fluidframework/gitresources": "^0.1036.2000",
+								"@fluidframework/protocol-base": "^0.1036.2000",
+								"@fluidframework/protocol-definitions": "^0.1028.1000",
+								"axios": "^0.26.0",
+								"crc-32": "1.2.0",
+								"debug": "^4.1.1",
+								"json-stringify-safe": "^5.0.1",
+								"jsrsasign": "^10.2.0",
+								"jwt-decode": "^3.0.0",
+								"sillyname": "^0.1.0",
+								"uuid": "^8.3.1"
+							}
+						}
 					}
 				},
 				"semver": {
@@ -610,6 +723,27 @@
 				"@fluidframework/server-services-client": "^0.1036.1000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/server-services-client": {
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
+						"@fluidframework/protocol-definitions": "^0.1028.1000",
+						"axios": "^0.26.0",
+						"crc-32": "1.2.0",
+						"debug": "^4.1.1",
+						"json-stringify-safe": "^5.0.1",
+						"jsrsasign": "^10.2.0",
+						"jwt-decode": "^3.0.0",
+						"sillyname": "^0.1.0",
+						"uuid": "^8.3.1"
+					}
+				}
 			}
 		},
 		"@fluidframework/azure-local-service": {
@@ -646,9 +780,9 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.64540",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-			"integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+			"version": "0.2.65117",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+			"integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -1032,6 +1166,25 @@
 						"ws": "^7.4.6"
 					}
 				},
+				"@fluidframework/server-services-client": {
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
+						"@fluidframework/protocol-definitions": "^0.1028.1000",
+						"axios": "^0.26.0",
+						"crc-32": "1.2.0",
+						"debug": "^4.1.1",
+						"json-stringify-safe": "^5.0.1",
+						"jsrsasign": "^10.2.0",
+						"jwt-decode": "^3.0.0",
+						"sillyname": "^0.1.0",
+						"uuid": "^8.3.1"
+					}
+				},
 				"@fluidframework/server-services-core": {
 					"version": "0.1036.2000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.2000.tgz",
@@ -1176,6 +1329,27 @@
 				"socket.io-client": "^4.4.1",
 				"url-parse": "^1.5.8",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/server-services-client": {
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
+						"@fluidframework/protocol-definitions": "^0.1028.1000",
+						"axios": "^0.26.0",
+						"crc-32": "1.2.0",
+						"debug": "^4.1.1",
+						"json-stringify-safe": "^5.0.1",
+						"jsrsasign": "^10.2.0",
+						"jwt-decode": "^3.0.0",
+						"sillyname": "^0.1.0",
+						"uuid": "^8.3.1"
+					}
+				}
 			}
 		},
 		"@fluidframework/runtime-definitions": {
@@ -1501,13 +1675,13 @@
 			}
 		},
 		"@fluidframework/server-services-client": {
-			"version": "0.1036.2000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
-			"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.3000-65108.tgz",
+			"integrity": "sha512-TEyXI6vP0mjt5Kcyq3GY7t6yzOwjEqNQVtzNE3rvjBOx/2PVqqQHNSz/a/Ikqj/HqzlPvQy/ncPbHvjmtqxPuQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "^0.1036.2000",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/gitresources": "0.1036.3000-65108",
+				"@fluidframework/protocol-base": "0.1036.3000-65108",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -1517,6 +1691,24 @@
 				"jwt-decode": "^3.0.0",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/gitresources": {
+					"version": "0.1036.3000-65108",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000-65108.tgz",
+					"integrity": "sha512-CkJ8GbSqgWEmLPeABT2199uSEV+8xipsi70z4j9x44WUMP5fw4Bg/53uSFfNdrAy9GjqV1dTiv9X97yaxeCdyQ=="
+				},
+				"@fluidframework/protocol-base": {
+					"version": "0.1036.3000-65108",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.3000-65108.tgz",
+					"integrity": "sha512-s9bc9bbJYEq3zOfSqR3SzrmoGYoR+90AzUBbdeBDjLk98QSJUjHJHg1bwnQ7m4LGrYJNQ6+iSsaA/x8oC75TFg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "0.1036.3000-65108",
+						"@fluidframework/protocol-definitions": "^0.1028.1000",
+						"lodash": "^4.17.21"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-services-core": {
@@ -1867,26 +2059,6 @@
 			"integrity": "sha512-ZRSSKPXMm/ni/hDztf38GMBtzFez0Q9XXaY5abd2rQz76A3wIK+yzQerTqnZYBnwrzGwZi22Ne1FXND1JeFMZA==",
 			"dev": true
 		},
-		"@fluidframework/tinylicious-client": {
-			"version": "0.59.2001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.2001.tgz",
-			"integrity": "sha512-gwYFS+1YxB9SRQAni2HDa1QQ9jZsqu0hn3zNCMxYCDvD4XYnjh7eiTLAj1kjNMEgL3zZHL6OOE+Fs6cZ1QSbqQ==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2001",
-				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2001",
-				"@fluidframework/fluid-static": "^0.59.2001",
-				"@fluidframework/map": "^0.59.2001",
-				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2001",
-				"@fluidframework/runtime-utils": "^0.59.2001",
-				"@fluidframework/tinylicious-driver": "^0.59.2001",
-				"uuid": "^8.3.1"
-			}
-		},
 		"@fluidframework/tinylicious-driver": {
 			"version": "0.59.2001",
 			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.2001.tgz",
@@ -1900,6 +2072,27 @@
 				"@fluidframework/server-services-client": "^0.1036.2000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/server-services-client": {
+					"version": "0.1036.2000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000.tgz",
+					"integrity": "sha512-8vqUlhbairY8UH6AaOfePpaecJy3jyhRqRuthfU5nweJC1dZkaCQusC2B4B/tp0VNh3nlOdFAJZgWPZHT6m9Qg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.32.1",
+						"@fluidframework/gitresources": "^0.1036.2000",
+						"@fluidframework/protocol-base": "^0.1036.2000",
+						"@fluidframework/protocol-definitions": "^0.1028.1000",
+						"axios": "^0.26.0",
+						"crc-32": "1.2.0",
+						"debug": "^4.1.1",
+						"json-stringify-safe": "^5.0.1",
+						"jsrsasign": "^10.2.0",
+						"jwt-decode": "^3.0.0",
+						"sillyname": "^0.1.0",
+						"uuid": "^8.3.1"
+					}
+				}
 			}
 		},
 		"@fluidframework/view-interfaces": {
@@ -20370,21 +20563,69 @@
 			}
 		},
 		"ts-loader": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
-			"integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+			"integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
 			"requires": {
-				"chalk": "^2.3.0",
+				"chalk": "^4.1.0",
 				"enhanced-resolve": "^4.0.0",
-				"loader-utils": "^1.0.2",
+				"loader-utils": "^2.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^6.0.0"
+				"semver": "^7.3.4"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"loader-utils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+					"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -57,9 +57,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.64540",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.64540.tgz",
-      "integrity": "sha512-mqmezRhvyYlqV7pJ/wKWvGVDuRbj3oLLxDzORBpQVhiIFCxdk2uPclGVdan81lNdjdm02Ex4uklyk0hfWZbrNA==",
+      "version": "0.2.65117",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.65117.tgz",
+      "integrity": "sha512-r47Ap/LRMeSD62Gs+/jxSIccGGNTKDpmLt8hpohFHyF7wYRpsYsvw9Hyidki9cTSCZArsMhgsvH9HJ4t4/JOOg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",

--- a/azure/package.json
+++ b/azure/package.json
@@ -44,7 +44,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.64540",
+    "@fluidframework/build-tools": "^0.2.65117",
     "@fluidframework/test-tools": "^0.2.3074",
     "@microsoft/api-documenter": "^7.17.9",
     "@microsoft/api-extractor": "^7.22.2",

--- a/azure/packages/external-controller/.eslintrc.js
+++ b/azure/packages/external-controller/.eslintrc.js
@@ -7,5 +7,7 @@ module.exports = {
     "extends": [
         "@fluidframework/eslint-config-fluid"
     ],
-    "rules": {}
+    "rules": {
+        "import/no-extraneous-dependencies": "warn",
+    }
 }

--- a/azure/packages/external-controller/.eslintrc.js
+++ b/azure/packages/external-controller/.eslintrc.js
@@ -8,6 +8,8 @@ module.exports = {
         "@fluidframework/eslint-config-fluid"
     ],
     "rules": {
+        // Demoted to warning as a workaround to layer-check challenges. Tracked by:
+        // https://github.com/microsoft/FluidFramework/issues/10226
         "import/no-extraneous-dependencies": "warn",
     }
 }


### PR DESCRIPTION
Since there's no CI yet, some issues snuck in in the original commit. Namely, build-tools had the wrong hoisted version, and an import lint issue needed to be suppressed. See #10226 for more details.