### PR TITLE
Added inactive object events for attachment blobs.

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -74,9 +74,9 @@ export class BlobManager {
         snapshot: IBlobManagerLoadInfo,
         private readonly getStorage: () => IDocumentStorageService,
         private readonly attachBlobCallback: (blobId: string) => void,
-        // To be called when a blob is requested. blobPath is the path of the blob's node in GC's graph. It's
-        // of the format `/<BlobManager.basePath>/<blobId>`;
-        private readonly blobRetrievedCallback: (blobPath: string) => void,
+        // To be called when a blob node is requested. blobPath is the path of the blob's node in GC's graph. It's
+        // of the format `/<BlobManager.basePath>/<blobId>`.
+        private readonly gcNodeUpdated: (blobPath: string) => void,
         private readonly runtime: IContainerRuntime,
         private readonly logger: ITelemetryLogger,
     ) {
@@ -105,8 +105,8 @@ export class BlobManager {
         const storageId = this.redirectTable?.get(blobId) ?? blobId;
         assert(this.hasBlob(storageId), 0x11f /* "requesting unknown blobs" */);
 
-        // When this blob is retrieved, let the container runtime know.
-        this.blobRetrievedCallback(this.getBlobGCNodePath(blobId));
+        // When this blob is retrieved, let the container runtime know that the corresponding GC node got updated.
+        this.gcNodeUpdated(this.getBlobGCNodePath(blobId));
 
         return new BlobHandle(
             `${BlobManager.basePath}/${storageId}`,

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -74,6 +74,9 @@ export class BlobManager {
         snapshot: IBlobManagerLoadInfo,
         private readonly getStorage: () => IDocumentStorageService,
         private readonly attachBlobCallback: (blobId: string) => void,
+        // To be called when a blob is requested. blobPath is the path of the blob's node in GC's graph. It's
+        // of the format `/<BlobManager.basePath>/<blobId>`;
+        private readonly blobRetrievedCallback: (blobPath: string) => void,
         private readonly runtime: IContainerRuntime,
         private readonly logger: ITelemetryLogger,
     ) {
@@ -89,9 +92,21 @@ export class BlobManager {
         return this.blobIds.has(id) || this.detachedBlobIds.has(id);
     }
 
+    /**
+     * For a blobId, returns its path in GC's graph. The node path is of the format `/<BlobManager.basePath>/<blobId>`
+     * This path must match the path of the blob handle returned by the createBlob API because blobs are marked
+     * referenced by storing these handles in a referenced DDS.
+     */
+    private getBlobGCNodePath(blobId: string) {
+        return `/${BlobManager.basePath}/${blobId}`;
+    }
+
     public async getBlob(blobId: string): Promise<IFluidHandle<ArrayBufferLike>> {
         const storageId = this.redirectTable?.get(blobId) ?? blobId;
         assert(this.hasBlob(storageId), 0x11f /* "requesting unknown blobs" */);
+
+        // When this blob is retrieved, let the container runtime know.
+        this.blobRetrievedCallback(this.getBlobGCNodePath(blobId));
 
         return new BlobHandle(
             `${BlobManager.basePath}/${storageId}`,
@@ -212,14 +227,10 @@ export class BlobManager {
      * about this for now because the data is a simple list of blob ids.
      */
     public getGCData(fullGC: boolean = false): IGarbageCollectionData {
-        const getGCNodePath = (blobId: string) => { return `/${BlobManager.basePath}/${blobId}`; };
         const gcData: IGarbageCollectionData = { gcNodes: {} };
-        /**
-          * The node path is of the format `/_blobs/blobId`. This path must match the path of the blob handle returned
-          * by the createBlob API because blobs are marked referenced by storing these handles in a referenced DDS.
-          */
+
         this.blobIds.forEach((blobId: string) => {
-            gcData.gcNodes[getGCNodePath(blobId)] = [];
+            gcData.gcNodes[this.getBlobGCNodePath(blobId)] = [];
         });
 
         /**
@@ -233,7 +244,7 @@ export class BlobManager {
             for (const [localId, storageId] of this.redirectTable) {
                 // Add node for the localId and add a route to the storageId node. The storageId node will have been
                 // added above when adding nodes for this.blobIds.
-                gcData.gcNodes[getGCNodePath(localId)] = [getGCNodePath(storageId)];
+                gcData.gcNodes[this.getBlobGCNodePath(localId)] = [this.getBlobGCNodePath(storageId)];
             }
         }
 
@@ -245,7 +256,8 @@ export class BlobManager {
      * @param unusedRoutes - These are the blob node ids that are unused and should be deleted.
      */
     public deleteUnusedRoutes(unusedRoutes: string[]): void {
-        // The routes or blob node paths are in the same format as returned in getGCData - `/_blobs/blobId`.
+        // The routes or blob node paths are in the same format as returned in getGCData -
+        // `/<BlobManager.basePath>/<blobId>`.
         for (const route of unusedRoutes) {
             const pathParts = route.split("/");
             assert(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1089,7 +1089,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.handleContext,
             blobManagerSnapshot,
             () => this.storage,
-            (blobId) => this.submit(ContainerMessageType.BlobAttach, undefined, undefined, { blobId }),
+            (blobId: string) => this.submit(ContainerMessageType.BlobAttach, undefined, undefined, { blobId }),
+            (blobPath: string) => this.garbageCollector.nodeUpdated(blobPath, "Loaded"),
             this,
             this.logger,
         );

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -90,8 +90,8 @@ export class DataStores implements IDisposable {
         private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
         getBaseGCDetails: () => Promise<Map<string, IGarbageCollectionDetailsBase>>,
-        private readonly dataStoreChanged: (
-            dataStorePath: string, timestampMs: number, packagePath?: readonly string[]) => void,
+        private readonly gcNodeUpdated: (
+            nodePath: string, timestampMs: number, packagePath?: readonly string[]) => void,
         private readonly aliasMap: Map<string, string>,
         private readonly writeGCDataAtRoot: boolean,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
@@ -399,8 +399,9 @@ export class DataStores implements IDisposable {
         assert(!!context, 0x162 /* "There should be a store context for the op" */);
         context.process(transformed, local, localMessageMetadata);
 
-        // Notify that a data store changed. This is used to detect if a deleted data store is being used.
-        this.dataStoreChanged(
+        // Notify that a GC node for the data store changed. This is used to detect if a deleted data store is
+        // being used.
+        this.gcNodeUpdated(
             `/${envelope.address}`,
             message.timestamp,
             context.isLoaded ? context.packagePath : undefined,


### PR DESCRIPTION
When an attachment blob is unreferenced for a certain amount of time, it it marked a inactive. Requesting or referencing an inactive attachment blob, results in an error telemetry being logged. These logs are used to determine if there are scenarios where an attachment blob is being used after delete. We have logs similar to these for data stores and DDSs.
This will us determine when its safe to turn GC sweep phase on.

Added tests to verify that these errors are logged as expected.

[AB#178](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/178)