### PR TITLE
Update azure-client peer dep on fluid-framework

### DIFF
--- a/azure/lerna-package-lock.json
+++ b/azure/lerna-package-lock.json
@@ -7301,21 +7301,6 @@
 			"resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
 			"integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
 		},
-		"chokidar": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-			"integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-			"requires": {
-				"anymatch": "~3.1.1",
-				"braces": "~3.0.2",
-				"fsevents": "~2.3.1",
-				"glob-parent": "~5.1.0",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.5.0"
-			}
-		},
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -17311,14 +17296,6 @@
 				"dezalgo": "^1.0.0",
 				"graceful-fs": "^4.1.2",
 				"once": "^1.3.0"
-			}
-		},
-		"readdirp": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-			"requires": {
-				"picomatch": "^2.2.1"
 			}
 		},
 		"readline-sync": {

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -78,7 +78,7 @@
     "typescript": "~4.5.5"
   },
   "peerDependencies": {
-    "fluid-framework": "^0.58.0"
+    "fluid-framework": "~0.59.3000"
   },
   "typeValidation": {
     "version": "0.59.3000",


### PR DESCRIPTION
Fixes #10283.

Due to bug #7913, we've published versions of azure-client with an invalid peer dependency on fluid-framework. This change updates the peerDep to be the most recently released version of fluid-framework, 0.59.3000.

Note that #7913 remains outstanding after this change -- this is merely a band-aid so we can publish a new version of azure-client with proper peer deps.