### PR TITLE
replace !isSystemMessage with isClientMessage

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -10,6 +10,7 @@ import { ICommittedProposal } from '@fluidframework/protocol-definitions';
 import { ICreateBlobResponse } from '@fluidframework/protocol-definitions';
 import { IDeltasFetchResult } from '@fluidframework/driver-definitions';
 import { IDocumentAttributes } from '@fluidframework/protocol-definitions';
+import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentService } from '@fluidframework/driver-definitions';
 import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
@@ -222,10 +223,16 @@ export interface IProgress {
 }
 
 // @public (undocumented)
+export function isClientMessage(message: ISequencedDocumentMessage | IDocumentMessage): boolean;
+
+// @public (undocumented)
 export const isFluidResolvedUrl: (resolved: IResolvedUrl | undefined) => resolved is IFluidResolvedUrl;
 
 // @public (undocumented)
 export function isOnline(): OnlineStatus;
+
+// @public (undocumented)
+export function isRuntimeMessage(message: ISequencedDocumentMessage | IDocumentMessage): boolean;
 
 // @public
 export interface ISummaryTreeAssemblerProps {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2922,9 +2922,9 @@
 					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 				},
 				"del": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/del/-/del-6.1.0.tgz",
-					"integrity": "sha512-OpcRktOt7G7HBfyxP0srBH4Djg4824EQORX8E1qvIhIzthNNArxxhrB/Mm7dRMiLi1nvFyUpDhzD2cTtbBhV8A==",
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+					"integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
 					"requires": {
 						"globby": "^11.0.1",
 						"graceful-fs": "^4.2.4",

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -16,7 +16,7 @@ import {
     InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
+import { isClientMessage } from "@fluidframework/driver-utils";
 import { IOdspSnapshot, ISnapshotCachedEntry, IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
@@ -323,7 +323,7 @@ async function fetchLatestSnapshotCore(
                     encodedBlobsSize,
                     sequenceNumber,
                     ops: snapshot.ops?.length ?? 0,
-                    nonSysOps: snapshot.ops?.filter((op) => !isSystemMessage(op)).length ?? 0,
+                    nonSysOps: snapshot.ops?.filter((op) => isClientMessage(op)).length ?? 0,
                     headers: Object.keys(response.requestHeaders).length !== 0 ? true : undefined,
                     // Interval between the first fetch until the last byte of the last redirect.
                     redirectTime,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -16,7 +16,7 @@ import {
     InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
+import { isRuntimeMessage } from "@fluidframework/driver-utils";
 import { IOdspSnapshot, ISnapshotCachedEntry, IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
@@ -323,7 +323,7 @@ async function fetchLatestSnapshotCore(
                     encodedBlobsSize,
                     sequenceNumber,
                     ops: snapshot.ops?.length ?? 0,
-                    nonSysOps: snapshot.ops?.filter((op) => !isSystemMessage(op)).length ?? 0,
+                    userOps: snapshot.ops?.filter((op) => isRuntimeMessage(op)).length ?? 0,
                     headers: Object.keys(response.requestHeaders).length !== 0 ? true : undefined,
                     // Interval between the first fetch until the last byte of the last redirect.
                     redirectTime,

--- a/packages/loader/container-loader/src/collabWindowTracker.ts
+++ b/packages/loader/container-loader/src/collabWindowTracker.ts
@@ -5,7 +5,7 @@
 
 import { assert, Timer } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
+import { isRuntimeMessage } from "@fluidframework/driver-utils";
 
 const defaultNoopTimeFrequency = 2000;
 const defaultNoopCountFrequency = 50;
@@ -63,7 +63,7 @@ export class CollabWindowTracker {
         // We don't acknowledge no-ops to avoid acknowledgement cycles (i.e. ack the MSN
         // update, which updates the MSN, then ack the update, etc...). Also, don't
         // count system messages in ops count.
-        if (isSystemMessage(message)) {
+        if (!isRuntimeMessage(message)) {
             return;
         }
         assert(message.type !== MessageType.NoOp, 0x0ce /* "Don't acknowledge no-ops" */);

--- a/packages/loader/container-loader/src/collabWindowTracker.ts
+++ b/packages/loader/container-loader/src/collabWindowTracker.ts
@@ -5,7 +5,7 @@
 
 import { assert, Timer } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
+import { isClientMessage } from "@fluidframework/driver-utils";
 
 const defaultNoopTimeFrequency = 2000;
 const defaultNoopCountFrequency = 50;
@@ -63,7 +63,7 @@ export class CollabWindowTracker {
         // We don't acknowledge no-ops to avoid acknowledgement cycles (i.e. ack the MSN
         // update, which updates the MSN, then ack the update, etc...). Also, don't
         // count system messages in ops count.
-        if (isSystemMessage(message)) {
+        if (!isClientMessage(message)) {
             return;
         }
         assert(message.type !== MessageType.NoOp, 0x0ce /* "Don't acknowledge no-ops" */);

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -32,6 +32,7 @@ import {
     waitForConnectedState,
     DeltaStreamConnectionForbiddenError,
     logNetworkFailure,
+    isRuntimeMessage,
 } from "@fluidframework/driver-utils";
 import {
     ConnectionMode,
@@ -782,7 +783,7 @@ export class ConnectionManager implements IConnectionManager {
 
     public sendMessages(messages: IDocumentMessage[]) {
         assert(this.connected, 0x2b4 /* "not connected on sending ops!" */);
-
+        messages.forEach((message) => assert(isRuntimeMessage(message), 0 /* "is a client message" */));
         // If connection is "read" or implicit "read" (got leave op for "write" connection),
         // then op can't make it through - we will get a nack if op is sent.
         // We can short-circuit this process.

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -32,7 +32,7 @@ import {
     waitForConnectedState,
     DeltaStreamConnectionForbiddenError,
     logNetworkFailure,
-    isRuntimeMessage,
+    isClientMessage,
 } from "@fluidframework/driver-utils";
 import {
     ConnectionMode,
@@ -783,7 +783,7 @@ export class ConnectionManager implements IConnectionManager {
 
     public sendMessages(messages: IDocumentMessage[]) {
         assert(this.connected, 0x2b4 /* "not connected on sending ops!" */);
-        messages.forEach((message) => assert(isRuntimeMessage(message), "is a client message"));
+        messages.forEach((message) => assert(isClientMessage(message), "is a client message"));
         // If connection is "read" or implicit "read" (got leave op for "write" connection),
         // then op can't make it through - we will get a nack if op is sent.
         // We can short-circuit this process.

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -783,7 +783,7 @@ export class ConnectionManager implements IConnectionManager {
 
     public sendMessages(messages: IDocumentMessage[]) {
         assert(this.connected, 0x2b4 /* "not connected on sending ops!" */);
-        messages.forEach((message) => assert(isRuntimeMessage(message), 0 /* "is a client message" */));
+        messages.forEach((message) => assert(isRuntimeMessage(message), "is a client message"));
         // If connection is "read" or implicit "read" (got leave op for "write" connection),
         // then op can't make it through - we will get a nack if op is sent.
         // We can short-circuit this process.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -51,9 +51,9 @@ import {
     combineAppAndProtocolSummary,
     runWithRetry,
     isFluidResolvedUrl,
+    isRuntimeMessage,
 } from "@fluidframework/driver-utils";
 import {
-    isSystemMessage,
     ProtocolOpHandler,
 } from "@fluidframework/protocol-base";
 import {
@@ -1722,7 +1722,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const local = this.clientId === message.clientId;
 
         // Forward non system messages to the loaded runtime for processing
-        if (!isSystemMessage(message)) {
+        if (isRuntimeMessage(message)) {
             this.context.process(message, local, undefined);
         }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -746,7 +746,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
         // All client meesages should have clientId
         // System messages may have no clientId (but some do, like propose, noop, summarize)
         assert(
-            message.clientId !== undefined === isClientMessage(message),
+            message.clientId !== undefined || isClientMessage(message),
             0x0ed /* "non-system message have to have clientId" */,
         );
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -31,7 +31,6 @@ import {
     IDocumentService,
     DriverErrorType,
 } from "@fluidframework/driver-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
 import {
     IDocumentMessage,
     ISequencedDocumentMessage,
@@ -41,6 +40,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     NonRetryableError,
+    isClientMessage,
 } from "@fluidframework/driver-utils";
 import {
     ThrottlingWarning,
@@ -747,7 +747,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
         // System messages may have no clientId (but some do, like propose, noop, summarize)
         assert(
             message.clientId !== undefined
-            || isSystemMessage(message),
+            || !isClientMessage(message),
             0x0ed /* "non-system message have to have clientId" */,
         );
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -31,7 +31,6 @@ import {
     IDocumentService,
     DriverErrorType,
 } from "@fluidframework/driver-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
 import {
     IDocumentMessage,
     ISequencedDocumentMessage,
@@ -41,6 +40,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     NonRetryableError,
+    isClientMessage,
 } from "@fluidframework/driver-utils";
 import {
     ThrottlingWarning,
@@ -743,11 +743,10 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
         const startTime = Date.now();
         this.lastProcessedMessage = message;
 
-        // All non-system messages are coming from some client, and should have clientId
+        // All client meesages should have clientId
         // System messages may have no clientId (but some do, like propose, noop, summarize)
         assert(
-            message.clientId !== undefined
-            || isSystemMessage(message),
+            message.clientId !== undefined === isClientMessage(message),
             0x0ed /* "non-system message have to have clientId" */,
         );
 

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -21,3 +21,4 @@ export * from "./rateLimiter";
 export * from "./runWithRetry";
 export * from "./treeConversions";
 export * from "./treeUtils";
+export * from "./messageRecognition";

--- a/packages/loader/driver-utils/src/messageRecognition.ts
+++ b/packages/loader/driver-utils/src/messageRecognition.ts
@@ -6,8 +6,8 @@ import { IDocumentMessage, ISequencedDocumentMessage, MessageType } from "@fluid
 
 /**
  *
- * @param message-this is just
- * @returns
+ * @param message-message
+ * @returns whether or not the message type is one listed below
  */
 export function isClientMessage(message: ISequencedDocumentMessage | IDocumentMessage) {
     if (isRuntimeMessage(message)) {
@@ -23,6 +23,11 @@ export function isClientMessage(message: ISequencedDocumentMessage | IDocumentMe
     }
 }
 
+/**
+ *
+ * @param message-message
+ * @returns whether or not the message type is one listed below
+ */
 export function isRuntimeMessage(message: ISequencedDocumentMessage | IDocumentMessage) {
     return message.type === MessageType.Operation || message.type === MessageType.Summarize;
 }

--- a/packages/loader/driver-utils/src/messageRecognition.ts
+++ b/packages/loader/driver-utils/src/messageRecognition.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { IDocumentMessage, ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+
+export function isClientMessage(message: ISequencedDocumentMessage | IDocumentMessage) {
+    switch (message.type) {
+        case MessageType.Propose:
+        case MessageType.Reject:
+        case MessageType.NoOp:
+        case MessageType.Summarize:
+        case MessageType.Operation:
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isRuntimeMessage(message: ISequencedDocumentMessage | IDocumentMessage) {
+    return message.type === MessageType.Operation || message.type === MessageType.Summarize;
+}

--- a/packages/loader/driver-utils/src/messageRecognition.ts
+++ b/packages/loader/driver-utils/src/messageRecognition.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { IDocumentMessage, ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+
+/**
+ *
+ * @param message-this is just
+ * @returns
+ */
+export function isClientMessage(message: ISequencedDocumentMessage | IDocumentMessage) {
+    if (isRuntimeMessage(message)) {
+        return true;
+    }
+    switch (message.type) {
+        case MessageType.Propose:
+        case MessageType.Reject:
+        case MessageType.NoOp:
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isRuntimeMessage(message: ISequencedDocumentMessage | IDocumentMessage) {
+    return message.type === MessageType.Operation || message.type === MessageType.Summarize;
+}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2353,7 +2353,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 gcBlobNodeCount: gcSummaryTreeStats?.blobNodeCount,
                 gcTotalBlobsSize: gcSummaryTreeStats?.totalBlobSize,
                 opsSizesSinceLastSummary: this.opTracker.opsSizeAccumulator,
-                nonSystemOpsSinceLastSummary: this.opTracker.nonSystemOpCount,
+                nonSystemOpsSinceLastSummary: this.opTracker.clientOpCount,
                 summaryNumber,
                 ...partialStats,
             };

--- a/packages/runtime/container-runtime/src/opTelemetry.ts
+++ b/packages/runtime/container-runtime/src/opTelemetry.ts
@@ -9,7 +9,7 @@ import {
     ISequencedDocumentMessage,
     ISequencedDocumentSystemMessage,
 } from "@fluidframework/protocol-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
+import { isClientMessage } from "@fluidframework/driver-utils";
 
 export class OpTracker {
     /**
@@ -49,7 +49,7 @@ export class OpTracker {
         });
 
         deltaManager.on("op", (message: ISequencedDocumentMessage) => {
-            this._nonSystemOpCount += isSystemMessage(message) ? 0 : 1;
+            this._nonSystemOpCount += !isClientMessage(message) ? 0 : 1;
             const id = OpTracker.messageId(message);
             this._opsSizeAccumulator += this.messageSize[id] ?? 0;
             this.messageSize.delete(id);

--- a/packages/runtime/container-runtime/src/opTelemetry.ts
+++ b/packages/runtime/container-runtime/src/opTelemetry.ts
@@ -9,7 +9,7 @@ import {
     ISequencedDocumentMessage,
     ISequencedDocumentSystemMessage,
 } from "@fluidframework/protocol-definitions";
-import { isSystemMessage } from "@fluidframework/protocol-base";
+import { isRuntimeMessage } from "@fluidframework/driver-utils";
 
 export class OpTracker {
     /**
@@ -17,9 +17,9 @@ export class OpTracker {
      * the message is pushed onto the inbound queue.
      */
     private readonly messageSize = new Map<number, number>();
-    private _nonSystemOpCount: number = 0;
-    public get nonSystemOpCount(): number {
-        return this._nonSystemOpCount;
+    private _clientOpCount: number = 0;
+    public get clientOpCount(): number {
+        return this._clientOpCount;
     }
 
     private _opsSizeAccumulator: number = 0;
@@ -49,7 +49,7 @@ export class OpTracker {
         });
 
         deltaManager.on("op", (message: ISequencedDocumentMessage) => {
-            this._nonSystemOpCount += isSystemMessage(message) ? 0 : 1;
+            this._clientOpCount += !isRuntimeMessage(message) ? 0 : 1;
             const id = OpTracker.messageId(message);
             this._opsSizeAccumulator += this.messageSize[id] ?? 0;
             this.messageSize.delete(id);
@@ -65,7 +65,7 @@ export class OpTracker {
     }
 
     public reset() {
-        this._nonSystemOpCount = 0;
+        this._clientOpCount = 0;
         this._opsSizeAccumulator = 0;
     }
 }

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -150,7 +150,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly gcBlobNodeCount?: number;
     /** Sum of the sizes of all op contents since the last summary */
     readonly opsSizesSinceLastSummary: number;
-    /** Number of non-system ops since the last summary @see isSystemMessage */
+    /** Number of non-system ops since the last summary @see isClientMessage */
     readonly nonSystemOpsSinceLastSummary: number;
     /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
     readonly summaryNumber: number;
@@ -426,7 +426,7 @@ type SummaryGeneratorOptionalTelemetryProperties =
     /** Delta in sum of op sizes between the current reference sequence number and the reference
      *  sequence number of the last summary */
     "opsSizesSinceLastSummary" |
-    /** Delta between the number of non-system ops since the last summary @see isSystemMessage */
+    /** Delta between the number of non-system ops since the last summary @see isClientMessage */
     "nonSystemOpsSinceLastSummary" |
     /** Time it took to generate the summary tree and stats. */
     "generateDuration" |

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -150,7 +150,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly gcBlobNodeCount?: number;
     /** Sum of the sizes of all op contents since the last summary */
     readonly opsSizesSinceLastSummary: number;
-    /** Number of non-system ops since the last summary @see isSystemMessage */
+    /** Number of client ops since the last summary @see isClientMessage */
     readonly nonSystemOpsSinceLastSummary: number;
     /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
     readonly summaryNumber: number;
@@ -426,7 +426,7 @@ type SummaryGeneratorOptionalTelemetryProperties =
     /** Delta in sum of op sizes between the current reference sequence number and the reference
      *  sequence number of the last summary */
     "opsSizesSinceLastSummary" |
-    /** Delta between the number of non-system ops since the last summary @see isSystemMessage */
+    /** Delta between the number of client ops since the last summary @see isClientMessage */
     "nonSystemOpsSinceLastSummary" |
     /** Time it took to generate the summary tree and stats. */
     "generateDuration" |


### PR DESCRIPTION
# [https://github.com/microsoft/FluidFramework/issues/9732]

## Description

1. Create new functions isClientMessage and isRuntimeMessage in driver-utils (by @curtisman)
2. Replace all usages of !isSystemMessage for new functions.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My code follows the code style of this project.
-   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [X ] No

## Other information or known dependencies

> -   TODO that are to be done after this PR : remove isSystemMessage function and possibly replace names "nonSysOps" for "clientOps" 
