### PR TITLE
Return token from attach

### DIFF
--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -20,6 +20,12 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
+export interface ContainerAttachReturnState {
+    containerId: string;
+    serviceToken?: unknown;
+}
+
+// @public
 export interface ContainerSchema {
     dynamicObjectTypes?: LoadableObjectClass<any>[];
     initialObjects: LoadableObjectClassRecord;
@@ -40,7 +46,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
     constructor(container: IContainer, rootDataObject: RootDataObject);
-    attach(): Promise<string>;
+    attach(): Promise<ContainerAttachReturnState>;
     get attachState(): AttachState;
     connect(): Promise<void>;
     get connected(): boolean;
@@ -61,7 +67,7 @@ export interface IConnection {
 
 // @public
 export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
-    attach(): Promise<string>;
+    attach(): Promise<ContainerAttachReturnState>;
     readonly attachState: AttachState;
     connect?(): void;
     // @deprecated

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -157,5 +157,4 @@ export class AzureClient {
             logger: this.props.logger,
         });
     }
-    // #endregion
 }

--- a/azure/packages/external-controller/src/app.ts
+++ b/azure/packages/external-controller/src/app.ts
@@ -83,7 +83,7 @@ async function start(): Promise<void> {
     const client = new AzureClient(clientProps);
     let container: IFluidContainer;
     let services: AzureContainerServices;
-    let id: string;
+    let containerId: string;
 
     // Get or create the document depending if we are running through the create new flow
     const createNew = location.hash.length === 0;
@@ -96,17 +96,17 @@ async function start(): Promise<void> {
 
         // If the app is in a `createNew` state, and the container is detached, we attach the container.
         // This uploads the container to the service and connects to the collaboration session.
-        id = await container.attach();
+        containerId = await container.attach();
         // The newly attached container is given a unique ID that can be used to access the container in another session
-        location.hash = id;
+        location.hash = containerId;
     } else {
-        id = location.hash.substring(1);
+        containerId = location.hash.substring(1);
         // Use the unique container ID to fetch the container created earlier.  It will already be connected to the
         // collaboration session.
-        ({ container, services } = await client.getContainer(id, containerSchema));
+        ({ container, services } = await client.getContainer(containerId, containerSchema));
     }
 
-    document.title = id;
+    document.title = containerId;
 
     // Here we are guaranteed that the maps have already been initialized for use with a DiceRollerController
     const sharedMap1 = container.initialObjects.map1 as SharedMap;

--- a/examples/data-objects/focus-tracker/src/app.ts
+++ b/examples/data-objects/focus-tracker/src/app.ts
@@ -59,7 +59,8 @@ async function start(): Promise<void> {
     if (createNew) {
         // The client will create a new container using the schema
         ({ container, services } = await client.createContainer(containerSchema));
-        containerId = await container.attach();
+        const attachState = await container.attach();
+        containerId = attachState.containerId;
         // The new container has its own unique ID that can be used to access it in another session
         location.hash = containerId;
     } else {

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -72,7 +72,7 @@ export interface IFluidContainerEvents extends IEvent {
  */
 export interface ContainerAttachReturnState {
     /**
-     * The ID of the container.
+     * The unique ID of the container.
      *
      * TODO: anything more interesting to say here?
      */

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -68,6 +68,24 @@ export interface IFluidContainerEvents extends IEvent {
 }
 
 /**
+ * State returned by {@link IFluidContainer.attach}
+ */
+export interface ContainerAttachReturnState {
+    /**
+     * The ID of the container.
+     *
+     * TODO: anything more interesting to say here?
+     */
+    containerId: string;
+
+    /**
+     * An optional token returned from the connected service.
+     * This token is service-specific and is opaque as far as the Fluid container is concerned.
+     */
+    serviceToken?: unknown;
+}
+
+/**
  * The IFluidContainer provides an entrypoint into the client side of collaborative Fluid data.  It provides access
  * to the data as well as status on the collaboration session.
  */
@@ -124,11 +142,13 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
     /**
      * A newly created container starts detached from the collaborative service.  Calling attach() uploads the
      * new container to the service and connects to the collaborative service.
-     * @returns A promise which resolves when the attach is complete, with the string identifier of the container.
+     * @returns A promise which resolves when the attach is complete.
+     * See {@link ContainerAttachReturnState} for the returned state.
      */
-    attach(): Promise<string>;
+    attach(): Promise<ContainerAttachReturnState>;
 
     /**
+     * TODO: define delta stream (file bug)
      * Attempts to connect the container to the delta stream and process ops
      */
     connect?(): void;
@@ -153,7 +173,7 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
 }
 
 /**
- * Implementation of the IFluidContainer.
+ * Implementation of the {@link IFluidContainer}.
  */
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
     private readonly connectedHandler = () => this.emit("connected");
@@ -219,7 +239,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     /**
      * {@inheritDoc IFluidContainer.attach}
      */
-    public async attach(): Promise<string> {
+    public async attach(): Promise<ContainerAttachReturnState> {
         throw new Error("Cannot attach container. Container is not in detached state");
     }
 

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -80,11 +80,14 @@ export class TinyliciousClient {
                 if (this.attachState !== AttachState.Detached) {
                     throw new Error("Cannot attach container. Container is not in detached state");
                 }
+
                 const request = createTinyliciousCreateNewRequest();
                 await container.attach(request);
                 const resolved = container.resolvedUrl;
                 ensureFluidResolvedUrl(resolved);
-                return resolved.id;
+
+                // TODO: token
+                return { containerId: resolved.id };
             }
         })(container, rootDataObject);
 

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -130,7 +130,7 @@ describe("TinyliciousClient", () => {
      */
     it("can get a container successfully", async () => {
         const containerCreate = (await tinyliciousClient.createContainer(schema)).container;
-        const containerId = await containerCreate.attach();
+        const { containerId } = await containerCreate.attach();
         await new Promise<void>((resolve, reject) => {
             containerCreate.on("connected", () => {
                 resolve();
@@ -151,7 +151,7 @@ describe("TinyliciousClient", () => {
      */
     it("can change initialObjects value", async () => {
         const containerCreate = (await tinyliciousClient.createContainer(schema)).container;
-        const containerId = await containerCreate.attach();
+        const { containerId: containerId } = await containerCreate.attach();
         await new Promise<void>((resolve, reject) => {
             containerCreate.on("connected", () => {
                 resolve();


### PR DESCRIPTION
# [9913](https://github.com/microsoft/FluidFramework/issues/9913)

## Description

Updates `IFluidContainer.attach` to return an object with the container ID as well as an opaque, service-specific token.

Note that this change is breaking. Consumers will need to handle the new return type accordingly.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My code follows the code style of this project.
-   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.
