### PR TITLE
chore: Remove unpaired `#endregion` comment

### DIFF
--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -157,5 +157,4 @@ export class AzureClient {
             logger: this.props.logger,
         });
     }
-    // #endregion
 }


### PR DESCRIPTION
Removes a lingering, unpaired `#endregion` comment