### PR TITLE
Allow for storing additional context in odsp locator

### DIFF
--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -259,7 +259,6 @@ export interface IThrottlingWarning extends IDriverErrorBase {
 
 // @public (undocumented)
 export interface IUrlResolver {
-    // (undocumented)
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;
     // (undocumented)
     resolve(request: IRequest): Promise<IResolvedUrl | undefined>;

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -135,9 +135,10 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 
 // @public
 export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
-    constructor(shareLinkFetcherProps?: ShareLinkFetcherProps | undefined, logger?: ITelemetryBaseLogger, appName?: string | undefined);
+    constructor(shareLinkFetcherProps?: ShareLinkFetcherProps | undefined, logger?: ITelemetryBaseLogger, appName?: string | undefined, getContext?: ((resolvedUrl: IOdspResolvedUrl, dataStorePath: string) => Promise<string | undefined>) | undefined);
     appendDataStorePath(requestUrl: URL, pathToAppend: string): string | undefined;
     static createDocumentUrl(baseUrl: string, driverInfo: OdspFluidDataStoreLocator): string;
+    // @deprecated
     static createNavParam(locator: OdspFluidDataStoreLocator): string;
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, dataStorePath: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;
     resolve(request: IRequest): Promise<IOdspResolvedUrl>;
@@ -149,6 +150,8 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     appName?: string;
     // (undocumented)
     containerPackageName?: string;
+    // (undocumented)
+    context?: string;
     // (undocumented)
     dataStorePath: string;
     // (undocumented)

--- a/packages/common/driver-definitions/src/urlResolver.ts
+++ b/packages/common/driver-definitions/src/urlResolver.ts
@@ -43,7 +43,13 @@ export interface IUrlResolver {
     // or do we split the token access from this?
     resolve(request: IRequest): Promise<IResolvedUrl | undefined>;
 
-    // Creates a url for the created container with any data store path given in the relative url.
+    /**
+     * Creates a url for the created container with any data store path given in the relative url.
+     * @param resolvedUrl - resolved url for the container.
+     * @param relativeUrl - relative url containing data store path; '/' represents root path.
+     * @param packageInfoSource - optional, represents container package information to be included in url.
+     * @returns absolute url combining container url with dta store path and optional additional information.
+     */
     getAbsoluteUrl(
         resolvedUrl: IResolvedUrl,
         relativeUrl: string,

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
@@ -5,7 +5,7 @@
 
 import { assert, fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
-import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
+import { IContainerPackageInfo, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { createOdspUrl, OdspDriverUrlResolver } from "@fluidframework/odsp-driver";
 import { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions";
 
@@ -49,6 +49,7 @@ export class FluidAppOdspUrlResolver implements IUrlResolver {
     public async getAbsoluteUrl(
         resolvedUrl: IResolvedUrl,
         relativeUrl: string,
+        packageInfoSource?: IContainerPackageInfo,
     ): Promise<string> {
         throw new Error("Not implemented");
     }

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -10,6 +10,7 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     appName?: string;
     containerPackageName?: string;
     fileVersion?: string;
+    context?: string;
 }
 
 export enum SharingLinkHeader {

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -108,7 +108,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 fileName,
                 summarizer: false,
                 codeHint: {
-                    containerPackageName: packageName ? packageName : undefined,
+                    containerPackageName: packageName ?? undefined,
                 },
                 fileVersion: undefined,
                 shareLinkInfo,

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -9,13 +9,14 @@ import { OdcFileSiteOrigin, OdcApiSiteOrigin } from "./constants";
 
 const fluidSignature = "1";
 const fluidSignatureParamName = "fluid";
-const fluidSitePathParamName = "s";
-const fluidDriveIdParamName = "d";
-const fluidItemIdParamName = "f";
-const fluidDataStorePathParamName = "c";
-const fluidAppNameParamName = "a";
-const fluidContainerPackageNameParamName = "p";
-const fluidFileVersionParamName = "v";
+const sitePathParamName = "s";
+const driveIdParamName = "d";
+const itemIdParamName = "f";
+const dataStorePathParamName = "c";
+const appNameParamName = "a";
+const containerPackageNameParamName = "p";
+const fileVersionParamName = "v";
+const additionalContextParamName = "x";
 
 /**
  * Transforms given Fluid data store locator into string that can be embedded into url
@@ -29,19 +30,20 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
     const itemId = encodeURIComponent(locator.itemId);
     const dataStorePath = encodeURIComponent(locator.dataStorePath);
 
-    let locatorSerialized = `${fluidSitePathParamName}=${sitePath}&${fluidDriveIdParamName}=${driveId}&${
-        fluidItemIdParamName}=${itemId}&${fluidDataStorePathParamName}=${dataStorePath}&${
+    let locatorSerialized = `${sitePathParamName}=${sitePath}&${driveIdParamName}=${driveId}&${
+        itemIdParamName}=${itemId}&${dataStorePathParamName}=${dataStorePath}&${
         fluidSignatureParamName}=${fluidSignature}`;
     if (locator.appName) {
-        locatorSerialized += `&${fluidAppNameParamName}=${encodeURIComponent(locator.appName)}`;
+        locatorSerialized += `&${appNameParamName}=${encodeURIComponent(locator.appName)}`;
     }
     if (locator.containerPackageName) {
-        locatorSerialized += `&${fluidContainerPackageNameParamName}=${
-            encodeURIComponent(locator.containerPackageName)}`;
+        locatorSerialized += `&${containerPackageNameParamName}=${encodeURIComponent(locator.containerPackageName)}`;
     }
     if (locator.fileVersion) {
-        locatorSerialized += `&${fluidFileVersionParamName}=${
-            encodeURIComponent(locator.fileVersion)}`;
+        locatorSerialized += `&${fileVersionParamName}=${encodeURIComponent(locator.fileVersion)}`;
+    }
+    if (locator.context) {
+        locatorSerialized += `&${additionalContextParamName}=${encodeURIComponent(locator.context)}`;
     }
 
     return fromUtf8ToBase64(locatorSerialized);
@@ -65,15 +67,16 @@ function decodeOdspFluidDataStoreLocator(
         return undefined;
     }
 
-    const sitePath = locatorInfo.get(fluidSitePathParamName);
-    const driveId = locatorInfo.get(fluidDriveIdParamName);
-    const itemId = locatorInfo.get(fluidItemIdParamName);
-    const dataStorePath = locatorInfo.get(fluidDataStorePathParamName);
-    const appName = locatorInfo.get(fluidAppNameParamName) ?? undefined;
-    const containerPackageName = locatorInfo.get(fluidContainerPackageNameParamName) ?? undefined;
-    const fileVersion = locatorInfo.get(fluidFileVersionParamName) ?? undefined;
+    const sitePath = locatorInfo.get(sitePathParamName);
+    const driveId = locatorInfo.get(driveIdParamName);
+    const itemId = locatorInfo.get(itemIdParamName);
+    const dataStorePath = locatorInfo.get(dataStorePathParamName);
+    const appName = locatorInfo.get(appNameParamName) ?? undefined;
+    const containerPackageName = locatorInfo.get(containerPackageNameParamName) ?? undefined;
+    const fileVersion = locatorInfo.get(fileVersionParamName) ?? undefined;
+    const context = locatorInfo.get(additionalContextParamName) ?? undefined;
     // "" is a valid value for dataStorePath so simply check for absence of the param;
-    // the rest of params must be present and non-empty
+    // file storage locator params must be present and non-empty
     if (!sitePath || !driveId || !itemId || dataStorePath === null) {
         return undefined;
     }
@@ -97,6 +100,7 @@ function decodeOdspFluidDataStoreLocator(
         appName,
         containerPackageName,
         fileVersion,
+        context,
     };
 }
 

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -25,6 +25,8 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     const dataStorePath = "dataStorePath";
     const fileName = "fileName";
     const fileVersion = "173.0";
+    const contextObject = { workspaceId: "id1", linkId: "id2" };
+    const contextStringified = JSON.stringify(contextObject);
     const sharelink = "https://microsoft.sharepoint-df.com/site/SHARELINK";
     const urlsWithNavParams = [
         // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1&v=173.0
@@ -187,13 +189,16 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 
     it("Encode and decode nav param", async () => {
         const encodedUrl = new URL(sharelink);
-        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, itemId, dataStorePath });
+        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, itemId, dataStorePath, context: contextStringified });
 
         const locator = getLocatorFromOdspUrl(encodedUrl);
         assert.strictEqual(locator?.driveId, driveId, "Drive id should be equal");
         assert.strictEqual(locator?.itemId, itemId, "Item id should be equal");
         assert.strictEqual(locator?.dataStorePath, dataStorePath, "DataStore path should be equal");
         assert.strictEqual(locator?.siteUrl, siteUrl, "SiteUrl should be equal");
+        assert.strictEqual(locator?.context, contextStringified, "Context should be equal");
+        const parsedContext = JSON.parse(locator?.context);
+        assert.deepStrictEqual(parsedContext, contextObject, "Context should be de-serializable");
     });
 
     it("Check nav param removal for share link", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -25,14 +25,18 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     const dataStorePath = "dataStorePath";
     const fileName = "fileName";
     const fileVersion = "173.0";
-    const contextObject = { workspaceId: "id1", linkId: "id2" };
+    const contextObject = { w: "id1", i: "id2" };
     const contextStringified = JSON.stringify(contextObject);
     const sharelink = "https://microsoft.sharepoint-df.com/site/SHARELINK";
     const urlsWithNavParams = [
         // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1&v=173.0
-        { hasVersion: true, url: "https://microsoft.sharepoint-df.com/test?nav=ZD1kcml2ZUlkJmY9ZmlsZUlkJmM9ZGF0YVN0b3JlUGF0aCZzPXNpdGVVcmwmZmx1aWQ9MSZ2PTE3My4w" },
+        { hasVersion: true, hasContext: false, url: "https://microsoft.sharepoint-df.com/test?nav=ZD1kcml2ZUlkJmY9ZmlsZUlkJmM9ZGF0YVN0b3JlUGF0aCZzPXNpdGVVcmwmZmx1aWQ9MSZ2PTE3My4w" },
         // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1
-        { hasVersion: false, url: "https://microsoft.sharepoint-df.com/test?nav=cz0lMkZzaXRlVXJsJmQ9ZHJpdmVJZCZmPWZpbGVJZCZjPWRhdGFTdG9yZVBhdGgmZmx1aWQ9MQ%3D%3D" },
+        { hasVersion: false, hasContext: false, url: "https://microsoft.sharepoint-df.com/test?nav=cz0lMkZzaXRlVXJsJmQ9ZHJpdmVJZCZmPWZpbGVJZCZjPWRhdGFTdG9yZVBhdGgmZmx1aWQ9MQ%3D%3D" },
+        // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1&v=173.0&c=%7B%22w%22%3A%22id1%22%2C%22i%22%3A%22id2%22%7D
+        { hasVersion: true, hasContext: true, url: "https://microsoft.sharepoint-df.com/test?nav=ZD1kcml2ZUlkJmY9ZmlsZUlkJmM9ZGF0YVN0b3JlUGF0aCZzPXNpdGVVcmwmZmx1aWQ9MSZ2PTE3My4wJmM9JTdCJTIydyUyMiUzQSUyMmlkMSUyMiUyQyUyMmklMjIlM0ElMjJpZDIlMjIlN0Q%3D" },
+        // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1&c=%7B%22w%22%3A%22id1%22%2C%22i%22%3A%22id2%22%7D
+        { hasVersion: false, hasContext: true, url: "https://microsoft.sharepoint-df.com/test?nav=ZD1kcml2ZUlkJmY9ZmlsZUlkJmM9ZGF0YVN0b3JlUGF0aCZzPXNpdGVVcmwmZmx1aWQ9MSZjPSU3QiUyMnclMjIlM0ElMjJpZDElMjIlMkMlMjJpJTIyJTNBJTIyaWQyJTIyJTdE" },
     ];
     let urlResolverWithShareLinkFetcher: OdspDriverUrlResolverForShareLink;
     let urlResolverWithoutShareLinkFetcher: OdspDriverUrlResolverForShareLink;
@@ -54,7 +58,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
         }
     }
     for (const urlWithNav of urlsWithNavParams) {
-        it(`resolve - Should resolve nav link correctly hasVersion: ${urlWithNav.hasVersion}`, async () => {
+        it(`resolve - Should resolve nav link correctly, hasVersion: ${urlWithNav.hasVersion}, hasContext: ${urlWithNav.hasContext}`, async () => {
             const runTest = async (resolver: OdspDriverUrlResolverForShareLink) => {
                 const resolvedUrl = await resolver.resolve({ url: urlWithNav.url });
                 assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
@@ -68,7 +72,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
             await runTest(urlResolverWithoutShareLinkFetcher);
         });
 
-        it(`resolve - Should resolve odsp driver url correctly hasVersion: ${urlWithNav.hasVersion}`, async () => {
+        it(`resolve - Should resolve odsp driver url correctly, hasVersion: ${urlWithNav.hasVersion}, hasContext: ${urlWithNav.hasContext}`, async () => {
             const runTest = async (resolver: OdspDriverUrlResolverForShareLink) => {
                 const resolvedUrl1 = await resolver.resolve({ url: urlWithNav.url });
                 const url: string = createOdspUrl({ ... resolvedUrl1, dataStorePath });
@@ -84,7 +88,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
             await runTest(urlResolverWithoutShareLinkFetcher);
         });
 
-        it(`resolve - Check conversion in either direction hasVersion: ${urlWithNav.hasVersion}`, async () => {
+        it(`resolve - Check conversion in either direction, hasVersion: ${urlWithNav.hasVersion}, hasContext: ${urlWithNav.hasContext}`, async () => {
             const resolvedUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
                 return urlResolverWithShareLinkFetcher.resolve({ url: urlWithNav.url });
             });


### PR DESCRIPTION
# [Work Item ID or Title](./link-to-the-work-item)

For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)

## Description

ODSP file locator is instrumental in the scenarios where additional information has to be passed together with file to the application that is capable of rendering Fluent content inline. So far locator allowed for strongly typed information which is generally applicable for any type of Fluid container.
There are scenarios where it is desirable to include container-specific information.
This change allows for 'pass-through' context property defined on locator that can be set to string value. For instance, it can describe user context at the time of locator instance creation so it can be later replicated when locator is deserialized.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.

## Testing

> -   Instructions for testing and validation of your code so the reviewer can follow those steps and validate code works as expected

## Any relevant logs or outputs

> -   Use this section to provide either screenshots or output of logs as code snippets

## Other information or known dependencies

> -   Any other information or known dependencies that is important to this PR.
> -   TODO that are to be done after this PR.
