### PR TITLE
Reject-slashes-in-ids for DataStore and DDS

### DIFF
--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -81,6 +81,7 @@
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.0",
     "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@^0.59.0",
+    "@fluidframework/test-runtime-utils": "^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -23,7 +23,7 @@ import {
     totalBlobSizePropertyName,
 } from "@fluidframework/runtime-definitions";
 import { ChildLogger, EventEmitterWithErrorHandling } from "@fluidframework/telemetry-utils";
-import { DataProcessingError } from "@fluidframework/container-utils";
+import { DataProcessingError, UsageError } from "@fluidframework/container-utils";
 import { FluidSerializer, IFluidSerializer } from "./serializer";
 import { SharedObjectHandle } from "./handle";
 import { SummarySerializer } from "./summarySerializer";
@@ -84,6 +84,10 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
         protected runtime: IFluidDataStoreRuntime,
         public readonly attributes: IChannelAttributes) {
         super((event: EventEmitterEventType, e: any) => this.eventListenerErrorHandler(event, e));
+
+        if (id.includes("/")) {
+            throw new UsageError(`Id cannot contain slashes: ${id}`);
+        }
 
         this.handle = new SharedObjectHandle(
             this,

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -23,7 +23,7 @@ import {
     totalBlobSizePropertyName,
 } from "@fluidframework/runtime-definitions";
 import { ChildLogger, EventEmitterWithErrorHandling } from "@fluidframework/telemetry-utils";
-import { DataProcessingError, UsageError } from "@fluidframework/container-utils";
+import { DataProcessingError } from "@fluidframework/container-utils";
 import { FluidSerializer, IFluidSerializer } from "./serializer";
 import { SharedObjectHandle } from "./handle";
 import { SummarySerializer } from "./summarySerializer";
@@ -85,9 +85,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
         public readonly attributes: IChannelAttributes) {
         super((event: EventEmitterEventType, e: any) => this.eventListenerErrorHandler(event, e));
 
-        if (id.includes("/")) {
-            throw new UsageError(`Id cannot contain slashes: ${id}`);
-        }
+        assert(!id.includes("/"), "Id cannot contain slashes");
 
         this.handle = new SharedObjectHandle(
             this,

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -18,7 +18,7 @@ import { SharedObject, SharedObjectCore } from "../sharedObject";
 class MySharedObject extends SharedObject {
     constructor(
         id: string) {
-        super(id, undefined as unknown as IFluidDataStoreRuntime, undefined as unknown as IChannelAttributes);
+        super(id, undefined as unknown as IFluidDataStoreRuntime, undefined as unknown as IChannelAttributes, "");
     }
 
     protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -1,0 +1,91 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    IChannelAttributes,
+    IChannelStorageService,
+    IFluidDataStoreRuntime }
+from "@fluidframework/datastore-definitions";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { IGarbageCollectionData, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
+import { UsageError } from "@fluidframework/container-utils";
+import { IFluidSerializer } from "../serializer";
+import { SharedObject, SharedObjectCore } from "../sharedObject";
+
+class MySharedObject extends SharedObject {
+    constructor(
+        id: string) {
+        super(id, undefined as unknown as IFluidDataStoreRuntime, undefined as unknown as IChannelAttributes);
+    }
+
+    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
+        throw new Error("Method not implemented.");
+    }
+    protected async loadCore(services: IChannelStorageService): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
+        throw new Error("Method not implemented.");
+    }
+    protected onDisconnect() {
+        throw new Error("Method not implemented.");
+    }
+    protected applyStashedOp(content: any): unknown {
+        throw new Error("Method not implemented.");
+    }
+}
+
+class MySharedObjectCore extends SharedObjectCore {
+    constructor(
+        id: string) {
+        super(id, undefined as unknown as IFluidDataStoreRuntime, undefined as unknown as IChannelAttributes);
+    }
+
+    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
+        throw new Error("Method not implemented.");
+    }
+    protected async loadCore(services: IChannelStorageService): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
+        throw new Error("Method not implemented.");
+    }
+    protected onDisconnect() {
+        throw new Error("Method not implemented.");
+    }
+    protected applyStashedOp(content: any): unknown {
+        throw new Error("Method not implemented.");
+    }
+    public getAttachSummary(fullTree?: boolean, trackState?: boolean): ISummaryTreeWithStats {
+        throw new Error("Method not implemented.");
+    }
+    public async summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats> {
+        throw new Error("Method not implemented.");
+    }
+    public getGCData(fullGC?: boolean): IGarbageCollectionData {
+        throw new Error("Method not implemented.");
+    }
+}
+
+describe("SharedObject", () => {
+    it("rejects slashes in id", () => {
+        const invalidId = "beforeSlash/afterSlash";
+        const codeBlock = () => new MySharedObject(invalidId);
+        assert.throws(codeBlock,
+            (e) => e instanceof UsageError
+                && e.message === `Id cannot contain slashes: ${invalidId}`);
+    });
+});
+
+describe("SharedObjectCore", () => {
+    it("rejects slashes in id", () => {
+        const invalidId = "beforeSlash/afterSlash";
+        const codeBlock = () => new MySharedObjectCore(invalidId);
+        assert.throws(codeBlock,
+            (e) => e instanceof UsageError
+                && e.message === `Id cannot contain slashes: ${invalidId}`);
+    });
+});

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -11,7 +11,7 @@ import {
 from "@fluidframework/datastore-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IGarbageCollectionData, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
-import { UsageError } from "@fluidframework/container-utils";
+import { ContainerErrorType } from "@fluidframework/container-definitions";
 import { IFluidSerializer } from "../serializer";
 import { SharedObject, SharedObjectCore } from "../sharedObject";
 
@@ -75,7 +75,7 @@ describe("SharedObject", () => {
         const invalidId = "beforeSlash/afterSlash";
         const codeBlock = () => new MySharedObject(invalidId);
         assert.throws(codeBlock,
-            (e) => e instanceof UsageError
+            (e) => e.errorType === ContainerErrorType.usageError
                 && e.message === `Id cannot contain slashes: ${invalidId}`);
     });
 });
@@ -85,7 +85,7 @@ describe("SharedObjectCore", () => {
         const invalidId = "beforeSlash/afterSlash";
         const codeBlock = () => new MySharedObjectCore(invalidId);
         assert.throws(codeBlock,
-            (e) => e instanceof UsageError
+            (e) => e.errorType === ContainerErrorType.usageError
                 && e.message === `Id cannot contain slashes: ${invalidId}`);
     });
 });

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -11,7 +11,7 @@ import {
 from "@fluidframework/datastore-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IGarbageCollectionData, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
-import { ContainerErrorType } from "@fluidframework/container-definitions";
+import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { IFluidSerializer } from "../serializer";
 import { SharedObject, SharedObjectCore } from "../sharedObject";
 
@@ -75,8 +75,7 @@ describe("SharedObject", () => {
         const invalidId = "beforeSlash/afterSlash";
         const codeBlock = () => new MySharedObject(invalidId);
         assert.throws(codeBlock,
-            (e) => e.errorType === ContainerErrorType.usageError
-                && e.message === `Id cannot contain slashes: ${invalidId}`);
+            (e) => validateAssertionError(e, "Id cannot contain slashes"));
     });
 });
 
@@ -85,7 +84,6 @@ describe("SharedObjectCore", () => {
         const invalidId = "beforeSlash/afterSlash";
         const codeBlock = () => new MySharedObjectCore(invalidId);
         assert.throws(codeBlock,
-            (e) => e.errorType === ContainerErrorType.usageError
-                && e.message === `Id cannot contain slashes: ${invalidId}`);
+            (e) => validateAssertionError(e, "Id cannot contain slashes"));
     });
 });

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -99,8 +99,9 @@ export interface IContainerRuntime extends
      * Majority of data stores in container should not be roots, and should be reachable (directly or indirectly)
      * through one of the roots.
      * @param pkg - Package name of the data store factory
-     * @param rootDataStoreId - data store ID. IDs naming space is global in container. If collision on name occurs,
-     * it results in container corruption - loading this file after that will always result in error.
+     * @param rootDataStoreId - data store ID. Must not contain slashes. IDs naming space is global in container.
+     * If collision on name occurs, it results in container corruption - loading this file after that will always
+     * result in error.
      */
     createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter>;
 
@@ -108,7 +109,7 @@ export interface IContainerRuntime extends
      * Creates detached data store context. Data store initialization is considered compete
      * only after context.attachRuntime() is called.
      * @param pkg - package path
-     * @param rootDataStoreId - data store ID (unique name)
+     * @param rootDataStoreId - data store ID (unique name). Must not contain slashes.
      */
     createDetachedRootDataStore(pkg: Readonly<string[]>, rootDataStoreId: string): IFluidDataStoreContextDetached;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2002,6 +2002,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     public async createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter> {
+        if (rootDataStoreId.includes("/")) {
+            throw new UsageError(`Id cannot contain slashes: '${rootDataStoreId}'`);
+        }
         return this._aliasingEnabled === true ?
             this.createAndAliasDataStore(pkg, rootDataStoreId) :
             this.createRootDataStoreLegacy(pkg, rootDataStoreId);
@@ -2046,6 +2049,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public createDetachedRootDataStore(
         pkg: Readonly<string[]>,
         rootDataStoreId: string): IFluidDataStoreContextDetached {
+        if (rootDataStoreId.includes("/")) {
+            throw new UsageError(`Id cannot contain slashes: '${rootDataStoreId}'`);
+        }
         return this.dataStores.createDetachedDataStoreCore(pkg, true, rootDataStoreId);
     }
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -352,6 +352,7 @@ export class DataStores implements IDisposable {
     }
 
     public _createFluidDataStoreContext(pkg: string[], id: string, isRoot: boolean, props?: any) {
+        assert(!id.includes("/"), "Id cannot contain slashes");
         const context = new LocalFluidDataStoreContext({
             id,
             pkg,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -329,6 +329,8 @@ export class DataStores implements IDisposable {
         pkg: Readonly<string[]>,
         isRoot: boolean,
         id = uuid()): IFluidDataStoreContextDetached {
+        assert(!id.includes("/"), "Id cannot contain slashes");
+
         const context = new LocalDetachedFluidDataStoreContext({
             id,
             pkg,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -6,8 +6,13 @@
 import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 import { createSandbox } from "sinon";
-import { AttachState, IContainerContext, ICriticalContainerError } from "@fluidframework/container-definitions";
-import { GenericError, UsageError } from "@fluidframework/container-utils";
+import {
+    AttachState,
+    ContainerErrorType,
+    IContainerContext,
+    ICriticalContainerError,
+} from "@fluidframework/container-definitions";
+import { GenericError } from "@fluidframework/container-utils";
 import {
     ISequencedDocumentMessage,
     MessageType,
@@ -881,7 +886,8 @@ describe("Runtime", () => {
                     await containerRuntime.createRootDataStore("", invalidId);
                 };
                 await assert.rejects(codeBlock,
-                    (e) => e instanceof UsageError && e.message === `Id cannot contain slashes: '${invalidId}'`);
+                    (e) => e.errorType === ContainerErrorType.usageError
+                        && e.message === `Id cannot contain slashes: '${invalidId}'`);
             });
 
             it("cannot create detached root data store with slashes in id", async () => {
@@ -890,7 +896,8 @@ describe("Runtime", () => {
                     containerRuntime.createDetachedRootDataStore([""], invalidId);
                 };
                 assert.throws(codeBlock,
-                    (e) => e instanceof UsageError && e.message === `Id cannot contain slashes: '${invalidId}'`);
+                    (e) => e.errorType === ContainerErrorType.usageError
+                        && e.message === `Id cannot contain slashes: '${invalidId}'`);
             });
         });
     });

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -863,7 +863,7 @@ describe("Runtime", () => {
             const getMockContext = ((): Partial<IContainerContext> => {
                 return {
                     deltaManager: new MockDeltaManager(),
-                    quorum: new MockQuorum(),
+                    quorum: new MockQuorumClients(),
                     taggedLogger: new MockLogger(),
                     clientDetails: { capabilities: { interactive: true } },
                     closeFn: (_error?: ICriticalContainerError): void => { },

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -182,9 +182,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     ) {
         super();
 
-        if (dataStoreContext.id.includes("/")) {
-            throw new UsageError(`Data store context ID cannot contain slashes: ${dataStoreContext.id}`);
-        }
+        assert(!dataStoreContext.id.includes("/"),
+            "Id cannot contain slashes. DataStoreContext should have validated this.");
 
         this.logger = ChildLogger.create(
             dataStoreContext.logger,
@@ -355,7 +354,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
     public createChannel(id: string = uuid(), type: string): IChannel {
         if (id.includes("/")) {
-            throw new UsageError(`Channel id cannot contain slashes: ${id}`);
+            throw new UsageError(`Id cannot contain slashes: ${id}`);
         }
 
         this.verifyNotClosed();

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -17,7 +17,7 @@ import {
     AttachState,
     ILoaderOptions,
 } from "@fluidframework/container-definitions";
-import { DataProcessingError } from "@fluidframework/container-utils";
+import { DataProcessingError, UsageError } from "@fluidframework/container-utils";
 import {
     assert,
     Deferred,
@@ -181,6 +181,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         existing: boolean,
     ) {
         super();
+
+        if (dataStoreContext.id.includes("/")) {
+            throw new UsageError(`Data store context ID cannot contain slashes: ${dataStoreContext.id}`);
+        }
 
         this.logger = ChildLogger.create(
             dataStoreContext.logger,
@@ -350,6 +354,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public createChannel(id: string = uuid(), type: string): IChannel {
+        if (id.includes("/")) {
+            throw new UsageError(`Channel id cannot contain slashes: ${id}`);
+        }
+
         this.verifyNotClosed();
 
         assert(!this.contexts.has(id), 0x179 /* "createChannel() with existing ID" */);

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -51,6 +51,7 @@ export abstract class LocalChannelContextBase implements IChannelContext {
                 readonly objectStorage: ChannelStorageService;
             }>,
     ) {
+        assert(!this.id.includes("/"), "Channel context ID cannot contain slashes");
     }
 
     public async getChannel(): Promise<IChannel> {

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -69,6 +69,8 @@ export class RemoteChannelContext implements IChannelContext {
         getBaseGCDetails: () => Promise<IGarbageCollectionDetailsBase>,
         private readonly attachMessageType?: string,
     ) {
+        assert(!this.id.includes("/"), "Channel context ID cannot contain slashes");
+
         this.subLogger = ChildLogger.create(this.runtime.logger, "RemoteChannelContext");
 
         this.services = createServiceEndpoints(

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -11,7 +11,7 @@ import {
     IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions";
 import { MockFluidDataStoreContext } from "@fluidframework/test-runtime-utils";
-import { UsageError } from "@fluidframework/container-utils";
+import { ContainerErrorType } from "@fluidframework/container-definitions";
 import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
 
 describe("FluidDataStoreRuntime Tests", () => {
@@ -37,7 +37,7 @@ describe("FluidDataStoreRuntime Tests", () => {
         dataStoreContext = new MockFluidDataStoreContext(invalidId);
         const codeBlock = () => loadRuntime(dataStoreContext, sharedObjectRegistry);
         assert.throws(codeBlock,
-            (e) => e instanceof UsageError
+            (e) => e.errorType === ContainerErrorType.usageError
                 && e.message === `Data store context ID cannot contain slashes: ${invalidId}`);
     });
 
@@ -46,7 +46,7 @@ describe("FluidDataStoreRuntime Tests", () => {
         dataStoreContext = new MockFluidDataStoreContext(invalidId);
         const codeBlock = () => new FluidDataStoreRuntime(dataStoreContext, sharedObjectRegistry, false);
         assert.throws(codeBlock,
-            (e) => e instanceof UsageError
+            (e) => e.errorType === ContainerErrorType.usageError
                 && e.message === `Data store context ID cannot contain slashes: ${invalidId}`);
     });
 
@@ -84,7 +84,7 @@ describe("FluidDataStoreRuntime Tests", () => {
         const invalidId = "beforeSlash/afterSlash";
         const codeBlock = () => dataStoreRuntime.createChannel(invalidId, "SomeType");
         assert.throws(codeBlock,
-            (e) => e instanceof UsageError
+            (e) => e.errorType === ContainerErrorType.usageError
                 && e.message === `Channel id cannot contain slashes: ${invalidId}`);
     });
 });

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -10,7 +10,7 @@ import {
     IGarbageCollectionData,
     IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions";
-import { MockFluidDataStoreContext } from "@fluidframework/test-runtime-utils";
+import { MockFluidDataStoreContext, validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { ContainerErrorType } from "@fluidframework/container-definitions";
 import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
 
@@ -37,8 +37,8 @@ describe("FluidDataStoreRuntime Tests", () => {
         dataStoreContext = new MockFluidDataStoreContext(invalidId);
         const codeBlock = () => loadRuntime(dataStoreContext, sharedObjectRegistry);
         assert.throws(codeBlock,
-            (e) => e.errorType === ContainerErrorType.usageError
-                && e.message === `Data store context ID cannot contain slashes: ${invalidId}`);
+            (e) => validateAssertionError(e,
+                "Id cannot contain slashes. DataStoreContext should have validated this."));
     });
 
     it("constructor rejects ids with forward slashes", () => {
@@ -46,8 +46,8 @@ describe("FluidDataStoreRuntime Tests", () => {
         dataStoreContext = new MockFluidDataStoreContext(invalidId);
         const codeBlock = () => new FluidDataStoreRuntime(dataStoreContext, sharedObjectRegistry, false);
         assert.throws(codeBlock,
-            (e) => e.errorType === ContainerErrorType.usageError
-                && e.message === `Data store context ID cannot contain slashes: ${invalidId}`);
+            (e) => validateAssertionError(e,
+                "Id cannot contain slashes. DataStoreContext should have validated this."));
     });
 
     it("can create a data store runtime", () => {
@@ -85,6 +85,6 @@ describe("FluidDataStoreRuntime Tests", () => {
         const codeBlock = () => dataStoreRuntime.createChannel(invalidId, "SomeType");
         assert.throws(codeBlock,
             (e) => e.errorType === ContainerErrorType.usageError
-                && e.message === `Channel id cannot contain slashes: ${invalidId}`);
+                && e.message === `Id cannot contain slashes: ${invalidId}`);
     });
 });

--- a/packages/runtime/datastore/src/test/localChannelContext.spec.ts
+++ b/packages/runtime/datastore/src/test/localChannelContext.spec.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    IContainerRuntimeBase,
+    IFluidDataStoreContext,
+} from "@fluidframework/runtime-definitions";
+import { MockFluidDataStoreContext, validateAssertionError } from "@fluidframework/test-runtime-utils";
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
+import { LocalChannelContext, RehydratedLocalChannelContext } from "../localChannelContext";
+
+describe("LocalChannelContext Tests", () => {
+    let dataStoreContext: MockFluidDataStoreContext;
+    let sharedObjectRegistry: ISharedObjectRegistry;
+    const loadRuntime = (context: IFluidDataStoreContext, registry: ISharedObjectRegistry) =>
+        FluidDataStoreRuntime.load(context, registry, /* existing */ false);
+
+    beforeEach(() => {
+        dataStoreContext = new MockFluidDataStoreContext();
+        // back-compat 0.38 - DataStoreRuntime looks in container runtime for certain properties that are unavailable
+        // in the data store context.
+        dataStoreContext.containerRuntime = {} as unknown as IContainerRuntimeBase;
+        sharedObjectRegistry = {
+            get(name: string) {
+                throw new Error("Not implemented");
+            },
+        };
+    });
+
+    it("LocalChannelContext rejects ids with forward slashes", () => {
+        const invalidId = "beforeSlash/afterSlash";
+        const dataStoreRuntime = loadRuntime(dataStoreContext, sharedObjectRegistry);
+        const codeBlock = () => new LocalChannelContext(invalidId, sharedObjectRegistry, "SomeType", dataStoreRuntime,
+            dataStoreContext, dataStoreContext.storage, dataStoreContext.logger,
+            () => {}, (s: string) => {}, (s) => {});
+        assert.throws(codeBlock,
+            (e) => validateAssertionError(e, "Channel context ID cannot contain slashes"),
+            "Expected exception was not thrown");
+    });
+
+    it("RehydratedLocalChannelContext rejects ids with forward slashes", () => {
+        const invalidId = "beforeSlash/afterSlash";
+        const dataStoreRuntime = loadRuntime(dataStoreContext, sharedObjectRegistry);
+        const codeBlock = () => new RehydratedLocalChannelContext(invalidId, sharedObjectRegistry,
+            dataStoreRuntime, dataStoreContext, dataStoreContext.storage, dataStoreContext.logger,
+            (content, localOpMetadata) => {}, (s: string) => {}, (s, o) => {}, null as unknown as ISnapshotTree);
+        assert.throws(codeBlock,
+            (e) => validateAssertionError(e, "Channel context ID cannot contain slashes"),
+            "Expected exception was not thrown");
+    });
+});

--- a/packages/runtime/datastore/src/test/localChannelContext.spec.ts
+++ b/packages/runtime/datastore/src/test/localChannelContext.spec.ts
@@ -4,10 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import {
-    IContainerRuntimeBase,
-    IFluidDataStoreContext,
-} from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { MockFluidDataStoreContext, validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
@@ -21,9 +18,6 @@ describe("LocalChannelContext Tests", () => {
 
     beforeEach(() => {
         dataStoreContext = new MockFluidDataStoreContext();
-        // back-compat 0.38 - DataStoreRuntime looks in container runtime for certain properties that are unavailable
-        // in the data store context.
-        dataStoreContext.containerRuntime = {} as unknown as IContainerRuntimeBase;
         sharedObjectRegistry = {
             get(name: string) {
                 throw new Error("Not implemented");

--- a/packages/runtime/datastore/src/test/remoteChannelContext.spec.ts
+++ b/packages/runtime/datastore/src/test/remoteChannelContext.spec.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    CreateChildSummarizerNodeFn,
+    IContainerRuntimeBase,
+    IFluidDataStoreContext,
+    IGarbageCollectionDetailsBase,
+} from "@fluidframework/runtime-definitions";
+import { MockFluidDataStoreContext, validateAssertionError } from "@fluidframework/test-runtime-utils";
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
+import { RemoteChannelContext } from "../remoteChannelContext";
+
+describe("RemoteChannelContext Tests", () => {
+    let dataStoreContext: MockFluidDataStoreContext;
+    let sharedObjectRegistry: ISharedObjectRegistry;
+    const loadRuntime = (context: IFluidDataStoreContext, registry: ISharedObjectRegistry) =>
+        FluidDataStoreRuntime.load(context, registry, /* existing */ false);
+
+    beforeEach(() => {
+        dataStoreContext = new MockFluidDataStoreContext();
+        // back-compat 0.38 - DataStoreRuntime looks in container runtime for certain properties that are unavailable
+        // in the data store context.
+        dataStoreContext.containerRuntime = {} as unknown as IContainerRuntimeBase;
+        sharedObjectRegistry = {
+            get(name: string) {
+                throw new Error("Not implemented");
+            },
+        };
+    });
+
+    it("rejects ids with forward slashes", () => {
+        const invalidId = "beforeSlash/afterSlash";
+        const dataStoreRuntime = loadRuntime(dataStoreContext, sharedObjectRegistry);
+        const codeBlock = () => new RemoteChannelContext(dataStoreRuntime,
+            dataStoreContext, dataStoreContext.storage,
+            (c, lom) => {}, (s: string) => {}, (s, o) => {},
+            invalidId, undefined as unknown as ISnapshotTree, sharedObjectRegistry, undefined,
+            undefined as unknown as CreateChildSummarizerNodeFn,
+            async () => (undefined as unknown as IGarbageCollectionDetailsBase), "SomeAttachMessageType");
+        assert.throws(codeBlock,
+            (e) => validateAssertionError(e, "Channel context ID cannot contain slashes"),
+            "Expected exception was not thrown");
+    });
+});


### PR DESCRIPTION
# [267](https://dev.azure.com/fluidframework/internal/_workitems/edit/267) and [268](https://dev.azure.com/fluidframework/internal/_workitems/edit/268)

## Description

Add validation + tests so ids of some objects are rejected if they contain forward slashes.

## PR Checklist

-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Testing

Run project/package tests.