### PR TITLE
Pin GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,38 +33,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'typescript' ] # checks javascript too
+        language: [ 'typescript' ]
+        # checks javascript too
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0e9acb6e5cd338179ea69a99146ca55f796799e0 # pin@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@0e9acb6e5cd338179ea69a99146ca55f796799e0 # pin@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+      #- run: |
+      #   make bootstrap
+      #   make release
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0e9acb6e5cd338179ea69a99146ca55f796799e0 # pin@v1

--- a/.github/workflows/linkcheck-reporter.yml
+++ b/.github/workflows/linkcheck-reporter.yml
@@ -1,7 +1,7 @@
 name: Update link report
 on:
   workflow_run:
-    workflows: ["Website validation"]
+    workflows: [ "Website validation" ]
     types:
       - completed
 
@@ -9,27 +9,22 @@ jobs:
   load_report:
     runs-on: ubuntu-latest
     steps:
-    - name: Download results
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        workflow: website-validation.yml
-        # workflow_conclusion: completed
-        run_id: ${{ github.event.workflow_run.id }}
-        name: website-validation-results
-        path: ./results
-    - name: Load PR number
-      id: load_pr
-      run: echo "::set-output name=pr::$(cat pr)"
-      working-directory: ./results
-    # - name: Load link report
-    #   run: |
-    #     export REPORT_MESSAGE="$(cat linkcheck)"
-    #   working-directory: ./results
-
-    - name: Post report in comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        header: linkreport
-        recreate: true
-        number: ${{ steps.load_pr.outputs.pr }}
-        path: ./results/linkcheck
+      - name: Download results
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39 # pin@v2
+        with:
+          workflow: website-validation.yml
+          # workflow_conclusion: completed
+          run_id: ${{ github.event.workflow_run.id }}
+          name: website-validation-results
+          path: ./results
+      - name: Load PR number
+        id: load_pr
+        run: echo "::set-output name=pr::$(cat pr)"
+        working-directory: ./results
+      - name: Post report in comment
+        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@v2
+        with:
+          header: linkreport
+          recreate: true
+          number: ${{ steps.load_pr.outputs.pr }}
+          path: ./results/linkcheck

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,29 +1,29 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   paths_label:
     runs-on: ubuntu-latest
     name: Label based on file paths
     steps:
-    - uses: actions/labeler@26546f6c4d63b6c0623e8e39bde7869e3c2b1d7b # pin@v3
-      with:
-        configuration-path: ".github/actions-labeler.yml"
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true # add/remove labels as modified paths in the PR change
+      - uses: actions/labeler@26546f6c4d63b6c0623e8e39bde7869e3c2b1d7b # pin@v3
+        with:
+          configuration-path: ".github/actions-labeler.yml"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true # add/remove labels as modified paths in the PR change
   branches_label:
     runs-on: ubuntu-latest
     name: Label base branches
     steps:
-    - uses: srvaroa/labeler@36ad6b8842ea13d9ce2e4d22993bbf6fc0d20b5e # pin@v0.9
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: srvaroa/labeler@36ad6b8842ea13d9ce2e4d22993bbf6fc0d20b5e # pin@v0.9
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   external_label:
     runs-on: ubuntu-latest
     name: Label external PRs
     steps:
-    - uses: tylerbutler/labelmaker-action@4d05a42cd2272689037a1cd82b7ad0e36aaddb23 # pin@main
-      with:
-        token: "${{ secrets.ORG_TOKEN }}"
+      - uses: tylerbutler/labelmaker-action@4d05a42cd2272689037a1cd82b7ad0e36aaddb23 # pin@main
+        with:
+          token: "${{ secrets.ORG_TOKEN }}"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,18 +1,18 @@
 name: "Fluid PR Validation"
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
     branches:
-    - main
-    - release/*
+      - main
+      - release/*
 
 jobs:
   validate-codeowners:
     name: Validate CODEOWNERS
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.6.0
-      with:
-        github_access_token: "${{ secrets.GITHUB_TOKEN }}"
-        checks: "files,duppatterns,syntax"
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: mszostok/codeowners-validator@2f6e3bb39aa6837d7dcf8eff2de5d6c046d0c9a9 # pin@v0.6.0
+        with:
+          github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+          checks: "files,duppatterns,syntax"

--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -1,7 +1,7 @@
 name: Website validation
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
     paths:
       - "docs/**"
 
@@ -15,70 +15,70 @@ jobs:
     runs-on: ubuntu-latest
     name: Build site
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: false
-    - uses: actions/setup-node@v2
-      with:
-        node-version: "14"
-        cache: "npm"
-        cache-dependency-path: docs/package-lock.json
-    - name: Build site artifact
-      run: |
-        npm ci
-        npm run ci:build
-    - name: Upload site artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: fluidframework-site
-        path: docs/public
-        retention-days: 3
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+        with:
+          submodules: false
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # pin@v2
+        with:
+          node-version: "14"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+      - name: Build site artifact
+        run: |
+          npm ci
+          npm run ci:build
+      - name: Upload site artifact
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
+        with:
+          name: fluidframework-site
+          path: docs/public
+          retention-days: 3
 
   broken_link_check:
     runs-on: ubuntu-latest
     name: 🔗 Broken Link Check
     needs: build_site
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: false
-    - uses: actions/setup-node@v2
-      with:
-        node-version: "14"
-        cache: "npm"
-        cache-dependency-path: docs/package-lock.json
-    - name: Create results folder
-      run: mkdir -p ./results
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+        with:
+          submodules: false
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # pin@v2
+        with:
+          node-version: "14"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+      - name: Create results folder
+        run: mkdir -p ./results
 
-    - name: Download site artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: fluidframework-site
-        path: docs/public
-    - name: Install dependencies
-      run: |
-        npm install pm2 -g
-        npm ci
-    - name: Start server in background
-      run: pm2 start $GITHUB_WORKSPACE/docs/serve.js
-    - name: Check for broken links
-      id: linkcheck
-      continue-on-error: true
-      run: |
-        set -o pipefail
-        npm run linkcheck | tee ./results/linkcheck-output.txt
+      - name: Download site artifact
+        uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # pin@v2
+        with:
+          name: fluidframework-site
+          path: docs/public
+      - name: Install dependencies
+        run: |
+          npm install pm2 -g
+          npm ci
+      - name: Start server in background
+        run: pm2 start $GITHUB_WORKSPACE/docs/serve.js
+      - name: Check for broken links
+        id: linkcheck
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          npm run linkcheck | tee ./results/linkcheck-output.txt
 
-    - name: Save PR number
-      run: echo ${{ github.event.number }} > ./results/pr
-    - name: Save linkcheck report
-      run: |
-        cat "$GITHUB_WORKSPACE/.github/workflows/data/linkcheck-${{ steps.linkcheck.outcome }}.md" | tee ./results/linkcheck
-        echo -e "\n#### linkcheck output\n\n\`\`\`" | tee -a ./results/linkcheck
-        cat ./results/linkcheck-output.txt | tee -a ./results/linkcheck
-        echo -e "\n\`\`\`" | tee -a ./results/linkcheck
-    - name: Upload results artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: website-validation-results
-        path: ./docs/results
-        retention-days: 3
+      - name: Save PR number
+        run: echo ${{ github.event.number }} > ./results/pr
+      - name: Save linkcheck report
+        run: |
+          cat "$GITHUB_WORKSPACE/.github/workflows/data/linkcheck-${{ steps.linkcheck.outcome }}.md" | tee ./results/linkcheck
+          echo -e "\n#### linkcheck output\n\n\`\`\`" | tee -a ./results/linkcheck
+          cat ./results/linkcheck-output.txt | tee -a ./results/linkcheck
+          echo -e "\n\`\`\`" | tee -a ./results/linkcheck
+      - name: Upload results artifact
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
+        with:
+          name: website-validation-results
+          path: ./docs/results
+          retention-days: 3


### PR DESCRIPTION
# GitHub actions should be pinned (fixes #9608)

## Description

GitHub actions that we use should be pinned to a commit hash to prevent upstream changes from affecting us (other than by breaking the action if the commit hash disappears entirely).

## Change summary

I used <https://github.com/mheap/pin-github-action> to pin the versions.