### PR TITLE
Update CODEOWNERS for azure projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,8 @@
 /.md-magic-templates/                                                     @microsoft/fluid-cr-docs
 /.vscode/                                                                 @microsoft/fluid-cr-infra
 
+/azure/                                                                   @microsoft/fluid-cr-framework
+
 /common/build/                                                            @microsoft/fluid-cr-infra
 /common/lib/                                                              @microsoft/fluid-cr-core
 /docs/                                                                    @microsoft/fluid-cr-docs
@@ -36,6 +38,7 @@
 /packages/utils/telemetry-utils/                                          @microsoft/fluid-cr-telemetry
 /server/                                                                  @microsoft/fluid-cr-server
 /tools/                                                                   @microsoft/fluid-cr-infra
+/tools/pipelines/build-azure.yml                                          @microsoft/fluid-cr-framework
 
 # PUBLIC API REPORTS
 # All packages are assumed to have public APIs unless defined otherwise in the sections below.


### PR DESCRIPTION
Fixes #10227.

The azure projects were moved but CODEOWNERS was not updated.