### PR TITLE
Stress: Fix tinylicious by installing necessary packages

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -37,7 +37,7 @@
     "start:mini": "node ./dist/nodeStressTest.js  --profile mini",
     "start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
     "start:reauth": "node ./dist/nodeStressTest.js --profile mini --browserAuth",
-    "start:t9s": "start-server-and-test start:tinylicious:test 7070 start:t9s:run",
+    "start:t9s": "npm install start-server-and-test && start-server-and-test start:tinylicious:test 7070 start:t9s:run",
     "start:t9s:run": "node ./dist/nodeStressTest.js --driver tinylicious ",
     "start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",
     "test": "npm run test:realsvc:run",
@@ -94,7 +94,9 @@
     "@fluidframework/tool-utils": "^0.59.3000",
     "commander": "^5.1.0",
     "ps-node": "^0.1.6",
-    "random-js": "^1.0.8"
+    "random-js": "^1.0.8",
+    "start-server-and-test": "^1.11.7",
+    "tinylicious": "^0.4.57763"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
@@ -122,8 +124,6 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.57763",
     "typescript": "~4.5.5"
   }
 }

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -37,7 +37,7 @@
     "start:mini": "node ./dist/nodeStressTest.js  --profile mini",
     "start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
     "start:reauth": "node ./dist/nodeStressTest.js --profile mini --browserAuth",
-    "start:t9s": "npm install start-server-and-test && start-server-and-test start:tinylicious:test 7070 start:t9s:run",
+    "start:t9s": "start-server-and-test start:tinylicious:test 7070 start:t9s:run",
     "start:t9s:run": "node ./dist/nodeStressTest.js --driver tinylicious ",
     "start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",
     "test": "npm run test:realsvc:run",


### PR DESCRIPTION
The tinylicious target requires a few more packages be installed to run, so moving tinylicious and start-server-and-test to regular dependencies. this matches the setup for our end to end test