### PR TITLE
Fix shared object terms in architecture doc

### DIFF
--- a/docs/content/docs/concepts/architecture/index.md
+++ b/docs/content/docs/concepts/architecture/index.md
@@ -136,7 +136,7 @@ the service knows nothing about the contents of any Fluid container.
                                                          v
                                              +-----------+-------------+
                                              |    Fluid Container or   |
-                                             |       Fluid Object      |
+                                             |       Shared Object     |
                                              |                         |
                                              +-------------------------+
 ```

--- a/docs/content/docs/concepts/architecture/index.md
+++ b/docs/content/docs/concepts/architecture/index.md
@@ -34,24 +34,24 @@ The Fluid loader connects to the Fluid service and loads a Fluid container.
 | | +--------------------------+  +----------------+  +----------------+ |  |  +---------------------+
 | | |                          |  |                |  |                | |  |  |                     |
 | | |                          |  |                |  |                | |  |  |    Fluid Service    |
-| | |   Fluid Object           |  | Fluid Object   |  | Fluid Object   | |  |  |                     |
+| | |   Shared Object          |  | Shared Object  |  | Shared Object  | |  |  |                     |
 | | |                          |  |                |  |                | |  |  +---------------------+
 | | |                          |  |                |  |                | |  |
+| | |                          |  |                |  |                | |  |
+| | |                          |  |                |  |                | |  |
+| | |  +-----+   +-----+       |  |    +-----+     |  |   +-----+      | |  |
+| | |  |     |   |     |       |  |    |     |     |  |   |     |      | |  |
+| | |  | DDS |   | DDS |       |  |    | DDS |     |  |   | DDS |      | |  |
+| | |  |     |   |     |       |  |    |     |     |  |   |     |      | |  |
+| | |  +-----+   +-----+       |  |    +-----+     |  |   +-----+      | |  |
 | | +--------------------------+  +----------------+  +----------------+ |  |
-| |                                                                      |  |
-| | +-----+   +-----+    +-----+       +-----+             +-----+       |  |
-| | |     |   |     |    |     |       |     |             |     |       |  |
-| | | DDS |   | DDS |    | DDS |       | DDS |             | DDS |       |  |
-| | |     |   |     |    |     |       |     |             |     |       |  |
-| | +-----+   +-----+    +-----+       +-----+             +-----+       |  |
-| |                                                                      |  |
 | +----------------------------------------------------------------------+  |
 |                                                                           |
 +---------------------------------------------------------------------------+
 ```
 The Fluid architecture consists of a client and service. The
 client contains the Fluid loader and the Fluid container. The Fluid loader contains a document service factory, code
-loader, scopes, and a URL resolver. The Fluid runtime is encapsulated within a container, which is built using Fluid
+loader, scopes, and a URL resolver. The Fluid runtime is encapsulated within a container, which is built using Shared
 objects and distributed data structures.
 
 If you want to load a Fluid container on your app or website, you'll load the container with the Fluid loader. If you


### PR DESCRIPTION
-Change "Fluid object in the first diagram for Shared Object" given that that's how the same document refers to it in line 61.
-DDS in the first diagram now inside the shared object instead of outside of them.  Not sure if we should go for "shared" or "fluid" object but at least keep it consistent.

