### PR TITLE
[gitrest] Persisting latest full summary during getSummary

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -69,7 +69,7 @@ async function getSummary(
         }
     }
 
-    // If we get to this point, it's because of:
+    // If we get to this point, it's because one of the options below:
     // 1) we did not want to read the latest full summary from storage
     // 2) we wanted to read the latest full summary, but it did not exist in the storage
     // 3) the summary being requestd is not the latest
@@ -84,6 +84,10 @@ async function getSummary(
     // Now that we computed the summary from scratch, we can persist it to storage if
     // the following conditions are met.
     if (persistLatestFullSummary && sha === latestSummarySha && fullSummary) {
+        // We persist the full summary in a fire-and-forget way because we don't want it
+        // to impact getSummary latency. So upon computing the full summary above, we should
+        // return as soon as possible. Also, we don't care about failures much, since the
+        // next getSummary or a createSummary request may trigger persisting to storage.
         persistLatestFullSummaryInStorage(
             fileSystemManager,
             getDocumentStorageDirectory(repoManager, repoManagerParams.storageRoutingId.documentId),

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -45,6 +45,11 @@ async function getSummary(
     externalWriterConfig?: IExternalWriterConfig,
     persistLatestFullSummary = false,
 ): Promise<IWholeFlatSummary> {
+    const lumberjackProperties = {
+        ...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
+        [BaseGitRestTelemetryProperties.sha]: sha,
+    };
+
     if (persistLatestFullSummary && sha === latestSummarySha) {
         try {
             const latestFullSummaryFromStorage = await retrieveLatestFullSummaryFromStorage(
@@ -54,24 +59,43 @@ async function getSummary(
             if (latestFullSummaryFromStorage !== undefined) {
                 return latestFullSummaryFromStorage;
             }
-        } catch (e) {
+        } catch (error) {
             // This read is for optimization purposes, so on failure
             // we can try to read the summary in typical fashion.
             Lumberjack.error(
                 "Failed to read latest full summary from storage.",
-                {
-                    ...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
-                    [BaseGitRestTelemetryProperties.sha]: sha,
-                },
-                e);
+                lumberjackProperties,
+                error);
         }
     }
 
+    // If we get to this point, it's because of:
+    // 1) we did not want to read the latest full summary from storage
+    // 2) we wanted to read the latest full summary, but it did not exist in the storage
+    // 3) the summary being requestd is not the latest
+    // Therefore, we need to compute the summary from scratch.
     const wholeSummaryManager = new GitWholeSummaryManager(
         repoManagerParams.storageRoutingId.documentId,
         repoManager,
         externalWriterConfig?.enabled ?? false,
     );
+    const fullSummary = await wholeSummaryManager.readSummary(sha);
+
+    // Now that we computed the summary from scratch, we can persist it to storage if
+    // the following conditions are met.
+    if (persistLatestFullSummary && sha === latestSummarySha && fullSummary) {
+        persistLatestFullSummaryInStorage(
+            fileSystemManager,
+            getDocumentStorageDirectory(repoManager, repoManagerParams.storageRoutingId.documentId),
+            fullSummary,
+        ).catch((error) => {
+            Lumberjack.error(
+                "Failed to persist latest full summary to storage during getSummary",
+                lumberjackProperties,
+                error);
+        });
+    }
+
     return wholeSummaryManager.readSummary(sha);
 }
 
@@ -120,11 +144,13 @@ async function createSummary(
                     );
                 } catch(error) {
                     Lumberjack.error(
-                        "Failed to persist latest full summary to storage",
+                        "Failed to persist latest full summary to storage during createSummary",
                         lumberjackProperties,
                         error);
                     // TODO: Find and add more information about this failure so that Scribe can retry as necessary.
-                    throw new NetworkError(500, "Failed to persist latest full summary to storage");
+                    throw new NetworkError(
+                        500,
+                        "Failed to persist latest full summary to storage during createSummary");
                 }
             }
             return latestFullSummary;

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -19,6 +19,6 @@
         "lib": {
             "name": "nodegit"
         },
-        "persistLatestFullSummary": false
+        "persistLatestFullSummary": true
     }
 }

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -19,6 +19,6 @@
         "lib": {
             "name": "nodegit"
         },
-        "persistLatestFullSummary": true
+        "persistLatestFullSummary": false
     }
 }


### PR DESCRIPTION
Optimization for GitRest's `getSummary()` used in the GET Summary API.

If:
* the request refers to the latest summary
* and we want to persist latest summaries to the storage
* and it happens that currently there is no latest full summary in that storage

We will be forced to compute that latest summary to scratch. But after doing that, we can optimize things by writing that full latest summary we just computed to the storage, thus helping subsequent GET Summary requests and avoiding recomputing the full summary again.

Additional bug fix: `NodegitRepositoryManager`'s `path()` implementation would return the NodeGit repo's path property. However, since it automatically adds a trailing slash, `getDocumentStorageDirectory()` in summaries.ts would return something like this when the system uses NodeGit: ` /home/node/documents/fluid/fluid//1d42b816-7d94-4a94-832d-6275ad8a2dd7`. Therefore, I updated `NodegitRepositoryManager`'s `path()` to return `directory` similar to what we do in `IsomorphicGitRepositoryManager`:
https://github.com/microsoft/FluidFramework/blob/e2eee21cf99b7d533835795fcded00690634e198/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts#L33
