### PR TITLE
Add azure pipeline as a dep for docs pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -98,6 +98,8 @@ resources:
     source: Build - driver-definitions
   - pipeline: protocol_definitions
     source: Build - protocol-definitions
+  - pipeline: azure
+    source: Build - azure
   - pipeline: client
     source: Build - client packages
     trigger:

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -31,6 +31,8 @@ steps:
   artifact: _api-extractor-temp
 - download: protocol_definitions
   artifact: _api-extractor-temp
+- download: azure
+  artifact: _api-extractor-temp
 - download: client
   artifact: _api-extractor-temp
 - download: server


### PR DESCRIPTION
Fixes #10223.

The build-docs pipeline is responsible for taking all the API JSON files that are produced by individual pipelines, combines them, and then does a build of the fluidframework.com site with the combined files.

The new azure pipeline publishes packages that should be included in docs, so this change updates the docs pipelines to include the azure packages.