### PR TITLE
Add support for driver endpoint in odsp driver test

### DIFF
--- a/api-report/test-driver-definitions.api.md
+++ b/api-report/test-driver-definitions.api.md
@@ -10,6 +10,9 @@ import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 
+// @public (undocumented)
+export type DriverEndpoint = RouterliciousEndpoint | OdspEndpoint;
+
 // @public
 export interface ITelemetryBufferedLogger extends ITelemetryBaseLogger {
     flush(): Promise<void>;
@@ -27,6 +30,9 @@ export interface ITestDriver {
     readonly userIndex?: number;
     readonly version: string;
 }
+
+// @public (undocumented)
+export type OdspEndpoint = "odsp" | "odsp-df";
 
 // @public (undocumented)
 export type RouterliciousEndpoint = "frs" | "r11s" | "docker";

--- a/api-report/test-drivers.api.md
+++ b/api-report/test-drivers.api.md
@@ -21,9 +21,16 @@ import { LocalDocumentServiceFactory } from '@fluidframework/local-driver';
 import { LocalResolver } from '@fluidframework/local-driver';
 import { OdspDocumentServiceFactory } from '@fluidframework/odsp-driver';
 import { OdspDriverUrlResolver } from '@fluidframework/odsp-driver';
+import { OdspEndpoint } from '@fluidframework/test-driver-definitions';
 import { RouterliciousDocumentServiceFactory } from '@fluidframework/routerlicious-driver';
 import { RouterliciousEndpoint } from '@fluidframework/test-driver-definitions';
 import { TestDriverTypes } from '@fluidframework/test-driver-definitions';
+
+// @public (undocumented)
+export function assertOdspEndpoint(endpoint: string | undefined): asserts endpoint is OdspEndpoint | undefined;
+
+// @public (undocumented)
+export function assertRouterliciousEndpoint(endpoint: string | undefined): asserts endpoint is RouterliciousEndpoint | undefined;
 
 // @public (undocumented)
 export function createFluidTestDriver(fluidTestDriverType?: TestDriverTypes, config?: FluidTestDriverConfig, api?: DriverApiType): Promise<LocalServerTestDriver | TinyliciousTestDriver | RouterliciousTestDriver | OdspTestDriver>;
@@ -112,6 +119,7 @@ export class OdspTestDriver implements ITestDriver {
         options?: HostStoragePolicy;
         supportsBrowserAuth?: boolean;
         tenantIndex?: number;
+        odspEndpointName?: string;
     }, api?: OdspDriverApiType): Promise<OdspTestDriver>;
     // (undocumented)
     createUrlResolver(): IUrlResolver;
@@ -147,7 +155,7 @@ export class RouterliciousTestDriver implements ITestDriver {
     createDocumentServiceFactory(): IDocumentServiceFactory;
     // (undocumented)
     static createFromEnv(config?: {
-        r11sEndpointName?: RouterliciousEndpoint;
+        r11sEndpointName?: string;
     }, api?: RouterliciousDriverApiType): RouterliciousTestDriver;
     // (undocumented)
     createUrlResolver(): InsecureUrlResolver;

--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -10,6 +10,10 @@ export type TestDriverTypes = "tinylicious" | "t9s" | "routerlicious" | "r11s" |
 
 export type RouterliciousEndpoint = "frs" | "r11s" | "docker";
 
+export type OdspEndpoint = "odsp" | "odsp-df";
+
+export type DriverEndpoint = RouterliciousEndpoint | OdspEndpoint;
+
 export interface ITestDriver{
     /**
      * The type of server the test driver executes against

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -107,10 +107,6 @@
   },
   "typeValidation": {
     "version": "0.59.3000",
-    "broken": {
-        "InterfaceDeclaration_FluidTestDriverConfig": {
-          "forwardCompat": false
-      }
-    }
+    "broken": {}
   }
 }

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -23,7 +23,7 @@ import {
     getDriveItemByRootFileName,
     IClientConfig,
 } from "@fluidframework/odsp-doclib-utils";
-import { ITestDriver } from "@fluidframework/test-driver-definitions";
+import { ITestDriver, OdspEndpoint } from "@fluidframework/test-driver-definitions";
 import { OdspDriverApiType, OdspDriverApi } from "./odspDriverApi";
 
 const passwordTokenConfig = (username, password): OdspTokenConfig => ({
@@ -62,14 +62,24 @@ interface LoginTenants {
     };
 }
 
+export function assertOdspEndpoint(
+    endpoint: string | undefined,
+): asserts endpoint is OdspEndpoint | undefined {
+    if (endpoint === undefined || endpoint === "odsp" || endpoint === "odsp-df") {
+        return;
+    }
+    throw new TypeError("Not a odsp endpoint");
+}
+
 /**
  * Get from the env a set of credential to use from a single tenant
  * @param tenantIndex - interger to choose the tenant from an array
  * @param requestedUserName - specific user name to filter to
  */
-function getCredentials(tenantIndex: number, requestedUserName?: string) {
+function getCredentials(odspEndpointName: OdspEndpoint, tenantIndex: number, requestedUserName?: string) {
     const creds: { [user: string]: string; } = {};
-    const loginTenants = process.env.login__odsp__test__tenants;
+    const loginTenants = odspEndpointName === "odsp" ?
+        process.env.login__odsp__test__tenants : process.env.login__odsp_df__test__tenants;
     if (loginTenants !== undefined) {
         const tenants: LoginTenants = JSON.parse(loginTenants);
         const tenantNames = Object.keys(tenants);
@@ -86,8 +96,9 @@ function getCredentials(tenantIndex: number, requestedUserName?: string) {
             }
         }
     } else {
-        const loginAccounts = process.env.login__odsp__test__accounts;
-        assert(loginAccounts !== undefined, "Missing login__odsp__test__accounts");
+        const loginAccounts = odspEndpointName === "odsp" ?
+            process.env.login__odsp__test__accounts : process.env.login__odsp_df__test__accounts;
+        assert(loginAccounts !== undefined, "Missing login__odsp/odspdf__test__accounts");
         // Expected format of login__odsp__test__accounts is simply string key-value pairs of username and password
         const passwords: { [user: string]: string; } = JSON.parse(loginAccounts);
 
@@ -134,11 +145,14 @@ export class OdspTestDriver implements ITestDriver {
             options?: HostStoragePolicy;
             supportsBrowserAuth?: boolean;
             tenantIndex?: number;
+            odspEndpointName?: string;
         },
         api: OdspDriverApiType = OdspDriverApi,
     ) {
         const tenantIndex = config?.tenantIndex ?? 0;
-        const creds = getCredentials(tenantIndex, config?.username);
+        assertOdspEndpoint(config?.odspEndpointName);
+        const endpointName = config?.odspEndpointName ?? "odsp";
+        const creds = getCredentials(endpointName, tenantIndex, config?.username);
         // Pick a random one on the list (only supported for >= 0.46)
         const users = Object.keys(creds);
         const randomUserIndex = compare(api.version, "0.46.0") >= 0 ?

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -84,10 +84,20 @@ function getConfigFromEnv(r11sEndpointName?: RouterliciousEndpoint) {
     return getEndpointConfigFromEnv(r11sEndpointName);
 }
 
+export function assertRouterliciousEndpoint(
+    endpoint: string | undefined,
+): asserts endpoint is RouterliciousEndpoint | undefined {
+    if (endpoint === undefined || endpoint === "frs" || endpoint === "r11s" || endpoint === "docker") {
+        return;
+    }
+    throw new TypeError("Not a routerlicious endpoint");
+}
+
 export class RouterliciousTestDriver implements ITestDriver {
-    public static createFromEnv(config?: { r11sEndpointName?: RouterliciousEndpoint; },
+    public static createFromEnv(config?: { r11sEndpointName?: string; },
         api: RouterliciousDriverApiType = RouterliciousDriverApi,
     ) {
+        assertRouterliciousEndpoint(config?.r11sEndpointName);
         const { serviceEndpoint, tenantId, tenantSecret, driverPolicies } = getConfigFromEnv(config?.r11sEndpointName);
         return new RouterliciousTestDriver(
             tenantId,

--- a/packages/test/test-drivers/src/test/types/validateTestDriversPrevious.ts
+++ b/packages/test/test-drivers/src/test/types/validateTestDriversPrevious.ts
@@ -120,7 +120,6 @@ declare function get_old_InterfaceDeclaration_FluidTestDriverConfig():
 declare function use_current_InterfaceDeclaration_FluidTestDriverConfig(
     use: TypeOnly<current.FluidTestDriverConfig>);
 use_current_InterfaceDeclaration_FluidTestDriverConfig(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_FluidTestDriverConfig());
 
 /*

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -7,7 +7,7 @@ import child_process from "child_process";
 import fs from "fs";
 import ps from "ps-node";
 import commander from "commander";
-import { TestDriverTypes, RouterliciousEndpoint } from "@fluidframework/test-driver-definitions";
+import { TestDriverTypes, DriverEndpoint } from "@fluidframework/test-driver-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ILoadTestConfig } from "./testConfigFile";
 import { createTestDriver, getProfile, initialize, loggerP, safeExit } from "./utils";
@@ -55,7 +55,7 @@ async function main() {
         .parse(process.argv);
 
     const driver: TestDriverTypes = commander.driver;
-    const endpoint: RouterliciousEndpoint | undefined = commander.driverEndpoint;
+    const endpoint: DriverEndpoint | undefined = commander.driverEndpoint;
     const profileArg: string = commander.profile;
     const testId: string | undefined = commander.testId;
     const debug: true | undefined = commander.debug;
@@ -86,7 +86,7 @@ async function main() {
  */
 async function orchestratorProcess(
     driver: TestDriverTypes,
-    endpoint: RouterliciousEndpoint | undefined,
+    endpoint: DriverEndpoint | undefined,
     profile: ILoadTestConfig & { name: string; testUsers?: ITestUserConfig; },
     args: { testId?: string; debug?: true; verbose?: true; seed?: number; browserAuth?: true;
         enableMetrics?: boolean; },

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -4,7 +4,11 @@
  */
 
 import commander from "commander";
-import { ITestDriver, TestDriverTypes, RouterliciousEndpoint } from "@fluidframework/test-driver-definitions";
+import {
+    ITestDriver,
+    TestDriverTypes,
+    DriverEndpoint,
+} from "@fluidframework/test-driver-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import random from "random-js";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
@@ -47,7 +51,7 @@ async function main() {
         .parse(process.argv);
 
     const driver: TestDriverTypes = commander.driver;
-    const endpoint: RouterliciousEndpoint | undefined = commander.driverEndpoint;
+    const endpoint: DriverEndpoint | undefined = commander.driverEndpoint;
     const profileArg: string = commander.profile;
     const url: string = commander.url;
     const runId: number = commander.runId;
@@ -127,7 +131,7 @@ function* factoryPermutations<T extends IDocumentServiceFactory>(create: () => T
  */
 async function runnerProcess(
     driver: TestDriverTypes,
-    endpoint: RouterliciousEndpoint | undefined,
+    endpoint: DriverEndpoint | undefined,
     runConfig: IRunConfig,
     url: string,
     seed: number,

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -18,7 +18,7 @@ import {
     ITelemetryBufferedLogger,
     ITestDriver,
     TestDriverTypes,
-    RouterliciousEndpoint,
+    DriverEndpoint,
 } from "@fluidframework/test-driver-definitions";
 import {
     createFluidTestDriver,
@@ -191,7 +191,7 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
 
 export async function createTestDriver(
     driver: TestDriverTypes,
-    r11sEndpointName: RouterliciousEndpoint | undefined,
+    endpointName: DriverEndpoint | undefined,
     seed: number,
     runId: number | undefined,
     supportsBrowserAuth?: true,
@@ -204,9 +204,10 @@ export async function createTestDriver(
                 directory: "stress",
                 options: options[(runId ?? seed) % options.length],
                 supportsBrowserAuth,
+                odspEndpointName: endpointName,
             },
             r11s: {
-                r11sEndpointName,
+                r11sEndpointName: endpointName,
             },
         });
 }


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/9693
Add support for driver endpoint in odsp driver test so that we can enable different endpoints like dogfood, production etc in stress test.

