### PR TITLE
fluid-build: Add ability to specify explicit script dependencies

### DIFF
--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -65,5 +65,14 @@
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
+  },
+  "fluidBuild": {
+    "buildDependencies": {
+      "merge": {
+        "build:compile": {
+          "@fluidframework/merge-tree": [ "build:test" ]
+        }
+      }
+    }
   }
 }

--- a/tools/build-tools/src/common/npmPackage.ts
+++ b/tools/build-tools/src/common/npmPackage.ts
@@ -24,6 +24,8 @@ import {
 import { MonoRepo } from "./monoRepo";
 import { options } from "../fluidBuild/options";
 
+export type ScriptDependencies = { [key: string]: string[] };
+
 interface IPerson {
     name: string;
     email: string;
@@ -59,6 +61,14 @@ interface IPackage {
     os: string[];
     cpu: string[];
     [key: string]: any;
+
+    fluidBuild?: {
+        buildDependencies: {
+            merge?: {
+                [key: string]: ScriptDependencies
+            }
+        }
+    };
 };
 
 export class Package {
@@ -248,7 +258,7 @@ export class Packages {
     public constructor(public readonly packages: Package[]) {
     }
 
-    public static loadDir(dirFullPath: string, group: string, ignoredDirFullPaths: string[] | undefined, monoRepo?: MonoRepo, ) {
+    public static loadDir(dirFullPath: string, group: string, ignoredDirFullPaths: string[] | undefined, monoRepo?: MonoRepo,) {
         const packageJsonFileName = path.join(dirFullPath, "package.json");
         if (existsSync(packageJsonFileName)) {
             return [new Package(packageJsonFileName, group, monoRepo)];

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -6,6 +6,7 @@
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
 import { toPosixPath, globFn, unquote, statAsync, readFileAsync } from "../../../common/utils";
 import { logVerbose } from "../../../common/logging";
+import { ScriptDependencies } from "../../../common/npmPackage";
 import * as path from "path";
 import { BuildPackage } from "../../buildGraph";
 
@@ -47,8 +48,8 @@ export class CopyfilesTask extends LeafTask {
     private readonly copySrcArg: string = "";
     private readonly copyDstArg: string = "";
 
-    constructor(node: BuildPackage, command: string) {
-        super(node, command);
+    constructor(node: BuildPackage, command: string, scriptDeps: ScriptDependencies) {
+        super(node, command, scriptDeps);
 
         // TODO: something better
         const args = this.command.split(" ");

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/prettierTask.ts
@@ -5,14 +5,15 @@
 
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
 import { BuildPackage } from "../../buildGraph";
+import { ScriptDependencies } from "../../../common/npmPackage";
 import { globFn, existsSync, readFileAsync } from "../../../common/utils";
 import ignore from "ignore";
 
 export class PrettierTask extends LeafWithDoneFileTask {
     private parsed: boolean = false;
     private glob: string | undefined;
-    constructor(node: BuildPackage, command: string) {
-        super(node, command);
+    constructor(node: BuildPackage, command: string, scriptDeps: ScriptDependencies) {
+        super(node, command, scriptDeps);
 
         // TODO: something better
         const args = this.command.split(" ");

--- a/tools/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -9,6 +9,7 @@ import { LeafTask, UnknownLeafTask } from "./leaf/leafTask";
 import { NPMTask } from "./npmTask";
 import { Task } from "./task";
 import { TscTask } from "./leaf/tscTask";
+import { ScriptDependencies } from "../../common/npmPackage";
 import { getExecutableFromCommand } from "../../common/utils";
 import { EsLintTask, TsFormatTask, TsLintTask } from "./leaf/lintTasks";
 import { ApiExtractorTask } from "./leaf/apiExtractorTask";
@@ -16,8 +17,19 @@ import { WebpackTask } from "./leaf/webpackTask";
 import { LesscTask, CopyfilesTask, EchoTask, GenVerTask, TypeValidationTask } from "./leaf/miscTasks";
 import { PrettierTask } from "./leaf/prettierTask";
 
+function mergeScriptDependencies(oldDeps: ScriptDependencies, newDeps?: ScriptDependencies) {
+    if (!newDeps) { return oldDeps; }
+    const mergedScriptDeps = { ...oldDeps };
+    for (const pkg of Object.keys(newDeps)) {
+        const oldValues = mergedScriptDeps[pkg];
+        const newValues = newDeps[pkg];
+        mergedScriptDeps[pkg] = oldValues ? oldValues.concat(newValues) : newValues;
+    }
+    return mergedScriptDeps;
+}
+
 // Map of executable name to LeafTasks
-const executableToLeafTask: { [key: string]: new (node: BuildPackage, command: string) => LeafTask } = {
+const executableToLeafTask: { [key: string]: new (node: BuildPackage, command: string, scriptDeps: ScriptDependencies) => LeafTask } = {
     tsc: TscTask,
     tslint: TsLintTask,
     eslint: EsLintTask,
@@ -34,29 +46,31 @@ const executableToLeafTask: { [key: string]: new (node: BuildPackage, command: s
 };
 
 export class TaskFactory {
-    public static Create(node: BuildPackage, command: string) {
+    private static Create(node: BuildPackage, command: string, scriptDeps: ScriptDependencies) {
         const concurrently = command.startsWith("concurrently ");
-
         if (concurrently) {
             const subTasks = new Array<Task>();
             const steps = command.substring("concurrently ".length).split(" ");
             for (const step of steps) {
                 const stepT = step.trim();
                 if (stepT.startsWith("npm:")) {
-                    subTasks.push(TaskFactory.Create(node, "npm run " + stepT.substring("npm:".length)));
+                    subTasks.push(TaskFactory.Create(node, "npm run " + stepT.substring("npm:".length), scriptDeps));
                 } else {
-                    subTasks.push(TaskFactory.Create(node, stepT));
+                    subTasks.push(TaskFactory.Create(node, stepT, scriptDeps));
                 }
             }
             return new ConcurrentNPMTask(node, command, subTasks);
         }
         if (command.startsWith("npm run ")) {
             const subTasks = new Array<Task>();
-            const script = node.pkg.getScript(command.substring("npm run ".length));
+            const scriptName = command.substring("npm run ".length);
+            const script = node.pkg.getScript(scriptName);
             if (script) {
+                const mergeDeps = node.pkg.packageJson.fluidBuild?.buildDependencies?.merge?.[scriptName];
+                const newScriptDeps = mergeScriptDependencies(scriptDeps, mergeDeps);
                 const steps = script.split("&&");
                 for (const step of steps) {
-                    subTasks.push(TaskFactory.Create(node, step.trim()));
+                    subTasks.push(TaskFactory.Create(node, step.trim(), newScriptDeps));
                 }
             }
             return new NPMTask(node, command, subTasks);
@@ -66,14 +80,14 @@ export class TaskFactory {
         const executable = getExecutableFromCommand(command).toLowerCase();
         const ctor = executableToLeafTask[executable];
         if (ctor) {
-            return new ctor(node, command);
+            return new ctor(node, command, scriptDeps);
         }
-        return new UnknownLeafTask(node, command);
+        return new UnknownLeafTask(node, command, scriptDeps);
     }
 
     public static CreateScriptTasks(node: BuildPackage, scripts: string[]) {
         if (scripts.length === 0) { return undefined; }
-        const tasks = scripts.map(value => TaskFactory.Create(node, `npm run ${value}`));
+        const tasks = scripts.map(value => TaskFactory.Create(node, `npm run ${value}`, {}));
         return tasks.length == 1 ? tasks[0] : new NPMTask(node, `npm run ${scripts.map(name => `npm run ${name}`).join(" && ")}`, tasks);
     }
 };


### PR DESCRIPTION
# Fixing `fluid-build` for #10231

## Description

Some of the dependencies between build scripts are not regular and hard to infer.  Add a way to explicit specify them for fluid-build to build an accurate dependency graph.  The dependencies are specified in the package's `package.json`.

## Steps to Reproduce Bug and Validate Solution

- Build the whole repo. 
- run `npm run clean` in `merge-tree` package.  
- run `fluid-build .` in `merge-tree-client-replay` package

Before the change, the build will error in `merge-tree-client-replay`
After the change, the build works without error.

## Other information or known dependencies

After merging this PR, `build-tool` needs to be published and the version dependencies bump for the repo before #10231 is fully fixed.