### PR TITLE
Collect more perf data for TreesLatest call - Add remote origin and Content-Encoding info #9399

### DIFF
--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -56,7 +56,7 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: { get: (id: string
 
     // x-fluid-telemetry contains a key value pair in the following format:
     // x-fluid-telemetry:key1=value1,key2,key3=value3,
-    // Ex. x-fluid-telemetry:Origin=c,isSomeDataPoint (there will be no isSomeDataPoint=false or isSomeDataPoint=True)
+    // Ex. x-fluid-telemetry:Origin=c
     const fluidTelemetry = headers.get("x-fluid-telemetry");
     if (fluidTelemetry !== undefined && fluidTelemetry !== null) {
         const keyValueMap = fluidTelemetry.split(",").map((keyValuePair) => keyValuePair.split("="));
@@ -71,7 +71,7 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: { get: (id: string
                         fieldValue = "graph";
                     break;
                     default:
-                        fieldValue = "undefined";
+                        fieldValue = value?.trim();
                 }
                 const logName = "responseOrigin";
                 additionalProps[logName] = fieldValue;

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -73,7 +73,7 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: { get: (id: string
         for (const [key, value] of keyValueMap) {
             const fluidKV = fluidKeyValuesToLog.find((t) => t.headerName === key.trim());
             if (fluidKV !== undefined) {
-                const fieldValue = value?.trim() ?? true;
+                const fieldValue = value?.trim() ?? true; // assume true for a key without value.
                 additionalProps[fluidKV.logName] = fluidKV.mapping?.get(fieldValue) ?? fieldValue;
             }
         }

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -30,7 +30,28 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: { get: (id: string
     interface LoggingHeader {
         headerName: string;
         logName: string;
+        subKeyName?: string;
+        mapping?: Map<string, string | number | boolean>;
     }
+    const mapResponseOrigin: Map<string, string> = new Map([
+        ["c", "cache"],
+        ["g", "graph"],
+      ]);
+
+    const xfluidTelemetry = "x-fluid-telemetry";
+    // X-Fluid-Telemetry contains a key value pair in the following format:
+    // X-Fluid-Telemetry:key1=value1,key2,key3=value3,
+    // Ex. X-Fluid-Telemetry:Origin=c,isSomeDataPoint (there will be no isSomeDataPoint=false or isSomeDataPoint=True)
+    const xFluidTelemetryParser = (fluidTelemetry: string, fieldName: string) => {
+        const outputMap = fluidTelemetry.split(",").map((keyValuePair) => keyValuePair.split("="));
+        for (const [key, value] of outputMap) {
+            if (key.trim() === fieldName) {
+                return value?.trim() ?? true;
+            }
+        }
+        return undefined;
+    };
+
     // We rename headers so that otel doesn't scrub them away. Otel doesn't allow
     // certain characters in headers including '-'
     const headersToLog: LoggingHeader[] = [
@@ -39,6 +60,9 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: { get: (id: string
         { headerName: "client-request-id", logName: "clientRequestId" },
         { headerName: "x-msedge-ref", logName: "xMsedgeRef" },
         { headerName: "X-Fluid-Retries", logName: "serverRetries" },
+        { headerName: "content-encoding", logName: "contentEncoding" },
+        { headerName: "content-type", logName: "contentType" },
+        { headerName: xfluidTelemetry, logName: "responseOrigin", subKeyName: "Origin", mapping: mapResponseOrigin },
     ];
     const additionalProps: ITelemetryProperties = {
         sprequestduration: TelemetryLogger.numberFromString(headers.get("sprequestduration")),
@@ -47,7 +71,14 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: { get: (id: string
     headersToLog.forEach((header) => {
         const headerValue = headers.get(header.headerName);
         if (headerValue !== undefined && headerValue !== null) {
-            additionalProps[header.logName] = headerValue;
+            if (header.subKeyName === undefined) {
+                additionalProps[header.logName] = headerValue;
+            } else if (header.headerName === xfluidTelemetry) {
+                const fieldValue = xFluidTelemetryParser(headerValue, header.subKeyName);
+                if (fieldValue !== undefined) {
+                    additionalProps[header.logName] = header.mapping?.get(fieldValue) ?? fieldValue;
+                }
+            }
         }
     });
     return additionalProps;


### PR DESCRIPTION
Fix for #9399 

## Description

There is a push to optimize boot performance, specifically P95 numbers.
Snapshot fetch is one of the biggest contributors and, in order to better understand the improvements that need to happen. we need to collect more data around the scenario: 
- Content-Encoding 
- Additional data to record whether the data is coming from Redis cache on SPO side or not. (responseOrigin == graph or cache)
Now the work item https://onedrive.visualstudio.com/SPIN/_workitems/edit/1309956   has been checked in, we can add this information on our end.  @vladsud   - I could simply upload the entire key value pair to the kusto db but I thought it would be better to add a field for each value key pair. As of now there is only one but it could easily change in the future as we add new keys to the bag).

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

