### PR TITLE
Fix Type Validations and Previous Versions

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1966,20 +1966,20 @@
 			}
 		},
 		"@fluid-experimental/task-manager-previous": {
-			"version": "npm:@fluid-experimental/task-manager@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-0.59.2002.tgz",
-			"integrity": "sha512-mtAz8v6xWlfio9I5EsmZRkgiFZdq/bUd/vixzIVAF+jWJpzFK+2RPqLk0cprHY621fFE5kSxxSpto/HWLUFZeQ==",
+			"version": "npm:@fluid-experimental/task-manager@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-0.59.3000.tgz",
+			"integrity": "sha512-f4ZZeNtfkoIH1U2I4ELuMONouVqqp8ZorysCPlCR4iORQlhf97TtVVJMfclLN+j5vfgIB7gaKSgAksv76NdaHw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -2017,15 +2017,15 @@
 			}
 		},
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-0.59.2002.tgz",
-			"integrity": "sha512-ZYcQgs/ie3ZBEsF5w4Qx2q6ExccGPn8KjXH3PxXB6axa1v5sZBz0FQ5galI4c2c51PAkn635N/7zynJp65b/Bw==",
+			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-0.59.3000.tgz",
+			"integrity": "sha512-BqX3IOEzVLCJrvsKwTNbIe3FIT81jrps3KHdhEDjyCNp6ECwnh+HmoNtYjKqfSEuG8rtPqffI8jyvCBYIQmdfg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002"
+				"@fluidframework/odsp-driver": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -2041,32 +2041,32 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-0.59.2002.tgz",
-			"integrity": "sha512-yNdle8+fGF7QCa1Cib4fVG7bbF38mnPm/3aJdNDUGEDojliytSsPaHyVHWerG3nar0qdx8T2oHUUKoaxf8R1Gw==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-0.59.3000.tgz",
+			"integrity": "sha512-amS+TymHnFGhJef0RVc7avJzIeX8J+deELXw/avMh/7FLyW7n5csy5OkHWYGM/VTuRNhA70pLnJl8NcWKS/86w==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.2002",
+				"@fluidframework/aqueduct": "^0.59.3000",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/local-driver": "^0.59.2002",
-				"@fluidframework/odsp-doclib-utils": "^0.59.2002",
-				"@fluidframework/odsp-driver": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/local-driver": "^0.59.3000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.3000",
+				"@fluidframework/odsp-driver": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/server-local-server": "^0.1036.2000",
-				"@fluidframework/server-services-client": "^0.1036.2000",
-				"@fluidframework/test-runtime-utils": "^0.59.2002",
-				"@fluidframework/tool-utils": "^0.59.2002",
-				"@fluidframework/view-adapters": "^0.59.2002",
-				"@fluidframework/view-interfaces": "^0.59.2002",
-				"@fluidframework/web-code-loader": "^0.59.2002",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/server-local-server": "^0.1036.3000",
+				"@fluidframework/server-services-client": "^0.1036.3000",
+				"@fluidframework/test-runtime-utils": "^0.59.3000",
+				"@fluidframework/tool-utils": "^0.59.3000",
+				"@fluidframework/view-adapters": "^0.59.3000",
+				"@fluidframework/view-interfaces": "^0.59.3000",
+				"@fluidframework/web-code-loader": "^0.59.3000",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
 				"nconf": "^0.11.4",
@@ -2365,20 +2365,20 @@
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.59.2002.tgz",
-			"integrity": "sha512-Gk7pD9OvgwMm1Vv6YRHk6aVzscVr74kmLQpZmU//vyGTxYNgtRgMRrwgQHgyroltfeBRqLhhA4mK2yT1lmnmtQ==",
+			"version": "npm:@fluidframework/agent-scheduler@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.59.3000.tgz",
+			"integrity": "sha512-UCMl1MiswdxaMVKK+mphyvsRgzCTT3rl+UU6wfj+gR32uf4nraPdHE1HNWgAUKsmYxWmLU1skzVVlcVq4h02Hw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/map": "^0.59.2002",
-				"@fluidframework/register-collection": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/map": "^0.59.3000",
+				"@fluidframework/register-collection": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2406,25 +2406,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.2002.tgz",
-			"integrity": "sha512-efc6u6mguTShhctFZtLY2X0ONPaRD0LuoZGtPZ50UHffYtdVoc3dbCgJRn6HstgFEDr1NHtD1fY6De+KwW16aQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.3000.tgz",
+			"integrity": "sha512-AjAVQECwi8AQy6V6MXJw2pbxgk8X/TvchoEWqcjmToxKYrBaGiSUC3/7xDVcUfEWK5uf3dHuqdY598lRcPMMLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
-				"@fluidframework/container-runtime": "^0.59.2002",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
+				"@fluidframework/container-runtime": "^0.59.3000",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/map": "^0.59.2002",
-				"@fluidframework/request-handler": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/synthesize": "^0.59.2002",
-				"@fluidframework/view-interfaces": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/map": "^0.59.3000",
+				"@fluidframework/request-handler": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/synthesize": "^0.59.3000",
+				"@fluidframework/view-interfaces": "^0.59.3000",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2452,25 +2452,25 @@
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.2002.tgz",
-			"integrity": "sha512-efc6u6mguTShhctFZtLY2X0ONPaRD0LuoZGtPZ50UHffYtdVoc3dbCgJRn6HstgFEDr1NHtD1fY6De+KwW16aQ==",
+			"version": "npm:@fluidframework/aqueduct@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.59.3000.tgz",
+			"integrity": "sha512-AjAVQECwi8AQy6V6MXJw2pbxgk8X/TvchoEWqcjmToxKYrBaGiSUC3/7xDVcUfEWK5uf3dHuqdY598lRcPMMLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
-				"@fluidframework/container-runtime": "^0.59.2002",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
+				"@fluidframework/container-runtime": "^0.59.3000",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/map": "^0.59.2002",
-				"@fluidframework/request-handler": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/synthesize": "^0.59.2002",
-				"@fluidframework/view-interfaces": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/map": "^0.59.3000",
+				"@fluidframework/request-handler": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/synthesize": "^0.59.3000",
+				"@fluidframework/view-interfaces": "^0.59.3000",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2495,16 +2495,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
-			}
-		},
-		"@fluidframework/azure-service-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/azure-service-utils/-/azure-service-utils-0.59.2002.tgz",
-			"integrity": "sha512-nsUPsFvNerpKXAbxtIrvICcRpCgN50tXNrsNwBuDmzu0sJRPZtD01QlDF/8/e8k70UscZ4xpDfYpG2DgJopvyw==",
-			"requires": {
-				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"jsrsasign": "^10.2.0",
-				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/build-common": {
@@ -2599,31 +2589,31 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.2002.tgz",
-			"integrity": "sha512-f7K8S44ZOLd8yIQRxP/rFDDjoGH7sDlB9cgQAwGdl7s7tQQLE8zvZ40wg6QWD1ZzulLlKwYskm8KIwCHk3cTZA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.3000.tgz",
+			"integrity": "sha512-9S0hzb3tGqAZzYZKe1S7WkAoPC0rZwT14cv8vsptvj4RBGBJei81zoAcG7MDkCBudASbICR8cypahsPAz5gq0A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.2002.tgz",
-			"integrity": "sha512-f7K8S44ZOLd8yIQRxP/rFDDjoGH7sDlB9cgQAwGdl7s7tQQLE8zvZ40wg6QWD1ZzulLlKwYskm8KIwCHk3cTZA==",
+			"version": "npm:@fluidframework/cell@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.59.3000.tgz",
+			"integrity": "sha512-9S0hzb3tGqAZzYZKe1S7WkAoPC0rZwT14cv8vsptvj4RBGBJei81zoAcG7MDkCBudASbICR8cypahsPAz5gq0A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -2663,20 +2653,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.2002.tgz",
-			"integrity": "sha512-4s0JO57ikvt2uVvvpMw/Dik/xPYqpENLX1agN4wVEJ5Fwhuh3gKE9qFiUh1WQnIdA12rs/mXyeqHnAvaswx3xQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.3000.tgz",
+			"integrity": "sha512-+UZZ3VYGvJw1/t598p18j3Q9mIeeUzjZgg2pAOsEMWJ+omU1eyHAq+oLP0E6+cR8JygqoRn7P6mWYyQZx24H4Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2723,20 +2713,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.2002.tgz",
-			"integrity": "sha512-4s0JO57ikvt2uVvvpMw/Dik/xPYqpENLX1agN4wVEJ5Fwhuh3gKE9qFiUh1WQnIdA12rs/mXyeqHnAvaswx3xQ==",
+			"version": "npm:@fluidframework/container-loader@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.59.3000.tgz",
+			"integrity": "sha512-+UZZ3VYGvJw1/t598p18j3Q9mIeeUzjZgg2pAOsEMWJ+omU1eyHAq+oLP0E6+cR8JygqoRn7P6mWYyQZx24H4Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2783,25 +2773,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.2002.tgz",
-			"integrity": "sha512-pyv6cxSHQEqabmA35o+ZUvrWwdXZWeGKEc2aMvzV+n2a0HnBIPuQTr1wqkxKoksvbzM3jXokUlbMytIilIicGg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.3000.tgz",
+			"integrity": "sha512-ucaW7hZKgyACp84bi+CxQBzwfD8dGxNSV9VTr83Iyk0MRJdV1DnLMeBt2DW6v8aWKwn2bvDuAcROqxeWFIIsTw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/garbage-collector": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/garbage-collector": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -2846,16 +2836,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.2002.tgz",
-			"integrity": "sha512-Wq0X5NxdrAEyYfy7HwPzCzIm2ONZ87NOZVIQi3Hdm7ItarSBMlnLpaUHLUhAkAZFlV+WAD0Km2jvLLM6ZBgvOQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.3000.tgz",
+			"integrity": "sha512-ty9/i7bLn8qCs5ZuGC2/p/5I2yTWxG438jfRt0hS9ZoMu/Seu4PM2juX/U/T3oJRzoHDqN7Rw5aSGFbHiPZXKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -2883,16 +2873,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.2002.tgz",
-			"integrity": "sha512-Wq0X5NxdrAEyYfy7HwPzCzIm2ONZ87NOZVIQi3Hdm7ItarSBMlnLpaUHLUhAkAZFlV+WAD0Km2jvLLM6ZBgvOQ==",
+			"version": "npm:@fluidframework/container-runtime-definitions@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.3000.tgz",
+			"integrity": "sha512-ty9/i7bLn8qCs5ZuGC2/p/5I2yTWxG438jfRt0hS9ZoMu/Seu4PM2juX/U/T3oJRzoHDqN7Rw5aSGFbHiPZXKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -2920,25 +2910,25 @@
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.2002.tgz",
-			"integrity": "sha512-pyv6cxSHQEqabmA35o+ZUvrWwdXZWeGKEc2aMvzV+n2a0HnBIPuQTr1wqkxKoksvbzM3jXokUlbMytIilIicGg==",
+			"version": "npm:@fluidframework/container-runtime@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.3000.tgz",
+			"integrity": "sha512-ucaW7hZKgyACp84bi+CxQBzwfD8dGxNSV9VTr83Iyk0MRJdV1DnLMeBt2DW6v8aWKwn2bvDuAcROqxeWFIIsTw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/garbage-collector": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/garbage-collector": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -2983,15 +2973,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.2002.tgz",
-			"integrity": "sha512-3nVzO4ipKR7hbH3dt0M+nF8Kp/CqRiGsmNP+46abnzWw1C6WoEpI+ASDV+2jhdXaLYPZU0LevBU0H9qyMLvhgg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.3000.tgz",
+			"integrity": "sha512-ytNDyNRm9BX0GHJ3zFM5AUhH1Syv+lJv1eJYQ0yahEzQl85qzx5u0XJ+diMqbsolCxMwEqAyeU/p0RxwdKhfng==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3018,15 +3008,15 @@
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.2002.tgz",
-			"integrity": "sha512-3nVzO4ipKR7hbH3dt0M+nF8Kp/CqRiGsmNP+46abnzWw1C6WoEpI+ASDV+2jhdXaLYPZU0LevBU0H9qyMLvhgg==",
+			"version": "npm:@fluidframework/container-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.3000.tgz",
+			"integrity": "sha512-ytNDyNRm9BX0GHJ3zFM5AUhH1Syv+lJv1eJYQ0yahEzQl85qzx5u0XJ+diMqbsolCxMwEqAyeU/p0RxwdKhfng==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3058,49 +3048,49 @@
 			"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
 		},
 		"@fluidframework/counter": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.2002.tgz",
-			"integrity": "sha512-n02glLZzVNn77PPlQvCIcu7RSpryci6NgcFDPY6av6QSqrv/C+TD58WKaYHWxUyz/yKnLo0ZiXxaJTwIihaZkA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.3000.tgz",
+			"integrity": "sha512-BDT7ZGmmrOi3N8yR/P9IBDCutsMyQ43kPm3KouVbUDV+j94NppP2MFgXG4N+LJNnouKBg8B5P6eyVJoQqvoyKA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.2002.tgz",
-			"integrity": "sha512-n02glLZzVNn77PPlQvCIcu7RSpryci6NgcFDPY6av6QSqrv/C+TD58WKaYHWxUyz/yKnLo0ZiXxaJTwIihaZkA==",
+			"version": "npm:@fluidframework/counter@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.59.3000.tgz",
+			"integrity": "sha512-BDT7ZGmmrOi3N8yR/P9IBDCutsMyQ43kPm3KouVbUDV+j94NppP2MFgXG4N+LJNnouKBg8B5P6eyVJoQqvoyKA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-0.59.2002.tgz",
-			"integrity": "sha512-MMuSTzJTsaqC4RKUamxjyOP5yL/myk2/B3Pmqah01V3A36PhF5qXOfryJT7+VsFJJl6bkI5GK7U0f1Pe3hpw+w==",
+			"version": "npm:@fluidframework/data-object-base@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-0.59.3000.tgz",
+			"integrity": "sha512-PzyUiewvCBPeOcYf3mpZmbXm8aQWKZdx/LIV55/iIecsEMhHV3k1ImMOLstIWT03JOkANfjwrf+JsjZ8AXK9EA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.2002",
+				"@fluidframework/container-runtime": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/request-handler": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/request-handler": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3127,24 +3117,24 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.2002.tgz",
-			"integrity": "sha512-Z269ai7eQCPBCvLnKDYhAOYh/bOAh7sPIDtjAWqXEWORG4cWDKTkPfjG6XMI/8uQoqCqbwvf33VYqz8B7eFtkw==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.3000.tgz",
+			"integrity": "sha512-W+JQcsBAYX/NgE/hZST1I+5KGCt1WzjQYQY3budTgRzvKi4a3vmtRNZEwZ+XDkEGaA3GA/1er55BzxiybdUqog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/garbage-collector": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/garbage-collector": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3189,16 +3179,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.2002.tgz",
-			"integrity": "sha512-69lmUjxicFMNBUZKe5J5OR7MSRJargPkH1vUUG4iry+5MLnsjVAb8TnGekhywZjm88Tp73rrdZYElhj/7pJNMA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.3000.tgz",
+			"integrity": "sha512-t1UYeC91+8kVLQQT1tt/05jTBVh9VTcCCojy0a7J4yZSi8tFPxX/SZXuNEEM6ajecYsWjsc2SyQqN8RvFx6Vlg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3226,16 +3216,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.2002.tgz",
-			"integrity": "sha512-69lmUjxicFMNBUZKe5J5OR7MSRJargPkH1vUUG4iry+5MLnsjVAb8TnGekhywZjm88Tp73rrdZYElhj/7pJNMA==",
+			"version": "npm:@fluidframework/datastore-definitions@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.3000.tgz",
+			"integrity": "sha512-t1UYeC91+8kVLQQT1tt/05jTBVh9VTcCCojy0a7J4yZSi8tFPxX/SZXuNEEM6ajecYsWjsc2SyQqN8RvFx6Vlg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3263,24 +3253,24 @@
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.2002.tgz",
-			"integrity": "sha512-Z269ai7eQCPBCvLnKDYhAOYh/bOAh7sPIDtjAWqXEWORG4cWDKTkPfjG6XMI/8uQoqCqbwvf33VYqz8B7eFtkw==",
+			"version": "npm:@fluidframework/datastore@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.3000.tgz",
+			"integrity": "sha512-W+JQcsBAYX/NgE/hZST1I+5KGCt1WzjQYQY3budTgRzvKi4a3vmtRNZEwZ+XDkEGaA3GA/1er55BzxiybdUqog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/garbage-collector": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/garbage-collector": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3325,27 +3315,27 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-0.59.2002.tgz",
-			"integrity": "sha512-F0dqUDTrT8P3Wo8ADZ6bu4T4cIipG7TB+qDjYvPai4Dkl1eE3UG/NbSOw6ei01dx1XfHUT+tuGe9moFc3ulnOA==",
+			"version": "npm:@fluidframework/dds-interceptions@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-0.59.3000.tgz",
+			"integrity": "sha512-qtGZ1UoCgllju+dISv5FNfF49tOnIvnr19I2ZCGPPwtdjxJqgpWsFvSc5GZMzX9IMk/Ja8Awmp0oyGRv47EaWA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^0.59.2002",
-				"@fluidframework/merge-tree": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/sequence": "^0.59.2002"
+				"@fluidframework/map": "^0.59.3000",
+				"@fluidframework/merge-tree": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/sequence": "^0.59.3000"
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-0.59.2002.tgz",
-			"integrity": "sha512-Pdpq23eUM97mnhFbQ/2JG/fGha1b5XoZ4xtqvLbMi7sBpQJ21ARc3h6m2lOtvmGU062OcZ4K9vBwrSAaaNJI3Q==",
+			"version": "npm:@fluidframework/debugger@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-0.59.3000.tgz",
+			"integrity": "sha512-+zWcOYvAKjz4GZmWb76iLUWUOaFc4PHNQL5M2ZYyLjZThtZmQfgt6ESay6OTaDhM7I8mU5O+Rq8C7qvNhklOTQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/replay-driver": "^0.59.2002",
+				"@fluidframework/replay-driver": "^0.59.3000",
 				"jsonschema": "^1.2.6"
 			},
 			"dependencies": {
@@ -3362,16 +3352,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.2002.tgz",
-			"integrity": "sha512-HXiQtll1vsDvdnY1a6oGqkT9MnPkNtkOcGXXmHIDjn9KAzETClEdnuoXO5TJhIBWDnK/cBKbiuS6Z9agaFnuTQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.3000.tgz",
+			"integrity": "sha512-0eJ9zz5RZ6n0IchdBduuWA0BzpvJ2deSPJ1n76S58AK7ZpQ/ktxkSMF3Ihy3BUgPHA5oUELut55ncpU9MSL8pA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -3387,16 +3377,16 @@
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.2002.tgz",
-			"integrity": "sha512-HXiQtll1vsDvdnY1a6oGqkT9MnPkNtkOcGXXmHIDjn9KAzETClEdnuoXO5TJhIBWDnK/cBKbiuS6Z9agaFnuTQ==",
+			"version": "npm:@fluidframework/driver-base@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.59.3000.tgz",
+			"integrity": "sha512-0eJ9zz5RZ6n0IchdBduuWA0BzpvJ2deSPJ1n76S58AK7ZpQ/ktxkSMF3Ihy3BUgPHA5oUELut55ncpU9MSL8pA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -3422,18 +3412,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.2002.tgz",
-			"integrity": "sha512-UIJqfGhuKPCN0v5ga0SM4kKCbx8TTcj4WmKpEVboGRpTYAWB4ePz8NGJBQtr30MnvWwK79ks+c9SRF1Mtid/wg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.3000.tgz",
+			"integrity": "sha512-u70dnpPPcDqr2yu7tBerllAGoFXl0XpoLRp/vcViBFE79BqyWje3U1Ot7fnajOxcbRia4AOpDRHhG/+PzYTHpA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/gitresources": "^0.1036.2000",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/gitresources": "^0.1036.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3467,18 +3457,18 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.2002.tgz",
-			"integrity": "sha512-UIJqfGhuKPCN0v5ga0SM4kKCbx8TTcj4WmKpEVboGRpTYAWB4ePz8NGJBQtr30MnvWwK79ks+c9SRF1Mtid/wg==",
+			"version": "npm:@fluidframework/driver-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.3000.tgz",
+			"integrity": "sha512-u70dnpPPcDqr2yu7tBerllAGoFXl0XpoLRp/vcViBFE79BqyWje3U1Ot7fnajOxcbRia4AOpDRHhG/+PzYTHpA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/gitresources": "^0.1036.2000",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/gitresources": "^0.1036.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3512,13 +3502,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-0.59.2002.tgz",
-			"integrity": "sha512-DFYybquEOgFqMJOnqnMv6ysFHCJLMFj10k3M0+v0NxqANdVteWaBHbiIVs9QHBafoFPESc+1ge2JjbgbKhMWPg==",
+			"version": "npm:@fluidframework/driver-web-cache@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-0.59.3000.tgz",
+			"integrity": "sha512-4H08CgnVZ+5aTkGRLHIQrvMktPio30ZTcqK0IGE7/6q/3r8pLeDRwnKR2WgvkupvFppz+XyIbfR6HV6ERLkUVA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3567,16 +3557,16 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-0.59.2002.tgz",
-			"integrity": "sha512-ZZgWfxgolO+3UmdNJrrIWx4rRPdBrPmyk6UpOJJE7Y2i5GsF8Su9cUSi5fRafikGmZQSTQ1bGUiFf2bRQ4nlnQ==",
+			"version": "npm:@fluidframework/file-driver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-0.59.3000.tgz",
+			"integrity": "sha512-WVB+u6HUXdqImOsfXe+jAUU3h7IjHgBY0vaaUtFJbjxjnjPy2nmkZV36nXpfUeTJo52eMvxMcwUD3Wm3CoYkgQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/replay-driver": "^0.59.2002"
+				"@fluidframework/replay-driver": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -3592,22 +3582,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.2002.tgz",
-			"integrity": "sha512-Vxw4lRaYLeBg/tRhGbJ2Utdszqpq7k+IGNAG8IsQWzjWhkGXQWvF+/FXL0ufIsumC3GCgzngxmOX/5T7I7LR3A==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.3000.tgz",
+			"integrity": "sha512-UG76ZY/ReDE7KXVm8u8nssqpA3LY+SeKBewxV/pe5SpMklBclTYiYTup6DamswG0Q1pIbbmzDOGscDH8VYdXng==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.2002",
+				"@fluidframework/aqueduct": "^0.59.3000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002"
+				"@fluidframework/request-handler": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3634,22 +3624,22 @@
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.2002.tgz",
-			"integrity": "sha512-Vxw4lRaYLeBg/tRhGbJ2Utdszqpq7k+IGNAG8IsQWzjWhkGXQWvF+/FXL0ufIsumC3GCgzngxmOX/5T7I7LR3A==",
+			"version": "npm:@fluidframework/fluid-static@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-0.59.3000.tgz",
+			"integrity": "sha512-UG76ZY/ReDE7KXVm8u8nssqpA3LY+SeKBewxV/pe5SpMklBclTYiYTup6DamswG0Q1pIbbmzDOGscDH8VYdXng==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.2002",
+				"@fluidframework/aqueduct": "^0.59.3000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002"
+				"@fluidframework/request-handler": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -3676,23 +3666,23 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.2002.tgz",
-			"integrity": "sha512-qYJHvUx7/cOLPhb3wmynHMq1Kll0a2VHMdrBL8sbU4zHSGLsPW7t3mF/9XhVPIML8hB7ku6V+4RPZcUqYYkS6Q==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.3000.tgz",
+			"integrity": "sha512-ZcXvi38zPgGc2E5y5oBy3DpZkXjwq+4sANlDO01tZq9QgC5eEKBEnkgyVlqhAJmOZ1f0kRwmYisy0LBNVBX5DA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.2002.tgz",
-			"integrity": "sha512-qYJHvUx7/cOLPhb3wmynHMq1Kll0a2VHMdrBL8sbU4zHSGLsPW7t3mF/9XhVPIML8hB7ku6V+4RPZcUqYYkS6Q==",
+			"version": "npm:@fluidframework/garbage-collector@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.3000.tgz",
+			"integrity": "sha512-ZcXvi38zPgGc2E5y5oBy3DpZkXjwq+4sANlDO01tZq9QgC5eEKBEnkgyVlqhAJmOZ1f0kRwmYisy0LBNVBX5DA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -3701,17 +3691,17 @@
 			"integrity": "sha512-QbfvNPPahZkgyQUgaFcb1ycYdt8i10wa5nhgSqNk/4sXyTa+ESdpHTd7ljEs0X3kx1aW0QOCQTZq2tL8JmZiLQ=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-0.59.2002.tgz",
-			"integrity": "sha512-rufSZjpI9iZ7ZbNjuyfI2IYP11TUbHsYLlmVeuzqf91ey+Coy+WyxvOzzUC9bDE6qpv982dw1QOXK8Apl0KCNg==",
+			"version": "npm:@fluidframework/iframe-driver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-0.59.3000.tgz",
+			"integrity": "sha512-SejvOWw8U7nD0q+0asBM6TzWsWk1td7BFyb13KPoSydtu1zkflmF7LSdu/8fFOE7w8wx8gibecZvyqEbiiJ1cQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"comlink": "^4.3.0"
 			},
 			"dependencies": {
@@ -3728,52 +3718,52 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.2002.tgz",
-			"integrity": "sha512-WbgECS7oS1ZyZx1OtNddloWGGQSIrPz3jc8IVdgWRCeFcUXjshsB2DFXjQ/qs/BNrnqotzMkHgs7ExU2tsRk9w==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.3000.tgz",
+			"integrity": "sha512-pIFSLbJbkTXvnDK+tU48XS7Q4YE2xv15n60lNhTsH304CGF29I1peBj+NApABXcj3jDJLpMJK8nFk2ZtA8iNow==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.2002.tgz",
-			"integrity": "sha512-WbgECS7oS1ZyZx1OtNddloWGGQSIrPz3jc8IVdgWRCeFcUXjshsB2DFXjQ/qs/BNrnqotzMkHgs7ExU2tsRk9w==",
+			"version": "npm:@fluidframework/ink@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.59.3000.tgz",
+			"integrity": "sha512-pIFSLbJbkTXvnDK+tU48XS7Q4YE2xv15n60lNhTsH304CGF29I1peBj+NApABXcj3jDJLpMJK8nFk2ZtA8iNow==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.2002.tgz",
-			"integrity": "sha512-Zm4ur4SASVP+Lno4EYkuwX581VcVyPv6rUBshttl209sQm6xuDm8tBGjNK3RZhvTZJNEZ8HKJn53W3O+22cZKQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.3000.tgz",
+			"integrity": "sha512-A3moSs/ZOQ7OrAlI2cyJGwqM7InkObidA7D+bphYBzV8FZI7sglz9Y6l4e89fChHP14qM/ISHOrkrjnKDB2BCw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.2002",
+				"@fluidframework/driver-base": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/server-local-server": "^0.1036.2000",
-				"@fluidframework/server-services-client": "^0.1036.2000",
-				"@fluidframework/server-services-core": "^0.1036.2000",
-				"@fluidframework/server-test-utils": "^0.1036.2000",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/server-local-server": "^0.1036.3000",
+				"@fluidframework/server-services-client": "^0.1036.3000",
+				"@fluidframework/server-services-core": "^0.1036.3000",
+				"@fluidframework/server-test-utils": "^0.1036.3000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -4042,22 +4032,22 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.2002.tgz",
-			"integrity": "sha512-Zm4ur4SASVP+Lno4EYkuwX581VcVyPv6rUBshttl209sQm6xuDm8tBGjNK3RZhvTZJNEZ8HKJn53W3O+22cZKQ==",
+			"version": "npm:@fluidframework/local-driver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.59.3000.tgz",
+			"integrity": "sha512-A3moSs/ZOQ7OrAlI2cyJGwqM7InkObidA7D+bphYBzV8FZI7sglz9Y6l4e89fChHP14qM/ISHOrkrjnKDB2BCw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.2002",
+				"@fluidframework/driver-base": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/server-local-server": "^0.1036.2000",
-				"@fluidframework/server-services-client": "^0.1036.2000",
-				"@fluidframework/server-services-core": "^0.1036.2000",
-				"@fluidframework/server-test-utils": "^0.1036.2000",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/server-local-server": "^0.1036.3000",
+				"@fluidframework/server-services-client": "^0.1036.3000",
+				"@fluidframework/server-services-core": "^0.1036.3000",
+				"@fluidframework/server-test-utils": "^0.1036.3000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -4326,57 +4316,57 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.2002.tgz",
-			"integrity": "sha512-+CTlLvHq+WISF7xsUJNCzrDS9awrV8PtKHqKljqsx3dMZr0A9SvaQSEa9nbEU+1nam6HmmHKcUOIsqcDJYqRzA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.3000.tgz",
+			"integrity": "sha512-ltZhvPo5hJgP2qbd4xAbr1H8lzr4jMktcJFZnvCTEiMPC8jaRGOm1ddgorUe3OIgNALOxAUn6uIAQpIFwcg8ug==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.2002.tgz",
-			"integrity": "sha512-+CTlLvHq+WISF7xsUJNCzrDS9awrV8PtKHqKljqsx3dMZr0A9SvaQSEa9nbEU+1nam6HmmHKcUOIsqcDJYqRzA==",
+			"version": "npm:@fluidframework/map@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.3000.tgz",
+			"integrity": "sha512-ltZhvPo5hJgP2qbd4xAbr1H8lzr4jMktcJFZnvCTEiMPC8jaRGOm1ddgorUe3OIgNALOxAUn6uIAQpIFwcg8ug==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.2002.tgz",
-			"integrity": "sha512-mktagBNp9wOEhDKZFbqmok1I+jB/6AijbsQXEGYnSKkqga/pJGpcIEHL4S1vp/ANPR4mNIMyouLOISBcTM7S6w==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.3000.tgz",
+			"integrity": "sha512-1t02AZ8LqJ9PNoGiyB+EZzMLkiugJOPqLTVPJVr9ZlgiKyNwF1j3a63iI/D9Fi9BKlrrv5cWJN8zCDwcIZzR3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/merge-tree": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/merge-tree": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4400,21 +4390,21 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.2002.tgz",
-			"integrity": "sha512-mktagBNp9wOEhDKZFbqmok1I+jB/6AijbsQXEGYnSKkqga/pJGpcIEHL4S1vp/ANPR4mNIMyouLOISBcTM7S6w==",
+			"version": "npm:@fluidframework/matrix@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.3000.tgz",
+			"integrity": "sha512-1t02AZ8LqJ9PNoGiyB+EZzMLkiugJOPqLTVPJVr9ZlgiKyNwF1j3a63iI/D9Fi9BKlrrv5cWJN8zCDwcIZzR3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/merge-tree": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/merge-tree": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4438,20 +4428,20 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.2002.tgz",
-			"integrity": "sha512-hfW2dImUSdP8QstNXrtXJlTRbCEF2Rjzf5mzD9/VcrOjqTsYbn2oWv8mEKa7nvPOEjIyTr1qKzGXSXwqIGPZKw==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.3000.tgz",
+			"integrity": "sha512-LHcMPn24OlpImPLaUk23x+fBGulHy7HlR2wVVJwBWxh6KsM1iZ5keaKRU/n+oVBYU5xiVAiD5enQaxC+0LbRuQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -4725,36 +4715,36 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.2002.tgz",
-			"integrity": "sha512-ehUW0SdFNvoKkoqlxpb51HjjAauGzK0AIEUU6VWrSDHs61GEFrHT+eV3fHfFSZPpZI3VE/dFERuJ69y+WFl1Hw==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.3000.tgz",
+			"integrity": "sha512-gpKPe8lALMXoEk/3Y5bE0I3OmfLIijEcAL9NHJZ7yijpIz8vjr4yOOOz3zbuVA01txulRGs9qSE7Kq9td+5mXg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^0.59.2002",
+				"@fluidframework/test-driver-definitions": "^0.59.3000",
 				"mocha": "^8.4.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.2002.tgz",
-			"integrity": "sha512-ehUW0SdFNvoKkoqlxpb51HjjAauGzK0AIEUU6VWrSDHs61GEFrHT+eV3fHfFSZPpZI3VE/dFERuJ69y+WFl1Hw==",
+			"version": "npm:@fluidframework/mocha-test-setup@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.59.3000.tgz",
+			"integrity": "sha512-gpKPe8lALMXoEk/3Y5bE0I3OmfLIijEcAL9NHJZ7yijpIz8vjr4yOOOz3zbuVA01txulRGs9qSE7Kq9td+5mXg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^0.59.2002",
+				"@fluidframework/test-driver-definitions": "^0.59.3000",
 				"mocha": "^8.4.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.2002.tgz",
-			"integrity": "sha512-a/jg/9co8YhSYo41Xy9Gsj1EpKo7h6J6NC3w2y90mWE3B+QICwpVquXOxdjyNs69ruixKhYODMzZs38I8sJVJw==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.3000.tgz",
+			"integrity": "sha512-nHYUt6ZMf7/GNDmyoMUICTJFTuUgMd0YnADKDhBtCnR8o7M+cIsX3yxyngCgV5XN6ohNYmMMrvRhqlX4CxjPIA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -4771,16 +4761,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.2002.tgz",
-			"integrity": "sha512-a/jg/9co8YhSYo41Xy9Gsj1EpKo7h6J6NC3w2y90mWE3B+QICwpVquXOxdjyNs69ruixKhYODMzZs38I8sJVJw==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.59.3000.tgz",
+			"integrity": "sha512-nHYUt6ZMf7/GNDmyoMUICTJFTuUgMd0YnADKDhBtCnR8o7M+cIsX3yxyngCgV5XN6ohNYmMMrvRhqlX4CxjPIA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -4797,22 +4787,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.2002.tgz",
-			"integrity": "sha512-2viU+qSZNLDSdxFOTB+yiyg+pLX7HrmYk7LiVO/+d+ZXGov60zufUVv4nZDP1C2ZVv6zNAj0kbLZcQmP3fZ5GA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.3000.tgz",
+			"integrity": "sha512-KcBTDW+n1BEJImmS7B+h0FNOi+Z8Qk6OcWbU6+13DuF46/iPaKaMYndq3UeUd5y4ymLFzl67b7p52us/4ntLog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.2002",
+				"@fluidframework/driver-base": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/gitresources": "^0.1036.2000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/gitresources": "^0.1036.3000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4848,9 +4838,9 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.2002.tgz",
-			"integrity": "sha512-1mf0REfJd3eozRjpgpc07bJa0RePvB/dKOKL5oVhI3Uho2UNcbMcZ1ciJPJvCi6w2Jn+DxujInuS/S2Doa3GGw==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.3000.tgz",
+			"integrity": "sha512-XwuBIl27el8b9a+xBuGHeOwI4DKwSta++mlpJMG4ZYfoSulCtJ/JUVx/TqoNt8CG0qQvHvqMVr/a1G9bWoWqtQ==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
 			},
@@ -4868,9 +4858,9 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.2002.tgz",
-			"integrity": "sha512-1mf0REfJd3eozRjpgpc07bJa0RePvB/dKOKL5oVhI3Uho2UNcbMcZ1ciJPJvCi6w2Jn+DxujInuS/S2Doa3GGw==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-0.59.3000.tgz",
+			"integrity": "sha512-XwuBIl27el8b9a+xBuGHeOwI4DKwSta++mlpJMG4ZYfoSulCtJ/JUVx/TqoNt8CG0qQvHvqMVr/a1G9bWoWqtQ==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
 			},
@@ -4888,22 +4878,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.2002.tgz",
-			"integrity": "sha512-2viU+qSZNLDSdxFOTB+yiyg+pLX7HrmYk7LiVO/+d+ZXGov60zufUVv4nZDP1C2ZVv6zNAj0kbLZcQmP3fZ5GA==",
+			"version": "npm:@fluidframework/odsp-driver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.59.3000.tgz",
+			"integrity": "sha512-KcBTDW+n1BEJImmS7B+h0FNOi+Z8Qk6OcWbU6+13DuF46/iPaKaMYndq3UeUd5y4ymLFzl67b7p52us/4ntLog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-base": "^0.59.2002",
+				"@fluidframework/driver-base": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/gitresources": "^0.1036.2000",
-				"@fluidframework/odsp-doclib-utils": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/gitresources": "^0.1036.3000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4939,14 +4929,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.2002.tgz",
-			"integrity": "sha512-I0AA7yhDWBylx3bnhsJd41I2YyX7Fi8VPCAOxgb211ZY8xsnItrw8a1ldu6QV02iF4CCdO6Ei+87J/mYFR0rig==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.3000.tgz",
+			"integrity": "sha512-wc2ukQVz7EMA508JFoJYR24WqxbpxqOgavoDWldB93qjkx+6q0PUejdUA2WXDs8r2Hk+PVcFBcsQ4asu10r06g==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002"
+				"@fluidframework/odsp-driver": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -4962,14 +4952,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.2002.tgz",
-			"integrity": "sha512-I0AA7yhDWBylx3bnhsJd41I2YyX7Fi8VPCAOxgb211ZY8xsnItrw8a1ldu6QV02iF4CCdO6Ei+87J/mYFR0rig==",
+			"version": "npm:@fluidframework/odsp-urlresolver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.59.3000.tgz",
+			"integrity": "sha512-wc2ukQVz7EMA508JFoJYR24WqxbpxqOgavoDWldB93qjkx+6q0PUejdUA2WXDs8r2Hk+PVcFBcsQ4asu10r06g==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/odsp-driver": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002"
+				"@fluidframework/odsp-driver": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -4985,32 +4975,32 @@
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.2002.tgz",
-			"integrity": "sha512-G4omWVfb1DmU69wGG889UyTbu22WIpSGBkWE3LGqdVjvxXMRTg2fPaTa0yJDcSl19s5BYJduqGY3XFF2jCLK5Q==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.3000.tgz",
+			"integrity": "sha512-OED771e/d8Zay3Vqzt9M7tvCkEnN7/fQRpS+tELtIc/7/cOK6NwZaH8neX0oQKLz+e4jcUFqIno4Ba4HKyNu3A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.2002.tgz",
-			"integrity": "sha512-G4omWVfb1DmU69wGG889UyTbu22WIpSGBkWE3LGqdVjvxXMRTg2fPaTa0yJDcSl19s5BYJduqGY3XFF2jCLK5Q==",
+			"version": "npm:@fluidframework/ordered-collection@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.59.3000.tgz",
+			"integrity": "sha512-OED771e/d8Zay3Vqzt9M7tvCkEnN7/fQRpS+tELtIc/7/cOK6NwZaH8neX0oQKLz+e4jcUFqIno4Ba4HKyNu3A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5034,17 +5024,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.2002.tgz",
-			"integrity": "sha512-2mlReQMzlbfRH5cohbwL/t12Wvk+9teGiyHYWzg8wCK7K9wTzHsp6msLLIvGqc6J7UY/zUN4GT8Caryghkt9qQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.3000.tgz",
+			"integrity": "sha512-fE+tMe4XKG0j7lkPLx3KZwmWJvyRw0/WSDHuZJ3WVqw//TM3jpn2VI7kAggP0jRwjr159QK9mFEZ3p6VQsAuHw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -5066,17 +5056,17 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.2002.tgz",
-			"integrity": "sha512-2mlReQMzlbfRH5cohbwL/t12Wvk+9teGiyHYWzg8wCK7K9wTzHsp6msLLIvGqc6J7UY/zUN4GT8Caryghkt9qQ==",
+			"version": "npm:@fluidframework/register-collection@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.59.3000.tgz",
+			"integrity": "sha512-fE+tMe4XKG0j7lkPLx3KZwmWJvyRw0/WSDHuZJ3WVqw//TM3jpn2VI7kAggP0jRwjr159QK9mFEZ3p6VQsAuHw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -5098,16 +5088,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.2002.tgz",
-			"integrity": "sha512-SyLReBAxqF1y2ZKSvDca8DkD3TdS8XxzPLQtllILyMRb2TW3zoa7zGiCxjPoQACqD7jYT7sf+6D+vOzV4cVvsQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.3000.tgz",
+			"integrity": "sha512-vIgMRFWlyH3ZuHF2BxnHOTfkQqGhK969xJQ+Qq0dEXub0yGb56lZYySydZO9IPvJn57Pkm77LO9kV6Y93y/E3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -5123,16 +5113,16 @@
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.2002.tgz",
-			"integrity": "sha512-SyLReBAxqF1y2ZKSvDca8DkD3TdS8XxzPLQtllILyMRb2TW3zoa7zGiCxjPoQACqD7jYT7sf+6D+vOzV4cVvsQ==",
+			"version": "npm:@fluidframework/replay-driver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-0.59.3000.tgz",
+			"integrity": "sha512-vIgMRFWlyH3ZuHF2BxnHOTfkQqGhK969xJQ+Qq0dEXub0yGb56lZYySydZO9IPvJn57Pkm77LO9kV6Y93y/E3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/driver-definitions": {
@@ -5148,44 +5138,44 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.2002.tgz",
-			"integrity": "sha512-0lIiC6g64CRygI7/h7mXRSi9NWm3Scz37NYz2LnkQ/ZR2EoIBseCbLgWdQKfXKbBUFflPeVJFaURL+hUTeX2pg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.3000.tgz",
+			"integrity": "sha512-dxEp8JDKF53iv2GGTc9LCfobO621cSJgXEWd2TwhAOKfkrVlXr7qOe7UbDXH4uetkYnZyTTYqBFbaVWQ+IkGtQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.2002.tgz",
-			"integrity": "sha512-0lIiC6g64CRygI7/h7mXRSi9NWm3Scz37NYz2LnkQ/ZR2EoIBseCbLgWdQKfXKbBUFflPeVJFaURL+hUTeX2pg==",
+			"version": "npm:@fluidframework/request-handler@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.59.3000.tgz",
+			"integrity": "sha512-dxEp8JDKF53iv2GGTc9LCfobO621cSJgXEWd2TwhAOKfkrVlXr7qOe7UbDXH4uetkYnZyTTYqBFbaVWQ+IkGtQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.2002.tgz",
-			"integrity": "sha512-wVnjIN6meK21FX4v0G8MBQ4MqBL6wPa8pgZabgqFjv5UJFBU/NdaJFVfewsmr58Z6KN1e/nY8V3WGEk0kbslLQ==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.3000.tgz",
+			"integrity": "sha512-aym9P3geXOKr2/PvpBfcGL3LoN9WAmo0ntNgAemQ9zWHm6mJoxrwb5vDgqTcA0U8ip+gEliyyHBA0o4KbLjxaA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^0.59.2002",
+				"@fluidframework/driver-base": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/gitresources": "^0.1036.2000",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/gitresources": "^0.1036.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "^0.1036.2000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/server-services-client": "^0.1036.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.4.1",
@@ -5246,20 +5236,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.2002.tgz",
-			"integrity": "sha512-wVnjIN6meK21FX4v0G8MBQ4MqBL6wPa8pgZabgqFjv5UJFBU/NdaJFVfewsmr58Z6KN1e/nY8V3WGEk0kbslLQ==",
+			"version": "npm:@fluidframework/routerlicious-driver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.59.3000.tgz",
+			"integrity": "sha512-aym9P3geXOKr2/PvpBfcGL3LoN9WAmo0ntNgAemQ9zWHm6mJoxrwb5vDgqTcA0U8ip+gEliyyHBA0o4KbLjxaA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^0.59.2002",
+				"@fluidframework/driver-base": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/gitresources": "^0.1036.2000",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/gitresources": "^0.1036.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/server-services-client": "^0.1036.2000",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/server-services-client": "^0.1036.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.4.1",
@@ -5320,9 +5310,9 @@
 			}
 		},
 		"@fluidframework/routerlicious-host-previous": {
-			"version": "npm:@fluidframework/routerlicious-host@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-0.59.2002.tgz",
-			"integrity": "sha512-he3JOryqrYgU6QGQ5/qq6U8rx9BwIQigB2saaXwONuJmj3OW58cTOYRJ6X+GJKm5wyUzkv+AllkHmzEYuAVxmQ==",
+			"version": "npm:@fluidframework/routerlicious-host@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-0.59.3000.tgz",
+			"integrity": "sha512-5s4KaRTGfRWN/xggVzd5qWGjLTgvXtwCYqnd5CpY3R1Q7me1uWzMDvvzVH/GJAkL5DJPtEBIFJxRewROyHsnig==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -5343,9 +5333,9 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-0.59.2002.tgz",
-			"integrity": "sha512-q++P0FtERjTDim/jOSPax3kvqEPLiyzFWEdl0otUwrCV3lDveAgYeN5wyeZFCW8GQIlTJCfKbtlvNaDPBM2eDQ==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-0.59.3000.tgz",
+			"integrity": "sha512-uoN+iNuvAfb/AOfkeGIF50as+zmFOEJRj6dnyF+3Z4Mt9QliTqXp/qTrJvjb2ny0U9cSkVed2YtQuud05RmL7A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -5367,9 +5357,9 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.2002.tgz",
-			"integrity": "sha512-wpUONKruxU/znxeba0r5wnHdXLFTVs2R5V/fuTgafayHc0CzFpNzX/9vJsy70tJThZIqKW8OOlvMWYcX17Mj5w==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.3000.tgz",
+			"integrity": "sha512-2tvJJaaz0ztMUVqQl/BD5QGNlWXfKyfE+FODC+oxaF7cyYtbBFUebW11O1yDejvLX2aGoR2XQqU0iTRLZruatg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -5404,9 +5394,9 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.2002.tgz",
-			"integrity": "sha512-wpUONKruxU/znxeba0r5wnHdXLFTVs2R5V/fuTgafayHc0CzFpNzX/9vJsy70tJThZIqKW8OOlvMWYcX17Mj5w==",
+			"version": "npm:@fluidframework/runtime-definitions@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.3000.tgz",
+			"integrity": "sha512-2tvJJaaz0ztMUVqQl/BD5QGNlWXfKyfE+FODC+oxaF7cyYtbBFUebW11O1yDejvLX2aGoR2XQqU0iTRLZruatg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -5441,21 +5431,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.2002.tgz",
-			"integrity": "sha512-cF87tSN/08+MLG3le8BgARIVjKk+HTKZUgY0nd7utu3Y+65OQCqz4th6xwHPjLfILs5qAs6gTXWR2uX0Lp7y2w==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.3000.tgz",
+			"integrity": "sha512-SBkwnvBXZEAjyIIw80j/JJNmjIPkFRZTKaAZBrEpQhYnu7UO8O6JFS+QatT47DHafGbFUtNMismqioJIJLUz0g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/garbage-collector": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/garbage-collector": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -5498,21 +5488,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.2002.tgz",
-			"integrity": "sha512-cF87tSN/08+MLG3le8BgARIVjKk+HTKZUgY0nd7utu3Y+65OQCqz4th6xwHPjLfILs5qAs6gTXWR2uX0Lp7y2w==",
+			"version": "npm:@fluidframework/runtime-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.3000.tgz",
+			"integrity": "sha512-SBkwnvBXZEAjyIIw80j/JJNmjIPkFRZTKaAZBrEpQhYnu7UO8O6JFS+QatT47DHafGbFUtNMismqioJIJLUz0g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/garbage-collector": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/garbage-collector": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -5555,20 +5545,20 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.2002.tgz",
-			"integrity": "sha512-8oltxcLVBh8lAmqnrQqHflz5afKcj7suxXoaLm1v1tj1v6BGZBsN5jgrc6F7hKEvzQp96rlXdGZcwl8DLwoQwg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.3000.tgz",
+			"integrity": "sha512-fna0Xdq3OKNOD9V4sCWr3VMN4hKjycDhVBVgrCOssS0t8J9hpKr0x3Xq93kS6fLZ5Dohfy1fiVuoDaNyM4LcEw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/merge-tree": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/merge-tree": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -6580,22 +6570,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.2002.tgz",
-			"integrity": "sha512-qjXw0hyYdI6usz8XvGTZlIhLKr3ZJ3R9aE6TUSD7hGu+14jE4EVjStBZhGfIx6u+ZBYlWkFucNHXVvYxoRt2jA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.3000.tgz",
+			"integrity": "sha512-rcELE/oB+WLdeirhqc9MsmPjXPzUoR2hQvJNm8GxGW8NTJpmZt2IR+eQCAcasIGAhkG494JwKcN+LBwCU1n4yg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.2002",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-runtime": "^0.59.3000",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6623,22 +6613,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.2002.tgz",
-			"integrity": "sha512-qjXw0hyYdI6usz8XvGTZlIhLKr3ZJ3R9aE6TUSD7hGu+14jE4EVjStBZhGfIx6u+ZBYlWkFucNHXVvYxoRt2jA==",
+			"version": "npm:@fluidframework/shared-object-base@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.3000.tgz",
+			"integrity": "sha512-rcELE/oB+WLdeirhqc9MsmPjXPzUoR2hQvJNm8GxGW8NTJpmZt2IR+eQCAcasIGAhkG494JwKcN+LBwCU1n4yg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-runtime": "^0.59.2002",
-				"@fluidframework/container-utils": "^0.59.2002",
+				"@fluidframework/container-runtime": "^0.59.3000",
+				"@fluidframework/container-utils": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6666,33 +6656,33 @@
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-0.59.2002.tgz",
-			"integrity": "sha512-ez1/LIK6ocSL7cTTtQcfeH1uGk3/ub9wPoNhYZT8E9WjmAngE5cuvYX7BVg0BG3GfuV5HaohZq7t7dqBiV7pfg==",
+			"version": "npm:@fluidframework/shared-summary-block@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-0.59.3000.tgz",
+			"integrity": "sha512-3FUtp7v9LXBC4R1l8Tig7ID6y/EVWitTBk8Ax4XN3cWodfB/RUvZQO6rMXzD66uP92AuZ0DWTHqFJLhZ9R4w4Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/shared-object-base": "^0.59.2002"
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/shared-object-base": "^0.59.3000"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.2002.tgz",
-			"integrity": "sha512-fRF+cWZMwwePCCQxGav3ByhRWBZ7rwq8VFqL8XqapI0hEEA7xwhpROw/n0UvICkzc0nDtz7AtMRfhZRBKh0oig=="
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.3000.tgz",
+			"integrity": "sha512-tqRBOlyElEBZR9p15pPL/aayr9Cqsz0FTSbdqiflbbQiOub3KsFWGtPPAwLpeq91YrpxNL3dsbuSyGj7+lFnfg=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.2002.tgz",
-			"integrity": "sha512-fRF+cWZMwwePCCQxGav3ByhRWBZ7rwq8VFqL8XqapI0hEEA7xwhpROw/n0UvICkzc0nDtz7AtMRfhZRBKh0oig=="
+			"version": "npm:@fluidframework/synthesize@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.59.3000.tgz",
+			"integrity": "sha512-tqRBOlyElEBZR9p15pPL/aayr9Cqsz0FTSbdqiflbbQiOub3KsFWGtPPAwLpeq91YrpxNL3dsbuSyGj7+lFnfg=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.2002.tgz",
-			"integrity": "sha512-WH6dHjjKSqcodPrLGbS1mjXFQVDKBnlGkdNg5BSsYbFzs23H+9aadt0cuQzNOL4wdpGwI428Q8jjxaqhGcRZRw==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.3000.tgz",
+			"integrity": "sha512-tMAVqWB1wqUq+jFxV7P5Gz9YDo8AiizpUiU4DEvMzOXNyy7NNa3brVaVjudDw0Oe7rTWkc28wDrWX1ss9eZYrQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6702,9 +6692,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.2002.tgz",
-			"integrity": "sha512-WH6dHjjKSqcodPrLGbS1mjXFQVDKBnlGkdNg5BSsYbFzs23H+9aadt0cuQzNOL4wdpGwI428Q8jjxaqhGcRZRw==",
+			"version": "npm:@fluidframework/telemetry-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.3000.tgz",
+			"integrity": "sha512-tMAVqWB1wqUq+jFxV7P5Gz9YDo8AiizpUiU4DEvMzOXNyy7NNa3brVaVjudDw0Oe7rTWkc28wDrWX1ss9eZYrQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6714,19 +6704,19 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-0.59.2002.tgz",
-			"integrity": "sha512-yokaVnJLJ/nKblCvu4V7bdb0KBk9IECDE5yjxHbD/ZJMDWaOPir4PkOMFKW2LXOry+KQcGeYkEcu7/AyWpDZJA==",
+			"version": "npm:@fluidframework/test-client-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-0.59.3000.tgz",
+			"integrity": "sha512-B0mDfqzlWBJ/j2Sx9ABhvftb+mZU0/fy4D8ToJNkjsYciE6knAHf9inkcQb4FnCxBwA7oTDbWW1k7YPtN6KaFg==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/test-runtime-utils": "^0.59.2002",
+				"@fluidframework/test-runtime-utils": "^0.59.3000",
 				"sillyname": "^0.1.0"
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.2002.tgz",
-			"integrity": "sha512-jQXVhzS0WiNpq9wgPGOE3YdpZrCJqvClMYwv8XooCaMlqKPH54cAHgD/fHbyBfMQZgqj469y6m+ghxrKuGZXgg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.3000.tgz",
+			"integrity": "sha512-aWwD2CmUSmi4UGDY1aHSA/ntREYqCFd45otSjvg6g0X3UsEGZO+35nZ7+cmGCWOhyqNfBMJJXXL+GuV9Gt2YSQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -6748,9 +6738,9 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "npm:@fluidframework/test-driver-definitions@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.2002.tgz",
-			"integrity": "sha512-jQXVhzS0WiNpq9wgPGOE3YdpZrCJqvClMYwv8XooCaMlqKPH54cAHgD/fHbyBfMQZgqj469y6m+ghxrKuGZXgg==",
+			"version": "npm:@fluidframework/test-driver-definitions@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.59.3000.tgz",
+			"integrity": "sha512-aWwD2CmUSmi4UGDY1aHSA/ntREYqCFd45otSjvg6g0X3UsEGZO+35nZ7+cmGCWOhyqNfBMJJXXL+GuV9Gt2YSQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -6772,27 +6762,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.2002.tgz",
-			"integrity": "sha512-PbtfhTCTGnQ94yUTjauPxA6VXW0YMPkhjZ0UnOifwt7crQHVlQeEvovkF92gctomXfUEPF9pJM5z0NvYaWDJ+Q==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.3000.tgz",
+			"integrity": "sha512-mcrzOo/LdH/pOQvIrCpnOpr5KHUTA3qlNNxEaUydQdFVtRVoIhXEzPcoBON029TZ0qfhKO7jmMkvx1TrAaGlsA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/local-driver": "^0.59.2002",
-				"@fluidframework/odsp-doclib-utils": "^0.59.2002",
-				"@fluidframework/odsp-driver": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
-				"@fluidframework/odsp-urlresolver": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/local-driver": "^0.59.3000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.3000",
+				"@fluidframework/odsp-driver": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
+				"@fluidframework/odsp-urlresolver": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/server-local-server": "^0.1036.2000",
-				"@fluidframework/test-driver-definitions": "^0.59.2002",
-				"@fluidframework/test-pairwise-generator": "^0.59.2002",
-				"@fluidframework/test-runtime-utils": "^0.59.2002",
-				"@fluidframework/tinylicious-driver": "^0.59.2002",
-				"@fluidframework/tool-utils": "^0.59.2002",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/server-local-server": "^0.1036.3000",
+				"@fluidframework/test-driver-definitions": "^0.59.3000",
+				"@fluidframework/test-pairwise-generator": "^0.59.3000",
+				"@fluidframework/test-runtime-utils": "^0.59.3000",
+				"@fluidframework/tinylicious-driver": "^0.59.3000",
+				"@fluidframework/tool-utils": "^0.59.3000",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -7064,27 +7054,27 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.2002.tgz",
-			"integrity": "sha512-PbtfhTCTGnQ94yUTjauPxA6VXW0YMPkhjZ0UnOifwt7crQHVlQeEvovkF92gctomXfUEPF9pJM5z0NvYaWDJ+Q==",
+			"version": "npm:@fluidframework/test-drivers@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.59.3000.tgz",
+			"integrity": "sha512-mcrzOo/LdH/pOQvIrCpnOpr5KHUTA3qlNNxEaUydQdFVtRVoIhXEzPcoBON029TZ0qfhKO7jmMkvx1TrAaGlsA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/local-driver": "^0.59.2002",
-				"@fluidframework/odsp-doclib-utils": "^0.59.2002",
-				"@fluidframework/odsp-driver": "^0.59.2002",
-				"@fluidframework/odsp-driver-definitions": "^0.59.2002",
-				"@fluidframework/odsp-urlresolver": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/local-driver": "^0.59.3000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.3000",
+				"@fluidframework/odsp-driver": "^0.59.3000",
+				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
+				"@fluidframework/odsp-urlresolver": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/server-local-server": "^0.1036.2000",
-				"@fluidframework/test-driver-definitions": "^0.59.2002",
-				"@fluidframework/test-pairwise-generator": "^0.59.2002",
-				"@fluidframework/test-runtime-utils": "^0.59.2002",
-				"@fluidframework/tinylicious-driver": "^0.59.2002",
-				"@fluidframework/tool-utils": "^0.59.2002",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/server-local-server": "^0.1036.3000",
+				"@fluidframework/test-driver-definitions": "^0.59.3000",
+				"@fluidframework/test-pairwise-generator": "^0.59.3000",
+				"@fluidframework/test-runtime-utils": "^0.59.3000",
+				"@fluidframework/tinylicious-driver": "^0.59.3000",
+				"@fluidframework/tool-utils": "^0.59.3000",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -7356,14 +7346,14 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-0.59.2002.tgz",
-			"integrity": "sha512-jaZWoTS9d26tCS2PsrzVGiS1xuB1IWuQAyYcvegM12t/gFACTWQ9SsU85SlYzmLxTecDlXZpgqSluQFQS+gxtw==",
+			"version": "npm:@fluidframework/test-loader-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-0.59.3000.tgz",
+			"integrity": "sha512-Ek1K6E0q12lvmggzJD4kzw1cQZb/LqLa+pmkM9jAR1xtW4bFs+4gWesXw7Rkbrc7W2Y46072Lf3vfrEx1HkooQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000"
 			},
 			"dependencies": {
@@ -7380,42 +7370,42 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.2002.tgz",
-			"integrity": "sha512-uQiZW7Pk9at98J4wQWPAMwhGUIxU/X5cL/QGNXzwaCEbbx4RvH0yoalheJfYiOJ4ZT46k3ObNbcJ8U+/20tB3A==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.3000.tgz",
+			"integrity": "sha512-/Lke/jnQjsmtZTM6/S4qUyC052K+X81dfLqQ8vTcl95WgOHurCnHIpG4HXHvO0eIjOPKWqiKQuDJmVAZFAuuPw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.2002.tgz",
-			"integrity": "sha512-uQiZW7Pk9at98J4wQWPAMwhGUIxU/X5cL/QGNXzwaCEbbx4RvH0yoalheJfYiOJ4ZT46k3ObNbcJ8U+/20tB3A==",
+			"version": "npm:@fluidframework/test-pairwise-generator@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-0.59.3000.tgz",
+			"integrity": "sha512-/Lke/jnQjsmtZTM6/S4qUyC052K+X81dfLqQ8vTcl95WgOHurCnHIpG4HXHvO0eIjOPKWqiKQuDJmVAZFAuuPw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.2002.tgz",
-			"integrity": "sha512-HulVKgjRoq43Mm1pR2kcZS+J59CRs29T4RluAoKQoB7M/Zdei0pjCdtf1nSRA+jpZIBPmkG/2NdeQK8VolEaVg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.3000.tgz",
+			"integrity": "sha512-rvwhzKO+lNDpV7enH5paW5HVnctrGhNJliM/YxBlUITJjnKYsRxiG/v3yT9JwLhuGWrxq64b2Css8elV4tcjnQ==",
 			"requires": {
-				"@fluidframework/azure-service-utils": "^0.59.2002",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"axios": "^0.26.0",
+				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7443,24 +7433,24 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.2002.tgz",
-			"integrity": "sha512-HulVKgjRoq43Mm1pR2kcZS+J59CRs29T4RluAoKQoB7M/Zdei0pjCdtf1nSRA+jpZIBPmkG/2NdeQK8VolEaVg==",
+			"version": "npm:@fluidframework/test-runtime-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.59.3000.tgz",
+			"integrity": "sha512-rvwhzKO+lNDpV7enH5paW5HVnctrGhNJliM/YxBlUITJjnKYsRxiG/v3yT9JwLhuGWrxq64b2Css8elV4tcjnQ==",
 			"requires": {
-				"@fluidframework/azure-service-utils": "^0.59.2002",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"axios": "^0.26.0",
+				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7494,32 +7484,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.2002.tgz",
-			"integrity": "sha512-4ELa2F5WqtLIKrMR1SmqJMGi11xF34RHtlWzKDaPT7WvSPbmsqaBIOMNCPpJB85wcA2sY/Q/WWGRP+HenjQbEg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.3000.tgz",
+			"integrity": "sha512-RCxQOQEY/SLWb4s5Y7RWo+nEX3tELaJXob/+GP3tis6yCtgqgOYq/XEkUqgWW6GVg7gMAW20zu8J6s4J0XHtsA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.2002",
+				"@fluidframework/aqueduct": "^0.59.3000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
-				"@fluidframework/container-runtime": "^0.59.2002",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
+				"@fluidframework/container-runtime": "^0.59.3000",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/local-driver": "^0.59.2002",
-				"@fluidframework/map": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/local-driver": "^0.59.3000",
+				"@fluidframework/map": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.2002",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
-				"@fluidframework/test-driver-definitions": "^0.59.2002",
-				"@fluidframework/test-runtime-utils": "^0.59.2002",
+				"@fluidframework/request-handler": "^0.59.3000",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
+				"@fluidframework/test-driver-definitions": "^0.59.3000",
+				"@fluidframework/test-runtime-utils": "^0.59.3000",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -7548,32 +7538,32 @@
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.2002.tgz",
-			"integrity": "sha512-4ELa2F5WqtLIKrMR1SmqJMGi11xF34RHtlWzKDaPT7WvSPbmsqaBIOMNCPpJB85wcA2sY/Q/WWGRP+HenjQbEg==",
+			"version": "npm:@fluidframework/test-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.59.3000.tgz",
+			"integrity": "sha512-RCxQOQEY/SLWb4s5Y7RWo+nEX3tELaJXob/+GP3tis6yCtgqgOYq/XEkUqgWW6GVg7gMAW20zu8J6s4J0XHtsA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.2002",
+				"@fluidframework/aqueduct": "^0.59.3000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
-				"@fluidframework/container-runtime": "^0.59.2002",
-				"@fluidframework/container-runtime-definitions": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
+				"@fluidframework/container-runtime": "^0.59.3000",
+				"@fluidframework/container-runtime-definitions": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/datastore": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/datastore": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/local-driver": "^0.59.2002",
-				"@fluidframework/map": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/local-driver": "^0.59.3000",
+				"@fluidframework/map": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/request-handler": "^0.59.2002",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/telemetry-utils": "^0.59.2002",
-				"@fluidframework/test-driver-definitions": "^0.59.2002",
-				"@fluidframework/test-runtime-utils": "^0.59.2002",
+				"@fluidframework/request-handler": "^0.59.3000",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/telemetry-utils": "^0.59.3000",
+				"@fluidframework/test-driver-definitions": "^0.59.3000",
+				"@fluidframework/test-runtime-utils": "^0.59.3000",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -7602,34 +7592,34 @@
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-0.59.2002.tgz",
-			"integrity": "sha512-/s0om0n2Y7+/proWE0iOZjSsMZ/CSd53OmMAxJa/Agvlq9t6Deq6UkHJFDX+oG6Oj7eFWzj6M1jya7YmHsd12g==",
+			"version": "npm:@fluidframework/test-version-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-0.59.3000.tgz",
+			"integrity": "sha512-afrZ5i8q2AW7sFUPXM2zC4SS7jrH1w1aS4NbDB6ET0ljmIzqkb3Gh+vDP3oD/VCETqysGxuDj4QUT2qrOUiXcg==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.59.2002",
-				"@fluidframework/cell": "^0.59.2002",
+				"@fluidframework/aqueduct": "^0.59.3000",
+				"@fluidframework/cell": "^0.59.3000",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
-				"@fluidframework/container-runtime": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
+				"@fluidframework/container-runtime": "^0.59.3000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/counter": "^0.59.2002",
-				"@fluidframework/datastore-definitions": "^0.59.2002",
+				"@fluidframework/counter": "^0.59.3000",
+				"@fluidframework/datastore-definitions": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/ink": "^0.59.2002",
-				"@fluidframework/map": "^0.59.2002",
-				"@fluidframework/matrix": "^0.59.2002",
-				"@fluidframework/mocha-test-setup": "^0.59.2002",
-				"@fluidframework/ordered-collection": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/ink": "^0.59.3000",
+				"@fluidframework/map": "^0.59.3000",
+				"@fluidframework/matrix": "^0.59.3000",
+				"@fluidframework/mocha-test-setup": "^0.59.3000",
+				"@fluidframework/ordered-collection": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/register-collection": "^0.59.2002",
-				"@fluidframework/runtime-definitions": "^0.59.2002",
-				"@fluidframework/sequence": "^0.59.2002",
-				"@fluidframework/test-driver-definitions": "^0.59.2002",
-				"@fluidframework/test-drivers": "^0.59.2002",
-				"@fluidframework/test-utils": "^0.59.2002",
+				"@fluidframework/register-collection": "^0.59.3000",
+				"@fluidframework/runtime-definitions": "^0.59.3000",
+				"@fluidframework/sequence": "^0.59.3000",
+				"@fluidframework/test-driver-definitions": "^0.59.3000",
+				"@fluidframework/test-drivers": "^0.59.3000",
+				"@fluidframework/test-utils": "^0.59.3000",
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
@@ -7659,22 +7649,22 @@
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.2002.tgz",
-			"integrity": "sha512-xnrNH0D/zIyxYwD0o5BYMeAXwTPP2zAGzRVDybTaTlhKqkOz7wkdI7knGfKRrwc9hYCO/8D7YgmubkRCEAuTXQ==",
+			"version": "npm:@fluidframework/tinylicious-client@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-0.59.3000.tgz",
+			"integrity": "sha512-lyu/apk4bclJRYQSWBfSBXL4b3wAvC9RIUBndptasWYB2Uyg4Dm9cXDrFQlk889gNMF63m+W1jEkwA4J1pc8gw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/container-definitions": "^0.48.1000",
-				"@fluidframework/container-loader": "^0.59.2002",
+				"@fluidframework/container-loader": "^0.59.3000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
-				"@fluidframework/fluid-static": "^0.59.2002",
-				"@fluidframework/map": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
+				"@fluidframework/fluid-static": "^0.59.3000",
+				"@fluidframework/map": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/runtime-utils": "^0.59.2002",
-				"@fluidframework/tinylicious-driver": "^0.59.2002",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/runtime-utils": "^0.59.3000",
+				"@fluidframework/tinylicious-driver": "^0.59.3000",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7702,16 +7692,16 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.2002.tgz",
-			"integrity": "sha512-977WjZWGn5ooTEdISzXrGDSoOArz3gJc3YwTkbpxINBuu+VIhByI0lNBk/UI9m4/WEA+O9Y8ev5vjcCLAwnE/g==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.3000.tgz",
+			"integrity": "sha512-MOBUFT3Wf3gvwgfQ/jJewk7To8q7q88GOczWN/BlrACkBiN3rPI/kxjzBXOi9QPnGk1tS7yKXmmvq+hmR+VZFw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/server-services-client": "^0.1036.2000",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/server-services-client": "^0.1036.3000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -7769,16 +7759,16 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.2002.tgz",
-			"integrity": "sha512-977WjZWGn5ooTEdISzXrGDSoOArz3gJc3YwTkbpxINBuu+VIhByI0lNBk/UI9m4/WEA+O9Y8ev5vjcCLAwnE/g==",
+			"version": "npm:@fluidframework/tinylicious-driver@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.59.3000.tgz",
+			"integrity": "sha512-MOBUFT3Wf3gvwgfQ/jJewk7To8q7q88GOczWN/BlrACkBiN3rPI/kxjzBXOi9QPnGk1tS7yKXmmvq+hmR+VZFw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/driver-utils": "^0.59.2002",
+				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
-				"@fluidframework/routerlicious-driver": "^0.59.2002",
-				"@fluidframework/server-services-client": "^0.1036.2000",
+				"@fluidframework/routerlicious-driver": "^0.59.3000",
+				"@fluidframework/server-services-client": "^0.1036.3000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
@@ -7836,13 +7826,13 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.2002.tgz",
-			"integrity": "sha512-hemh6Q+F+UTp5VAWMZ4OG7LjF7x/n6lv9sZJFwKc1X/kZIIewEqS3fBYhRtGkezrbtGDXwh0bDPshyoZjpjZ4A==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.3000.tgz",
+			"integrity": "sha512-x/2RnN6v/TxfE9VBGvN8XujOB6hNo4pt0bcRqWizqI/2gYp1CnLWadS9OBmSbAB2Hl48MAdH4GcvigD7cRkjUg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"async-mutex": "^0.3.1",
 				"debug": "^4.1.1",
@@ -7869,13 +7859,13 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.2002.tgz",
-			"integrity": "sha512-hemh6Q+F+UTp5VAWMZ4OG7LjF7x/n6lv9sZJFwKc1X/kZIIewEqS3fBYhRtGkezrbtGDXwh0bDPshyoZjpjZ4A==",
+			"version": "npm:@fluidframework/tool-utils@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.59.3000.tgz",
+			"integrity": "sha512-x/2RnN6v/TxfE9VBGvN8XujOB6hNo4pt0bcRqWizqI/2gYp1CnLWadS9OBmSbAB2Hl48MAdH4GcvigD7cRkjUg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^0.59.2002",
-				"@fluidframework/protocol-base": "^0.1036.2000",
+				"@fluidframework/odsp-doclib-utils": "^0.59.3000",
+				"@fluidframework/protocol-base": "^0.1036.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"async-mutex": "^0.3.1",
 				"debug": "^4.1.1",
@@ -7902,58 +7892,58 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.2002.tgz",
-			"integrity": "sha512-PA7hlOQSez1k92ryBdfw3sA20chu+/bbWBDFJz7XmpP6Y5ApYL9HX6BxiEaQCbmvYaa+drpArqv+aM/iWIw/Lg==",
+			"version": "npm:@fluidframework/undo-redo@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.3000.tgz",
+			"integrity": "sha512-AJF9EjvQPm2JwgRM5ejOpZ6/z6XgWatcRhzoFv1/7p49eG2uEzxkPDyjFuVN2W/A3HJtTuz6HA2P07OgBNfiEg==",
 			"requires": {
-				"@fluidframework/map": "^0.59.2002",
-				"@fluidframework/matrix": "^0.59.2002",
-				"@fluidframework/merge-tree": "^0.59.2002",
-				"@fluidframework/sequence": "^0.59.2002"
+				"@fluidframework/map": "^0.59.3000",
+				"@fluidframework/matrix": "^0.59.3000",
+				"@fluidframework/merge-tree": "^0.59.3000",
+				"@fluidframework/sequence": "^0.59.3000"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.2002.tgz",
-			"integrity": "sha512-/9sf9299gDFAgs2RDLfxB32TcfYr9xz7aMKEGV/RLxlwxYQtQOVNDgx2YMTjukPrM3J8uxp4IgzOcTOb+1+HFA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.3000.tgz",
+			"integrity": "sha512-vk8VKxUaU9tComncvte5zyDCaCeLaDCjt3Ji5P07xk3ZbJpcHg1BM5D0u0/90215/u0n8g8IZ6KrSNTTtCn3YQ==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/view-interfaces": "^0.59.2002",
+				"@fluidframework/view-interfaces": "^0.59.3000",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.2002.tgz",
-			"integrity": "sha512-/9sf9299gDFAgs2RDLfxB32TcfYr9xz7aMKEGV/RLxlwxYQtQOVNDgx2YMTjukPrM3J8uxp4IgzOcTOb+1+HFA==",
+			"version": "npm:@fluidframework/view-adapters@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-0.59.3000.tgz",
+			"integrity": "sha512-vk8VKxUaU9tComncvte5zyDCaCeLaDCjt3Ji5P07xk3ZbJpcHg1BM5D0u0/90215/u0n8g8IZ6KrSNTTtCn3YQ==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/view-interfaces": "^0.59.2002",
+				"@fluidframework/view-interfaces": "^0.59.3000",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.2002.tgz",
-			"integrity": "sha512-HRxVIcaED+IXXf/k6kq8jCGOojNSdC6dyrsHe3LYCFB2lA2ZjYxuwCA/sSivdjApCeTxAPwXAZphKLA2di06HA==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.3000.tgz",
+			"integrity": "sha512-N7Vtf9v0npU9P0wFSSN73HL09E2mur6ERy3V8vxlwxFFx4jDZ4FBuo7q4S535JLF3bjAsFtWyLf3b7g3w2CyGw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.2002.tgz",
-			"integrity": "sha512-HRxVIcaED+IXXf/k6kq8jCGOojNSdC6dyrsHe3LYCFB2lA2ZjYxuwCA/sSivdjApCeTxAPwXAZphKLA2di06HA==",
+			"version": "npm:@fluidframework/view-interfaces@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.59.3000.tgz",
+			"integrity": "sha512-N7Vtf9v0npU9P0wFSSN73HL09E2mur6ERy3V8vxlwxFFx4jDZ4FBuo7q4S535JLF3bjAsFtWyLf3b7g3w2CyGw==",
 			"requires": {
 				"@fluidframework/core-interfaces": "^0.43.1000"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.2002.tgz",
-			"integrity": "sha512-lAQ8gzCOkh6ZtlUXKnTE8BTua0n7TyMRZS3khE4ZFMW4yHcrOi/uAfOLAkDRA0j4WWxT4WVa0bJ3dtDBYxBnQg==",
+			"version": "0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.3000.tgz",
+			"integrity": "sha512-Geq1QPsXFFKSaoJ8o0AYGurpM8DndEPNgr1Nz+diHreQDchYEfpSc+xsPhjAjRYutZFek/aHLuhjrgzlqE8ASg==",
 			"requires": {
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
@@ -7984,9 +7974,9 @@
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@0.59.2002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.2002.tgz",
-			"integrity": "sha512-lAQ8gzCOkh6ZtlUXKnTE8BTua0n7TyMRZS3khE4ZFMW4yHcrOi/uAfOLAkDRA0j4WWxT4WVa0bJ3dtDBYxBnQg==",
+			"version": "npm:@fluidframework/web-code-loader@0.59.3000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-0.59.3000.tgz",
+			"integrity": "sha512-Geq1QPsXFFKSaoJ8o0AYGurpM8DndEPNgr1Nz+diHreQDchYEfpSc+xsPhjAjRYutZFek/aHLuhjrgzlqE8ASg==",
 			"requires": {
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -100,6 +100,8 @@
   },
   "typeValidation": {
     "version": "0.60.1000",
-    "broken": { }
+    "broken": {
+      "ClassDeclaration_SharedSegmentSequenceRevertible": {"backCompat": false}
+    }
   }
 }

--- a/packages/framework/undo-redo/src/test/types/validateUndoRedoPrevious.ts
+++ b/packages/framework/undo-redo/src/test/types/validateUndoRedoPrevious.ts
@@ -108,6 +108,7 @@ declare function get_current_ClassDeclaration_SharedSegmentSequenceRevertible():
 declare function use_old_ClassDeclaration_SharedSegmentSequenceRevertible(
     use: TypeOnly<old.SharedSegmentSequenceRevertible>);
 use_old_ClassDeclaration_SharedSegmentSequenceRevertible(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_SharedSegmentSequenceRevertible());
 
 /*

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.ts
@@ -187,6 +187,18 @@ use_old_FunctionDeclaration_configurableUrlResolver(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedFunctionDeclaration_convertSnapshotAndBlobsToSummaryTree": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedFunctionDeclaration_convertSnapshotAndBlobsToSummaryTree": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_convertSummaryTreeToSnapshotITree": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_convertSummaryTreeToSnapshotITree():
@@ -620,6 +632,18 @@ use_old_FunctionDeclaration_isOnline(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_ISummaryTreeAssemblerProps": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_ISummaryTreeAssemblerProps": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_logNetworkFailure": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_logNetworkFailure():
@@ -1025,6 +1049,18 @@ declare function use_old_FunctionDeclaration_streamObserver(
     use: TypeOnly<typeof old.streamObserver>);
 use_old_FunctionDeclaration_streamObserver(
     get_current_FunctionDeclaration_streamObserver());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedClassDeclaration_SummaryTreeAssembler": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedClassDeclaration_SummaryTreeAssembler": {"backCompat": false}
+*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -137,7 +137,12 @@
         "backCompat": false
       },
       "InterfaceDeclaration_IConnectableRuntime": {"backCompat": false},
-      "InterfaceDeclaration_ISummarizerRuntime": {"backCompat": false}
+      "InterfaceDeclaration_ISummarizerRuntime": {"backCompat": false},
+      "InterfaceDeclaration_IGeneratedSummaryStats": {"backCompat": false},
+      "InterfaceDeclaration_IGenerateSummaryTreeResult": {"backCompat": false},
+      "InterfaceDeclaration_ISubmitSummaryOpResult": {"backCompat": false},
+      "InterfaceDeclaration_IUploadSummaryResult": {"backCompat": false},
+      "TypeAliasDeclaration_SubmitSummaryResult": {"backCompat": false}
 
     }
   }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -592,6 +592,7 @@ declare function get_current_InterfaceDeclaration_IGeneratedSummaryStats():
 declare function use_old_InterfaceDeclaration_IGeneratedSummaryStats(
     use: TypeOnly<old.IGeneratedSummaryStats>);
 use_old_InterfaceDeclaration_IGeneratedSummaryStats(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IGeneratedSummaryStats());
 
 /*
@@ -616,6 +617,7 @@ declare function get_current_InterfaceDeclaration_IGenerateSummaryTreeResult():
 declare function use_old_InterfaceDeclaration_IGenerateSummaryTreeResult(
     use: TypeOnly<old.IGenerateSummaryTreeResult>);
 use_old_InterfaceDeclaration_IGenerateSummaryTreeResult(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IGenerateSummaryTreeResult());
 
 /*
@@ -880,6 +882,7 @@ declare function get_current_InterfaceDeclaration_ISubmitSummaryOpResult():
 declare function use_old_InterfaceDeclaration_ISubmitSummaryOpResult(
     use: TypeOnly<old.ISubmitSummaryOpResult>);
 use_old_InterfaceDeclaration_ISubmitSummaryOpResult(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISubmitSummaryOpResult());
 
 /*
@@ -1302,6 +1305,7 @@ declare function get_current_InterfaceDeclaration_IUploadSummaryResult():
 declare function use_old_InterfaceDeclaration_IUploadSummaryResult(
     use: TypeOnly<old.IUploadSummaryResult>);
 use_old_InterfaceDeclaration_IUploadSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IUploadSummaryResult());
 
 /*
@@ -1470,6 +1474,7 @@ declare function get_current_TypeAliasDeclaration_SubmitSummaryResult():
 declare function use_old_TypeAliasDeclaration_SubmitSummaryResult(
     use: TypeOnly<old.SubmitSummaryResult>);
 use_old_TypeAliasDeclaration_SubmitSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_SubmitSummaryResult());
 
 /*

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -105,8 +105,7 @@
     "broken": {
       "EnumDeclaration_TelemetryDataTag": {
         "backCompat": false
-      },
-      "ClassDeclaration_MockLogger": {"forwardCompat": false}
+      }
     }
   }
 }

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
@@ -672,7 +672,6 @@ declare function get_old_ClassDeclaration_MockLogger():
 declare function use_current_ClassDeclaration_MockLogger(
     use: TypeOnly<current.MockLogger>);
 use_current_ClassDeclaration_MockLogger(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockLogger());
 
 /*


### PR DESCRIPTION
We have an issue with npm publishing that is causing our latest version to move back in time, which causes problems for things like that type. We've manual fixed up the latest version, and this change consumes that in next