### PR TITLE
Prototype 2 with loader layer for odsp domain change handling(Not for merging)

### DIFF
--- a/common/lib/driver-definitions/src/driverError.ts
+++ b/common/lib/driver-definitions/src/driverError.ts
@@ -75,6 +75,10 @@ export enum DriverErrorType {
       * The document is read-only and delta stream connection is forbidden.
       */
      deltaStreamConnectionForbidden = "deltaStreamConnectionForbidden",
+
+    // The location of file can change. So if the file location moves and we try to access the older location, then
+    // this error is thrown by server to let the client know about the new redirect location.
+    locationRedirection = "locationRedirection",
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -162,12 +162,19 @@ export class OdspDriverUrlResolver implements IUrlResolver {
         resolvedUrl: IResolvedUrl,
         relativeUrl: string,
         packageInfoSource?: IContainerPackageInfo,
+        redirectLocation?: string,
     ): Promise<string> {
         let dataStorePath = relativeUrl;
         if (dataStorePath.startsWith("/")) {
             dataStorePath = dataStorePath.substr(1);
         }
         const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
+        if (redirectLocation !== undefined) {
+            // Generate the new SiteUrl from the redirection location.
+            const newSiteDomain = new URL(redirectLocation).origin;
+            const newSiteUrl = `${newSiteDomain}${new URL(odspResolvedUrl.siteUrl).pathname}`;
+            odspResolvedUrl.siteUrl = newSiteUrl;
+        }
         // back-compat: GitHub #9653
         const isFluidPackage = (pkg: any) =>
             typeof pkg === "object"

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -191,8 +191,15 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         resolvedUrl: IResolvedUrl,
         dataStorePath: string,
         packageInfoSource?: IContainerPackageInfo,
+        redirectLocation?: string,
     ): Promise<string> {
         const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
+        if (redirectLocation !== undefined) {
+            // Generate the new SiteUrl from the redirection location.
+            const newSiteDomain = new URL(redirectLocation).origin;
+            const newSiteUrl = `${newSiteDomain}${new URL(odspResolvedUrl.siteUrl).pathname}`;
+            odspResolvedUrl.siteUrl = newSiteUrl;
+        }
         const shareLink = await this.getShareLinkPromise(odspResolvedUrl);
         const shareLinkUrl = new URL(shareLink);
         // back-compat: GitHub #9653

--- a/packages/loader/container-loader/src/resolveWithDomainMoveError.ts
+++ b/packages/loader/container-loader/src/resolveWithDomainMoveError.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DriverErrorType } from "@fluidframework/driver-definitions";
+
+/**
+ * Checks if the error is domain move error.
+ * @param error - error whose type is to be determined.
+ * @returns - True is the error is domain move error.
+ */
+export function isDomainMoveError(error: any) {
+    if (typeof error === "object" && error !== null
+        && error.errorType === DriverErrorType.locationRedirection) {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/10117

For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)

## Description
This is one prototype for handling odsp domain change within the loader layer. However. I am liking the other prototype here: https://github.com/microsoft/FluidFramework/pull/10319
