### PR TITLE
protocol-definitions: Remove project-wide lint disables

### DIFF
--- a/common/lib/protocol-definitions/.eslintrc.js
+++ b/common/lib/protocol-definitions/.eslintrc.js
@@ -8,8 +8,5 @@ module.exports = {
         "@fluidframework/eslint-config-fluid"
     ],
     rules: {
-        "@typescript-eslint/no-use-before-define": "off",
-        "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-case-declarations": "off"
     }
 }


### PR DESCRIPTION
This PR updates the lint config for protocol-definitions to remove project-wide disables.

Disabling rules project-wide is a bad practice that lets unlinted code slip through. Many of our packages, including this one, have unnecessary disables, too, for rules that aren't even being broken in the project.