### PR TITLE
Ignore some flaky font-related links

### DIFF
--- a/docs/skipped-urls.txt
+++ b/docs/skipped-urls.txt
@@ -5,3 +5,4 @@ https://aka.ms/fluentui/
 https://github.com/microsoft/FluidFramework/edit/*
 https://twitter.com/intent/follow*
 https://twitter.com/intent/tweet*
+https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/*/latest.*


### PR DESCRIPTION
Fixes #10267.

These font links are flaky when accessed from our CI systems, but as far as we know there's no customer impact in practice.