### PR TITLE
Update dependency on `protocol-definitions` for server

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-core": "^0.1036.4000"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-core": "^0.1036.4000"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-memory-orderer": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-memory-orderer": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-base": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-kafka-orderer": "^0.1036.4000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-kafka-orderer": "^0.1036.4000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-kafka-orderer": "^0.1036.4000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-kafka-orderer": "^0.1036.4000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "axios": "^0.26.0",
     "crc-32": "1.2.0",
     "debug": "^4.1.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "axios": "^0.26.0",
     "crc-32": "1.2.0",
     "debug": "^4.1.1",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",
     "@types/nconf": "^0.10.2",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",
     "@types/nconf": "^0.10.2",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1036.4000",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1036.4000",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000",
+   "@fluidframework/protocol-definitions": "^0.1028.2000-0",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",


### PR DESCRIPTION
Part of [260](https://dev.azure.com/fluidframework/internal/_workitems/edit/260)

Need to propagate https://github.com/microsoft/FluidFramework/pull/10322 downstream