### PR TITLE
Add support for custom deli control messages

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -151,17 +151,48 @@ interface ICheckpoint {
 }
 
 export enum OpEventType {
+    /**
+     * There have been no sequenced ops for X milliseconds since the last message.
+     */
     Idle,
+
+    /**
+     * More than X amount of ops have been ticketed since the emit.
+     */
     MaxOps,
+
+    /**
+     * There was no previous emit for the last X milliseconds.
+     */
     MaxTime,
+
+    /**
+     * Indicates the durable sequence number was updated.
+     */
     UpdatedDurableSequenceNumber,
 }
 
 export interface IDeliLambdaEvents extends IEvent {
+    /**
+     * Emitted when certain op event heuristics are triggered.
+     */
     (event: "opEvent",
         listener: (type: OpEventType, sequenceNumber: number, sequencedMessagesSinceLastOpEvent: number) => void);
+
+    /**
+     * Emitted when the lambda is updating the durable sequence number.
+     * This usually occurs via a control message after a summary was created.
+     */
     (event: "updatedDurableSequenceNumber", listener: (durableSequenceNumber: number) => void);
+
+    /**
+     * Emitted when the lambda recieves an custom control message.
+     */
     (event: "controlMessage", listener: (controlMessage: IControlMessage) => void);
+
+    /**
+     * Emitted when the lambda is closing.
+     */
     (event: "close", listener: (type: LambdaCloseType) => void);
 }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -161,6 +161,7 @@ export interface IDeliLambdaEvents extends IEvent {
     (event: "opEvent",
         listener: (type: OpEventType, sequenceNumber: number, sequencedMessagesSinceLastOpEvent: number) => void);
     (event: "updatedDurableSequenceNumber", listener: (durableSequenceNumber: number) => void);
+    (event: "controlMessage", listener: (controlMessage: IControlMessage) => void);
     (event: "close", listener: (type: LambdaCloseType) => void);
 }
 
@@ -962,7 +963,9 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                     }
 
                     default:
-                        // ignore unknown control messages
+                        // an unknown control message was received
+                        // emit a control message event to support custom control messages
+                        this.emit("controlMessage", controlMessage);
                         break;
                 }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -186,7 +186,7 @@ export interface IDeliLambdaEvents extends IEvent {
     (event: "updatedDurableSequenceNumber", listener: (durableSequenceNumber: number) => void);
 
     /**
-     * Emitted when the lambda recieves an custom control message.
+     * Emitted when the lambda recieves a custom control message.
      */
     (event: "controlMessage", listener: (controlMessage: IControlMessage) => void);
 


### PR DESCRIPTION
Emit a `controlMessage` event when a custom control message type is received. This will allow implementing custom control messages outside the deli lambda.

I also added some comments to the events the lambda will emit.