### PR TITLE
common-utils: Remove project-wide lint disables

### DIFF
--- a/common/lib/common-utils/.eslintrc.js
+++ b/common/lib/common-utils/.eslintrc.js
@@ -11,9 +11,5 @@ module.exports = {
         "project": [ "./tsconfig.json", "./src/test/mocha/tsconfig.json", "./src/test/jest/tsconfig.json", "./src/test/types/tsconfig.json" ]
     },
     "rules": {
-        "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-bitwise": "off",
-        "prefer-rest-params": "off"
     }
 }

--- a/common/lib/common-utils/src/eventForwarder.ts
+++ b/common/lib/common-utils/src/eventForwarder.ts
@@ -76,7 +76,7 @@ export class EventForwarder<TEvent = IEvent>
         for (const event of events) {
             if (event !== undefined && !EventForwarder.isEmitterEvent(event)) {
                 const sources = this.forwardingEvents.get(event);
-                if (sources?.has(source)) {
+                if ((sources?.has(source)) === true) {
                     if (this.listenerCount(event) === 0) {
                         const listenerRemover = sources.get(source);
                         if (listenerRemover !== undefined) {

--- a/common/lib/common-utils/src/heap.ts
+++ b/common/lib/common-utils/src/heap.ts
@@ -76,6 +76,7 @@ export class Heap<T> {
         this.swap(1, this.count());
         const x = this.L.pop();
         this.fixdown(1);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return x!.value;
     }
 
@@ -134,6 +135,7 @@ export class Heap<T> {
     private fixup(pos: number) {
         let k = pos;
         while (this.isGreaterThanParent(k)) {
+            // eslint-disable-next-line no-bitwise
             const parent = k >> 1;
             this.swap(k, parent);
             k = parent;
@@ -141,12 +143,15 @@ export class Heap<T> {
     }
 
     private isGreaterThanParent(k: number): boolean {
+        // eslint-disable-next-line no-bitwise
         return k > 1 && (this.comp.compare(this.L[k >> 1].value, this.L[k].value) > 0);
     }
 
     private fixdown(pos: number) {
         let k = pos;
+        // eslint-disable-next-line no-bitwise
         while ((k << 1) <= this.count()) {
+            // eslint-disable-next-line no-bitwise
             let j = k << 1;
             if ((j < this.count()) && (this.comp.compare(this.L[j].value, this.L[j + 1].value) > 0)) {
                 j++;

--- a/common/lib/common-utils/src/lazy.ts
+++ b/common/lib/common-utils/src/lazy.ts
@@ -30,6 +30,7 @@ export class Lazy<T> {
             this._evaluated = true;
             this._value = this.valueGenerator();
         }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return this._value!;
     }
 }

--- a/common/lib/common-utils/src/promises.ts
+++ b/common/lib/common-utils/src/promises.ts
@@ -78,16 +78,19 @@ export class LazyPromise<T> implements Promise<T> {
         onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null | undefined,
         onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined):
         Promise<TResult1 | TResult2> {
+        // eslint-disable-next-line prefer-rest-params
         return this.getPromise().then<TResult1, TResult2>(...arguments);
     }
 
     public async catch<TResult = never>(
         onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null | undefined):
         Promise<T | TResult> {
+        // eslint-disable-next-line prefer-rest-params
         return this.getPromise().catch<TResult>(...arguments);
     }
 
     public async finally(onfinally?: (() => void) | null | undefined): Promise<T> {
+        // eslint-disable-next-line prefer-rest-params
         return this.getPromise().finally(...arguments);
     }
 

--- a/common/lib/common-utils/src/rangeTracker.ts
+++ b/common/lib/common-utils/src/rangeTracker.ts
@@ -103,6 +103,7 @@ export class RangeTracker {
         // Get quicker references to the head of the range
         const head = this.ranges[this.ranges.length - 1];
         const primaryHead = head.primary + head.length;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const secondaryHead = head.secondary! + head.length;
 
         // Same secondary indicates this is not a true inflection point - we can ignore it
@@ -156,6 +157,7 @@ export class RangeTracker {
         // If the difference is within the stored range use it - otherwise add in the length - 1 as the highest
         // stored secondary value to use.
         const closestRange = this.ranges[index - 1];
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return Math.min(primary - closestRange.primary, closestRange.length) + closestRange.secondary!;
     }
 
@@ -182,6 +184,7 @@ export class RangeTracker {
         // Update the last range values
         const range = this.ranges[index - 1];
         const delta = primary - range.primary;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         range.secondary = range.secondary! + Math.min(delta, range.length);
         range.length = Math.max(range.length - delta, 0);
         range.primary = primary;

--- a/common/lib/common-utils/src/rateLimiter.ts
+++ b/common/lib/common-utils/src/rateLimiter.ts
@@ -35,6 +35,7 @@ export class RateLimiter {
             if (!this.requestMap.has(key)) {
                 this.requestMap.set(key, currentTime);
                 approvedList.push(message);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             } else if (this.requestMap.get(key)! + this.windowMSec > currentTime) {
                 continue;
             } else {


### PR DESCRIPTION
This PR updates the lint config for common-utils to remove project-wide disables. Most of the code changes were due to @typescript-eslint/strict-boolean-expressions.

Disabling rules project-wide is a bad practice that lets unlinted code slip through. Many of our packages, including this one, have unnecessary disables, too, for rules that aren't even being broken in the project.