### PR TITLE
Fix deli trying to nack system sent messages

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1235,10 +1235,16 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
         code: number,
         type: NackErrorType,
         reason: string,
-        retryAfter?: number): INackMessageOutput {
+        retryAfter?: number): INackMessageOutput | undefined {
+        const clientId = message.clientId;
+        if (!clientId) {
+            // message was sent by the system and not a client
+            // "nacking" the system is not supported
+            return undefined;
+        }
+
         const nackMessage: INackMessage = {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            clientId: message.clientId!,
+            clientId,
             documentId: this.documentId,
             operation: {
                 content: {


### PR DESCRIPTION
There was a non-null assertation for `message.clientId!` - this was hiding a bug. It was letting deli create nack messages for messages sent by a `null` client id. That led to broadcaster sending a redis pubsub message to a `client#null` channel, which is pointless because nothing is listening to messages sent to that channel.

The fix is to not create a nack message when there is no client to send the message to.