### PR TITLE
Fix inconsistent version dependency in fluid-framework package

### DIFF
--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.48.1000",
-    "@fluidframework/fluid-static": "^0.59.2000",
-    "@fluidframework/map": "^0.59.2000",
-    "@fluidframework/sequence": "^0.59.2000"
+    "@fluidframework/fluid-static": "^0.59.3000",
+    "@fluidframework/map": "^0.59.3000",
+    "@fluidframework/sequence": "^0.59.3000"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",


### PR DESCRIPTION
This PR bumps dependencies to make them consistent with other client packages. This is done in order to continue with the release process.