### PR TITLE
Bump protocol-defs dependency in driver-defs

### DIFF
--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -43,7 +43,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -191,6 +191,17 @@
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/core-interfaces": "^0.43.1000",
         "@fluidframework/protocol-definitions": "^0.1028.1000"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1028.1000",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
+          "integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        }
       }
     },
     "@fluidframework/eslint-config-fluid": {
@@ -242,9 +253,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1028.1000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-      "integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
+      "version": "0.1028.2000-68027",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000-68027.tgz",
+      "integrity": "sha512-nwOwcxq8EDN2vC26gvX/9/x75cz6/+40mTSrOud+UojI2alJ1kYXfPGy/cOjBRpLE7nS4VsFYlz+GONq+Jua0g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1"
       }

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/protocol-definitions": "^0.1028.1000"
+    "@fluidframework/protocol-definitions": "^0.1028.2000-0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",


### PR DESCRIPTION
The driver-defs dependency on protocol-defs was bumped in main, but not in next. To ease the merge, we are updating the deps on the next branch in this PR and then will publish a new driver-defs pre-release.