### PR TITLE
Updated inactive object telemetry to not always log for non-summarizer clients

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1029,6 +1029,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.mc.logger,
             existing,
             metadata,
+            this.context.clientDetails.type === summarizerClientType,
         );
 
         const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -255,7 +255,7 @@ export class GarbageCollector implements IGarbageCollector {
         baseLogger: ITelemetryLogger,
         existing: boolean,
         metadata: IContainerRuntimeMetadata | undefined,
-        summarizerClient: boolean,
+        isSummarizerClient: boolean,
     ): IGarbageCollector {
         return new GarbageCollector(
             provider,
@@ -267,7 +267,7 @@ export class GarbageCollector implements IGarbageCollector {
             baseLogger,
             existing,
             metadata,
-            summarizerClient,
+            isSummarizerClient,
         );
     }
 
@@ -304,7 +304,6 @@ export class GarbageCollector implements IGarbageCollector {
      * Tracks if GC should run or not. Even if GC is enabled for a document (see gcEnabled), it can be explicitly
      * disabled via runtime options or feature flags.
      */
-
     public readonly shouldRunGC: boolean;
     /**
      * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
@@ -378,7 +377,7 @@ export class GarbageCollector implements IGarbageCollector {
         baseLogger: ITelemetryLogger,
         existing: boolean,
         metadata: IContainerRuntimeMetadata | undefined,
-        private readonly summarizerClient: boolean = true,
+        private readonly isSummarizerClient: boolean = true,
     ) {
         this.mc = loggerToMonitoringContext(
             ChildLogger.create(baseLogger, "GarbageCollector", { all: { gcRunCount: () => this.gcRunCount } }),
@@ -1132,7 +1131,7 @@ export class GarbageCollector implements IGarbageCollector {
 
         // For non-summarizer clients, only log "Loaded" type events since these objects may not be loaded in the
         // summarizer clients if they are based off of user actions (such as scrolling to content for these objects).
-        if (!this.summarizerClient && eventType !== "Loaded") {
+        if (!this.isSummarizerClient && eventType !== "Loaded") {
             return;
         }
 

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -619,10 +619,13 @@ export class GarbageCollector implements IGarbageCollector {
                 );
                 dpe.addTelemetryProperties({
                     gcEnabled: this.gcEnabled,
+                    sweepEnabled: this.sweepEnabled,
+                    runGC: this.shouldRunGC,
                     runSweep: this.shouldRunSweep,
                     writeAtRoot: this._writeDataAtRoot,
                     testMode: this.testMode,
                     sessionExpiry: this.sessionExpiryTimeoutMs,
+                    inactiveTimeout: this.inactiveTimeoutMs,
                 });
                 throw dpe;
             });

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -689,9 +689,10 @@ export class GarbageCollector implements IGarbageCollector {
                 this.runtime.deleteUnusedRoutes(gcResult.deletedNodeIds);
             }
 
+            event.end({ ...gcStats, gcRunCount: this.gcRunCount });
+
             this.gcRunCount++;
 
-            event.end({ ...gcStats });
             return gcStats;
         },
         { end: true, cancel: "error" });

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -610,8 +610,7 @@ export class GarbageCollector implements IGarbageCollector {
             return baseGCDetailsMap;
         });
 
-        // Initialize the base state that is used to detect when inactive objects are used. It is explicitly initialized
-        // for non-summarizer clients as they don't run GC. Summarizer clients do this when GC runs first time.
+        // Initialize the base state that is used to detect when inactive objects are used.
         if (this.shouldRunGC) {
             this.initializeBaseStateP.catch((error) => {
                 const dpe = DataProcessingError.wrapIfUnrecognized(
@@ -688,7 +687,7 @@ export class GarbageCollector implements IGarbageCollector {
                 this.runtime.deleteUnusedRoutes(gcResult.deletedNodeIds);
             }
 
-            event.end({ ...gcStats, completedGCRuns: this.completedRuns });
+            event.end({ ...gcStats });
 
             this.completedRuns++;
 

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -88,6 +88,7 @@ describe("Garbage Collection Tests", () => {
             mockLogger,
             metadata !== undefined /* existing */,
             metadata,
+            true /* summarizerClient */,
         );
     };
 
@@ -544,6 +545,40 @@ describe("Garbage Collection Tests", () => {
                     { eventName: loadedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive events not generated as expected",
+            );
+        });
+    });
+
+    describe("GC run count", () => {
+        const gcEndEvent = "GarbageCollector:GarbageCollection_end";
+
+        it("increments GC run count in logged events correctly", async () => {
+            const garbageCollector = createGarbageCollector();
+
+            await garbageCollector.collectGarbage({});
+            assert(
+                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 1 }]),
+                "gcRunCount should be 1 for the first gcEndEvent",
+            );
+
+            await garbageCollector.collectGarbage({});
+            assert(
+                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 2 }]),
+                "gcRunCount should be 2 for the second gcEndEvent",
+            );
+
+            await garbageCollector.collectGarbage({});
+            assert(
+                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 3 }]),
+                "gcRunCount should be 3 for the third gcEndEvent",
+            );
+
+            // The GC run count should reset for new garbage collector.
+            const garbageCollector2 = createGarbageCollector();
+            await garbageCollector2.collectGarbage({});
+            assert(
+                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 1 }]),
+                "gcRunCount should be 1 for the first gcEndEvent in new garbage collector",
             );
         });
     });

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -557,28 +557,28 @@ describe("Garbage Collection Tests", () => {
 
             await garbageCollector.collectGarbage({});
             assert(
+                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 0 }]),
+                "gcRunCount should be 0 since this event was logged before first GC run completed",
+            );
+
+            await garbageCollector.collectGarbage({});
+            assert(
                 mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 1 }]),
-                "gcRunCount should be 1 for the first gcEndEvent",
+                "gcRunCount should be 1 since this event was logged after first GC run completed",
             );
 
             await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 2 }]),
-                "gcRunCount should be 2 for the second gcEndEvent",
-            );
-
-            await garbageCollector.collectGarbage({});
-            assert(
-                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 3 }]),
-                "gcRunCount should be 3 for the third gcEndEvent",
+                "gcRunCount should be 2 since this event was logged after second GC run completed",
             );
 
             // The GC run count should reset for new garbage collector.
             const garbageCollector2 = createGarbageCollector();
             await garbageCollector2.collectGarbage({});
             assert(
-                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 1 }]),
-                "gcRunCount should be 1 for the first gcEndEvent in new garbage collector",
+                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 0 }]),
+                "gcRunCount should be 0 since this event was logged before first GC run in new garbage collector",
             );
         });
     });

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -549,36 +549,36 @@ describe("Garbage Collection Tests", () => {
         });
     });
 
-    describe("GC run count", () => {
+    describe("GC completed runs", () => {
         const gcEndEvent = "GarbageCollector:GarbageCollection_end";
 
-        it("increments GC run count in logged events correctly", async () => {
+        it("increments GC completed runs in logged events correctly", async () => {
             const garbageCollector = createGarbageCollector();
 
             await garbageCollector.collectGarbage({});
             assert(
-                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 0 }]),
-                "gcRunCount should be 0 since this event was logged before first GC run completed",
+                mockLogger.matchEvents([{ eventName: gcEndEvent, completedGCRuns: 0 }]),
+                "completedGCRuns should be 0 since this event was logged before first GC run completed",
             );
 
             await garbageCollector.collectGarbage({});
             assert(
-                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 1 }]),
-                "gcRunCount should be 1 since this event was logged after first GC run completed",
+                mockLogger.matchEvents([{ eventName: gcEndEvent, completedGCRuns: 1 }]),
+                "completedGCRuns should be 1 since this event was logged after first GC run completed",
             );
 
             await garbageCollector.collectGarbage({});
             assert(
-                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 2 }]),
-                "gcRunCount should be 2 since this event was logged after second GC run completed",
+                mockLogger.matchEvents([{ eventName: gcEndEvent, completedGCRuns: 2 }]),
+                "completedGCRuns should be 2 since this event was logged after second GC run completed",
             );
 
             // The GC run count should reset for new garbage collector.
             const garbageCollector2 = createGarbageCollector();
             await garbageCollector2.collectGarbage({});
             assert(
-                mockLogger.matchEvents([{ eventName: gcEndEvent, gcRunCount: 0 }]),
-                "gcRunCount should be 0 since this event was logged before first GC run in new garbage collector",
+                mockLogger.matchEvents([{ eventName: gcEndEvent, completedGCRuns: 0 }]),
+                "completedGCRuns should be 0 since this event was logged before first GC run in new garbage collector",
             );
         });
     });


### PR DESCRIPTION
## Description
This is one of many PRs that updates the inactive object telemetry that can be used to identify GC related bugs in apps.

Added `completedGCRuns` property to all GC telemetry which is the number of GC has run on this container at that point in time. This will help us in couple of ways:
1. We can filter out events that are generated before the first time GC runs. For example, we would like to know the inactiveObjectRevived and inactiveObjectChanged events that are generated because of trailing ops vs current ops.
2. It will help us correlate all GC events for a given GC run.

For non-summarizer clients, updated to only log the inactiveObjectLoaded telemetry. This telemetry tells whether a data store or DDS that has been unreferenced for 7+ days is explicitly requested /loaded. The inactive object events, in general, gives us a reasonable sense of whether objects are being used after they are deleted from Fluid apps.

This telemetry is based off the reference state of these objects that is updated by GC. GC only runs in summarizer client so it has the up-to-date reference state of all objects. In non-summarizer clients, the reference state is as latest as the snapshot it is loaded from. So, it is not-up-to date and logging these events can lead to false positives. However, data stores / DDSs are usually requested explicitly in non-summarizer clients only so this is our best bet of getting this information. Even if it contains false positives, we can do some filtering based on events from summarizer clients while looking at the telemetry.

## PR Checklist
-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Testing
Added tests to validate that the `gcRunCount` is correctly updated.

[AB#253](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/253).
