### PR TITLE
Remove eslint-plugin-no-null

### DIFF
--- a/common/lib/common-utils/.eslintrc.js
+++ b/common/lib/common-utils/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-bitwise": "off",
-        "no-null/no-null": "off",
         "prefer-rest-params": "off"
     }
 }

--- a/examples/data-objects/monaco/.eslintrc.js
+++ b/examples/data-objects/monaco/.eslintrc.js
@@ -10,6 +10,5 @@ module.exports = {
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-bitwise": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/examples/data-objects/prosemirror/.eslintrc.js
+++ b/examples/data-objects/prosemirror/.eslintrc.js
@@ -12,6 +12,5 @@ module.exports = {
         "@typescript-eslint/restrict-plus-operands": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-case-declarations": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/examples/data-objects/table-view/.eslintrc.js
+++ b/examples/data-objects/table-view/.eslintrc.js
@@ -9,6 +9,5 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions":"off",
-        "no-null/no-null": "off"
     }
 }

--- a/examples/data-objects/webflow/.eslintrc.js
+++ b/examples/data-objects/webflow/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
         "max-len": "off",
         "no-bitwise": "off",
         "no-case-declarations": "off",
-        "no-null/no-null": "off"
     },
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -83,7 +83,6 @@
     "eslint": "~8.6.0",
     "eslint-plugin-eslint-comments": "~3.2.0",
     "eslint-plugin-import": "~2.25.4",
-    "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-prefer-arrow": "~1.2.2",
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
     },
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"no-null/no-null": "off",
         "import/no-internal-modules": "off",
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",

--- a/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
     },
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"no-null/no-null": "off",
         "import/no-internal-modules": "off",
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",

--- a/experimental/PropertyDDS/examples/schemas/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/schemas/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     },
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"no-null/no-null": "off",
         "unicorn/filename-case": "off",
         "import/no-default-export": "off",
 	},

--- a/experimental/PropertyDDS/examples/schemas/package.json
+++ b/experimental/PropertyDDS/examples/schemas/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-editorconfig": "~3.2.0",
     "eslint-plugin-eslint-comments": "~3.2.0",
     "eslint-plugin-import": "~2.25.4",
-    "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-prefer-arrow": "~1.2.2",
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",

--- a/experimental/PropertyDDS/packages/property-dds/.eslintrc.js
+++ b/experimental/PropertyDDS/packages/property-dds/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     },
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"no-null/no-null": "off",
         "tsdoc/syntax": "off",
 	},
 };

--- a/experimental/dds/tree-graphql/.eslintrc.js
+++ b/experimental/dds/tree-graphql/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
 		// unicorn/no-null
 		// GraphQL uses null rather than undefined. See https://github.com/graphql/graphql-js/issues/1298
 		// TODO: Determine if we want to use a helper library to convert null to undefined automatically
-        'unicorn/no-null': 'off',
+		'unicorn/no-null': 'off',
 	},
 	overrides: [
 		{

--- a/experimental/dds/tree-graphql/.eslintrc.js
+++ b/experimental/dds/tree-graphql/.eslintrc.js
@@ -40,10 +40,10 @@ module.exports = {
 			},
 		],
 
-		// eslint-plugin-no-null
+		// unicorn/no-null
 		// GraphQL uses null rather than undefined. See https://github.com/graphql/graphql-js/issues/1298
 		// TODO: Determine if we want to use a helper library to convert null to undefined automatically
-		'no-null/no-null': 'off',
+        'unicorn/no-null': 'off',
 	},
 	overrides: [
 		{

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -24491,11 +24491,6 @@
 				}
 			}
 		},
-		"eslint-plugin-no-null": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-null/-/eslint-plugin-no-null-1.0.2.tgz",
-			"integrity": "sha1-EjaoEjkTkKGHetQAfCbnRTQclR8="
-		},
 		"eslint-plugin-node": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",

--- a/packages/dds/map/.eslintrc.js
+++ b/packages/dds/map/.eslintrc.js
@@ -13,6 +13,5 @@ module.exports = {
     "rules": {
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/dds/merge-tree/.eslintrc.js
+++ b/packages/dds/merge-tree/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
         "@typescript-eslint/strict-boolean-expressions": "off",
         "keyword-spacing": "off", // Off because it conflicts with typescript-formatter
         "no-case-declarations": "off",
-        "no-null/no-null": "off",
         "prefer-arrow/prefer-arrow-functions": "off"
     }
 }

--- a/packages/dds/test-dds-utils/.eslintrc.js
+++ b/packages/dds/test-dds-utils/.eslintrc.js
@@ -9,6 +9,5 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/drivers/debugger/.eslintrc.js
+++ b/packages/drivers/debugger/.eslintrc.js
@@ -12,6 +12,5 @@ module.exports = {
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-inner-declarations": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/drivers/driver-web-cache/.eslintrc.js
+++ b/packages/drivers/driver-web-cache/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off",
         "@typescript-eslint/promise-function-async": "off",
         "@typescript-eslint/no-misused-promises": "off",
     },

--- a/packages/drivers/file-driver/.eslintrc.js
+++ b/packages/drivers/file-driver/.eslintrc.js
@@ -9,6 +9,5 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/drivers/iframe-driver/.eslintrc.js
+++ b/packages/drivers/iframe-driver/.eslintrc.js
@@ -9,6 +9,5 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/drivers/odsp-driver/.eslintrc.js
+++ b/packages/drivers/odsp-driver/.eslintrc.js
@@ -14,6 +14,5 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off",
     }
 }

--- a/packages/drivers/replay-driver/.eslintrc.js
+++ b/packages/drivers/replay-driver/.eslintrc.js
@@ -9,6 +9,5 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/drivers/routerlicious-driver/.eslintrc.js
+++ b/packages/drivers/routerlicious-driver/.eslintrc.js
@@ -14,6 +14,5 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-case-declarations": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/loader/container-loader/.eslintrc.js
+++ b/packages/loader/container-loader/.eslintrc.js
@@ -11,6 +11,5 @@ module.exports = {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
     },
     "rules": {
-        "no-null/no-null": "off"
     }
 }

--- a/packages/loader/container-utils/.eslintrc.js
+++ b/packages/loader/container-utils/.eslintrc.js
@@ -13,6 +13,5 @@ module.exports = {
     "rules": {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/runtime/agent-scheduler/.eslintrc.js
+++ b/packages/runtime/agent-scheduler/.eslintrc.js
@@ -12,6 +12,5 @@ module.exports = {
     },
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/runtime/container-runtime/.eslintrc.js
+++ b/packages/runtime/container-runtime/.eslintrc.js
@@ -12,6 +12,5 @@ module.exports = {
     },
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/runtime/test-runtime-utils/.eslintrc.js
+++ b/packages/runtime/test-runtime-utils/.eslintrc.js
@@ -12,6 +12,5 @@ module.exports = {
     },
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off"
     }
 }

--- a/packages/tools/fetch-tool/.eslintrc.js
+++ b/packages/tools/fetch-tool/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
     "rules": {
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-null/no-null": "off",
         "import/no-internal-modules": "off"
     }
 }

--- a/packages/utils/telemetry-utils/.eslintrc.js
+++ b/packages/utils/telemetry-utils/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-bitwise": "off",
-        "no-null/no-null": "off",
         "prefer-rest-params": "off"
     }
 }

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -258,7 +258,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -320,9 +320,9 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.61804",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.61804.tgz",
-			"integrity": "sha512-p1RphdHriaUJJUE3zQnnrGJ9gqLY2/kI3i569WBB31qMv7eYrh9x0N3OCGdT3xuQyJd3KcEhsXcZdTMi/6BoUA==",
+			"version": "0.2.66048",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.66048.tgz",
+			"integrity": "sha512-iqWE2c6q1qtTGq+uieBuepgtcunxGSdAsfdZBB2VYHF2CZeR4LzNuw3ghUeuajYxK88Q27d0iZypw+/wYlBRMw==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -462,17 +462,17 @@
 			}
 		},
 		"@fluidframework/gitresources": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.2000-63043.tgz",
-			"integrity": "sha512-ubQH8rCE41aJxOTG6oG0eVmx0jhoSFBqUIIO9YBVlrA9JMWI4tv9Hba1B0Tjj3Qu+Z6yIVvQTXlgoXXWZgE9/w=="
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000-65108.tgz",
+			"integrity": "sha512-CkJ8GbSqgWEmLPeABT2199uSEV+8xipsi70z4j9x44WUMP5fw4Bg/53uSFfNdrAy9GjqV1dTiv9X97yaxeCdyQ=="
 		},
 		"@fluidframework/protocol-base": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.2000-63043.tgz",
-			"integrity": "sha512-B3KNKH1AyoKBsi/JZM+JzGPLprz/+7rrtO53qYaD6V+hWQJ1VEP+KxYLP3/qGxoiNhSnqsCbZcPBJDjPkLLW1w==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.3000-65108.tgz",
+			"integrity": "sha512-s9bc9bbJYEq3zOfSqR3SzrmoGYoR+90AzUBbdeBDjLk98QSJUjHJHg1bwnQ7m4LGrYJNQ6+iSsaA/x8oC75TFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "0.1036.2000-63043",
+				"@fluidframework/gitresources": "0.1036.3000-65108",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"lodash": "^4.17.21"
 			},
@@ -509,19 +509,19 @@
 			}
 		},
 		"@fluidframework/server-services": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services/-/server-services-0.1036.2000-63043.tgz",
-			"integrity": "sha512-CTW4rgPX2RMurp3CmyfjbHqx5/SObRcU3gBkV+csuxF84y7iBrYE1BCc7Z+TeHSwS1Iso7gORPEbLxCt2kupvw==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services/-/server-services-0.1036.3000-65108.tgz",
+			"integrity": "sha512-HoVc0FaihsuY1YPS65gUt5wfuGo4zYX8Yy++5kpXY8YMnOirV/IE/pJS2sc3E+RizZ7+TpOq4jFwpogc09fVkw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "0.1036.2000-63043",
-				"@fluidframework/server-services-core": "0.1036.2000-63043",
-				"@fluidframework/server-services-ordering-kafkanode": "0.1036.2000-63043",
-				"@fluidframework/server-services-ordering-rdkafka": "0.1036.2000-63043",
-				"@fluidframework/server-services-shared": "0.1036.2000-63043",
-				"@fluidframework/server-services-telemetry": "0.1036.2000-63043",
-				"@fluidframework/server-services-utils": "0.1036.2000-63043",
+				"@fluidframework/server-services-client": "0.1036.3000-65108",
+				"@fluidframework/server-services-core": "0.1036.3000-65108",
+				"@fluidframework/server-services-ordering-kafkanode": "0.1036.3000-65108",
+				"@fluidframework/server-services-ordering-rdkafka": "0.1036.3000-65108",
+				"@fluidframework/server-services-shared": "0.1036.3000-65108",
+				"@fluidframework/server-services-telemetry": "0.1036.3000-65108",
+				"@fluidframework/server-services-utils": "0.1036.3000-65108",
 				"@socket.io/redis-emitter": "^4.1.0",
 				"amqplib": "^0.8.0",
 				"axios": "^0.26.0",
@@ -529,7 +529,7 @@
 				"ioredis": "^4.24.2",
 				"lru-cache": "^6.0.0",
 				"mongodb": "3.2.2",
-				"nconf": "^0.11.4",
+				"nconf": "^0.12.0",
 				"socket.io": "^4.1.2",
 				"telegrafjs": "^0.1.3",
 				"uuid": "^8.3.1",
@@ -557,6 +557,22 @@
 						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				},
+				"ini": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+				},
+				"nconf": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+					"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+					"requires": {
+						"async": "^3.0.0",
+						"ini": "^2.0.0",
+						"secure-keys": "^1.0.0",
+						"yargs": "^16.1.1"
+					}
+				},
 				"uuid": {
 					"version": "8.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -565,13 +581,13 @@
 			}
 		},
 		"@fluidframework/server-services-client": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.2000-63043.tgz",
-			"integrity": "sha512-PqTXE2Jk8UZa17xDCtnH3lP2MreHo93i65sYZB+n0paVRQ8/ETZpcdNbRtqQk+yd0Hi1tgEOqjOFy6eRBkISVQ==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.3000-65108.tgz",
+			"integrity": "sha512-TEyXI6vP0mjt5Kcyq3GY7t6yzOwjEqNQVtzNE3rvjBOx/2PVqqQHNSz/a/Ikqj/HqzlPvQy/ncPbHvjmtqxPuQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "0.1036.2000-63043",
-				"@fluidframework/protocol-base": "0.1036.2000-63043",
+				"@fluidframework/gitresources": "0.1036.3000-65108",
+				"@fluidframework/protocol-base": "0.1036.3000-65108",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"axios": "^0.26.0",
 				"crc-32": "1.2.0",
@@ -612,19 +628,19 @@
 			}
 		},
 		"@fluidframework/server-services-core": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.2000-63043.tgz",
-			"integrity": "sha512-pUiTEy3niT7HpECtoNN8sXJ8Gyp9smpt6/7HoMDkM1NX5dGH0WFd2gxDqASI8wh2Ls9YAgcXtVf+KWPI7+711w==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.3000-65108.tgz",
+			"integrity": "sha512-lI8+oIkrTxsmUe11pZe/ePhEPEuaToF/hNld5MA61JkWYijKJT7kZoFPbsfLtkMqZSst+r6FDRhh6bcADEANcQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "0.1036.2000-63043",
+				"@fluidframework/gitresources": "0.1036.3000-65108",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "0.1036.2000-63043",
-				"@fluidframework/server-services-telemetry": "0.1036.2000-63043",
-				"@types/nconf": "^0.10.0",
+				"@fluidframework/server-services-client": "0.1036.3000-65108",
+				"@fluidframework/server-services-telemetry": "0.1036.3000-65108",
+				"@types/nconf": "^0.10.2",
 				"@types/node": "^14.18.0",
 				"debug": "^4.1.1",
-				"nconf": "^0.11.4"
+				"nconf": "^0.12.0"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -652,29 +668,63 @@
 					"version": "0.10.2",
 					"resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.2.tgz",
 					"integrity": "sha512-qy5EPdN8hnlix/q/QYr4ZnICDgaEFh2qivsNYlg4/KlvM7Ye2CqeDo0UXxSoiWplZzyl2PzOxwx4MODaxS+KpA=="
+				},
+				"ini": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+				},
+				"nconf": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+					"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+					"requires": {
+						"async": "^3.0.0",
+						"ini": "^2.0.0",
+						"secure-keys": "^1.0.0",
+						"yargs": "^16.1.1"
+					}
 				}
 			}
 		},
 		"@fluidframework/server-services-ordering-kafkanode": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-ordering-kafkanode/-/server-services-ordering-kafkanode-0.1036.2000-63043.tgz",
-			"integrity": "sha512-t/yVJnXHnJ9zdGE5lpequ6iUXyxXRBb5p/Fi54Q4dzIEh8umAZB1Fg5qiZH7vvLMVwBBoeYgjakwqntNvsNdeQ==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-ordering-kafkanode/-/server-services-ordering-kafkanode-0.1036.3000-65108.tgz",
+			"integrity": "sha512-9YFsoxFr4rtRWt4o0V0KSLR/5buuBou2XfKpapQHSsydwISvpvECi2F0qeF7a9Ccenu5CyCQdsQiUzulfld/Kg==",
 			"requires": {
-				"@fluidframework/server-services-core": "0.1036.2000-63043",
-				"@fluidframework/server-services-ordering-zookeeper": "0.1036.2000-63043",
+				"@fluidframework/server-services-core": "0.1036.3000-65108",
+				"@fluidframework/server-services-ordering-zookeeper": "0.1036.3000-65108",
 				"kafka-node": "^5.0.0",
-				"nconf": "^0.11.4",
+				"nconf": "^0.12.0",
 				"sillyname": "^0.1.0"
+			},
+			"dependencies": {
+				"ini": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+				},
+				"nconf": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+					"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+					"requires": {
+						"async": "^3.0.0",
+						"ini": "^2.0.0",
+						"secure-keys": "^1.0.0",
+						"yargs": "^16.1.1"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-services-ordering-rdkafka": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-ordering-rdkafka/-/server-services-ordering-rdkafka-0.1036.2000-63043.tgz",
-			"integrity": "sha512-czHRAQ9HB5vKou65uHtdk5oos2BDN//rO8AH4k7ftZDB+MEoNDXvVi1D0IDlgJjsCJ9RHuldI5QvVT3ZX8tmqg==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-ordering-rdkafka/-/server-services-ordering-rdkafka-0.1036.3000-65108.tgz",
+			"integrity": "sha512-3/CLGDPymFFG5PRY16QqzrCZIimSuMyjhs3IA7L29pV0Y1DkpxaseNn2U7o9DP4HZHiemRYuwxYJJBegG8hjDQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/server-services-core": "0.1036.2000-63043",
-				"nconf": "^0.11.4",
+				"@fluidframework/server-services-core": "0.1036.3000-65108",
+				"nconf": "^0.12.0",
 				"node-rdkafka": "^2.11.0",
 				"sillyname": "^0.1.0"
 			},
@@ -691,36 +741,52 @@
 						"lodash": "^4.17.21",
 						"sha.js": "^2.4.11"
 					}
+				},
+				"ini": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+				},
+				"nconf": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+					"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+					"requires": {
+						"async": "^3.0.0",
+						"ini": "^2.0.0",
+						"secure-keys": "^1.0.0",
+						"yargs": "^16.1.1"
+					}
 				}
 			}
 		},
 		"@fluidframework/server-services-ordering-zookeeper": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-ordering-zookeeper/-/server-services-ordering-zookeeper-0.1036.2000-63043.tgz",
-			"integrity": "sha512-5zLrPCzn+nHjqLQshLPBEZww6p7wUdrDMtc9vDZeQBX9IizQEibe002lvm26uwKMOuHgQzB3mF0SBrYaOCKRdg==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-ordering-zookeeper/-/server-services-ordering-zookeeper-0.1036.3000-65108.tgz",
+			"integrity": "sha512-8ZyK9c6Ej1MEidK5XIANgnYSe4wh8s9tN6ajGf66TNw8C/SlDqcd1ilVY0VaB+8JYexrwv+Fe6aWF99GnKoY8A==",
 			"requires": {
-				"@fluidframework/server-services-core": "0.1036.2000-63043",
+				"@fluidframework/server-services-core": "0.1036.3000-65108",
 				"zookeeper": "^5.3.2"
 			}
 		},
 		"@fluidframework/server-services-shared": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1036.2000-63043.tgz",
-			"integrity": "sha512-4MuVj9+2/guNa8Scr07vZuiuXZsiqJPW8bzA4gAI/haVE5DjI5PvIhzerVFxlAKK9PlAfOR/z1ngqTHhs/ueIg==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1036.3000-65108.tgz",
+			"integrity": "sha512-qBE7QPnNIxw2YllXy+WWRqkBq8K6B8kH5/gdlAtEQrkGO3c3Pbpw64Ps/U8ZYh2wzT3wb8O9TFHtjhJl3VSALw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "0.1036.2000-63043",
-				"@fluidframework/protocol-base": "0.1036.2000-63043",
+				"@fluidframework/gitresources": "0.1036.3000-65108",
+				"@fluidframework/protocol-base": "0.1036.3000-65108",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "0.1036.2000-63043",
-				"@fluidframework/server-services-core": "0.1036.2000-63043",
-				"@fluidframework/server-services-telemetry": "0.1036.2000-63043",
+				"@fluidframework/server-services-client": "0.1036.3000-65108",
+				"@fluidframework/server-services-core": "0.1036.3000-65108",
+				"@fluidframework/server-services-telemetry": "0.1036.3000-65108",
 				"@socket.io/redis-adapter": "^7.0.0",
 				"debug": "^4.1.1",
 				"formidable": "2.0.0-canary.20200504.1",
 				"ioredis": "^4.24.2",
 				"lodash": "^4.17.21",
-				"nconf": "^0.11.4",
+				"nconf": "^0.12.0",
 				"notepack.io": "^2.3.0",
 				"socket.io": "^4.1.2",
 				"socket.io-adapter": "^2.3.1",
@@ -761,6 +827,22 @@
 						"qs": "^6.9.3"
 					}
 				},
+				"ini": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+				},
+				"nconf": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+					"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+					"requires": {
+						"async": "^3.0.0",
+						"ini": "^2.0.0",
+						"secure-keys": "^1.0.0",
+						"yargs": "^16.1.1"
+					}
+				},
 				"qs": {
 					"version": "6.10.3",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -777,9 +859,9 @@
 			}
 		},
 		"@fluidframework/server-services-telemetry": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.2000-63043.tgz",
-			"integrity": "sha512-hgxfDwUtDPEPnE9yNE5N6J+vUfCqFeb1q8n5hB4KkIc9rXOq5A29l1kV6TsFSX6zCLegyI2HqmB0EX0ZvTaryQ==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.3000-65108.tgz",
+			"integrity": "sha512-HkAqea7ia1+daDI+3oZrH794/a1BlU8xOkBmFyChM9CtEfdg1LaX6NGydlC0k2fYfDzm2m566hySlKBlOYbcOw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"json-stringify-safe": "^5.0.1",
@@ -809,20 +891,20 @@
 			}
 		},
 		"@fluidframework/server-services-utils": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1036.2000-63043.tgz",
-			"integrity": "sha512-28WZiCnBrCh77udg7gKAmJflkbkGkkO3nRbINPwbJROB/38kJLZ0zQFJNp6m9sPLWWQdsBRL6F5ZAPH2czlsuA==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1036.3000-65108.tgz",
+			"integrity": "sha512-6SORFTk9l2/WDARwPRuIlB36DekC4zVQXKVH2ifASc09Oqlpud4MmpJLFMeqwAd+p0NYYuIsuAn9KGri24eQXw==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "0.1036.2000-63043",
-				"@fluidframework/server-services-core": "0.1036.2000-63043",
-				"@fluidframework/server-services-telemetry": "0.1036.2000-63043",
+				"@fluidframework/server-services-client": "0.1036.3000-65108",
+				"@fluidframework/server-services-core": "0.1036.3000-65108",
+				"@fluidframework/server-services-telemetry": "0.1036.3000-65108",
 				"debug": "^4.1.1",
 				"express": "^4.16.3",
 				"ioredis": "^4.24.2",
 				"json-stringify-safe": "^5.0.1",
 				"jsonwebtoken": "^8.4.0",
-				"nconf": "^0.11.4",
+				"nconf": "^0.12.0",
 				"serialize-error": "^8.1.0",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1",
@@ -837,6 +919,22 @@
 						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				},
+				"ini": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+				},
+				"nconf": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+					"integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+					"requires": {
+						"async": "^3.0.0",
+						"ini": "^2.0.0",
+						"secure-keys": "^1.0.0",
+						"yargs": "^16.1.1"
+					}
+				},
 				"uuid": {
 					"version": "8.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -845,17 +943,17 @@
 			}
 		},
 		"@fluidframework/server-test-utils": {
-			"version": "0.1036.2000-63043",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.2000-63043.tgz",
-			"integrity": "sha512-lNKaUScerLLmMmdHqvrjM92gLKTHnKtUMb8JaitQjiIdkcDYg9wlCjoBKkpydGcwxhmjvU/M17Tu+rNE7dENRg==",
+			"version": "0.1036.3000-65108",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.3000-65108.tgz",
+			"integrity": "sha512-GUpdurZWdAdJYa2jTLzsRe9WkaSYx+YKGdbECuGRQHwu4qONjfhxEo5i+H9oj6x9C0WdkUx5xfhvdfolJ0F6KQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "0.1036.2000-63043",
-				"@fluidframework/protocol-base": "0.1036.2000-63043",
+				"@fluidframework/gitresources": "0.1036.3000-65108",
+				"@fluidframework/protocol-base": "0.1036.3000-65108",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "0.1036.2000-63043",
-				"@fluidframework/server-services-core": "0.1036.2000-63043",
-				"@fluidframework/server-services-telemetry": "0.1036.2000-63043",
+				"@fluidframework/server-services-client": "0.1036.3000-65108",
+				"@fluidframework/server-services-core": "0.1036.3000-65108",
+				"@fluidframework/server-services-telemetry": "0.1036.3000-65108",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.21",
 				"string-hash": "^1.1.3",
@@ -4181,24 +4279,19 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
 		},
-		"@socket.io/base64-arraybuffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-			"integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ=="
-		},
 		"@socket.io/component-emitter": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
 		"@socket.io/redis-adapter": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.1.0.tgz",
-			"integrity": "sha512-vbsNJKUQgtVHcOqNL2ac8kSemTVNKHRzYPldqQJt0eFKvlAtAviuAMzBP0WmOp5OoRLQMjhVsVvgMzzMsVsK5g==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
+			"integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
 			"requires": {
 				"debug": "~4.3.1",
 				"notepack.io": "~2.2.0",
-				"socket.io-adapter": "~2.3.0",
+				"socket.io-adapter": "^2.4.0",
 				"uid2": "0.0.3"
 			},
 			"dependencies": {
@@ -4214,11 +4307,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
 					"integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw=="
-				},
-				"socket.io-adapter": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-					"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ=="
 				}
 			}
 		},
@@ -7508,9 +7596,9 @@
 			}
 		},
 		"engine.io": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
-			"integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
+			"integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
 			"requires": {
 				"@types/cookie": "^0.4.1",
 				"@types/cors": "^2.8.12",
@@ -7540,12 +7628,9 @@
 			}
 		},
 		"engine.io-parser": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
-			"integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
-			"requires": {
-				"@socket.io/base64-arraybuffer": "~1.0.2"
-			}
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+			"integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg=="
 		},
 		"enquirer": {
 			"version": "2.3.6",
@@ -8132,12 +8217,6 @@
 					}
 				}
 			}
-		},
-		"eslint-plugin-no-null": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-null/-/eslint-plugin-no-null-1.0.2.tgz",
-			"integrity": "sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=",
-			"dev": true
 		},
 		"eslint-plugin-optimize-regex": {
 			"version": "1.1.7",
@@ -8839,9 +8918,9 @@
 			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
 		},
 		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+			"integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
 			"dev": true
 		},
 		"foreground-child": {
@@ -10721,9 +10800,9 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "10.5.17",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.17.tgz",
-			"integrity": "sha512-HcFL6xetAobRceTHT4KN69eebUI8bPsvBLPz3tn1NxM7zzw5pYAoHs7OjHV/rCnLwjmkf4C++IjNFJxe6M5Z+A=="
+			"version": "10.5.20",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.20.tgz",
+			"integrity": "sha512-YHL6y8o6cnRoxwUY0eGpfvwj0pm9o0NToD4KXVp2UJC19oXSR2RgnSdSMplIRRKFovLAJGrAHqdb5MMznnhQDQ=="
 		},
 		"jsx-ast-utils": {
 			"version": "3.2.1",
@@ -12633,9 +12712,9 @@
 					"dev": true
 				},
 				"is-core-module": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-					"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+					"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 					"dev": true,
 					"requires": {
 						"has": "^1.0.3"
@@ -14295,9 +14374,9 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "17.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-					"integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+					"version": "17.5.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.0.tgz",
+					"integrity": "sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==",
 					"dev": true,
 					"requires": {
 						"cliui": "^7.0.2",
@@ -14803,15 +14882,15 @@
 			}
 		},
 		"socket.io": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
-			"integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
+			"integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
 			"requires": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
 				"debug": "~4.3.2",
-				"engine.io": "~6.1.0",
-				"socket.io-adapter": "~2.3.3",
+				"engine.io": "~6.2.0",
+				"socket.io-adapter": "~2.4.0",
 				"socket.io-parser": "~4.0.4"
 			},
 			"dependencies": {
@@ -14822,11 +14901,6 @@
 					"requires": {
 						"ms": "2.1.2"
 					}
-				},
-				"socket.io-adapter": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-					"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ=="
 				},
 				"socket.io-parser": {
 					"version": "4.0.4",
@@ -15867,9 +15941,9 @@
 			"dev": true
 		},
 		"underscore": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-			"integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
+			"integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==",
 			"dev": true
 		},
 		"unique-filename": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -243,7 +243,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -300,9 +300,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.63777",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.63777.tgz",
-      "integrity": "sha512-8dYzL84O8uJxwblk5cclpUoIhAxD5vIP/gPV08l/ZLxZJwPSmdYTJBMAFP/QRbXIxWGpo/DNlVshYF+sW3w+Aw==",
+      "version": "0.2.66048",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.66048.tgz",
+      "integrity": "sha512-iqWE2c6q1qtTGq+uieBuepgtcunxGSdAsfdZBB2VYHF2CZeR4LzNuw3ghUeuajYxK88Q27d0iZypw+/wYlBRMw==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -7100,12 +7100,6 @@
         }
       }
     },
-    "eslint-plugin-no-null": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-null/-/eslint-plugin-no-null-1.0.2.tgz",
-      "integrity": "sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=",
-      "dev": true
-    },
     "eslint-plugin-optimize-regex": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/eslint-plugin-optimize-regex/-/eslint-plugin-optimize-regex-1.1.7.tgz",
@@ -7668,9 +7662,9 @@
       "dev": true
     },
     "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
       "dev": true
     },
     "foreground-child": {
@@ -7801,10 +7795,177 @@
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+          "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "regexp.prototype.flags": "^1.4.1",
+            "string.prototype.trimend": "^1.0.5",
+            "string.prototype.trimstart": "^1.0.5",
+            "unbox-primitive": "^1.0.2"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-negative-zero": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+          "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        }
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
     "gauge": {
@@ -8173,6 +8334,15 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -8911,18 +9081,30 @@
         "has-tostringtag": "^1.0.0"
       },
       "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
         "es-abstract": {
-          "version": "1.19.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-          "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+          "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.1",
             "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
             "internal-slot": "^1.0.3",
             "is-callable": "^1.2.4",
@@ -8934,10 +9116,17 @@
             "object-inspect": "^1.12.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
+            "regexp.prototype.flags": "^1.4.1",
+            "string.prototype.trimend": "^1.0.5",
+            "string.prototype.trimstart": "^1.0.5",
+            "unbox-primitive": "^1.0.2"
           }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+          "dev": true
         },
         "has-symbols": {
           "version": "1.0.3",
@@ -8990,6 +9179,40 @@
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
           "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
         }
       }
     },
@@ -12660,9 +12883,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-          "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
+          "version": "17.5.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.0.tgz",
+          "integrity": "sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -14126,18 +14349,30 @@
         "is-typed-array": "^1.1.7"
       },
       "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
         "es-abstract": {
-          "version": "1.19.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-          "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+          "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.1",
             "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
             "internal-slot": "^1.0.3",
             "is-callable": "^1.2.4",
@@ -14149,10 +14384,17 @@
             "object-inspect": "^1.12.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
+            "regexp.prototype.flags": "^1.4.1",
+            "string.prototype.trimend": "^1.0.5",
+            "string.prototype.trimstart": "^1.0.5",
+            "unbox-primitive": "^1.0.2"
           }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+          "dev": true
         },
         "has-symbols": {
           "version": "1.0.3",
@@ -14205,6 +14447,40 @@
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
           "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
         }
       }
     },

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -68,7 +68,6 @@
     "eslint": "~8.6.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
     "eslint-plugin-import": "~2.25.4",
-    "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -75,7 +75,6 @@
     "eslint": "~8.6.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
     "eslint-plugin-import": "~2.25.4",
-    "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -61,7 +61,6 @@
     "eslint": "~8.6.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
     "eslint-plugin-import": "~2.25.4",
-    "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",


### PR DESCRIPTION
Fixes #8831.

The no-null/no-null eslint rule has been replaced and is no longer used in our shared lint config. This change removes the last remaining no-null related code and config.