### PR TITLE
Enable upload full container summary for spdf

### DIFF
--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -69,9 +69,7 @@ export class OdspSummaryUploadManager {
         referenceSequenceNumber: number,
         tree: api.ISummaryTree,
     ): Promise<IWriteSummaryResponse> {
-        const enableContainerTypeSummaryUpload = this.mc.config.getBoolean("Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload");
-        const containsProtocolTree = enableContainerTypeSummaryUpload &&
-            Object.keys(tree.tree).includes(".protocol");
+        const containsProtocolTree = Object.keys(tree.tree).includes(".protocol");
         const { snapshotTree, blobs } = await this.convertSummaryToSnapshotTree(
             parentHandle,
             tree,
@@ -112,7 +110,6 @@ export class OdspSummaryUploadManager {
                     size: postBody.length,
                     referenceSequenceNumber,
                     type: snapshot.type,
-                    enableContainerTypeSummaryUpload,
                 },
                 async () => {
                     const response = await this.epochTracker.fetchAndParseAsJSON<IWriteSummaryResponse>(

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -69,7 +69,8 @@ export class OdspSummaryUploadManager {
         referenceSequenceNumber: number,
         tree: api.ISummaryTree,
     ): Promise<IWriteSummaryResponse> {
-        const enableContainerTypeSummaryUpload = this.mc.config.getBoolean("Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload");
+        // Enable it by default.
+        const enableContainerTypeSummaryUpload = this.mc.config.getBoolean("Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload") ?? true;
         const containsProtocolTree = enableContainerTypeSummaryUpload &&
             Object.keys(tree.tree).includes(".protocol");
         const { snapshotTree, blobs } = await this.convertSummaryToSnapshotTree(

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -69,8 +69,7 @@ export class OdspSummaryUploadManager {
         referenceSequenceNumber: number,
         tree: api.ISummaryTree,
     ): Promise<IWriteSummaryResponse> {
-        // Enable it by default.
-        const enableContainerTypeSummaryUpload = this.mc.config.getBoolean("Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload") ?? true;
+        const enableContainerTypeSummaryUpload = this.mc.config.getBoolean("Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload");
         const containsProtocolTree = enableContainerTypeSummaryUpload &&
             Object.keys(tree.tree).includes(".protocol");
         const { snapshotTree, blobs } = await this.convertSummaryToSnapshotTree(

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -593,7 +593,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.mc = loggerToMonitoringContext(ChildLogger.create(this.subLogger, "Container"));
 
         const summarizeProtocolTree =
-            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree");
+            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree")
+            ?? this.loader.services.options.summarizeProtocolTree;
 
         this.options = {
             ... this.loader.services.options,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -593,7 +593,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.mc = loggerToMonitoringContext(ChildLogger.create(this.subLogger, "Container"));
 
         const summarizeProtocolTree =
-            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree") ?? true;
+            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree");
 
         this.options = {
             ... this.loader.services.options,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -593,8 +593,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.mc = loggerToMonitoringContext(ChildLogger.create(this.subLogger, "Container"));
 
         const summarizeProtocolTree =
-            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree")
-            ?? this.loader.services.options.summarizeProtocolTree;
+            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree") ?? true;
 
         this.options = {
             ... this.loader.services.options,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -13,15 +13,13 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
-                        "Fluid.Container.summarizeProtocolTree": [true]
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 },
                 "odsp-odsp-df":{
                     "configurations":{
                         "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
-                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
-                        "Fluid.Container.summarizeProtocolTree": [true]
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 }
             }
@@ -46,8 +44,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
-                        "Fluid.Container.summarizeProtocolTree": [true]
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 }
             }
@@ -106,21 +103,6 @@
                 "odsp":{
                     "configurations":{
                         "Fluid.Driver.Odsp.snapshotFormatFetchType": [1]
-                    }
-                }
-            }
-        },
-        "odspContainerTypeSummaryUpload": {
-            "opRatePerMin": 60,
-            "progressIntervalMs": 5000,
-            "numClients": 4,
-            "totalSendCount": 150,
-            "readWriteCycleMs": 10000,
-            "optionOverrides":{
-                "odsp":{
-                    "configurations":{
-                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
-                        "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 }
             }

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -12,16 +12,14 @@
             "faultInjectionMaxMs": 150000,
             "optionOverrides":{
                 "odsp":{
-                    "loader":{
-                        "summarizeProtocolTree": [false]
+                    "configurations":{
+                        "Fluid.Container.summarizeProtocolTree": [false]
                     }
                 },
                 "odsp-odsp-df":{
-                    "loader":{
-                        "summarizeProtocolTree": [false]
-                    },
                     "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1]
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
+                        "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 }
             }
@@ -45,8 +43,8 @@
             "faultInjectionMaxMs": 50000,
             "optionOverrides":{
                 "odsp":{
-                    "loader":{
-                        "summarizeProtocolTree": [false]
+                    "configurations":{
+                        "Fluid.Container.summarizeProtocolTree": [false]
                     }
                 }
             }
@@ -118,10 +116,8 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true]
-                    },
-                    "loader":{
-                        "summarizeProtocolTree": [true]
+                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
+                        "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 }
             }

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -13,7 +13,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Container.summarizeProtocolTree": [false]
+                        "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 },
                 "odsp-odsp-df":{
@@ -44,7 +44,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Container.summarizeProtocolTree": [false]
+                        "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 }
             }

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -13,12 +13,14 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
+                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
                         "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 },
                 "odsp-odsp-df":{
                     "configurations":{
                         "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
+                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
                         "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 }
@@ -44,6 +46,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
+                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true],
                         "Fluid.Container.summarizeProtocolTree": [true]
                     }
                 }


### PR DESCRIPTION
## Description
1.) Enable upload full container summary by default which contains both app and protocol tree for spdf
2.) Replace the loader option with configurations in tests for the same.
