### PR TITLE
Added note to breaking.md regarding removal of bindToContext from IFluidDataStoreChannel

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -27,7 +27,7 @@ Changes will be made in the way heuristic summaries are run based on observed te
 ### bindToContext to be removed from IFluidDataStoreChannel
 `bindToContext` will be removed from `IFluidDataStoreChannel` in the next major release.
 It was deprecated in 0.50 but due to [this bug](https://github.com/microsoft/FluidFramework/issues/9127) it still had to be called after creating a non-root data store. The bug was fixed in 0.59.
-These calls to `bindToContext` should now be removed in this version since N / N-1 compatibility across container runtime and data store runtime boundary will be maintained. Basically, container runtime version 0.60 running with data store runtime version 0.59 will not this bug.
+To prepare for the removal in the following release, calls to `bindToContext` can and should be removed as soon as this version is consumed. Since the compatibility window between container runtime and data store runtime is N / N-1, all runtime code will have the required bug fix (released in the previous version 0.59) and it can be safely removed.
 
 ## 0.60 Breaking changes
 - [Changed AzureConnectionConfig API](#Changed-AzureConnectionConfig-API)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,10 +18,15 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 0.60 Upcoming changes
 - [Summarize heuristic changes based on telemetry](#Summarize-heuristic-changes-based-on-telemetry)
+- [bindToContext to be removed from IFluidDataStoreChannel](#bindToContext-to-be-removed-from-IFluidDataStoreChannel)
 
 ### Summarize heuristic changes based on telemetry
 Changes will be made in the way heuristic summaries are run based on observed telemetry (see `ISummaryConfigurationHeuristics`). Please evaluate if such policies make sense for you, and if not, clone the previous defaults and pass it to the `ContainerRuntime` object to shield yourself from these changes:
 - Change `minOpsForLastSummaryAttempt` from `50` -> `10`
+
+### bindToContext to be removed from IFluidDataStoreChannel
+`bindToContext` will be removed from `IFluidDataStoreChannel` in the next major release. It was deprecated in 0.50 but due to [this bug](https://github.com/microsoft/FluidFramework/issues/9127) it still had to be called after creating a non-root data store.
+This bug was fixed in 0.59 and the call to `bindToContext` after creating data stores can now be removed from this version onwards.
 
 ## 0.60 Breaking changes
 - [Changed AzureConnectionConfig API](#Changed-AzureConnectionConfig-API)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -25,8 +25,9 @@ Changes will be made in the way heuristic summaries are run based on observed te
 - Change `minOpsForLastSummaryAttempt` from `50` -> `10`
 
 ### bindToContext to be removed from IFluidDataStoreChannel
-`bindToContext` will be removed from `IFluidDataStoreChannel` in the next major release. It was deprecated in 0.50 but due to [this bug](https://github.com/microsoft/FluidFramework/issues/9127) it still had to be called after creating a non-root data store.
-This bug was fixed in 0.59 and the call to `bindToContext` after creating data stores can now be removed from this version onwards.
+`bindToContext` will be removed from `IFluidDataStoreChannel` in the next major release.
+It was deprecated in 0.50 but due to [this bug](https://github.com/microsoft/FluidFramework/issues/9127) it still had to be called after creating a non-root data store. The bug was fixed in 0.59.
+These calls to `bindToContext` should now be removed in this version since N / N-1 compatibility across container runtime and data store runtime boundary will be maintained. Basically, container runtime version 0.60 running with data store runtime version 0.59 will not this bug.
 
 ## 0.60 Breaking changes
 - [Changed AzureConnectionConfig API](#Changed-AzureConnectionConfig-API)


### PR DESCRIPTION
[AB#276](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/276)

## Description
Added a upcoming change not in BREAKING.md that `bindToContext` will be removed from `IFluidDataStoreChannel` in the next major release following 1.0 (or 0.60). This API was deprecated in 0.50 but because of https://github.com/microsoft/FluidFramework/issues/9127, this still had to be called after creation of non-root data stores. https://github.com/microsoft/FluidFramework/issues/9127 was fixed in 0.59 and we are waiting couple of major versions before removing it from `IFluiDataStoreChannel`.

