### PR TITLE
Skip tests when collateral is not present

### DIFF
--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -145,6 +145,8 @@ export async function processOneNode(args: IWorkerArgs) {
 export async function processContent(mode: Mode, concurrently = true) {
     const limiter = new ConcurrencyLimiter(numberOfThreads);
 
+    ensureTestCollateralPath();
+
     for (const node of fs.readdirSync(fileLocation, { withFileTypes: true })) {
         if (!node.isDirectory()) {
             continue;
@@ -412,4 +414,16 @@ function cleanFailedSnapshots(dir: string) {
     }
 
     fs.rmdirSync(failedSnapshotsDir);
+}
+
+let collateralPathValidated: boolean;
+
+/**
+ * Validates that the required external files exist.
+ */
+function ensureTestCollateralPath() {
+    if (!collateralPathValidated) {
+        assert(fs.existsSync(fileLocation), `Cannot find test collateral path: ${fileLocation}`);
+        collateralPathValidated = true;
+    }
 }

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -25,7 +25,6 @@ function getFileLocations(): [string, string] {
     // Relative to this generated js file being executed
     testCollateralPath = nodePath.join(__dirname, "..", testCollateralPath);
     workerPath = nodePath.join(__dirname, "..", workerPath);
-    assert(fs.existsSync(testCollateralPath), `Cannot find test collateral path: ${origTestCollateralPath}`);
     assert(fs.existsSync(workerPath), `Cannot find worker js file: ${workerPath}`);
     return [testCollateralPath, workerPath];
 }
@@ -192,6 +191,10 @@ export async function processContent(mode: Mode, concurrently = true) {
     }
 
     return limiter.waitAll();
+}
+
+export function testCollateralExists() {
+    return fs.existsSync(fileLocation);
 }
 
 /**

--- a/packages/test/snapshots/src/test/replay.spec.ts
+++ b/packages/test/snapshots/src/test/replay.spec.ts
@@ -8,29 +8,31 @@ import { Mode, processContent, testCollateralExists } from "../replayMultipleFil
 describe("Snapshots", function() {
     this.timeout(300000);
 
-    function skipIfCollateralDoesNotExist(itFnScope) {
-        if (!testCollateralExists()) {
-            itFnScope.skip();
-        }
-    }
+    let collateralExists = false;
 
-    it("Stress Test", async function() {
-        skipIfCollateralDoesNotExist(this);
+    before(() => {
+        collateralExists = testCollateralExists();
+    });
+
+    beforeEach(function() {
+        if (!collateralExists) {
+            this.skip();
+        }
+    });
+
+    it("Stress Test", async () => {
         await processContent(Mode.Stress);
     });
 
-    it("writes snapshot in correct format", async function() {
-        skipIfCollateralDoesNotExist(this);
+    it("writes snapshot in correct format", async () => {
         await processContent(Mode.Compare);
     });
 
-    it("loads snapshots in old format", async function() {
-        skipIfCollateralDoesNotExist(this);
+    it("loads snapshots in old format", async () => {
         await processContent(Mode.Validate);
     });
 
-    it("loads snapshots in old format and writes in correct format", async function() {
-        skipIfCollateralDoesNotExist(this);
+    it("loads snapshots in old format and writes in correct format", async () => {
         await processContent(Mode.BackCompat);
     });
 });

--- a/packages/test/snapshots/src/test/replay.spec.ts
+++ b/packages/test/snapshots/src/test/replay.spec.ts
@@ -3,24 +3,34 @@
  * Licensed under the MIT License.
  */
 
-import { Mode, processContent } from "../replayMultipleFiles";
+import { Mode, processContent, testCollateralExists } from "../replayMultipleFiles";
 
 describe("Snapshots", function() {
     this.timeout(300000);
 
-    it("Stress Test", async () => {
+    function skipIfCollateralDoesNotExist(itFnScope) {
+        if (!testCollateralExists()) {
+            itFnScope.skip();
+        }
+    }
+
+    it("Stress Test", async function() {
+        skipIfCollateralDoesNotExist(this);
         await processContent(Mode.Stress);
     });
 
-    it("writes snapshot in correct format", async () => {
+    it("writes snapshot in correct format", async function() {
+        skipIfCollateralDoesNotExist(this);
         await processContent(Mode.Compare);
     });
 
-    it("loads snapshots in old format", async () => {
+    it("loads snapshots in old format", async function() {
+        skipIfCollateralDoesNotExist(this);
         await processContent(Mode.Validate);
     });
 
-    it("loads snapshots in old format and writes in correct format", async () => {
+    it("loads snapshots in old format and writes in correct format", async function() {
+        skipIfCollateralDoesNotExist(this);
         await processContent(Mode.BackCompat);
     });
 });

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -35,6 +35,15 @@ describe(`Container Serialization Backwards Compatibility`, () => {
     let filename: string;
     const contentFolder = "content/serializedContainerTestContent";
 
+    // Ideally we would have each test call this.skip() but in this case they're created dynamically
+    // based on the contents of the folder which might or might not exist, so this is the alternative
+    // I came up with.
+    if (!fs.existsSync(contentFolder)) {
+        it(`Skipping dynamic tests in this suite - test collateral folder (${contentFolder}) doesn't exist`,
+            function() { this.skip(); });
+        return;
+    }
+
     for (filename of recurseFiles(contentFolder)) {
         disableIsolatedChannels = false;
         tests();


### PR DESCRIPTION
# [AB#275](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/275)

## Description

Skip tests that depend on the test collateral submodule to be present. This is in part so that `npm run test` succeeds on a fresh clone of the repository after a successful build, per the instructions in the main README.

## Steps to Reproduce Bug and Validate Solution

Currently, the steps suggested by the main README to build and run tests locally result in some tests failing (assumes the correct version of Node.js is already installed):

```
git clone https://github.com/microsoft/FluidFramework.git
cd FluidFramework
npm install
npm run build:fast
npm run test
```

Alternatively, running the tests directly for the `@fluid-internal/test-snapshots` package if the test collateral submodule is not present also shows its tests failing.

## PR Checklist

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Testing

Follow the steps above. Tests now succeed.

