### PR TITLE
9694 Create new ISummaryTelemetryData

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -130,7 +130,7 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     readonly attachState: AttachState;
     // @deprecated (undocumented)
     bindToContext(): void;
-    getAttachSummary(): ISummaryTreeWithStats;
+    getAttachSummary(summaryTelemetryData?: ISummaryTelemetryData): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     // (undocumented)
     readonly id: string;
@@ -140,7 +140,7 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     reSubmit(type: string, content: any, localOpMetadata: unknown): any;
     rollback?(type: string, content: any, localOpMetadata: unknown): void;
     setConnectionState(connected: boolean, clientId?: string): any;
-    summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, trackState?: boolean, summaryTelemetryData?: ISummaryTelemetryData): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
     // (undocumented)
     readonly visibilityState?: VisibilityState_2;
@@ -306,7 +306,7 @@ export interface ISummarizeResult {
 export interface ISummarizerNode {
     // (undocumented)
     createChild(
-    summarizeInternalFn: (fullTree: boolean) => Promise<ISummarizeInternalResult>,
+    summarizeInternalFn: SummarizeInternalFn,
     id: string,
     createParam: CreateChildSummarizerNodeParam,
     config?: ISummarizerNodeConfig): ISummarizerNode;
@@ -320,7 +320,7 @@ export interface ISummarizerNode {
     loadBaseSummaryWithoutDifferential(snapshot: ISnapshotTree): void;
     recordChange(op: ISequencedDocumentMessage): void;
     readonly referenceSequenceNumber: number;
-    summarize(fullTree: boolean): Promise<ISummarizeResult>;
+    summarize(fullTree: boolean, trackState?: boolean, summaryTelemetryData?: ISummaryTelemetryData): Promise<ISummarizeResult>;
 }
 
 // @public (undocumented)
@@ -338,7 +338,7 @@ export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
     // (undocumented)
     createChild(
-    summarizeInternalFn: (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>,
+    summarizeInternalFn: SummarizeInternalFn,
     id: string,
     createParam: CreateChildSummarizerNodeParam,
     config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>, getInitialGCSummaryDetailsFn?: () => Promise<IGarbageCollectionSummaryDetails>): ISummarizerNodeWithGC;
@@ -350,8 +350,6 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     // @deprecated (undocumented)
     getGCSummaryDetails(): IGarbageCollectionSummaryDetails;
     isReferenced(): boolean;
-    // (undocumented)
-    summarize(fullTree: boolean, trackState?: boolean): Promise<ISummarizeResult>;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
 }
 
@@ -369,6 +367,12 @@ export interface ISummaryStats {
     unreferencedBlobSize: number;
 }
 
+// @public
+export interface ISummaryTelemetryData {
+    add(prefix: string, value: string): void;
+    serialize(): string;
+}
+
 // @public (undocumented)
 export interface ISummaryTreeWithStats {
     // (undocumented)
@@ -384,7 +388,7 @@ export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreReg
 export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
 
 // @public (undocumented)
-export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
+export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, summaryTelemetryData?: ISummaryTelemetryData) => Promise<ISummarizeInternalResult>;
 
 // @public
 const VisibilityState_2: {

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -251,7 +251,11 @@ export interface IFluidDataStoreChannel extends
      * @param trackState - This tells whether we should track state from this summary.
      * @param summaryTelemetryData - summary data passed through the layers for telemetry purposes
      */
-    summarize(fullTree?: boolean, trackState?: boolean, summaryTelemetryData?: ISummaryTelemetryData): Promise<ISummaryTreeWithStats>;
+    summarize(
+        fullTree?: boolean,
+        trackState?: boolean,
+        summaryTelemetryData?: ISummaryTelemetryData,
+    ): Promise<ISummaryTreeWithStats>;
 
     /**
      * Returns the data used for garbage collection. This includes a list of GC nodes that represent this context

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -37,6 +37,7 @@ import { IInboundSignalMessage } from "./protocol";
 import {
     CreateChildSummarizerNodeParam,
     ISummarizerNodeWithGC,
+    ISummaryTelemetryData,
     ISummaryTreeWithStats,
     SummarizeInternalFn,
 } from "./summary";
@@ -229,8 +230,9 @@ export interface IFluidDataStoreChannel extends
 
     /**
      * Retrieves the summary used as part of the initial summary message
+     * @param summaryTelemetryData - summary data passed through the layers for telemetry purposes
      */
-    getAttachSummary(): ISummaryTreeWithStats;
+    getAttachSummary(summaryTelemetryData?: ISummaryTelemetryData): ISummaryTreeWithStats;
 
     /**
      * Processes the op.
@@ -247,8 +249,9 @@ export interface IFluidDataStoreChannel extends
      * Introduced with summarizerNode - will be required in a future release.
      * @param fullTree - true to bypass optimizations and force a full summary tree.
      * @param trackState - This tells whether we should track state from this summary.
+     * @param summaryTelemetryData - summary data passed through the layers for telemetry purposes
      */
-    summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, trackState?: boolean, summaryTelemetryData?: ISummaryTelemetryData): Promise<ISummaryTreeWithStats>;
 
     /**
      * Returns the data used for garbage collection. This includes a list of GC nodes that represent this context

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -56,7 +56,11 @@ export interface IGarbageCollectionState {
     gcNodes: { [ id: string ]: IGarbageCollectionNodeData };
 }
 
-export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, summaryTelemetryData?: ISummaryTelemetryData) => Promise<ISummarizeInternalResult>;
+export type SummarizeInternalFn = (
+    fullTree: boolean,
+    trackState: boolean,
+    summaryTelemetryData?: ISummaryTelemetryData,
+) => Promise<ISummarizeInternalResult>;
 
 export interface ISummarizerNodeConfig {
     /**


### PR DESCRIPTION
Also consumes `ISummaryTelemetryData` in relevant places

#9694 
[AB#161](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/161)