### PR TITLE
remove eslint config prerelease dependencies

### DIFF
--- a/azure/lerna-package-lock.json
+++ b/azure/lerna-package-lock.json
@@ -373,7 +373,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -1011,9 +1011,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.28.2000-64187",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-			"integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+			"version": "0.28.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+			"integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -49,7 +49,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/azure-local-service": "^0.1.38773",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-client-utils": "^0.59.2001",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",

--- a/azure/packages/azure-service-utils/src/generateToken.ts
+++ b/azure/packages/azure-service-utils/src/generateToken.ts
@@ -45,7 +45,7 @@ export function generateToken(
     const now = Math.round(Date.now() / 1000);
     const docId = documentId ?? "";
 
-    const claims: ITokenClaims & { jti: string } = {
+    const claims: ITokenClaims & { jti: string; } = {
         documentId: docId,
         scopes,
         tenantId,

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.59.2001",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/fluid-static": "^0.59.2001",
     "@fluidframework/test-client-utils": "^0.59.2001",
     "@fluidframework/test-tools": "^0.2.3074",

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -43,7 +43,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -179,9 +179,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/common/lib/common-definitions/src/events.ts
+++ b/common/lib/common-definitions/src/events.ts
@@ -58,7 +58,7 @@ export type ExtendEventProvider<
 
 // This is the place holder type that should be used instead of this in events
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type IEventThisPlaceHolder = { thisPlaceHolder: "thisPlaceHolder" };
+export type IEventThisPlaceHolder = { thisPlaceHolder: "thisPlaceHolder"; };
 
 // This does the type replacement by changing types of IEventThisPlaceHolder to TThis
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> =
@@ -78,22 +78,22 @@ export type TransformedEvent<TThis, E, A extends any[]> =
 export type IEventTransformer<TThis, TEvent extends IEvent> =
     TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: infer E8, listener: (...args: infer A8) => void),
-        (event: infer E9, listener: (...args: infer A9) => void),
-        (event: infer E10, listener: (...args: infer A10) => void),
-        (event: infer E11, listener: (...args: infer A11) => void),
-        (event: infer E12, listener: (...args: infer A12) => void),
-        (event: infer E13, listener: (...args: infer A13) => void),
-        (event: infer E14, listener: (...args: infer A14) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: infer E8, listener: (...args: infer A8) => void);
+        (event: infer E9, listener: (...args: infer A9) => void);
+        (event: infer E10, listener: (...args: infer A10) => void);
+        (event: infer E11, listener: (...args: infer A11) => void);
+        (event: infer E12, listener: (...args: infer A12) => void);
+        (event: infer E13, listener: (...args: infer A13) => void);
+        (event: infer E14, listener: (...args: infer A14) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
@@ -102,21 +102,21 @@ export type IEventTransformer<TThis, TEvent extends IEvent> =
     TransformedEvent<TThis, E12, A12> & TransformedEvent<TThis, E13, A13> & TransformedEvent<TThis, E14, A14>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: infer E8, listener: (...args: infer A8) => void),
-        (event: infer E9, listener: (...args: infer A9) => void),
-        (event: infer E10, listener: (...args: infer A10) => void),
-        (event: infer E11, listener: (...args: infer A11) => void),
-        (event: infer E12, listener: (...args: infer A12) => void),
-        (event: infer E13, listener: (...args: infer A13) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: infer E8, listener: (...args: infer A8) => void);
+        (event: infer E9, listener: (...args: infer A9) => void);
+        (event: infer E10, listener: (...args: infer A10) => void);
+        (event: infer E11, listener: (...args: infer A11) => void);
+        (event: infer E12, listener: (...args: infer A12) => void);
+        (event: infer E13, listener: (...args: infer A13) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
@@ -125,20 +125,20 @@ export type IEventTransformer<TThis, TEvent extends IEvent> =
     TransformedEvent<TThis, E12, A12> & TransformedEvent<TThis, E13, A13>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: infer E8, listener: (...args: infer A8) => void),
-        (event: infer E9, listener: (...args: infer A9) => void),
-        (event: infer E10, listener: (...args: infer A10) => void),
-        (event: infer E11, listener: (...args: infer A11) => void),
-        (event: infer E12, listener: (...args: infer A12) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: infer E8, listener: (...args: infer A8) => void);
+        (event: infer E9, listener: (...args: infer A9) => void);
+        (event: infer E10, listener: (...args: infer A10) => void);
+        (event: infer E11, listener: (...args: infer A11) => void);
+        (event: infer E12, listener: (...args: infer A12) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
@@ -147,19 +147,19 @@ export type IEventTransformer<TThis, TEvent extends IEvent> =
     TransformedEvent<TThis, E12, A12>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: infer E8, listener: (...args: infer A8) => void),
-        (event: infer E9, listener: (...args: infer A9) => void),
-        (event: infer E10, listener: (...args: infer A10) => void),
-        (event: infer E11, listener: (...args: infer A11) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: infer E8, listener: (...args: infer A8) => void);
+        (event: infer E9, listener: (...args: infer A9) => void);
+        (event: infer E10, listener: (...args: infer A10) => void);
+        (event: infer E11, listener: (...args: infer A11) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
@@ -167,18 +167,18 @@ export type IEventTransformer<TThis, TEvent extends IEvent> =
     TransformedEvent<TThis, E9, A9> & TransformedEvent<TThis, E10, A10> & TransformedEvent<TThis, E11, A11>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: infer E8, listener: (...args: infer A8) => void),
-        (event: infer E9, listener: (...args: infer A9) => void),
-        (event: infer E10, listener: (...args: infer A10) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: infer E8, listener: (...args: infer A8) => void);
+        (event: infer E9, listener: (...args: infer A9) => void);
+        (event: infer E10, listener: (...args: infer A10) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
@@ -186,17 +186,17 @@ export type IEventTransformer<TThis, TEvent extends IEvent> =
     TransformedEvent<TThis, E9, A9> & TransformedEvent<TThis, E10, A10>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: infer E8, listener: (...args: infer A8) => void),
-        (event: infer E9, listener: (...args: infer A9) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: infer E8, listener: (...args: infer A8) => void);
+        (event: infer E9, listener: (...args: infer A9) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
@@ -204,101 +204,101 @@ export type IEventTransformer<TThis, TEvent extends IEvent> =
     TransformedEvent<TThis, E9, A9>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: infer E8, listener: (...args: infer A8) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: infer E8, listener: (...args: infer A8) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
     TransformedEvent<TThis, E6, A6> & TransformedEvent<TThis, E7, A7> & TransformedEvent<TThis, E8, A8>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: infer E7, listener: (...args: infer A7) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: infer E7, listener: (...args: infer A7) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
     TransformedEvent<TThis, E6, A6> & TransformedEvent<TThis, E7, A7>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: infer E6, listener: (...args: infer A6) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: infer E6, listener: (...args: infer A6) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5> &
     TransformedEvent<TThis, E6, A6>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: infer E5, listener: (...args: infer A5) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: infer E5, listener: (...args: infer A5) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4> & TransformedEvent<TThis, E5, A5>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: infer E4, listener: (...args: infer A4) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: infer E4, listener: (...args: infer A4) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3> & TransformedEvent<TThis, E4, A4>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2> &
     TransformedEvent<TThis, E3, A3>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1> & TransformedEvent<TThis, E2, A2>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1>
     : TEvent extends
     {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: string, listener: (...args: any[]) => void),
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
     ? TransformedEvent<TThis, E0, A0>
     : TransformedEvent<TThis, string, any[]>;

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -17,8 +17,8 @@ export type TelemetryEventPropertyType = string | number | boolean | undefined;
  * party scenarios. For example, tags are used to mark PII that should not be stored in logs.
  */
 export interface ITaggedTelemetryPropertyType {
-    value: TelemetryEventPropertyType,
-    tag: string,
+    value: TelemetryEventPropertyType;
+    tag: string;
 }
 export interface ITelemetryProperties {
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -387,7 +387,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -584,9 +584,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -87,7 +87,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@^0.32.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/base64-js": "^1.3.0",

--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -142,7 +142,6 @@ export class IsoBuffer extends Uint8Array {
     /**
      * Sanitize a base64 string to provide to base64-js library.  base64-js
      * is not as tolerant of the same malformed base64 as Node's Buffer is.
-     * @param str
      */
     private static sanitizeBase64(str: string): string {
         let sanitizedStr = str;

--- a/common/lib/common-utils/src/promiseCache.ts
+++ b/common/lib/common-utils/src/promiseCache.ts
@@ -10,10 +10,10 @@
  * - sliding: entries expire after the given duration in MS of inactivity (i.e. get resets the clock)
  */
 export type PromiseCacheExpiry = {
-    policy: "indefinite"
+    policy: "indefinite";
 } | {
-    policy: "absolute" | "sliding",
-    durationMs: number,
+    policy: "absolute" | "sliding";
+    durationMs: number;
 };
 
 /**
@@ -21,9 +21,9 @@ export type PromiseCacheExpiry = {
  */
 export interface PromiseCacheOptions {
     /** Common expiration policy for all items added to this cache */
-    expiry?: PromiseCacheExpiry,
+    expiry?: PromiseCacheExpiry;
     /** If the stored Promise is rejected with a particular error, should the given key be removed? */
-    removeOnError?: (e: any) => boolean,
+    removeOnError?: (e: any) => boolean;
 }
 
 /**

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -43,7 +43,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -205,9 +205,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@0.48.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -43,7 +43,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -179,9 +179,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@0.43.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -43,7 +43,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -194,9 +194,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@0.46.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -43,7 +43,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -178,9 +178,9 @@
       "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@0.1028.1000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/orderedmap": "^1",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/marked": "^2.0.2",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/runtime-utils": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -90,7 +90,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/runtime-utils": "^0.59.3000",
     "@fluidframework/test-utils": "^0.59.3000",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
     "@types/semver": "^7.3.6",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -41,7 +41,7 @@
     "@cerner/duplicate-package-checker-webpack-plugin": "^2.3.0",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -55,7 +55,7 @@
     "@fluid-experimental/property-common": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.46.1000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/local-driver": "^0.59.3000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/sequence": "^0.59.3000",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-loader": "^0.59.3000",
     "@fluidframework/container-runtime": "^0.59.3000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/runtime-utils": "^0.59.3000",
     "@fluidframework/test-driver-definitions": "^0.59.3000",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1630,7 +1630,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -2972,9 +2972,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.28.2000-65653",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-65653.tgz",
-			"integrity": "sha512-6xmnnVrmpXJ+TQKSsJFpnfx/Ouelp9U2k6GB4Bc5YOJUOUDu3b/gDtWDgoonunk+/0XNplaIw8ISr9KhbA8WfA==",
+			"version": "0.28.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+			"integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/cell-previous": "npm:@fluidframework/cell@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/counter-previous": "npm:@fluidframework/counter@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/ink-previous": "npm:@fluidframework/ink@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -76,7 +76,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/map-previous": "npm:@fluidframework/map@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -77,7 +77,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -73,7 +73,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/quorum/package.json
+++ b/packages/dds/quorum/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -72,7 +72,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -79,7 +79,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/gitresources": "^0.1036.3000-0",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@0.59.2000",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -78,7 +78,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -76,7 +76,7 @@
     "@fluid-internal/test-dds-utils": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jest": "22.2.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
     "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@0.59.2000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -52,7 +52,7 @@
     "@fluid-experimental/get-container": "^0.59.3000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@0.59.2000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.3000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.59.3000",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@0.59.2000",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-loader-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
     "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@0.59.2000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@0.59.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-loader": "^0.59.3000",
     "@fluidframework/container-runtime": "^0.59.3000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/protocol-definitions": "^0.1028.1000",
     "@fluidframework/sequence": "^0.59.3000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/driver-base": "^0.59.3000",
     "@fluidframework/driver-definitions": "^0.46.1000",
     "@fluidframework/driver-utils": "^0.59.3000",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/ink": "^0.59.3000",
     "@fluidframework/local-driver": "^0.59.3000",
     "@fluidframework/map": "^0.59.3000",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -116,7 +116,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -101,7 +101,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/json-stable-stringify": "^1.0.32",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -95,7 +95,7 @@
     "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@0.59.2000",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@0.59.2000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.66793",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.3000",
     "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@0.59.2000",
     "@microsoft/api-extractor": "^7.22.2",

--- a/server/azure-local-service/package-lock.json
+++ b/server/azure-local-service/package-lock.json
@@ -95,9 +95,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/server/azure-local-service/package.json
+++ b/server/azure-local-service/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -267,7 +267,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -459,9 +459,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.28.2000-65653",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-65653.tgz",
-			"integrity": "sha512-6xmnnVrmpXJ+TQKSsJFpnfx/Ouelp9U2k6GB4Bc5YOJUOUDu3b/gDtWDgoonunk+/0XNplaIw8ISr9KhbA8WfA==",
+			"version": "0.28.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+			"integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -270,7 +270,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -131,6 +131,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
                 const operation = message.operation;
                 if (operation && operation.traces === undefined) {
                     operation.traces = [];
+                // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
                 } else if (operation && operation.traces && operation.traces.length > 1) {
                     operation.traces.push(
                         {

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/async": "^3.2.9",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^8.2.2",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/uuid": "^8.3.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-local-server": "^0.1036.3000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -78,5 +78,6 @@ export async function getSession(ordererUrl: string,
     tempSession.isSessionAlive = isSessionAlive;
     Lumberjack.info(`Returning the session from the discovery: ${JSON.stringify(tempSession)}`,
         lumberjackProperties);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return tempSession;
 }

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-local-server": "^0.1036.3000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -42,6 +42,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
 
     const checkpointHeuristics = config.get("deli:checkpointHeuristics") as
                             IDeliCheckpointHeuristicsServerConfiguration;
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
     if (checkpointHeuristics && checkpointHeuristics.enable) {
         core.DefaultServiceConfiguration.deli.checkpointHeuristics = checkpointHeuristics;
     }

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -277,6 +277,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		}
 
 		await new Promise<void>((resolve) => {
+			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
 			if (this.consumer && this.consumer.isConnected()) {
 				this.consumer.disconnect(resolve);
 			} else {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -163,6 +163,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 		await new Promise<void>((resolve) => {
 			const producer = this.producer;
 			this.producer = undefined;
+			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
 			if (producer && producer.isConnected()) {
 				producer.disconnect(resolve);
 			} else {

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
     "@types/formidable": "1.2.3",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-utils/src/executeOnInterval.ts
+++ b/server/routerlicious/packages/services-utils/src/executeOnInterval.ts
@@ -28,6 +28,7 @@ export function executeOnInterval(
                 if (onErrorFn !== undefined) {
                     onErrorFn(error);
                 }
+                // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
                 if (shouldTerminateOnError !== undefined && shouldTerminateOnError(error)) {
                     Lumberjack.info(`Terminating job on error ${error} for ${callName}`);
                     scheduledJob.kill();

--- a/server/routerlicious/packages/services-utils/src/logger.ts
+++ b/server/routerlicious/packages/services-utils/src/logger.ts
@@ -63,11 +63,13 @@ export function configureLogging(configOrPath: nconf.Provider | string) {
 
     const lumberjackConfig = config.get("lumberjack");
     const engineList =
+        // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
         lumberjackConfig && lumberjackConfig.engineList ?
         lumberjackConfig.engineList as ILumberjackEngine[] :
         [new WinstonLumberjackEngine()];
 
     const schemaValidatorList =
+        // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
         lumberjackConfig && lumberjackConfig.schemaValidator ?
         lumberjackConfig.schemaValidator as ILumberjackSchemaValidator[] :
         undefined;

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/server-test-utils": "^0.1036.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services/src/messageSender.ts
+++ b/server/routerlicious/packages/services/src/messageSender.ts
@@ -58,6 +58,7 @@ class RabbitmqTaskSender implements ITaskMessageSender {
 // Factory to switch between specific message sender implementations. Returns a dummy implementation
 // if rabbitmq configs are not provided.
 export function createMessageSender(rabbitmqConfig: any, config: any): ITaskMessageSender {
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
     if (rabbitmqConfig && rabbitmqConfig.connectionString) {
         return new RabbitmqTaskSender(rabbitmqConfig, config);
     } else {

--- a/server/routerlicious/packages/services/src/throttler.ts
+++ b/server/routerlicious/packages/services/src/throttler.ts
@@ -51,6 +51,7 @@ export class Throttler implements IThrottler {
 
         // check cached throttle status, but allow operation through if status is not yet cached
         const cachedThrottlerResponse = this.throttlerResponseCache.get(id);
+        // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
         if (cachedThrottlerResponse && cachedThrottlerResponse.throttleStatus) {
             const retryAfterInSeconds = Math.ceil(cachedThrottlerResponse.retryAfterInMs / 1000);
             this.logger?.info(`Throttled: ${id}`, {

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^8.2.2",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -102,9 +102,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/tinylicious/src/services/inMemorycollection.ts
+++ b/server/tinylicious/src/services/inMemorycollection.ts
@@ -64,7 +64,7 @@ export class Collection<T> implements ICollection<T> {
         return this.insertOneInternal(value);
     }
 
-    public async findOrCreate(query: any, value: any): Promise<{ value: any, existing: boolean }> {
+    public async findOrCreate(query: any, value: any): Promise<{ value: any; existing: boolean; }> {
         const existing = this.findOneInternal(query);
         if (existing) {
             return { value: existing, existing: true };

--- a/server/tinylicious/src/services/levelDbCollection.ts
+++ b/server/tinylicious/src/services/levelDbCollection.ts
@@ -87,7 +87,7 @@ export class Collection<T> implements ICollection<T> {
         return this.insertOneInternal(value);
     }
 
-    public async findOrCreate(query: any, value: any): Promise<{ value: any, existing: boolean }> {
+    public async findOrCreate(query: any, value: any): Promise<{ value: any; existing: boolean; }> {
         const existing = await this.findOneInternal(query);
         if (existing) {
             return { value: existing, existing: true };

--- a/server/tinylicious/src/services/tenantManager.ts
+++ b/server/tinylicious/src/services/tenantManager.ts
@@ -51,7 +51,7 @@ export class TenantManager implements ITenantManager {
     constructor(private readonly url: string) {
     }
 
-    public async createTenant(tenantId?: string): Promise<ITenantConfig & { key: string }> {
+    public async createTenant(tenantId?: string): Promise<ITenantConfig & { key: string; }> {
         throw new Error("Method not implemented.");
     }
 

--- a/server/tinylicious/src/test/dbFactory.spec.ts
+++ b/server/tinylicious/src/test/dbFactory.spec.ts
@@ -31,7 +31,7 @@ interface ITestDelta {
     tenantId: string;
     operation: {
         sequenceNumber: number;
-    }
+    };
 }
 
 /**
@@ -43,8 +43,8 @@ interface ITestConfig {
         db: {
             inMemory: boolean;
             path?: string;
-        }
-    }
+        };
+    };
 
     // dispose method to allow the config to do any cleanup - i.e. delete the temporary
     // directory used by leveldb

--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -412,9 +412,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.28.2000-64187",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000-64187.tgz",
-      "integrity": "sha512-6qzLw5PE/19HLjvEKRIGNZS9z17CL/jidiAyYhMw1ljnZELk0tcgk5mMpEv7xsRUk8jFogr2g7b40P5t8R1N4Q==",
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.28.2000-0",
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.41.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",


### PR DESCRIPTION
I have released @fluidframework/eslint-config-fluid version 0.28.2000. This PR updates the prerelease dependencies for this package.