### PR TITLE
Remove offline marking from generic fetch errors

### DIFF
--- a/common/lib/driver-definitions/src/driverError.ts
+++ b/common/lib/driver-definitions/src/driverError.ts
@@ -52,9 +52,9 @@ export enum DriverErrorType {
 
     /**
      * Generic fetch failure.
-     * Most of such failures are due to client being offline, or DNS is not reachable, such errors map to
-     * DriverErrorType.offlineError. Anything else that can't be diagnose as likely offline maps to this error.
-     * This can also indicate no response from server.
+     * This may be due to the client being offline (though, if we are able to detect offline state it will be
+     * logged as an offlineError instead).  Other possibilities could be DNS errors, malformed fetch request,
+     * CSP violation, etc.  This can also indicate no response from server.
      */
     fetchFailure = "fetchFailure",
 

--- a/common/lib/driver-definitions/src/driverError.ts
+++ b/common/lib/driver-definitions/src/driverError.ts
@@ -51,10 +51,10 @@ export enum DriverErrorType {
     writeError = "writeError",
 
     /**
-     * Generic fetch failure.
+     * A generic fetch failure that indicates we were not able to get a response from the server.
      * This may be due to the client being offline (though, if we are able to detect offline state it will be
      * logged as an offlineError instead).  Other possibilities could be DNS errors, malformed fetch request,
-     * CSP violation, etc.  This can also indicate no response from server.
+     * CSP violation, etc.
      */
     fetchFailure = "fetchFailure",
 

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -354,8 +354,6 @@ async function fetchLatestSnapshotCore(
         ).catch((error) => {
             // We hit these errors in stress tests, under load
             // It's useful to try one more time in such case.
-            // We might want to add DriverErrorType.offlineError in the future if we see evidence it happens
-            // (not in "real" offline) and it actually helps.
             if (typeof error === "object" && error !== null && (error.errorType === DriverErrorType.fetchFailure ||
                 error.errorType === OdspErrorType.fetchTimeout)) {
                 error[getWithRetryForTokenRefreshRepeat] = true;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -129,14 +129,9 @@ export async function fetchHelper(
             duration: performance.now() - start,
         };
     }, (error) => {
-        // While we do not know for sure whether computer is offline, this error is not actionable and
-        // is pretty good indicator we are offline. Treating it as offline scenario will make it
-        // easier to see other errors in telemetry.
-        let online = isOnline();
+        const online = isOnline();
         const errorText = `${error}`;
-        if (errorText === "TypeError: Failed to fetch") {
-            online = OnlineStatus.Offline;
-        }
+
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {
             throw new RetryableError(
@@ -158,6 +153,8 @@ export async function fetchHelper(
                 // pre-0.58 error message prefix: Offline
                 `ODSP fetch failure (Offline): ${errorText}`, DriverErrorType.offlineError, { driverVersion });
         } else {
+            // It is perhaps still possible that this is due to being offline, the error does not reveal enough
+            // information to conclude.  Could also be DNS errors, malformed fetch request, CSP violation, etc.
             throw new RetryableError(
                 // pre-0.58 error message prefix: Fetch error
                 `ODSP fetch failure: ${errorText}`, DriverErrorType.fetchFailure, { driverVersion });


### PR DESCRIPTION
Resolves #8196

This came up again in OCE rotation, so going ahead with a simple fix.  Again in this case it's almost assuredly not offline (getting 400 errors at the same time, flagged as online).

With this change the "ODSP fetch failure (Offline): TypeError: Failed to fetch" error will become a very strong signal that we can ignore the error, whereas today it combines a mixture of real offline cases that are safe to ignore but also some real issues that we should get visibility on.  "ODSP fetch failure:" remains easy to filter on based on the particular failure to observe.