### PR TITLE
Added test feature flag to override GC inactive timeout

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -66,13 +66,13 @@ const runSweepKey = "Fluid.GarbageCollection.RunSweep";
 // Feature gate key to write GC data at the root of the summary tree.
 const writeAtRootKey = "Fluid.GarbageCollection.WriteDataAtRoot";
 // Feature gate key to expire a session after a set period of time.
-const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
+export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
 // Feature gate key to disable expiring session after a set period of time, even if expiry value is present
-const disableSessionExpiryKey = "Fluid.GarbageCollection.DisableSessionExpiry";
+export const disableSessionExpiryKey = "Fluid.GarbageCollection.DisableSessionExpiry";
 // Feature gate key to log error messages if GC reference validation fails.
-const logUnknownOutboundReferencesKey = "Fluid.GarbageCollection.LogUnknownOutboundReferences";
+export const logUnknownOutboundReferencesKey = "Fluid.GarbageCollection.LogUnknownOutboundReferences";
 
-const defaultDeleteTimeoutMs = 7 * 24 * 60 * 60 * 1000; // 7 days
+const defaultInactiveTimeoutMs = 7 * 24 * 60 * 60 * 1000; // 7 days
 export const defaultSessionExpiryDurationMs = 30 * 24 * 60 * 60 * 1000; // 30 days
 
 /** The statistics of the system state after a garbage collection run. */
@@ -345,8 +345,8 @@ export class GarbageCollector implements IGarbageCollector {
     private readonly initializeBaseStateP: Promise<void>;
     // The map of data store ids to their GC details in the base summary returned in getDataStoreGCDetails().
     private readonly baseGCDetailsP: Promise<Map<string, IGarbageCollectionDetailsBase>>;
-    // The time after which an unreferenced node can be deleted. Currently, we only set the node's state to expired.
-    private readonly deleteTimeoutMs: number;
+    // The time after which an unreferenced node is inactive.
+    private readonly inactiveTimeoutMs: number;
     // Map of node ids to their unreferenced state tracker.
     private readonly unreferencedNodesState: Map<string, UnreferencedStateTracker> = new Map();
     // The timeout responsible for closing the container when the session has expired
@@ -373,8 +373,6 @@ export class GarbageCollector implements IGarbageCollector {
     ) {
         this.mc = loggerToMonitoringContext(
             ChildLogger.create(baseLogger, "GarbageCollector"));
-
-        this.deleteTimeoutMs = this.gcOptions.deleteTimeoutMs ?? defaultDeleteTimeoutMs;
 
         let prevSummaryGCVersion: number | undefined;
 
@@ -455,6 +453,12 @@ export class GarbageCollector implements IGarbageCollector {
         this.shouldRunSweep = this.shouldRunGC && (
             this.mc.config.getBoolean(runSweepKey) ?? (this.sessionExpiryTimeoutMs !== undefined && this.sweepEnabled)
         );
+
+        // Override inactive timeout if test config or gc options to override it is set.
+        this.inactiveTimeoutMs =
+            this.mc.config.getNumber("Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs") ??
+            this.gcOptions.inactiveTimeoutMs ??
+            defaultInactiveTimeoutMs;
 
         // Whether we are running in test mode. In this mode, unreferenced nodes are immediately deleted.
         this.testMode = this.mc.config.getBoolean(gcTestModeKey) ?? gcOptions.runGCInTestMode === true;
@@ -552,7 +556,7 @@ export class GarbageCollector implements IGarbageCollector {
                         nodeId,
                         new UnreferencedStateTracker(
                             nodeData.unreferencedTimestampMs,
-                            this.deleteTimeoutMs,
+                            this.inactiveTimeoutMs,
                             currentReferenceTimestampMs,
                         ),
                     );
@@ -865,7 +869,7 @@ export class GarbageCollector implements IGarbageCollector {
                     nodeId,
                     new UnreferencedStateTracker(
                         currentReferenceTimestampMs,
-                        this.deleteTimeoutMs,
+                        this.inactiveTimeoutMs,
                         currentReferenceTimestampMs,
                     ),
                 );
@@ -1112,7 +1116,7 @@ export class GarbageCollector implements IGarbageCollector {
                 eventName,
                 id: nodeId,
                 age: currentReferenceTimestampMs - nodeState.unreferencedTimestampMs,
-                timeout: this.deleteTimeoutMs,
+                timeout: this.inactiveTimeoutMs,
                 lastSummaryTime: this.getLastSummaryTimestampMs(),
                 externalRequest: requestHeaders?.[RuntimeHeaders.externalRequest],
                 viaHandle: requestHeaders?.[RuntimeHeaders.viaHandle],

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -25,6 +25,9 @@ import {
     gcTreeKey,
     IGarbageCollectionRuntime,
     IGarbageCollector,
+    runSessionExpiryKey,
+    disableSessionExpiryKey,
+    logUnknownOutboundReferencesKey,
 } from "../garbageCollection";
 import { IContainerRuntimeMetadata } from "../summaryFormat";
 
@@ -41,8 +44,8 @@ describe("Garbage Collection Tests", () => {
     const mockLogger: MockLogger = new MockLogger();
     const mc = mixinMonitoringContext(mockLogger, sessionStorageConfigProvider.value);
     let closeCalled = false;
-    // Time after which unreferenced nodes can be deleted.
-    const deleteTimeoutMs = 500;
+    // Time after which unreferenced nodes becomes inactive.
+    const inactiveTimeoutMs = 500;
     const testPkgPath = ["testPkg"];
     // The package data is tagged in the telemetry event.
     const eventPkg = { value: `/${testPkgPath.join("/")}`, tag: TelemetryDataTag.PackageData };
@@ -77,7 +80,7 @@ describe("Garbage Collection Tests", () => {
     ) => {
         return GarbageCollector.create(
             gcRuntime,
-            { gcAllowed: true, deleteTimeoutMs },
+            { gcAllowed: true, inactiveTimeoutMs },
             (nodeId: string) => testPkgPath,
             () => Date.now(),
             baseSnapshot,
@@ -88,35 +91,32 @@ describe("Garbage Collection Tests", () => {
         );
     };
 
+    const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
+    let injectedSettings = {};
+
     before(() => {
         clock = useFakeTimers();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
     });
 
     afterEach(() => {
         clock.reset();
         mockLogger.clear();
+        injectedSettings = {};
     });
 
     after(() => {
         clock.restore();
+        sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
     });
 
     describe("Session expiry", () => {
-        const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
-        const injectedSettings = {};
-        const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
-        const disableSessionExpiryKey = "Fluid.GarbageCollection.DisableSessionExpiry";
         const testOverrideSessionExpiryMsKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
-        before(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
-        });
+
         beforeEach(() => {
             closeCalled = false;
             injectedSettings[runSessionExpiryKey] = "true";
-        });
-        after(() => {
-            sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
         });
 
         function closeCalledAfterExactTicks(ticks: number) {
@@ -246,6 +246,7 @@ describe("Garbage Collection Tests", () => {
             defaultGCData.gcNodes[nodes[2]] = [nodes[3]];
             defaultGCData.gcNodes[nodes[3]] = [nodes[0]];
         });
+
         it("doesn't generate events for referenced nodes", async () => {
             const garbageCollector = createGarbageCollector();
 
@@ -259,7 +260,7 @@ describe("Garbage Collection Tests", () => {
             validateNoInactiveEvents();
 
             // Expire the unreferenced timer (if any).
-            clock.tick(deleteTimeoutMs + 1);
+            clock.tick(inactiveTimeoutMs + 1);
 
             // Change all nodes again.
             updateAllNodes(garbageCollector);
@@ -283,17 +284,17 @@ describe("Garbage Collection Tests", () => {
             validateNoInactiveEvents();
 
             // Expire the unreferenced timer (if any).
-            clock.tick(deleteTimeoutMs + 1);
+            clock.tick(inactiveTimeoutMs + 1);
 
             // Update all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
             // are inactive.
             updateAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive events not generated as expected",
             );
@@ -302,7 +303,7 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
@@ -317,14 +318,14 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
 
             // Expire the unreferenced timer (if any).
-            clock.tick(deleteTimeoutMs + 1);
+            clock.tick(inactiveTimeoutMs + 1);
 
             // Update all nodes. This should result in an inactiveObjectChanged event for node 3 since it's inactive.
             updateAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive events not generated as expected",
             );
@@ -340,7 +341,7 @@ describe("Garbage Collection Tests", () => {
          * for these nodes.
          */
         it("generates events for nodes that are inactive on load", async () => {
-            // Create GC state where node 3's unreferenced time was > deleteTimeoutMs ago.
+            // Create GC state where node 3's unreferenced time was > inactiveTimeoutMs ago.
             // This means this node should become inactive as soon as its data is loaded.
 
             // Create a snapshot tree to be used as the GC snapshot tree.
@@ -359,7 +360,7 @@ describe("Garbage Collection Tests", () => {
             const gcState: IGarbageCollectionState = { gcNodes: {} };
             const node3Data: IGarbageCollectionNodeData = {
                 outboundRoutes: [],
-                unreferencedTimestampMs: Date.now() - (deleteTimeoutMs + 100),
+                unreferencedTimestampMs: Date.now() - (inactiveTimeoutMs + 100),
             };
             gcState.gcNodes[nodes[3]] = node3Data;
 
@@ -382,8 +383,8 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive events not generated as expected",
             );
@@ -392,7 +393,7 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
@@ -403,11 +404,11 @@ describe("Garbage Collection Tests", () => {
          * test validates that we generate inactive events for these nodes.
          */
         it("generates events for nodes that are inactive on load - old snapshot format", async () => {
-            // Create GC details for node 3's GC blob whose unreferenced time was > deleteTimeoutMs ago.
+            // Create GC details for node 3's GC blob whose unreferenced time was > inactiveTimeoutMs ago.
             // This means this node should become inactive as soon as its data is loaded.
             const node3GCDetails: IGarbageCollectionDetailsBase = {
                 gcData: { gcNodes: { "/": [] } },
-                unrefTimestamp: Date.now() - (deleteTimeoutMs + 100),
+                unrefTimestamp: Date.now() - (inactiveTimeoutMs + 100),
             };
             const node3Snapshot = getDummySnapshotTree();
             node3Snapshot.blobs[gcBlobKey] = "node3GCDetails";
@@ -435,8 +436,8 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
@@ -445,7 +446,7 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
@@ -457,10 +458,10 @@ describe("Garbage Collection Tests", () => {
          */
         it(`generates events for nodes that are inactive on load - multi blob GC data`, async () => {
             const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
-            const expiredTimestampMs = Date.now() - (deleteTimeoutMs + 100);
+            const expiredTimestampMs = Date.now() - (inactiveTimeoutMs + 100);
 
             // Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
-            // time was > deletedTimeoutMs ago. These three GC blobs are the added to the GC tree in summary.
+            // time was > inactiveTimeoutMs ago. These three GC blobs are the added to the GC tree in summary.
             const blob1Id = "blob1";
             const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
             blob1GCState.gcNodes[nodes[1]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
@@ -504,11 +505,45 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[1], pkg: eventPkg },
-                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[1], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
+            );
+        });
+
+        it("can override inactive timeout via feature flags", async () => {
+            const inactiveTimeoutOverrideMs = 100;
+            const testOverrideInactiveTimeoutMsKey = "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs";
+            injectedSettings[testOverrideInactiveTimeoutMsKey] = inactiveTimeoutOverrideMs;
+            const garbageCollector = createGarbageCollector();
+
+            // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+            defaultGCData.gcNodes[nodes[1]] = [];
+
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Update all nodes.
+            updateAllNodes(garbageCollector);
+
+            // Validate that no inactive events are generated yet.
+            validateNoInactiveEvents();
+
+            // Advance the clock so that inactive timeout expires.
+            clock.tick(inactiveTimeoutOverrideMs + 1);
+
+            // Update all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
+            // are inactive.
+            updateAllNodes(garbageCollector);
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: changedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[3], pkg: eventPkg },
+                ]),
+                "inactive events not generated as expected",
             );
         });
     });
@@ -556,18 +591,12 @@ describe("Garbage Collection Tests", () => {
             }
             return nodeTimestamps;
         }
-        const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
+
         beforeEach(() => {
             closeCalled = false;
-            const settings = { "Fluid.GarbageCollection.LogUnknownOutboundReferences": "true" };
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            sessionStorageConfigProvider.value.getRawConfig = (name) => settings[name];
+            injectedSettings[logUnknownOutboundReferencesKey] = "true";
             defaultGCData.gcNodes = {};
             garbageCollector = createGarbageCollector();
-        });
-
-        afterEach(() => {
-            sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
         });
 
         /**

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -29,10 +29,10 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
         TestDataObject,
         [],
         []);
-    const deleteTimeoutMs = 100;
+    const inactiveTimeoutMs = 100;
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: { disableSummaries: true },
-        gcOptions: { gcAllowed: true, deleteTimeoutMs },
+        gcOptions: { gcAllowed: true, inactiveTimeoutMs },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
         dataObjectFactory,
@@ -54,10 +54,10 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
     let summarizerDefaultDataStore: TestDataObject;
     let mockLogger: MockLogger;
 
-    /** Waits for the delete timeout to expire. */
-    async function waitForDeleteTimeout(): Promise<void> {
+    /** Waits for the inactive timeout to expire. */
+    async function waitForInactiveTimeout(): Promise<void> {
         await new Promise<void>((resolve) => {
-            setTimeout(resolve, deleteTimeoutMs + 10);
+            setTimeout(resolve, inactiveTimeoutMs + 10);
         });
     }
 
@@ -104,9 +104,9 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
     });
 
     itExpects("can generate events when unreferenced data store is accessed after it's inactive", [
-        { eventName: changedEvent, timeout: deleteTimeoutMs },
-        { eventName: loadedEvent, timeout: deleteTimeoutMs },
-        { eventName: revivedEvent, timeout: deleteTimeoutMs },
+        { eventName: changedEvent, timeout: inactiveTimeoutMs },
+        { eventName: loadedEvent, timeout: inactiveTimeoutMs },
+        { eventName: revivedEvent, timeout: inactiveTimeoutMs },
     ], async () => {
         const dataStore1 = await dataObjectFactory.createInstance(defaultDataStore.containerRuntime);
         defaultDataStore._root.set("dataStore1", dataStore1.handle);
@@ -128,8 +128,8 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
         await summarize();
         validateNoInactiveEvents();
 
-        // Wait for delete timeout. This will ensure that the unreferenced data store is inactive.
-        await waitForDeleteTimeout();
+        // Wait for inactive timeout. This will ensure that the unreferenced data store is inactive.
+        await waitForInactiveTimeout();
 
         // Make changes to the inactive data store and validate that we get the changedEvent.
         dataStore1._root.set("key", "value");
@@ -138,7 +138,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             mockLogger.matchEvents([
                 {
                     eventName: changedEvent,
-                    timeout: deleteTimeoutMs,
+                    timeout: inactiveTimeoutMs,
                     id: `/${dataStore1.id}`,
                     pkg: { value: `/${pkg}`, tag: TelemetryDataTag.PackageData },
                 },
@@ -152,7 +152,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             mockLogger.matchEvents([
                 {
                     eventName: loadedEvent,
-                    timeout: deleteTimeoutMs,
+                    timeout: inactiveTimeoutMs,
                     id: `/${dataStore1.id}`,
                 },
             ]),
@@ -172,7 +172,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             mockLogger.matchEvents([
                 {
                     eventName: revivedEvent,
-                    timeout: deleteTimeoutMs,
+                    timeout: inactiveTimeoutMs,
                     id: `/${dataStore1.id}`,
                     pkg: { value: `/${pkg}`, tag: TelemetryDataTag.PackageData },
                 },
@@ -182,8 +182,8 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
     });
 
     itExpects("can generate events when unreferenced attachment blob is accessed after it's inactive", [
-        { eventName: loadedEvent, timeout: deleteTimeoutMs },
-        { eventName: revivedEvent, timeout: deleteTimeoutMs },
+        { eventName: loadedEvent, timeout: inactiveTimeoutMs },
+        { eventName: revivedEvent, timeout: inactiveTimeoutMs },
     ], async () => {
         // Upload an attachment blobs and mark them referenced.
         const blobContents = "Blob contents";
@@ -206,8 +206,8 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
         await summarize();
         validateNoInactiveEvents();
 
-        // Wait for delete timeout. This will ensure that the unreferenced blob is inactive.
-        await waitForDeleteTimeout();
+        // Wait for inactive timeout. This will ensure that the unreferenced blob is inactive.
+        await waitForInactiveTimeout();
 
         // Retrieve the blob in the summarizer client now and validate that we get the loadedEvent.
         await summarizerBlobHandle.get();
@@ -215,7 +215,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             mockLogger.matchEvents([
                 {
                     eventName: loadedEvent,
-                    timeout: deleteTimeoutMs,
+                    timeout: inactiveTimeoutMs,
                     id: summarizerBlobHandle.absolutePath,
                 },
             ]),
@@ -229,7 +229,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             mockLogger.matchEvents([
                 {
                     eventName: revivedEvent,
-                    timeout: deleteTimeoutMs,
+                    timeout: inactiveTimeoutMs,
                     id: summarizerBlobHandle.absolutePath,
                 },
             ]),


### PR DESCRIPTION
## Description
Added a test feature flag to override the inactive timeout in GC. It can be used for following:
1.  To set it to a smaller value and validate that we don't get the inactiveObjectX events.
2. To set it to a value similar (or a little over) session expiry timeout. This will help us emulate sweep without waiting for 30 days.

Also, renamed `deleteTimeoutMs` -> `inactiveTimeoutMs` to better reflect that it means.

## PR Checklist
-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

[AB#515](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/515)