### PR TITLE
Fix lint issue in treeUtils.ts that was introduced due to merge

### DIFF
--- a/packages/loader/driver-utils/src/treeUtils.ts
+++ b/packages/loader/driver-utils/src/treeUtils.ts
@@ -29,7 +29,7 @@ export interface ISummaryTreeAssemblerProps {
  */
 export class SummaryTreeAssembler {
     private attachmentCounter: number = 0;
-    private readonly summaryTree: { [path: string]: SummaryObject } = {};
+    private readonly summaryTree: { [path: string]: SummaryObject; } = {};
 
     constructor(
         private readonly props?: ISummaryTreeAssemblerProps,


### PR DESCRIPTION
Looks like https://github.com/microsoft/FluidFramework/pull/10159 introduced a lint issue. This was probably not caught because of the new linting rules that were added while the PR was in progress.
@tylerbutler @ssimic2