### PR TITLE
Enable `@typescript-eslint/no-unused-vars` rule in shared eslint configuration and pre-apply fixes

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -121,7 +121,7 @@ module.exports = {
         "@typescript-eslint/member-ordering": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-parameter-properties": "off",
-        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": "error",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/typedef": "off",
         "func-call-spacing": "off", // Off because it conflicts with typescript-formatter

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -121,7 +121,9 @@ module.exports = {
         "@typescript-eslint/member-ordering": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-parameter-properties": "off",
-        "@typescript-eslint/no-unused-vars": "error",
+        // Disallow unused variables except those named explicitly to be ignored.
+        // Allows patterns like `const [_, foo] = bar();`
+        "@typescript-eslint/no-unused-vars": ["error", { args: "none", varsIgnorePattern: "^_$" }],
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/typedef": "off",
         "func-call-spacing": "off", // Off because it conflicts with typescript-formatter

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -123,7 +123,7 @@ module.exports = {
         "@typescript-eslint/no-parameter-properties": "off",
         // Disallow unused variables except those named explicitly to be ignored.
         // Allows patterns like `const [_, foo] = bar();`
-        "@typescript-eslint/no-unused-vars": ["error", { args: "none", varsIgnorePattern: "^_$" }],
+        "@typescript-eslint/no-unused-vars": ["error", { args: "none", varsIgnorePattern: "^_" }],
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/typedef": "off",
         "func-call-spacing": "off", // Off because it conflicts with typescript-formatter

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -242,7 +242,7 @@
             "error"
         ],
         "@typescript-eslint/no-unused-vars": [
-            "error"
+            ["error", { "args": "none", "varsIgnorePattern": "^_$" }]
         ],
         "@typescript-eslint/no-use-before-declare": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -242,7 +242,7 @@
             "error"
         ],
         "@typescript-eslint/no-unused-vars": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/no-use-before-declare": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -242,7 +242,7 @@
             "error"
         ],
         "@typescript-eslint/no-unused-vars": [
-            ["error", { "args": "none", "varsIgnorePattern": "^_$" }]
+            ["error", { "args": "none", "varsIgnorePattern": "^_" }]
         ],
         "@typescript-eslint/no-use-before-declare": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -242,7 +242,7 @@
             "error"
         ],
         "@typescript-eslint/no-unused-vars": [
-            "error"
+            ["error", { "args": "none", "varsIgnorePattern": "^_$" }]
         ],
         "@typescript-eslint/no-use-before-declare": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -242,7 +242,7 @@
             "error"
         ],
         "@typescript-eslint/no-unused-vars": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/no-use-before-declare": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -242,7 +242,7 @@
             "error"
         ],
         "@typescript-eslint/no-unused-vars": [
-            ["error", { "args": "none", "varsIgnorePattern": "^_$" }]
+            ["error", { "args": "none", "varsIgnorePattern": "^_" }]
         ],
         "@typescript-eslint/no-use-before-declare": [
             "off"

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -11,13 +11,7 @@ import { copy as cloneDeep } from "fastest-json-copy";
 import { Packr } from "msgpackr";
 
 import { AttachState } from "@fluidframework/container-definitions";
-import {
-	ISequencedDocumentMessage,
-	MessageType,
-	FileMode,
-	TreeEntry,
-	ITreeEntry,
-} from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
@@ -25,7 +19,7 @@ import {
 	IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 
-import { bufferToString, stringToBuffer, assert } from "@fluidframework/common-utils";
+import { bufferToString, stringToBuffer } from "@fluidframework/common-utils";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { IFluidSerializer, SharedObject } from "@fluidframework/shared-object-base";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
@@ -45,9 +39,6 @@ import { PropertyTreeFactory } from "./propertyTreeFactory";
 export type SerializedChangeSet = any;
 
 export type Metadata = any;
-
-type FetchUnrebasedChangeFn = (guid: string) => IRemotePropertyTreeMessage;
-type FetchRebasedChangesFn = (startGuid: string, endGuid?: string) => IPropertyTreeMessage[];
 
 export const enum OpKind {
 	// eslint-disable-next-line @typescript-eslint/no-shadow
@@ -428,7 +419,6 @@ export class SharedPropertyTree extends SharedObject {
 	}
 
 	protected async loadCore(storage: IChannelStorageService): Promise<void> {
-		const runtime = this.runtime;
 		const handleTableChunk = await storage.readBlob("properties");
 		const utf8 = bufferToString(handleTableChunk, "utf8");
 

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -65,8 +65,6 @@ describe("PropertyTree", () => {
 	}
 
 	describe("Local state", () => {
-		let propertyTree: SharedPropertyTree;
-
 		beforeEach(async () => {
 			opProcessingController = new LoaderContainerTracker();
 			deltaConnectionServer = LocalDeltaConnectionServer.create();

--- a/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
@@ -130,7 +130,7 @@ describe("PropertyDDS", () => {
 					try {
 						const numOperations = random.irandom(maxOperations);
 						const maxCount = operationCumSums[operationCumSums.length - 1];
-						for (const j of _.range(numOperations)) {
+						for (const _j of _.range(numOperations)) {
 							const operationId = 1 + random.irandom(maxCount);
 							const selectedOperation = _.sortedIndex(operationCumSums, operationId);
 
@@ -185,7 +185,7 @@ describe("PropertyDDS", () => {
             }
 
             // Attach error handlers to make debugging easier and ensure that internal failures cause the test to fail
-            errorHandler = (err) => { }; // This enables the create random tests function to register its own handler
+            errorHandler = () => { }; // This enables the create random tests function to register its own handler
             container1.on("closed", (err: any) => {
                 if (err !== undefined) {
                     errorHandler(err);
@@ -379,7 +379,7 @@ describe("PropertyDDS", () => {
                             let testString = "";
 
                             const numOperations = random.irandom(30);
-                            for (const j of _.range(numOperations)) {
+                            for (const _j of _.range(numOperations)) {
                                 const operation = random.irandom(6);
                                 switch (operation) {
                                     case 0:
@@ -432,6 +432,7 @@ describe("PropertyDDS", () => {
                                 testString +=
                                     "await opProcessingController.ensureSynchronized();\n";
                             }
+                            console.log(testString);
                         });
                     }
                 });

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/EditableValueCell.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/EditableValueCell.tsx
@@ -69,9 +69,7 @@ const EditableValueCell: React.FunctionComponent<WithStyles<typeof styles> & IEd
   const {
     classes,
     className,
-    followReferences,
     rowData,
-    iconRenderer,
     ...restProps // tslint:disable-line
   } = props;
 

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
@@ -28,9 +28,15 @@ import { ExpiryModal } from "./ExpiryModal";
 import { getDefaultInspectorTableIcons } from "./icons";
 import { InspectorTableFooter } from "./InspectorTableFooter";
 import { InspectorTableHeader } from "./InspectorTableHeader";
-import { IColumns, IDataGetterParameter, IInspectorRow, IInspectorSearchCallback,
-  IInspectorSearchMatch, IInspectorSearchMatchMap, IInspectorTableProps,
-  IInspectorTableState } from "./InspectorTableTypes";
+import {
+    IColumns,
+    IInspectorRow,
+    IInspectorSearchCallback,
+    IInspectorSearchMatch,
+    IInspectorSearchMatchMap,
+    IInspectorTableProps,
+    IInspectorTableState,
+} from "./InspectorTableTypes";
 import { ModalConsumer } from "./ModalManager";
 import { NameCell } from "./NameCell";
 import { NewDataForm } from "./NewDataForm";
@@ -206,7 +212,7 @@ export const defaultInspectorTableNameGetter = (name: string): any => name;
  * The default implementation of the `dataGetter` callback for the Inspector table
  * @param params function handle
  */
-export const defaultInspectorTableDataGetter = (params: IDataGetterParameter): React.ReactNode | null => null;
+export const defaultInspectorTableDataGetter = (): React.ReactNode | null => null;
 
 /**
  * A component for inspecting the workspace data. It supports displaying the name, context, typeid and value of
@@ -405,24 +411,18 @@ class InspectorTable extends React.Component<WithStyles<typeof styles> & IInspec
 
     public render() {
       const {
-        childGetter,
         classes,
-        columns,
         currentUrn,
         data,
         deleteRepo,
         expired,
-        followReferences,
         getRepoExpiry,
         height,
         isV1Urn,
-        nameGetter,
         repositoryUrn,
-        rowIconRenderer,
         searchBoxProps,
         setRepoExpiry,
         width,
-        activeRepositoryGuid,
         ...restProps } = this.props;
 
       const {

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/Number.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/Number.tsx
@@ -30,7 +30,6 @@ const handleKeyDown: HandleKeyDownType = (event, props) => {
 
 export const NumberView: React.FunctionComponent<NumberProps> = (props) => {
   const {
-    iconRenderer,
     followReferences,
     TextFieldProps: textFieldProps,
     rowData,

--- a/experimental/dds/tree-graphql/src/graphql-generated/Pizza.ts
+++ b/experimental/dds/tree-graphql/src/graphql-generated/Pizza.ts
@@ -7,6 +7,7 @@ export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
 	ID: string;
@@ -52,11 +53,6 @@ export enum Drink {
 	Lemonade = 'LEMONADE',
 }
 
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
 import {
 	getString,
 	getFloat,
@@ -64,14 +60,7 @@ import {
 	getBoolean,
 	getID,
 	getNodeID,
-	getScalar,
 	getStringList,
-	getFloatList,
-	getIntList,
-	getBooleanList,
-	getIDList,
-	getTrait,
-	getNonNullTrait,
 	getListTrait,
 } from '../graphql-plugins/SharedTreePlugin';
 

--- a/experimental/dds/tree-graphql/src/graphql-plugins/SharedTreePlugin.ts
+++ b/experimental/dds/tree-graphql/src/graphql-plugins/SharedTreePlugin.ts
@@ -22,11 +22,7 @@ interface FieldInfo {
 	isList?: boolean;
 }
 
-export const plugin: PluginFunction<unknown> = (
-	schema: GraphQLSchema,
-	documents: Types.DocumentFile[],
-	config: unknown
-) => {
+export const plugin: PluginFunction<unknown> = (schema: GraphQLSchema) => {
 	const printedSchema = printSchema(schema);
 	const astNode = parse(printedSchema);
 	const result = visit(astNode, {

--- a/experimental/dds/tree-graphql/src/graphql-plugins/SharedTreePlugin.ts
+++ b/experimental/dds/tree-graphql/src/graphql-plugins/SharedTreePlugin.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { PluginFunction } from '@graphql-codegen/plugin-helpers';
 import { NodeId, RevisionView, SharedTree, StableNodeId, TraitLabel, TreeViewNode } from '@fluid-experimental/tree';
 import {
 	FieldDefinitionNode,

--- a/experimental/dds/tree-graphql/src/test/SharedTreeQuerier.tests.ts
+++ b/experimental/dds/tree-graphql/src/test/SharedTreeQuerier.tests.ts
@@ -324,7 +324,7 @@ describe('SharedTreeQuerier', () => {
 	});
 
 	it('can query the special identifier field', async () => {
-		const { querier, tree } = init(fourPizzasTreeFactory);
+		const { querier } = init(fourPizzasTreeFactory);
 		const result = await querier.query(`{
 			pizzas {
 				id

--- a/experimental/dds/tree/src/Checkout.ts
+++ b/experimental/dds/tree/src/Checkout.ts
@@ -361,7 +361,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 	 * release all unmanaged resources
 	 * e.g. unregister event listeners
 	 */
-	public dispose(error?: Error): void {
+	public dispose(): void {
 		if (this.disposed) {
 			return;
 		}

--- a/experimental/dds/tree/src/EagerCheckout.ts
+++ b/experimental/dds/tree/src/EagerCheckout.ts
@@ -19,7 +19,7 @@ export class EagerCheckout extends Checkout {
 	 * @param tree - the tree
 	 */
 	public constructor(tree: SharedTree) {
-		super(tree, tree.currentView, (args: EditCommittedEventArguments) => {
+		super(tree, tree.currentView, () => {
 			this.emitChange();
 		});
 	}

--- a/experimental/dds/tree/src/EagerCheckout.ts
+++ b/experimental/dds/tree/src/EagerCheckout.ts
@@ -5,7 +5,7 @@
 
 import { Checkout } from './Checkout';
 import { RevisionView } from './RevisionView';
-import { EditCommittedEventArguments, SharedTree } from './SharedTree';
+import { SharedTree } from './SharedTree';
 
 /**
  * Checkout that always stays up to date with the SharedTree.

--- a/experimental/dds/tree/src/LazyCheckout.ts
+++ b/experimental/dds/tree/src/LazyCheckout.ts
@@ -6,7 +6,7 @@
 import { Checkout } from './Checkout';
 import { EditId } from './Identifiers';
 import { RevisionView } from './RevisionView';
-import { EditCommittedEventArguments, SharedTree } from './SharedTree';
+import { SharedTree } from './SharedTree';
 import { ValidEditingResult } from './TransactionInternal';
 
 /**
@@ -23,7 +23,7 @@ export class LazyCheckout extends Checkout {
 	 * @param tree - the tree
 	 */
 	public constructor(tree: SharedTree) {
-		super(tree, tree.currentView, (args: EditCommittedEventArguments) => {});
+		super(tree, tree.currentView, () => {});
 		this.latestView = tree.currentView;
 	}
 

--- a/experimental/dds/tree/src/test/Forest.perf.tests.ts
+++ b/experimental/dds/tree/src/test/Forest.perf.tests.ts
@@ -108,7 +108,7 @@ describe('Forest Perf', () => {
 function walk(s: RevisionView, id: NodeId): number {
 	let count = 1;
 	const n = s.getViewNode(id);
-	for (const [_label, v] of n.traits.entries()) {
+	for (const [_, v] of n.traits.entries()) {
 		for (const child of v) {
 			count += walk(s, child);
 		}

--- a/packages/dds/matrix/src/productSet.ts
+++ b/packages/dds/matrix/src/productSet.ts
@@ -346,8 +346,8 @@ const tryUnionSubspaces = (() => {
             }
             if (newDim === dense) {
                 // we are actually deleting the `differentDimension`, so the variable
-                // `deleted` must be there. Hence disabling the rule here.
-                const { [differentDimension]: deleted, ...leftBoundsWithoutDifferentDimension } = left.bounds;
+                // `_` must be there.
+                const { [differentDimension]: _, ...leftBoundsWithoutDifferentDimension } = left.bounds;
                 return (cache.res = subspace<unknown>(leftBoundsWithoutDifferentDimension));
             }
 
@@ -704,8 +704,8 @@ function tryExceptSubspaces<T>(
         }
         if (newDim === dense) {
             // we are actually deleting the `differentDimension`, so the variable
-            // `deleted` must be there. Hence disabling the rule here.
-            const { [notContainedDimension]: deleted, ...leftBoundsWithoutDifferentDimension } = left.bounds;
+            // `_` must be there.
+            const { [notContainedDimension]: _, ...leftBoundsWithoutDifferentDimension } = left.bounds;
             return subspace<unknown>(leftBoundsWithoutDifferentDimension);
         }
         const newBounds: UntypedProduct<T> = {

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -270,7 +270,7 @@ export class Client {
 
     public walkSegments<TClientData>(handler: ISegmentAction<TClientData>,
         start: number | undefined, end: number | undefined, accum: TClientData, splitRange?: boolean): void;
-    public walkSegments<undefined>(handler: ISegmentAction<undefined>,
+    public walkSegments(handler: ISegmentAction<undefined>,
         start?: number, end?: number, accum?: undefined, splitRange?: boolean): void;
     public walkSegments<TClientData>(
         handler: ISegmentAction<TClientData>,

--- a/packages/drivers/file-driver/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentStorageService.ts
@@ -7,8 +7,12 @@ import fs from "fs";
 import { assert, bufferToString } from "@fluidframework/common-utils";
 import {
     IDocumentStorageService,
-    IDocumentStorageServicePolicies,    // these are needed for api-extractor
-    ISummaryContext,                    // these are needed for api-extractor
+
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    // these are needed for api-extractor
+    IDocumentStorageServicePolicies,
+    ISummaryContext,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
 } from "@fluidframework/driver-definitions";
 import { buildSnapshotTree, convertSummaryTreeToSnapshotITree } from "@fluidframework/driver-utils";
 import * as api from "@fluidframework/protocol-definitions";
@@ -72,7 +76,7 @@ export class FluidFetchReader extends ReadDocumentStorageServiceBase implements 
      * @param versionId - version ID.
      * @param count - Number of versions to be returned.
      */
-    public async getVersions(versionId: string | null, count: number): Promise<api.IVersion[]> {
+    public async getVersions(versionId: string | null): Promise<api.IVersion[]> {
         if (versionId === FileStorageDocumentName || versionId === null) {
             if (this.docTree || this.versionName !== undefined) {
                 return [{ id: "latest", treeId: FileStorageVersionTreeId }];
@@ -120,7 +124,7 @@ export const FileSnapshotWriterClassFactory = <TBase extends ReaderConstructor>(
             this.docId = undefined;
         }
 
-        public onSnapshotHandler(snapshot: IFileSnapshot): void {
+        public onSnapshotHandler(_snapshot: IFileSnapshot): void {
             throw new Error("onSnapshotHandler is not setup! Please provide your handler!");
         }
 
@@ -156,7 +160,7 @@ export const FileSnapshotWriterClassFactory = <TBase extends ReaderConstructor>(
             return super.getSnapshotTree(version);
         }
 
-        public async uploadSummaryWithContext(summary: api.ISummaryTree, context: ISummaryContext): Promise<string> {
+        public async uploadSummaryWithContext(summary: api.ISummaryTree): Promise<string> {
             const tree = convertSummaryTreeToSnapshotITree(summary);
 
             // Remove tree IDs for easier comparison of snapshots

--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -274,7 +274,7 @@ export async function fluidFetchMessages(documentService?: IDocumentService, sav
             dumpMessages,
             messageTypeFilter);
     } else {
-        let item;
-        for await (item of generator) { }
+        let _item;
+        for await (_item of generator) { }
     }
 }


### PR DESCRIPTION
From the [rule documentation](https://typescript-eslint.io/rules/no-unused-vars/):

> Disallow unused variables.
