### PR TITLE
Enable `use-isnan` rule in shared eslint configuration

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -95,6 +95,7 @@ module.exports = {
                 "ignoreEOLComments": true
             }
         ],
+        "use-isnan": "error",
 
         // Catches a common coding mistake where "resolve" and "reject" are confused.
         "promise/param-names": "warn",


### PR DESCRIPTION
From [the rule documentation](https://eslint.org/docs/rules/use-isnan):

> Requires calls to isNaN() when checking for NaN.
> 
> In JavaScript, NaN is a special value of the Number type. It's used to represent any of the "not-a-number" values represented by the double-precision 64-bit format as specified by the IEEE Standard for Binary Floating-Point Arithmetic.
> 
> Because NaN is unique in JavaScript by not being equal to anything, including itself, the results of comparisons to NaN are confusing:
> 
> NaN === NaN or NaN == NaN evaluate to false
> NaN !== NaN or NaN != NaN evaluate to true
> Therefore, use Number.isNaN() or global isNaN() functions to test whether a value is NaN.

Notes:
- We currently have no violations of this rule, so it can be turned on without any code changes
- The json files under `printed-configs` already had this rule enabled, so they did not require an update.