### PR TITLE
r11s-driver: pass refresh=true to TokenProvider when retrying 401 on socket connection

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -42,7 +42,7 @@ export class DocumentService implements api.IDocumentService {
 
     private documentStorageService: DocumentStorageService | undefined;
 
-    public dispose() {}
+    public dispose() { }
 
     /**
      * Connects to a storage endpoint for snapshot service.
@@ -128,10 +128,11 @@ export class DocumentService implements api.IDocumentService {
      * @returns returns the document delta stream service for routerlicious driver.
      */
     public async connectToDeltaStream(client: IClient): Promise<api.IDocumentDeltaConnection> {
-        const connect = async () => {
+        const connect = async (refreshToken?: boolean) => {
             const ordererToken = await this.tokenProvider.fetchOrdererToken(
                 this.tenantId,
                 this.documentId,
+                refreshToken,
             );
             return R11sDocumentDeltaConnection.create(
                 this.tenantId,
@@ -153,7 +154,7 @@ export class DocumentService implements api.IDocumentService {
             if (error?.statusCode === 401) {
                 // Fetch new token and retry once,
                 // otherwise 401 will be bubbled up as non-retriable AuthorizationError.
-                return connect();
+                return connect(true /* refreshToken */);
             }
             throw error;
         }

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -83,7 +83,7 @@ export class RouterliciousRestWrapper extends RestWrapper {
         // Failure
         if (response.status === 401 && canRetry) {
             // Refresh Authorization header and retry once
-            this.authorizationHeader = await this.getAuthorizationHeader(true);
+            this.authorizationHeader = await this.getAuthorizationHeader(true /* refreshToken */);
             return this.request<T>(config, statusCode, false);
         }
         if (response.status === 429 && responseBody?.retryAfter > 0) {
@@ -144,12 +144,12 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
         const defaultQueryString = {
             token: `${fromUtf8ToBase64(tenantId)}`,
         };
-        const getAuthorizationHeader: AuthorizationHeaderGetter = async (refresh?: boolean): Promise<string> => {
+        const getAuthorizationHeader: AuthorizationHeaderGetter = async (refreshToken?: boolean): Promise<string> => {
             // Craft credentials using tenant id and token
             const storageToken = await tokenProvider.fetchStorageToken(
                 tenantId,
                 documentId,
-                refresh,
+                refreshToken,
             );
             const credentials = {
                 password: storageToken.jwt,
@@ -193,11 +193,11 @@ export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
         useRestLess: boolean,
         baseurl?: string,
     ): Promise<RouterliciousOrdererRestWrapper> {
-        const getAuthorizationHeader: AuthorizationHeaderGetter = async (refresh?: boolean): Promise<string> => {
+        const getAuthorizationHeader: AuthorizationHeaderGetter = async (refreshToken?: boolean): Promise<string> => {
             const ordererToken = await tokenProvider.fetchOrdererToken(
                 tenantId,
                 documentId,
-                refresh,
+                refreshToken,
             );
             return `Basic ${ordererToken.jwt}`;
         };


### PR DESCRIPTION
# Socket connections do not recover from 401 if TokenProvider has a cache

For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)

## Description

> Should include a concise description of the changes (bug or feature), it's impact, along with a summary of the solution

`TokenProvider.fetch*Token` expects an optional `refresh` parameter to be `true` when the TokenProvider needs to generate a new token. For example, when a token has expired, the TokenProvider cannot keep using a cached token. This was already handled in HTTP request error handling, but was neglected for socket connections.

## Steps to Reproduce Bug and Validate Solution

> Only applicable if the work is to address a bug. Please remove this section if the work is for a feature or story
> Provide details on the environment the bug is found, and detailed steps to recreate the bug.
> This should be detailed enough for a team member to confirm that the bug no longer occurs

1. Alter TokenProvider to pass a short lived token (like 30 seconds), and implement a simple cache that respects the refresh param
2. Connect to R11s op stream
3. After 30 seconds, see token expire and connection fail
4. See connection fail again on reconnect attempt from token expired error

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.

## Testing

> -   Instructions for testing and validation of your code so the reviewer can follow those steps and validate code works as expected

See above repro steps. After fix, reconnect attempt does not fail because refresh is true.

## Any relevant logs or outputs

> -   Use this section to provide either screenshots or output of logs as code snippets

## Other information or known dependencies

> -   Any other information or known dependencies that is important to this PR.
> -   TODO that are to be done after this PR.
