### PR TITLE
fixed fluidapp url resolver to handle oneNote links

### DIFF
--- a/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
@@ -57,7 +57,7 @@ export class FluidAppOdspUrlResolver implements IUrlResolver {
 async function initializeFluidOfficeOrOneNote(urlSource: URL): Promise<IOdspUrlParts | undefined> {
     const pathname = urlSource.pathname;
     // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-    const siteDriveItemMatch = pathname.match(/\/(p|preview|meetingnotes)\/([^/]*)\/([^/]*)\/([^/]*)/);
+    const siteDriveItemMatch = pathname.match(/\/(p|preview|meetingnotes|notes)\/([^/]*)\/([^/]*)\/([^/]*)/);
     if (siteDriveItemMatch === null) {
         return undefined;
     }


### PR DESCRIPTION
Fixed #8994 

For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)

## Description
Added `notes` to expected format of siteDriveItem so URLs can be successfully recognized and parsed.

