### PR TITLE
Fix lint issue in treeUtils.ts that was introduced due to merge

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -348,11 +348,10 @@ export interface IGarbageCollectionRuntime {
 // @public (undocumented)
 export interface IGCRuntimeOptions {
     [key: string]: any;
-    // (undocumented)
     disableGC?: boolean;
     gcAllowed?: boolean;
     runFullGC?: boolean;
-    runSweep?: boolean;
+    sweepAllowed?: boolean;
 }
 
 // @public

--- a/packages/loader/driver-utils/src/treeUtils.ts
+++ b/packages/loader/driver-utils/src/treeUtils.ts
@@ -29,7 +29,7 @@ export interface ISummaryTreeAssemblerProps {
  */
 export class SummaryTreeAssembler {
     private attachmentCounter: number = 0;
-    private readonly summaryTree: { [path: string]: SummaryObject } = {};
+    private readonly summaryTree: { [path: string]: SummaryObject; } = {};
 
     constructor(
         private readonly props?: ISummaryTreeAssemblerProps,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1466,10 +1466,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             summaryNumber: this.nextSummaryNumber++,
             summaryFormatVersion: 1,
             disableIsolatedChannels: this.disableIsolatedChannels || undefined,
+            ...this.garbageCollector.getMetadata(),
             // The last message processed at the time of summary. If there are no new messages, use the message from the
             // last summary.
             message: extractSummaryMetadataMessage(this.deltaManager.lastMessage) ?? this.messageAtLastSummary,
-            ...this.garbageCollector.getMetadata(),
         };
         addBlobToSummary(summaryTree, metadataBlobName, JSON.stringify(metadata));
     }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -208,29 +208,34 @@ const DefaultSummaryConfiguration: ISummaryConfiguration = {
 };
 
 export interface IGCRuntimeOptions {
-    /* Flag that will disable garbage collection if set to true. */
-    disableGC?: boolean;
-
     /**
-     * Flag representing the summary's preference for allowing garbage collection.
-     * This is stored in the summary and unchangeable (for now). So this runtime option
-     * only takes affect on new containers.
-     * Currently if this is set to false, it will take priority and any container will
-     * never run GC.
+     * Flag that if true, will enable running garbage collection (GC) in a container. GC has mark phase and sweep phase.
+     * In mark phase, unreferenced objects are identified and marked as such in the summary. This option enables the
+     * mark phase.
+     * In sweep phase, unreferenced objects are eventually deleted from the container if they meet certain conditions.
+     * Sweep phase can be enabled via the "sweepAllowed" option.
+     * Note: This setting becomes part of the container's summary and cannot be changed.
      */
     gcAllowed?: boolean;
 
     /**
-     * Flag that will bypass optimizations and generate GC data for all nodes irrespective of whether the node
+     * Flag that if true, enables GC's sweep phase which will eventually delete unreferenced objects from the container.
+     * This flag should only be set to true if "gcAllowed" is true.
+     * Note: This setting becomes part of the container's summary and cannot be changed.
+     */
+    sweepAllowed?: boolean;
+
+    /**
+     * Flag that will disable garbage collection if set to true. Can be used to disable running GC on container where
+     * is allowed via the gcAllowed option.
+     */
+    disableGC?: boolean;
+
+    /**
+     * Flag that will bypass optimizations and generate GC data for all nodes irrespective of whether a node
      * changed or not.
      */
     runFullGC?: boolean;
-
-    /**
-     * Flag that if true, will run sweep which may delete unused objects that meet certain criteria. Only takes
-     * effect if GC is enabled.
-     */
-    runSweep?: boolean;
 
     /**
      * Allows additional GC options to be passed.
@@ -1461,11 +1466,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             summaryNumber: this.nextSummaryNumber++,
             summaryFormatVersion: 1,
             disableIsolatedChannels: this.disableIsolatedChannels || undefined,
-            gcFeature: this.garbageCollector.gcSummaryFeatureVersion,
             // The last message processed at the time of summary. If there are no new messages, use the message from the
             // last summary.
             message: extractSummaryMetadataMessage(this.deltaManager.lastMessage) ?? this.messageAtLastSummary,
-            sessionExpiryTimeoutMs: this.garbageCollector.sessionExpiryTimeoutMs,
+            ...this.garbageCollector.getMetadata(),
         };
         addBlobToSummary(summaryTree, metadataBlobName, JSON.stringify(metadata));
     }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -6,7 +6,7 @@
 import { ITelemetryLogger, ITelemetryPerformanceEvent } from "@fluidframework/common-definitions";
 import { assert, LazyPromise, Timer } from "@fluidframework/common-utils";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
-import { ClientSessionExpiredError, DataProcessingError } from "@fluidframework/container-utils";
+import { ClientSessionExpiredError, DataProcessingError, UsageError } from "@fluidframework/container-utils";
 import { IRequestHeader } from "@fluidframework/core-interfaces";
 import {
     cloneGCData,
@@ -46,6 +46,7 @@ import {
     metadataBlobName,
     ReadFluidDataStoreAttributes,
     dataStoreAttributesBlobName,
+    IGCMetadata,
 } from "./summaryFormat";
 
 /** This is the current version of garbage collection. */
@@ -140,14 +141,6 @@ export interface IGarbageCollectionRuntime {
 export interface IGarbageCollector {
     /** Tells whether GC should run or not. */
     readonly shouldRunGC: boolean;
-    /** The time in ms to expire a session for a client for gc. */
-    readonly sessionExpiryTimeoutMs: number | undefined;
-    /**
-     * This tracks two things:
-     * 1. Whether GC is enabled - If this is 0, GC is disabled. If this is greater than 0, GC is enabled.
-     * 2. If GC is enabled, the version of GC used to generate the GC data written in a summary.
-     */
-    readonly gcSummaryFeatureVersion: number;
     /** Tells whether the GC state in summary needs to be reset in the next summary. */
     readonly summaryStateNeedsReset: boolean;
     /** Tells whether GC data should be written to the root of the summary tree. */
@@ -158,6 +151,8 @@ export interface IGarbageCollector {
     ): Promise<IGCStats>;
     /** Summarizes the GC data and returns it as a summary tree. */
     summarize(): ISummaryTreeWithStats | undefined;
+    /** Returns the garbage collector specific metadata to be written into the summary. */
+    getMetadata(): IGCMetadata;
     /** Returns a map of each node id to its base GC details in the base summary. */
     getBaseGCDetails(): Promise<Map<string, IGarbageCollectionDetailsBase>>;
     /** Called when the latest summary of the system has been refreshed. */
@@ -271,23 +266,9 @@ export class GarbageCollector implements IGarbageCollector {
     }
 
     /**
-     * Tells whether GC should be run based on the GC options and local storage flags.
-     */
-    public readonly shouldRunGC: boolean;
-
-    /**
      * The time in ms to expire a session for a client for gc.
      */
-    public readonly sessionExpiryTimeoutMs: number | undefined;
-
-    /**
-     * This tracks two things:
-     * 1. Whether GC is enabled - If this is 0, GC is disabled. If this is greater than 0, GC is enabled.
-     * 2. If GC is enabled, the version of GC used to generate the GC data written in a summary.
-     */
-    public get gcSummaryFeatureVersion(): number {
-        return this.gcEnabled ? this.currentGCVersion : 0;
-    }
+    private readonly sessionExpiryTimeoutMs: number | undefined;
 
     /**
      * Tells whether the GC state needs to be reset in the next summary. We need to do this if:
@@ -307,7 +288,23 @@ export class GarbageCollector implements IGarbageCollector {
      * throughout its lifetime.
      */
     private readonly gcEnabled: boolean;
+    /**
+     * Tracks if sweep phase is enabled for this document. This is specified during document creation and doesn't change
+     * throughout its lifetime.
+     */
+    private readonly sweepEnabled: boolean;
+
+    /**
+     * Tracks if GC should run or not. Even if GC is enabled for a document (see gcEnabled), it can be explicitly
+     * disabled via runtime options or feature flags.
+     */
+    public readonly shouldRunGC: boolean;
+    /**
+     * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
+     * can be explicitly disabled via feature flags. It also won't run if session expiry is not enabled.
+     */
     private readonly shouldRunSweep: boolean;
+
     private readonly testMode: boolean;
     private readonly mc: MonitoringContext;
 
@@ -379,22 +376,37 @@ export class GarbageCollector implements IGarbageCollector {
 
         let prevSummaryGCVersion: number | undefined;
 
-        // GC can only be enabled during creation. After that, it can never be enabled again. So, for existing
-        // documents, we get this information from the metadata blob. Similarly the session timeout should be
-        // consistent across all clients, thus we grab it as well from the metadata blob, and set it once on creation.
+        /**
+         * The following GC state is enabled during container creation and cannot be changed throughout its lifetime:
+         * 1. Whether running GC mark phase is allowed or not.
+         * 2. Whether running GC sweep phase is allowed or not.
+         * 3. Whether GC session expiry is enabled or not.
+         * For existing containers, we get this information from the metadata blob of its summary.
+         */
         if (existing) {
             prevSummaryGCVersion = getGCVersion(metadata);
             // Existing documents which did not have metadata blob or had GC disabled have version as 0. For all
             // other existing documents, GC is enabled.
             this.gcEnabled = prevSummaryGCVersion > 0;
             this.sessionExpiryTimeoutMs = metadata?.sessionExpiryTimeoutMs;
+            this.sweepEnabled = metadata?.sweepEnabled ?? false;
         } else {
+            // Sweep should not be enabled without enabling GC mark phase. We could silently disable sweep in this
+            // scenario but explicitly failing makes it clearer and promotes correct usage.
+            if (gcOptions.sweepAllowed && !gcOptions.gcAllowed) {
+                throw new UsageError("GC sweep phase cannot be enabled without enabling GC mark phase");
+            }
+
             // For new documents, GC has to be explicitly enabled via the gcAllowed flag in GC options.
             this.gcEnabled = gcOptions.gcAllowed === true;
+
             // Set the Session Expiry only if the flag is enabled or the test option is set.
             if (this.mc.config.getBoolean(runSessionExpiryKey) && this.gcEnabled) {
                 this.sessionExpiryTimeoutMs = defaultSessionExpiryDurationMs;
             }
+
+            // For new documents, sweep has to be explicitly enabled via sweepAllowed flag in GC options.
+            this.sweepEnabled = gcOptions.sweepAllowed === true;
         }
 
         // If session expiry is enabled, we need to close the container when the timeout expires
@@ -421,7 +433,14 @@ export class GarbageCollector implements IGarbageCollector {
         // latest tracked GC version. For new documents, we will be writing the first summary with the current version.
         this.latestSummaryGCVersion = prevSummaryGCVersion ?? this.currentGCVersion;
 
-        // Whether GC should run or not. Can override with localStorage flag.
+        // Whether GC should run or not. Even if GC is enabled for this container, whether it should run or not can
+        // be overridden via feature flags or the disableGC option.
+        /**
+         * Whether GC should run or not. The following conditions have to be met to run sweep:
+         * 1. GC should be enabled for this container.
+         * 2. GC should not be disabled via disableGC GC option.
+         * These conditions can be overridden via runGCKey feature flag.
+         */
         this.shouldRunGC = this.mc.config.getBoolean(runGCKey) ?? (
             // GC must be enabled for the document.
             this.gcEnabled
@@ -429,11 +448,15 @@ export class GarbageCollector implements IGarbageCollector {
             && !gcOptions.disableGC
         );
 
-        // Whether GC sweep phase should run or not. If this is false, only GC mark phase is run. Can override with
-        // localStorage flag.
-        this.shouldRunSweep = this.shouldRunGC &&
-            (this.mc.config.getBoolean(runSweepKey) ?? gcOptions.runSweep === true)
-            && this.sessionExpiryTimer !== undefined;
+        /**
+         * Whether sweep should run or not. The following conditions have to be met to run sweep:
+         * 1. Overall GC or mark phase must be enabled (this.shouldRunGC).
+         * 2. Session expiry and sweep should be enabled for this container. Without session expiry we cannot safely
+         *    delete unreferenced objects. This condition (#2) can be overridden via runSweepKey feature flag.
+         */
+        this.shouldRunSweep = this.shouldRunGC && (
+            this.mc.config.getBoolean(runSweepKey) ?? (this.sessionExpiryTimeoutMs !== undefined && this.sweepEnabled)
+        );
 
         // Whether we are running in test mode. In this mode, unreferenced nodes are immediately deleted.
         this.testMode = this.mc.config.getBoolean(gcTestModeKey) ?? gcOptions.runGCInTestMode === true;
@@ -677,6 +700,18 @@ export class GarbageCollector implements IGarbageCollector {
         const builder = new SummaryTreeBuilder();
         builder.addBlob(`${gcBlobPrefix}_root`, JSON.stringify(gcState));
         return builder.getSummaryTree();
+    }
+
+    public getMetadata(): IGCMetadata {
+        return {
+            /**
+             * If GC is enabled, the GC data is written using the current GC version and that is the gcFeature that goes
+             * into the metadata blob. If GC is disabled, the gcFeature is 0.
+             */
+            gcFeature: this.gcEnabled ? this.currentGCVersion : 0,
+            sessionExpiryTimeoutMs: this.sessionExpiryTimeoutMs,
+            sweepEnabled: this.sweepEnabled,
+        };
     }
 
     /**

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -74,8 +74,7 @@ export function hasIsolatedChannels(attributes: ReadFluidDataStoreAttributes): b
     return !!attributes.summaryFormatVersion && !attributes.disableIsolatedChannels;
 }
 
-export type GCVersion = number;
-export interface IContainerRuntimeMetadata extends ICreateContainerMetadata {
+export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGCMetadata {
     readonly summaryFormatVersion: 1;
     /** The last message processed at the time of summary. Only primitive property types are added to the summary. */
     readonly message: ISummaryMetadataMessage | undefined;
@@ -85,13 +84,13 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata {
     readonly gcFeature?: GCVersion;
     /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
     readonly summaryNumber?: number;
-    /** If this is present, the session for this container will expire after this time and the container will close */
-    readonly sessionExpiryTimeoutMs?: number;
     /**
      * @deprecated - User summaryNumber instead.
      * Counter of the last summary happened, increments every time we summarize
-     * */
+     */
     readonly summaryCount?: number;
+    /** If this is present, the session for this container will expire after this time and the container will close */
+    readonly sessionExpiryTimeoutMs?: number;
 }
 
 export interface ICreateContainerMetadata {
@@ -99,6 +98,25 @@ export interface ICreateContainerMetadata {
     createContainerRuntimeVersion?: string;
     /** Timestamp of the container when it was first created */
     createContainerTimestamp?: number;
+}
+
+export type GCVersion = number;
+export interface IGCMetadata {
+    /**
+     * The version of the GC code that was run to generate the GC data that is written in the summary.
+     * Also, used to determine whether GC is enabled for this container or not:
+     * - A value of 0 or undefined means GC is disabled.
+     * - A value > 0 means GC is enabled.
+     */
+    readonly gcFeature?: GCVersion;
+    /** If this is present, the session for this container will expire after this time and the container will close */
+    readonly sessionExpiryTimeoutMs?: number;
+    /**
+     * Tells whether the GC sweep phase is enabled for this container.
+     * - True means sweep phase is enabled.
+     * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
+     */
+    readonly sweepEnabled?: boolean;
 }
 
 /** The properties of an ISequencedDocumentMessage to be stored in the metadata blob in summary. */
@@ -151,7 +169,7 @@ export function rootHasIsolatedChannels(metadata?: IContainerRuntimeMetadata): b
     return !!metadata && !metadata.disableIsolatedChannels;
 }
 
-export function getGCVersion(metadata?: IContainerRuntimeMetadata): GCVersion {
+export function getGCVersion(metadata?: IGCMetadata): GCVersion {
     if (!metadata) {
         // Force to 0/disallowed in prior versions
         return 0;

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -106,7 +106,7 @@ export interface IGCMetadata {
      * The version of the GC code that was run to generate the GC data that is written in the summary.
      * Also, used to determine whether GC is enabled for this container or not:
      * - A value of 0 or undefined means GC is disabled.
-     * - A value > 0 means GC is enabled.
+     * - A value greater than 0 means GC is enabled.
      */
     readonly gcFeature?: GCVersion;
     /** If this is present, the session for this container will expire after this time and the container will close */

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -80,8 +80,6 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGC
     readonly message: ISummaryMetadataMessage | undefined;
     /** True if channels are not isolated in .channels subtrees, otherwise isolated. */
     readonly disableIsolatedChannels?: true;
-    /** 0 to disable GC, \> 0 to enable GC, undefined defaults to disabled. */
-    readonly gcFeature?: GCVersion;
     /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
     readonly summaryNumber?: number;
     /**
@@ -89,8 +87,6 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGC
      * Counter of the last summary happened, increments every time we summarize
      */
     readonly summaryCount?: number;
-    /** If this is present, the session for this container will expire after this time and the container will close */
-    readonly sessionExpiryTimeoutMs?: number;
 }
 
 export interface ICreateContainerMetadata {

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -54,7 +54,7 @@ const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
     disableGC: booleanCases,
     gcAllowed: booleanCases,
     runFullGC: booleanCases,
-    runSweep: [false],
+    sweepAllowed: [false],
 };
 
 const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {


### PR DESCRIPTION
Looks like https://github.com/microsoft/FluidFramework/pull/10159 introduced a lint issue. This was probably not caught because of the new linting rules that were added.
@tylerbutler @ssimic2 