### PR TITLE
Draft: Temporarily add an empty .commits to the snapshots to support …

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -7,6 +7,7 @@ import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { ISnapshotContents } from "./odspUtils";
 import { ReadBuffer } from "./ReadBufferUtils";
+import { ISnapshotTreeEx } from "./contracts";
 import {
     assertBlobCoreInstance,
     assertBoolInstance,
@@ -66,8 +67,9 @@ function readOpsSection(node: NodeTypes) {
  * @param node - tree node to de-serialize from
  */
 function readTreeSection(node: NodeCore) {
-    const snapshotTree: ISnapshotTree = {
+    const snapshotTree: ISnapshotTreeEx = {
         blobs: {},
+        commits: {},
         trees: {},
     };
     for (let count = 0; count < node.length; count++) {

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -7,6 +7,20 @@ import * as api from "@fluidframework/protocol-definitions";
 import { HostStoragePolicy } from "@fluidframework/odsp-driver-definitions";
 import { ISnapshotContents } from "./odspUtils";
 
+/** https://portal.microsofticm.com/imp/v3/incidents/details/308931013/home
+ * The commits property was removed from protocol-definitions but in order to support back compat, we will
+ * temporarily add back in this local structure in order to upload the snapshot to support rolling back to 0.58.
+ * Notice this entire interface will be removed once the backward compatibility is not required anymore.
+*/
+export interface ISnapshotTreeEx {
+    id?: string;
+    blobs: { [path: string]: string };
+    commits: { [path: string]: string };
+    trees: { [path: string]: ISnapshotTreeEx };
+    // Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
+    unreferenced?: true;
+}
+
 /**
  * Socket storage discovery api response
  */

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -14,9 +14,9 @@ import { ISnapshotContents } from "./odspUtils";
 */
 export interface ISnapshotTreeEx {
     id?: string;
-    blobs: { [path: string]: string };
-    commits: { [path: string]: string };
-    trees: { [path: string]: ISnapshotTreeEx };
+    blobs: { [path: string]: string; };
+    commits: { [path: string]: string; };
+    trees: { [path: string]: ISnapshotTreeEx; };
     // Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
     unreferenced?: true;
 }

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -4,10 +4,11 @@
  */
 
 import { v4 as uuid } from "uuid";
-import { ISnapshotTree, ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { getDocAttributesFromProtocolSummary } from "@fluidframework/driver-utils";
 import { stringToBuffer, unreachableCase } from "@fluidframework/common-utils";
 import { ISnapshotContents } from "./odspUtils";
+import { ISnapshotTreeEx } from "./contracts";
 
 /**
  * Converts a summary(ISummaryTree) taken in detached container to snapshot tree and blobs
@@ -33,9 +34,10 @@ function convertCreateNewSummaryTreeToTreeAndBlobsCore(
     summary: ISummaryTree,
     blobs: Map<string, ArrayBuffer>,
 ) {
-    const treeNode: ISnapshotTree = {
+    const treeNode: ISnapshotTreeEx = {
         blobs: {},
         trees: {},
+        commits: {},
         unreferenced: summary.unreferenced,
     };
     const keys = Object.keys(summary.tree);

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -5,7 +5,7 @@
 
 import { assert, stringToBuffer } from "@fluidframework/common-utils";
 import * as api from "@fluidframework/protocol-definitions";
-import { IOdspSnapshot, IOdspSnapshotCommit } from "./contracts";
+import { IOdspSnapshot, IOdspSnapshotCommit, ISnapshotTreeEx } from "./contracts";
 import { ISnapshotContents } from "./odspUtils";
 
 /**
@@ -18,7 +18,7 @@ import { ISnapshotContents } from "./odspUtils";
 function buildHierarchy(flatTree: IOdspSnapshotCommit): api.ISnapshotTree {
     const lookup: { [path: string]: api.ISnapshotTree; } = {};
     // id is required for root tree as it will be used to determine the version we loaded from.
-    const root: api.ISnapshotTree = { id: flatTree.id, blobs: {}, trees: {} };
+    const root: ISnapshotTreeEx = { id: flatTree.id, blobs: {}, commits: {}, trees: {} };
     lookup[""] = root;
 
     for (const entry of flatTree.entries) {
@@ -31,9 +31,10 @@ function buildHierarchy(flatTree: IOdspSnapshotCommit): api.ISnapshotTree {
 
         // Add in either the blob or tree
         if (entry.type === "tree") {
-            const newTree: api.ISnapshotTree = {
+            const newTree: ISnapshotTreeEx = {
                 blobs: {},
                 trees: {},
+                commits: {},
                 unreferenced: entry.unreferenced,
             };
             node.trees[decodeURIComponent(entryPathBase)] = newTree;

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -6,15 +6,17 @@
 /* eslint-disable max-len */
 
 import { strict as assert } from "assert";
-import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { stringToBuffer } from "@fluidframework/common-utils";
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser";
 import { convertToCompactSnapshot } from "../compactSnapshotWriter";
 import { ISnapshotContents } from "../odspUtils";
+import { ISnapshotTreeEx } from "../contracts";
 
-const snapshotTree: ISnapshotTree = {
+const snapshotTree: ISnapshotTreeEx = {
     id: "SnapshotId",
     blobs: {},
+    commits: {},
     trees: {
         ".protocol": {
             blobs: {
@@ -22,24 +24,29 @@ const snapshotTree: ISnapshotTree = {
                 quorumMembers: "bARBkx1nses1pHL1vKnmFUfIC",
                 quorumProposals: "bARBkx1nses1pHL1vKnmFUfIC",
             },
+            commits: {},
             trees: {},
         },
         ".app": {
                 blobs: { ".metadata": "bARD4RKvW4LL1KmaUKp6hUMSp" },
+                commits: {},
                 trees: {
                     ".channels": {
                         blobs: {},
+                        commits: {},
                         trees: {
                             default: {
                                     blobs: {
                                         ".component": "bARC6dCXlcrPxQHw3PeROtmKc",
                                         "gc": "bARDNMoBed+nKrsf04id52iUA",
                                     },
+                                    commits: {},
                                     trees: {
                                         ".channels": {
                                             blobs: {},
+                                            commits: {},
                                             trees: {
-                                                root: { blobs: {}, trees: {} },
+                                                root: { blobs: {}, commits:{}, trees: {} },
                                             },
                                         },
                                     },
@@ -47,7 +54,7 @@ const snapshotTree: ISnapshotTree = {
                         },
                         unreferenced: true,
                     },
-                    ".blobs": { blobs: {}, trees: {} },
+                    ".blobs": { blobs: {}, commits: {}, trees: {} },
                 },
                 unreferenced: true,
         },

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -46,7 +46,7 @@ const snapshotTree: ISnapshotTreeEx = {
                                             blobs: {},
                                             commits: {},
                                             trees: {
-                                                root: { blobs: {}, commits:{}, trees: {} },
+                                            root: { blobs: {}, commits: {}, trees: {} },
                                             },
                                         },
                                     },


### PR DESCRIPTION
…backward compatibility (#10414)

Temporarily add commits to the snapshots to support backward compatibility with 0.58.

 #10428  [Release 0.59.3000: Temporarily add an empty .commits to the snapshots to support backward compatibility](https://github.com/microsoft/FluidFramework/issues/10428)

## Description

A document created on 0.59 will not store the .commits property that used to be required back in 0.58.
Due to an incident, the FFX team had to rollback from 0,59 down to 0.58 and the user would get an error during the first page load:
[Incident 308931013](https://portal.microsofticm.com/imp/v3/incidents/details/308931013/home) : [TypeError: Cannot convert undefined or null to object] OWH LoadComponent ACE Success Rate Dogfood-Microsoft Teams Web is unhealthy

## Steps to Reproduce Bug and Validate Solution
repro:
create document in previously deployed (later) DF version [20220517009](https://office.visualstudio.com/OC/_build/results?buildId=13433145&view=results)
open the document in currently deployed (earlier) DF version [20220513008](https://office.visualstudio.com/OC/_build/results?buildId=13383396&view=results)

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.

## Testing

Create a document using 0.59 to save and then, rollback to 0.58 and try to open the same document. That should not generate an error .

