### PR TITLE
Add (disabled) test for cancelling an in-progress connection attempt

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -446,7 +446,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
         assert.strictEqual(
             container.connectionState,
             ConnectionState.Disconnected,
-            "container connected trying to cancel with disconnect()",
+            "container connected after trying to cancel with disconnect()",
         );
     });
 });


### PR DESCRIPTION
This PR adds a (disabled) test which ensures that `Container.disconnect()` will cancel any in-progress connection attempts and the container will remain disconnected. This test is disabled because it would fail in the codebase's current state. It will be enabled when https://github.com/microsoft/FluidFramework/issues/9789 is resolved and the underlying behavior is corrected.