### PR TITLE
[GitRest] Implementing repo per doc model

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -31,6 +31,7 @@ data:
             "lib": {
                 "name": "{{ .Values.gitrest.git.lib.name }}"
             },
-            "persistLatestFullSummary": {{ .Values.gitrest.git.persistLatestFullSummary }}
+            "persistLatestFullSummary": {{ .Values.gitrest.git.persistLatestFullSummary }},
+            "repoPerDocEnabled": {{ .Values.gitrest.git.repoPerDocEnabled }}
         }
     }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -41,6 +41,7 @@ gitrest:
     lib:
       name: nodegit
     persistLatestFullSummary: false
+    repoPerDocEnabled: false
 
 gitssh:
   name: gitssh

--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -5605,6 +5605,21 @@
 			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.3.1.tgz",
 			"integrity": "sha512-zK7xap9UnttfbE23JmcrNIyueAn6jWshihJqA33U/hEnKprF/lVGBDsBv/bqLm2YMMl1DnpHhUY044eA0t1TUw=="
 		},
+		"async-mutex": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+			"integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+			"requires": {
+				"tslib": "^2.3.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -36,6 +36,7 @@
     "@fluidframework/server-services-shared": "^0.1036.4000-68094",
     "@fluidframework/server-services-telemetry": "^0.1036.4000-68094",
     "@fluidframework/server-services-utils": "^0.1036.4000-68094",
+    "async-mutex": "^0.3.2",
     "axios": "^0.26.0",
     "body-parser": "^1.17.2",
     "compression": "^1.7.3",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -23,7 +23,7 @@
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
     "start": "node dist/www.js",
-    "test": "nyc --all -x dist/test/**/* mocha dist/test -g 'Can create and retrieve a blob'",
+    "test": "nyc --all -x dist/test/**/* mocha dist/test",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -23,7 +23,7 @@
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
     "start": "node dist/www.js",
-    "test": "nyc --all -x dist/test/**/* mocha dist/test",
+    "test": "nyc --all -x dist/test/**/* mocha dist/test -g 'Can create and retrieve a blob'",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
@@ -7,13 +7,19 @@ import { ICreateBlobParams } from "@fluidframework/gitresources";
 import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
-import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory, logAndThrowApiError } from "../../utils";
+import {
+    getRepoManagerFroWriteAPI,
+    getRepoManagerParamsFromRequest,
+    IRepositoryManagerFactory,
+    logAndThrowApiError,
+} from "../../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
+    const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
     router.post("/repos/:owner/:repo/git/blobs", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = repoManagerFactory.open(repoManagerParams)
+        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createBlob(
                 request.body as ICreateBlobParams,
             )).catch((error) => logAndThrowApiError(error, request, repoManagerParams));

--- a/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
@@ -8,7 +8,7 @@ import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
-    getRepoManagerFroWriteAPI,
+    getRepoManagerFromWriteAPI,
     getRepoManagerParamsFromRequest,
     IRepositoryManagerFactory,
     logAndThrowApiError,
@@ -19,7 +19,7 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
     const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
     router.post("/repos/:owner/:repo/git/blobs", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
+        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createBlob(
                 request.body as ICreateBlobParams,
             )).catch((error) => logAndThrowApiError(error, request, repoManagerParams));

--- a/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
@@ -8,6 +8,7 @@ import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
+    getRepoManagerFroWriteAPI,
     getRepoManagerParamsFromRequest,
     IRepositoryManagerFactory,
     logAndThrowApiError,
@@ -15,12 +16,13 @@ import {
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
+    const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
     // * https://developer.github.com/v3/git/commits/
 
     router.post("/repos/:owner/:repo/git/commits", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = repoManagerFactory.open(repoManagerParams)
+        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createCommit(request.body as ICreateCommitParams))
             .catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 

--- a/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
@@ -8,7 +8,7 @@ import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
-    getRepoManagerFroWriteAPI,
+    getRepoManagerFromWriteAPI,
     getRepoManagerParamsFromRequest,
     IRepositoryManagerFactory,
     logAndThrowApiError,
@@ -22,7 +22,7 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
 
     router.post("/repos/:owner/:repo/git/commits", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
+        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createCommit(request.body as ICreateCommitParams))
             .catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 

--- a/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
@@ -11,6 +11,7 @@ import { Router } from "express";
 import nconf from "nconf";
 import {
     getExternalWriterParams,
+    getRepoManagerFroWriteAPI,
     getRepoManagerParamsFromRequest,
     IRepositoryManagerFactory,
     logAndThrowApiError,
@@ -28,6 +29,7 @@ export function create(
     repoManagerFactory: IRepositoryManagerFactory,
 ): Router {
     const router: Router = Router();
+    const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
     // https://developer.github.com/v3/git/refs/
 
@@ -53,7 +55,7 @@ export function create(
     router.post("/repos/:owner/:repo/git/refs", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
         const createRefParams = request.body as ICreateRefParamsExternal;
-        const resultP = repoManagerFactory.open(repoManagerParams)
+        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createRef(
                 createRefParams,
                 createRefParams.config,
@@ -64,7 +66,7 @@ export function create(
     router.patch("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
         const patchRefParams = request.body as IPatchRefParamsExternal;
-        const resultP = repoManagerFactory.open(repoManagerParams)
+        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.patchRef(
                 getRefId(request.params[0]),
                 patchRefParams,

--- a/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
@@ -11,7 +11,7 @@ import { Router } from "express";
 import nconf from "nconf";
 import {
     getExternalWriterParams,
-    getRepoManagerFroWriteAPI,
+    getRepoManagerFromWriteAPI,
     getRepoManagerParamsFromRequest,
     IRepositoryManagerFactory,
     logAndThrowApiError,
@@ -55,7 +55,7 @@ export function create(
     router.post("/repos/:owner/:repo/git/refs", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
         const createRefParams = request.body as ICreateRefParamsExternal;
-        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
+        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createRef(
                 createRefParams,
                 createRefParams.config,
@@ -66,7 +66,7 @@ export function create(
     router.patch("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
         const patchRefParams = request.body as IPatchRefParamsExternal;
-        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
+        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.patchRef(
                 getRefId(request.params[0]),
                 patchRefParams,

--- a/server/gitrest/packages/gitrest-base/src/routes/git/repos.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/repos.ts
@@ -18,6 +18,17 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
      */
     router.post("/:owner/repos", (request, response, next) => {
         if (repoPerDocEnabled) {
+            // GitRest now supports an alternative setup called "repo-per-doc model". In that setup,
+            // the idea is that we map Git repositories to Fluid documents - previously, we would map
+            // each repo to a tenantId, and each document would be a branch in that repo. "repo-per-doc"
+            // provides interesting advantages in terms of Git performance, Garbage Collection, etc.
+            // Traditionally, getOrCreateRepository() from services-utils would be used to create Git repos.
+            // Now, repos would be created "just in time" by GitRest Write APIs. To avoid making "repo-per-doc"
+            // a breaking change and to reduce changing components as much as possible, we scoped the change down
+            // to GitRest. In other words, getOrCreateRepository() will temporarily keep calling these "repo" APIs.
+            // But they will be no-op when `repoPerDocEnabled` is true. So in that case, we just reply with a
+            // dummy 201 response.
+            // TODO: remove this repos.ts file once Routerlicious can function without getOrCreateRepository().
             return response.status(201).send();
         }
 
@@ -41,6 +52,23 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
         const result = { name: request.params.repo };
 
         if (repoPerDocEnabled) {
+            // GitRest now supports an alternative setup called "repo-per-doc model". In that setup,
+            // the idea is that we map Git repositories to Fluid documents - previously, we would map
+            // each repo to a tenantId, and each document would be a branch in that repo. "repo-per-doc"
+            // provides interesting advantages in terms of Git performance, Garbage Collection, etc.
+            // Traditionally, getOrCreateRepository() from services-utils would be used to create Git repos.
+            // Now, repos would be created "just in time" by GitRest Write APIs. To avoid making "repo-per-doc"
+            // a breaking change and to reduce changing components as much as possible, we scoped the change down
+            // to GitRest. In other words, getOrCreateRepository() will temporarily keep calling these "repo" APIs.
+            // But they will be no-op when `repoPerDocEnabled` is true. So in that case, we just reply with a
+            // dummy 200 response. Please note that the body of the response is semantically inaccurate, though:
+            // In the "repo-per-doc" model, the repo name would be `tenantId/documentId`. Here, we are using the
+            // body from the request sent by getOrCreateRepository(), which maps to `tenantId` only.
+            // getOrCreateRepository() does not have any knowledge about documentId, which means this route
+            // does not either. Since this is just a workaround until GitRest fully uses "repo-per-doc",
+            // it's ok for the repo name in the dummy response to be inaccurate - it's actually never read by
+            // getOrCreateRepository().
+            // TODO: remove this repos.ts file once Routerlicious can function without getOrCreateRepository().
             return response.status(200).json(result);
         }
 

--- a/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
@@ -7,16 +7,22 @@ import { ICreateTagParams } from "@fluidframework/gitresources";
 import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
-import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory, logAndThrowApiError } from "../../utils";
+import {
+    getRepoManagerFroWriteAPI,
+    getRepoManagerParamsFromRequest,
+    IRepositoryManagerFactory,
+    logAndThrowApiError,
+} from "../../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
+    const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
     // https://developer.github.com/v3/git/tags/
 
     router.post("/repos/:owner/:repo/git/tags", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = repoManagerFactory.open(repoManagerParams)
+        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createTag(request.body as ICreateTagParams))
             .catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 

--- a/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
@@ -8,7 +8,7 @@ import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
-    getRepoManagerFroWriteAPI,
+    getRepoManagerFromWriteAPI,
     getRepoManagerParamsFromRequest,
     IRepositoryManagerFactory,
     logAndThrowApiError,
@@ -22,7 +22,7 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
 
     router.post("/repos/:owner/:repo/git/tags", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
+        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createTag(request.body as ICreateTagParams))
             .catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 

--- a/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
@@ -7,14 +7,20 @@ import { ICreateTreeParams } from "@fluidframework/gitresources";
 import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
-import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory, logAndThrowApiError } from "../../utils";
+import {
+    getRepoManagerFroWriteAPI,
+    getRepoManagerParamsFromRequest,
+    IRepositoryManagerFactory,
+    logAndThrowApiError,
+} from "../../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
+    const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
     router.post("/repos/:owner/:repo/git/trees", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = repoManagerFactory.open(repoManagerParams)
+        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createTree(request.body as ICreateTreeParams))
             .catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 

--- a/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
@@ -8,7 +8,7 @@ import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
-    getRepoManagerFroWriteAPI,
+    getRepoManagerFromWriteAPI,
     getRepoManagerParamsFromRequest,
     IRepositoryManagerFactory,
     logAndThrowApiError,
@@ -20,7 +20,7 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
 
     router.post("/repos/:owner/:repo/git/trees", async (request, response, next) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
+        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager) => repoManager.createTree(request.body as ICreateTreeParams))
             .catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -31,6 +31,7 @@ import {
     BaseGitRestTelemetryProperties,
     IRepoManagerParams,
     getLumberjackBasePropertiesFromRepoManagerParams,
+    getRepoManagerFroWriteAPI,
 } from "../utils";
 
 function getDocumentStorageDirectory(repoManager: IRepositoryManager, documentId: string): string {
@@ -181,6 +182,7 @@ export function create(
 ): Router {
     const router: Router = Router();
     const persistLatestFullSummary: boolean = store.get("git:persistLatestFullSummary") ?? false;
+    const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
     /**
      * Retrieves a summary.
@@ -220,7 +222,7 @@ export function create(
             return;
         }
         const wholeSummaryPayload: IWholeSummaryPayload = request.body;
-        const resultP = repoManagerFactory.open(repoManagerParams)
+        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager): Promise<IWriteSummaryResponse | IWholeFlatSummary> => createSummary(
                 repoManager,
                 fileSystemManagerFactory.create(repoManagerParams.fileSystemManagerParams),

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -31,7 +31,7 @@ import {
     BaseGitRestTelemetryProperties,
     IRepoManagerParams,
     getLumberjackBasePropertiesFromRepoManagerParams,
-    getRepoManagerFroWriteAPI,
+    getRepoManagerFromWriteAPI,
 } from "../utils";
 
 function getDocumentStorageDirectory(repoManager: IRepositoryManager, documentId: string): string {
@@ -222,7 +222,7 @@ export function create(
             return;
         }
         const wholeSummaryPayload: IWholeSummaryPayload = request.body;
-        const resultP = getRepoManagerFroWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
+        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
             .then(async (repoManager): Promise<IWriteSummaryResponse | IWholeFlatSummary> => createSummary(
                 repoManager,
                 fileSystemManagerFactory.create(repoManagerParams.fileSystemManagerParams),

--- a/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
@@ -56,6 +56,7 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
                 return new IsomorphicGitManagerFactory(
                     storageDirectoryConfig,
                     fileSystemManagerFactory,
+                    externalStorageManager,
                     repoPerDocEnabled,
                 );
             }

--- a/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
@@ -43,17 +43,20 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
         const externalStorageManager = new ExternalStorageManager(config);
         const storageDirectoryConfig: IStorageDirectoryConfig = config.get("storageDir") as IStorageDirectoryConfig;
         const gitLibrary: string | undefined = config.get("git:lib:name");
+        const repoPerDocEnabled: boolean = config.get("git:repoPerDocEnabled") ?? false;
         const getRepositoryManagerFactory = () => {
             if (!gitLibrary || gitLibrary === "nodegit") {
                 return new NodegitRepositoryManagerFactory(
                     storageDirectoryConfig,
                     fileSystemManagerFactory,
                     externalStorageManager,
+                    repoPerDocEnabled,
                 );
             } else if (gitLibrary === "isomorphic-git") {
                 return new IsomorphicGitManagerFactory(
                     storageDirectoryConfig,
                     fileSystemManagerFactory,
+                    repoPerDocEnabled,
                 );
             }
             throw new Error("Invalid git library name.");

--- a/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
@@ -218,6 +218,7 @@ testModes.forEach((mode) => {
             return new IsomorphicGitManagerFactory(
                 testUtils.defaultProvider.get("storageDir"),
                 fileSystemManagerFactory,
+                externalStorageManager,
                 testMode.repoPerDocEnabled,
             );
         }

--- a/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
@@ -141,21 +141,21 @@ const testModes: testUtils.ITestMode[] = [
         gitLibrary: "nodegit",
         repoPerDocEnabled: true,
     },
-    {
-        name: "Using NodeGit as RepoManager with repoPerDoc disabled",
-        gitLibrary: "nodegit",
-        repoPerDocEnabled: false,
-    },
-    {
-        name: "Using isomorphic-git as RepoManager with repoPerDoc enabled",
-        gitLibrary: "isomorphic-git",
-        repoPerDocEnabled: true,
-    },
-    {
-        name: "Using isomorphic-git as RepoManager with repoPerDoc disabled",
-        gitLibrary: "isomorphic-git",
-        repoPerDocEnabled: false,
-    },
+    // {
+    //     name: "Using NodeGit as RepoManager with repoPerDoc disabled",
+    //     gitLibrary: "nodegit",
+    //     repoPerDocEnabled: false,
+    // },
+    // {
+    //     name: "Using isomorphic-git as RepoManager with repoPerDoc enabled",
+    //     gitLibrary: "isomorphic-git",
+    //     repoPerDocEnabled: true,
+    // },
+    // {
+    //     name: "Using isomorphic-git as RepoManager with repoPerDoc disabled",
+    //     gitLibrary: "isomorphic-git",
+    //     repoPerDocEnabled: false,
+    // },
 ];
 
 testModes.forEach((mode) => {

--- a/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
@@ -141,21 +141,21 @@ const testModes: testUtils.ITestMode[] = [
         gitLibrary: "nodegit",
         repoPerDocEnabled: true,
     },
-    // {
-    //     name: "Using NodeGit as RepoManager with repoPerDoc disabled",
-    //     gitLibrary: "nodegit",
-    //     repoPerDocEnabled: false,
-    // },
-    // {
-    //     name: "Using isomorphic-git as RepoManager with repoPerDoc enabled",
-    //     gitLibrary: "isomorphic-git",
-    //     repoPerDocEnabled: true,
-    // },
-    // {
-    //     name: "Using isomorphic-git as RepoManager with repoPerDoc disabled",
-    //     gitLibrary: "isomorphic-git",
-    //     repoPerDocEnabled: false,
-    // },
+    {
+        name: "Using NodeGit as RepoManager with repoPerDoc disabled",
+        gitLibrary: "nodegit",
+        repoPerDocEnabled: false,
+    },
+    {
+        name: "Using isomorphic-git as RepoManager with repoPerDoc enabled",
+        gitLibrary: "isomorphic-git",
+        repoPerDocEnabled: true,
+    },
+    {
+        name: "Using isomorphic-git as RepoManager with repoPerDoc disabled",
+        gitLibrary: "isomorphic-git",
+        repoPerDocEnabled: false,
+    },
 ];
 
 testModes.forEach((mode) => {

--- a/server/gitrest/packages/gitrest-base/src/test/utils.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/utils.ts
@@ -12,9 +12,10 @@ export type gitLibType = "nodegit" | "isomorphic-git";
 export interface ITestMode {
     name: string;
     gitLibrary: gitLibType;
+    repoPerDocEnabled: boolean;
 }
 
-export const defaultProvider = new nconf.Provider({}).defaults({
+export const defaultProvider = new nconf.Provider({}).use("memory").defaults({
     logger: {
         colorize: true,
         json: false,

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -88,12 +88,19 @@ export interface IRepoManagerParams {
 export interface IRepositoryManagerFactory {
     /**
      * Create a new repository and return its manager instance.
+     * To be used when the config `repoPerDocEnabled` is false.
      */
     create(params: IRepoManagerParams): Promise<IRepositoryManager>;
     /**
      * Open an existing repository and return its manager instance.
      */
     open(params: IRepoManagerParams): Promise<IRepositoryManager>;
+    /**
+     * Tries to open a repository and return its manager instance.
+     * If it does not exist, creates a new repository.
+     * To be used when the config `repoPerDocEnabled` is true.
+     */
+     openOrCreate(params: IRepoManagerParams): Promise<IRepositoryManager>;
 }
 
 // 100644 for file (blob)

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -87,20 +87,15 @@ export interface IRepoManagerParams {
 
 export interface IRepositoryManagerFactory {
     /**
-     * Create a new repository and return its manager instance.
-     * To be used when the config `repoPerDocEnabled` is false.
+     * Tries to create a new repository and return its manager instance.
+     * If the repository already exists, then it is returned.
      */
     create(params: IRepoManagerParams): Promise<IRepositoryManager>;
     /**
      * Open an existing repository and return its manager instance.
+     * If the repository does not exist, throws an error.
      */
     open(params: IRepoManagerParams): Promise<IRepositoryManager>;
-    /**
-     * Tries to open a repository and return its manager instance.
-     * If it does not exist, creates a new repository.
-     * To be used when the config `repoPerDocEnabled` is true.
-     */
-     openOrCreate(params: IRepoManagerParams): Promise<IRepositoryManager>;
 }
 
 // 100644 for file (blob)

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -123,27 +123,24 @@ export async function retrieveLatestFullSummaryFromStorage(
 export function getRepoPath(
     repoPerDocEnabled: boolean,
     tenantId: string,
-    documentId: string,
+    documentId?: string,
     owner?: string): string {
     // `tenantId` needs to be always present and valid.
     if (!tenantId || path.parse(tenantId).dir !== "") {
-        throw new NetworkError(400, `Invalid repo name (tenantId) provided.`);
+        throw new NetworkError(400, `Invalid repo name (tenantId) provided: ${tenantId}`);
     }
 
     // When `owner` is present, it needs to be valid.
     if (owner && path.parse(owner).dir !== "") {
-        throw new NetworkError(400, `Invalid repo owner provided.`);
+        throw new NetworkError(400, `Invalid repo owner provided: ${owner}`);
     }
 
-    if (repoPerDocEnabled) {
-        // `documentId` needs to be always present and valid.
-        if (!documentId || path.parse(documentId).dir !== "") {
-            throw new NetworkError(400, `Invalid repo name (documentId) provided.`);
-        }
-        return owner ? `${owner}/${tenantId}/${documentId}` : `${tenantId}/${documentId}`;
+    // When `documentId` is present, it needs to be valid.
+    if (documentId || path.parse(documentId).dir !== "") {
+        throw new NetworkError(400, `Invalid repo name (documentId) provided: ${documentId}`);
     }
 
-    return owner ? `${owner}/${tenantId}` : tenantId;
+    return [owner, tenantId, documentId].filter(x => x !== undefined).join("/");
 }
 
 export function getGitDirectory(repoPath: string, baseDir?: string): string {

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -194,7 +194,7 @@ export function logAndThrowApiError(error: any, request: Request, params: IRepoM
     throw new NetworkError(400, `Error when processing ${request.method} request to ${request.url}`);
 }
 
-export async function getRepoManagerFroWriteAPI(
+export async function getRepoManagerFromWriteAPI(
     repoManagerFactory: IRepositoryManagerFactory,
     repoManagerParams: IRepoManagerParams,
     repoPerDocEnabled: boolean) {

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -135,7 +135,7 @@ export function getRepoPath(
     }
 
     // When `documentId` is present, it needs to be valid.
-    if (documentId || path.parse(documentId).dir !== "") {
+    if (documentId && path.parse(documentId).dir !== "") {
         throw new NetworkError(400, `Invalid repo name (documentId) provided: ${documentId}`);
     }
 

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -121,7 +121,6 @@ export async function retrieveLatestFullSummaryFromStorage(
  * Retrieves the full repository path. Or throws an error if not valid.
  */
 export function getRepoPath(
-    repoPerDocEnabled: boolean,
     tenantId: string,
     documentId?: string,
     owner?: string): string {
@@ -140,7 +139,7 @@ export function getRepoPath(
         throw new NetworkError(400, `Invalid repo name (documentId) provided: ${documentId}`);
     }
 
-    return [owner, tenantId, documentId].filter(x => x !== undefined).join("/");
+    return [owner, tenantId, documentId].filter((x) => x !== undefined).join("/");
 }
 
 export function getGitDirectory(repoPath: string, baseDir?: string): string {

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -364,7 +364,7 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
     private readonly mutexes = new Map<string, MutexInterface>();
     private readonly internalHandler: (
         params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => Promise<IsomorphicGitRepositoryManager> | never,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
         shouldUseMutex: boolean) => Promise<IsomorphicGitRepositoryManager>;
 
     constructor(
@@ -393,13 +393,6 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
                     ...(args?.lumberjackBaseProperties),
                     [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
                 });
-            const repoManager = new IsomorphicGitRepositoryManager(
-                args?.fileSystemManager,
-                params.repoOwner,
-                args?.repoName,
-                args?.directoryPath,
-                args?.lumberjackBaseProperties);
-            return repoManager;
         };
 
         return this.internalHandler(params, onRepoNotExists, true);
@@ -413,8 +406,8 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
                     ...(args?.lumberjackBaseProperties),
                     [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
                 });
-            // services-client/getOrCreateRepository depends on a 400 response code
-            throw new NetworkError(400, `Repo does not exist ${args?.directoryPath}`);
+                // services-client/getOrCreateRepository depends on a 400 response code
+                throw new NetworkError(400, `Repo does not exist ${args?.directoryPath}`);
         };
 
         return this.internalHandler(params, onRepoNotExists, false);
@@ -422,7 +415,7 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
 
     public async openOrCreate(params: IRepoManagerParams): Promise<IsomorphicGitRepositoryManager> {
         try {
-            return this.open(params);
+            return await this.open(params);
         } catch (error: any) {
             if (error instanceof Error &&
                 error?.name === "NetworkError" &&
@@ -435,7 +428,7 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
 
     private async repoPerDocInternalHandler(
         params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => Promise<IsomorphicGitRepositoryManager> | never,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
         shouldUseMutex: boolean): Promise<IsomorphicGitRepositoryManager> {
         if (!params.storageRoutingId?.tenantId || !params.storageRoutingId?.documentId) {
             throw new NetworkError(400, `Invalid ${Constants.StorageRoutingIdHeader} header`);
@@ -459,7 +452,7 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
 
     private async repoPerTenantInternalHandler(
         params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => Promise<IsomorphicGitRepositoryManager> | never,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
         shouldUseMutex: boolean): Promise<IsomorphicGitRepositoryManager> {
         const repoPath = helpers.getRepoPath(
             params.repoName,
@@ -481,7 +474,7 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
         repoPath: string,
         directoryPath: string,
         repoName: string,
-        onRepoNotExists: (args?: any) => Promise<IsomorphicGitRepositoryManager> | never,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
         shouldUseMutex: boolean): Promise<IsomorphicGitRepositoryManager> {
         const lumberjackBaseProperties = helpers.getLumberjackBasePropertiesFromRepoManagerParams(params);
         const fileSystemManager = this.fileSystemManagerFactory.create(params.fileSystemManagerParams);

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -3,24 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { E_TIMEOUT, Mutex, MutexInterface, withTimeout } from "async-mutex";
 import * as isomorphicGit from "isomorphic-git";
 import type * as resources from "@fluidframework/gitresources";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { IExternalStorageManager } from "../externalStorageManager";
 import * as helpers from "./helpers";
 import * as conversions from "./isomorphicgitConversions";
 import {
-    IRepositoryManagerFactory,
     IExternalWriterConfig,
     IRepositoryManager,
     IFileSystemManager,
     IFileSystemManagerFactory,
-    IRepoManagerParams,
     IStorageDirectoryConfig,
     BaseGitRestTelemetryProperties,
-    Constants,
 } from "./definitions";
+import { RepositoryManagerFactoryBase } from "./repositoryManagerFactoryBase";
 
 export class IsomorphicGitRepositoryManager implements IRepositoryManager {
     constructor(
@@ -359,167 +357,41 @@ export class IsomorphicGitRepositoryManager implements IRepositoryManager {
     }
 }
 
-export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
-    private readonly repositoryCache = new Set<string>();
-    private readonly mutexes = new Map<string, MutexInterface>();
-    private readonly internalHandler: (
-        params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => Promise<void> | never,
-        shouldUseMutex: boolean) => Promise<IsomorphicGitRepositoryManager>;
-
+export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<void> {
     constructor(
-        private readonly storageDirectoryConfig: IStorageDirectoryConfig,
-        private readonly fileSystemManagerFactory: IFileSystemManagerFactory,
+        storageDirectoryConfig: IStorageDirectoryConfig,
+        fileSystemManagerFactory: IFileSystemManagerFactory,
+        externalStorageManager: IExternalStorageManager,
         repoPerDocEnabled: boolean,
     ) {
-        if (repoPerDocEnabled) {
-            this.internalHandler = this.repoPerDocInternalHandler.bind(this);
-        } else {
-            this.internalHandler = this.repoPerTenantInternalHandler.bind(this);
-        }
+        super(storageDirectoryConfig, fileSystemManagerFactory, externalStorageManager, repoPerDocEnabled);
     }
 
-    public async create(params: IRepoManagerParams): Promise<IsomorphicGitRepositoryManager> {
-        const onRepoNotExists = async (args?: any) => {
-            await isomorphicGit.init({
-                fs: args?.fileSystemManager,
-                gitdir: args?.directoryPath,
-                bare: true,
-            });
-            this.repositoryCache.add(args?.repoPath);
-            Lumberjack.info(
-                "Created a new repo",
-                {
-                    ...(args?.lumberjackBaseProperties),
-                    [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
-                });
-        };
-
-        return this.internalHandler(params, onRepoNotExists, true);
+    protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<void> {
+        return isomorphicGit.init({
+            fs,
+            gitdir,
+            bare: true,
+        });
     }
 
-    public async open(params: IRepoManagerParams): Promise<IsomorphicGitRepositoryManager> {
-        const onRepoNotExists = (args?: any) => {
-            Lumberjack.error(
-                `Repo does not exist ${args?.directoryPath}`,
-                {
-                    ...(args?.lumberjackBaseProperties),
-                    [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
-                });
-                // services-client/getOrCreateRepository depends on a 400 response code
-                throw new NetworkError(400, `Repo does not exist ${args?.directoryPath}`);
-        };
-
-        return this.internalHandler(params, onRepoNotExists, false);
+    protected async openGitRepo(gitdir: string): Promise<void> {
+        return;
     }
 
-    public async openOrCreate(params: IRepoManagerParams): Promise<IsomorphicGitRepositoryManager> {
-        try {
-            return await this.open(params);
-        } catch (error: any) {
-            if (error instanceof Error &&
-                error?.name === "NetworkError" &&
-                (error as NetworkError)?.code === 400) {
-                    return this.create(params);
-            }
-            throw error;
-        }
-    }
-
-    private async repoPerDocInternalHandler(
-        params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => Promise<void> | never,
-        shouldUseMutex: boolean): Promise<IsomorphicGitRepositoryManager> {
-        if (!params.storageRoutingId?.tenantId || !params.storageRoutingId?.documentId) {
-            throw new NetworkError(400, `Invalid ${Constants.StorageRoutingIdHeader} header`);
-        }
-
-        const repoPath = helpers.getRepoPath(
-            params.storageRoutingId.tenantId,
-            params.storageRoutingId.documentId,
-            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
-        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
-        const repoName = `${params.storageRoutingId.tenantId}/${params.storageRoutingId.documentId}`;
-
-        return this.internalHandlerCore(
-            params,
-            repoPath,
-            directoryPath,
-            repoName,
-            onRepoNotExists,
-            shouldUseMutex);
-    }
-
-    private async repoPerTenantInternalHandler(
-        params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => Promise<void> | never,
-        shouldUseMutex: boolean): Promise<IsomorphicGitRepositoryManager> {
-        const repoPath = helpers.getRepoPath(
-            params.repoName,
-            undefined,
-            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
-        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
-
-        return this.internalHandlerCore(
-            params,
-            repoPath,
-            directoryPath,
-            params.repoName,
-            onRepoNotExists,
-            shouldUseMutex);
-    }
-
-    private async internalHandlerCore(
-        params: IRepoManagerParams,
-        repoPath: string,
-        directoryPath: string,
+    protected createRepoManager(
+        fileSystemManager: IFileSystemManager,
+        repoOwner: string,
         repoName: string,
-        onRepoNotExists: (args?: any) => Promise<void> | never,
-        shouldUseMutex: boolean): Promise<IsomorphicGitRepositoryManager> {
-        const lumberjackBaseProperties = helpers.getLumberjackBasePropertiesFromRepoManagerParams(params);
-        const fileSystemManager = this.fileSystemManagerFactory.create(params.fileSystemManagerParams);
-
-        // We define the function below to be able to call it either on its own or within the mutex.
-        const action = async () => {
-            if (!(this.repositoryCache.has(repoPath))) {
-                const repoExists = await helpers.exists(fileSystemManager, directoryPath);
-                if (!repoExists || !repoExists.isDirectory()) {
-                    await onRepoNotExists({
-                        fileSystemManager,
-                        repoPath,
-                        directoryPath,
-                        lumberjackBaseProperties });
-                } else {
-                    this.repositoryCache.add(repoPath);
-                }
-            }
-
-            const repoManager = new IsomorphicGitRepositoryManager(
+        repo: void,
+        gitdir: string,
+        externalStorageManager: IExternalStorageManager,
+        lumberjackBaseProperties: Record<string, any>): IRepositoryManager {
+            return new IsomorphicGitRepositoryManager(
                 fileSystemManager,
-                params.repoOwner,
+                repoOwner,
                 repoName,
-                directoryPath,
+                gitdir,
                 lumberjackBaseProperties);
-            return repoManager;
-        };
-
-        if (shouldUseMutex) {
-            if (!this.mutexes.has(repoName)) {
-                this.mutexes.set(repoName, withTimeout(new Mutex(), 10000));
-            }
-            const mutex = this.mutexes.get(repoName);
-            try {
-                return mutex.runExclusive(async () => {
-                    return action();
-                });
-            } catch (e: any) {
-                if (e === E_TIMEOUT) {
-                    throw new NetworkError(500, "Could not complete action due to mutex timeout.");
-                }
-                throw new NetworkError(500, `Unknown error when trying to run action:  ${e?.message}`);
-            }
-        } else {
-            return action();
-        }
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -416,8 +416,8 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
         shouldUseMutex: boolean) {
             const repoPath = helpers.getRepoPath(
                 this.repoPerDocEnabled,
-            params.repoName, /* tenantId */
-            params.storageRoutingId?.documentId,
+                params.repoName, /* tenantId */
+                params.storageRoutingId?.documentId,
                 this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
             const directoryPath = helpers.getGitDirectory(
                 repoPath,

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { E_TIMEOUT, Mutex, MutexInterface, withTimeout } from "async-mutex";
 import nodegit from "nodegit";
 import type * as resources from "@fluidframework/gitresources";
 import { NetworkError } from "@fluidframework/server-services-client";
@@ -12,16 +11,15 @@ import { IExternalStorageManager } from "../externalStorageManager";
 import * as helpers from "./helpers";
 import * as conversions from "./nodegitConversions";
 import {
-    IRepositoryManagerFactory,
     GitObjectType,
     IExternalWriterConfig,
     IRepositoryManager,
     IFileSystemManagerFactory,
-    IRepoManagerParams,
     IStorageDirectoryConfig,
     BaseGitRestTelemetryProperties,
-    Constants,
+    IFileSystemManager,
 } from "./definitions";
+import { RepositoryManagerFactoryBase } from "./repositoryManagerFactoryBase";
 
 export class NodegitRepositoryManager implements IRepositoryManager {
     constructor(
@@ -351,171 +349,41 @@ export class NodegitRepositoryManager implements IRepositoryManager {
     }
 }
 
-export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactory {
-    // Cache repositories to allow for reuse
-    private repositoryPCache: { [key: string]: Promise<nodegit.Repository> } = {};
-    private readonly mutexes = new Map<string, MutexInterface>();
-    private readonly internalHandler: (
-        params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => void | never,
-        shouldUseMutex: boolean) => Promise<NodegitRepositoryManager>;
-
+export class NodegitRepositoryManagerFactory extends RepositoryManagerFactoryBase<nodegit.Repository> {
     constructor(
-        private readonly storageDirectoryConfig: IStorageDirectoryConfig,
-        private readonly fileSystemManagerFactory: IFileSystemManagerFactory,
-        private readonly externalStorageManager: IExternalStorageManager,
+        storageDirectoryConfig: IStorageDirectoryConfig,
+        fileSystemManagerFactory: IFileSystemManagerFactory,
+        externalStorageManager: IExternalStorageManager,
         repoPerDocEnabled: boolean,
     ) {
-        if (repoPerDocEnabled) {
-            this.internalHandler = this.repoPerDocInternalHandler.bind(this);
-        } else {
-            this.internalHandler = this.repoPerTenantInternalHandler.bind(this);
-        }
+        super(storageDirectoryConfig, fileSystemManagerFactory, externalStorageManager, repoPerDocEnabled);
     }
 
-    public async create(params: IRepoManagerParams): Promise<NodegitRepositoryManager> {
-        const onRepoNotExists = (args?: any) => {
-            // Create and then cache the repository
-            const isBare = 1;
-            const repositoryP = nodegit.Repository.init(
-                args?.directoryPath,
-                isBare);
-            this.repositoryPCache[args?.repoPath] = repositoryP;
-            Lumberjack.info(
-                "Created a new repo",
-                {
-                    ...(args?.lumberjackBaseProperties),
-                    [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
-                });
-        };
-
-        return this.internalHandler(params, onRepoNotExists, true);
+    protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<nodegit.Repository> {
+        const isBare = 1;
+        return nodegit.Repository.init(
+            gitdir,
+            isBare);
     }
 
-    public async open(params: IRepoManagerParams): Promise<NodegitRepositoryManager> {
-        const onRepoNotExists = (args?: any) => {
-            Lumberjack.error(
-                `Repo does not exist ${args?.directoryPath}`,
-                {
-                    ...(args?.lumberjackBaseProperties),
-                    [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
-                });
-                // services-client/getOrCreateRepository depends on a 400 response code
-                throw new NetworkError(400, `Repo does not exist ${args?.directoryPath}`);
-            };
-
-        return this.internalHandler(params, onRepoNotExists, false);
+    protected async openGitRepo(gitdir: string): Promise<nodegit.Repository> {
+        return nodegit.Repository.open(gitdir);
     }
 
-    public async openOrCreate(params: IRepoManagerParams): Promise<NodegitRepositoryManager> {
-        try {
-            return await this.open(params);
-        } catch (error: any) {
-            if (error instanceof Error &&
-                error?.name === "NetworkError" &&
-                (error as NetworkError)?.code === 400) {
-                    return this.create(params);
-            }
-            throw error;
-        }
-    }
-
-    private async repoPerDocInternalHandler(
-        params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => void | never,
-        shouldUseMutex: boolean): Promise<NodegitRepositoryManager> {
-        if (!params.storageRoutingId?.tenantId || !params.storageRoutingId?.documentId) {
-            throw new NetworkError(400, `Invalid ${Constants.StorageRoutingIdHeader} header`);
-        }
-
-        const repoPath = helpers.getRepoPath(
-            params.storageRoutingId.tenantId,
-            params.storageRoutingId.documentId,
-            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
-        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
-        const repoName = `${params.storageRoutingId.tenantId}/${params.storageRoutingId.documentId}`;
-
-        return this.internalHandlerCore(
-            params,
-            repoPath,
-            directoryPath,
-            repoName,
-            onRepoNotExists,
-            shouldUseMutex);
-    }
-
-    private async repoPerTenantInternalHandler(
-        params: IRepoManagerParams,
-        onRepoNotExists: (args?: any) => void | never,
-        shouldUseMutex: boolean): Promise<NodegitRepositoryManager> {
-        const repoPath = helpers.getRepoPath(
-            params.repoName,
-            undefined,
-            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
-        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
-
-        return this.internalHandlerCore(
-            params,
-            repoPath,
-            directoryPath,
-            params.repoName,
-            onRepoNotExists,
-            shouldUseMutex);
-    }
-
-    private async internalHandlerCore(
-        params: IRepoManagerParams,
-        repoPath: string,
-        directoryPath: string,
+    protected createRepoManager(
+        fileSystemManager: IFileSystemManager,
+        repoOwner: string,
         repoName: string,
-        onRepoNotExists: (args?: any) => void | never,
-        shouldUseMutex: boolean): Promise<NodegitRepositoryManager> {
-        const lumberjackBaseProperties = helpers.getLumberjackBasePropertiesFromRepoManagerParams(params);
-        const fileSystemManager = this.fileSystemManagerFactory.create(params.fileSystemManagerParams);
-
-        // We define the function below to be able to call it either on its own or within the mutex.
-        const action = async () => {
-            if (!(repoPath in this.repositoryPCache)) {
-                const repoExists = await helpers.exists(fileSystemManager, directoryPath);
-                if (!repoExists || !repoExists.isDirectory()) {
-                    onRepoNotExists({
-                        fileSystemManager,
-                        repoPath,
-                        directoryPath,
-                        lumberjackBaseProperties });
-                } else {
-                    this.repositoryPCache[repoPath] = nodegit.Repository.open(directoryPath);
-                }
-            }
-
-            const repository = await this.repositoryPCache[repoPath];
-            const repoManager = new NodegitRepositoryManager(
-                params.repoOwner,
+        repo: nodegit.Repository,
+        gitdir: string,
+        externalStorageManager: IExternalStorageManager,
+        lumberjackBaseProperties: Record<string, any>): IRepositoryManager {
+            return new NodegitRepositoryManager(
+                repoOwner,
                 repoName,
-                repository,
-                directoryPath,
-                this.externalStorageManager,
+                repo,
+                gitdir,
+                externalStorageManager,
                 lumberjackBaseProperties);
-            return repoManager;
-        };
-
-        if (shouldUseMutex) {
-            if (!this.mutexes.has(repoName)) {
-                this.mutexes.set(repoName, withTimeout(new Mutex(), 10000));
-            }
-            const mutex = this.mutexes.get(repoName);
-            try {
-                return mutex.runExclusive(async () => {
-                    return action();
-                });
-            } catch (e: any) {
-                if (e === E_TIMEOUT) {
-                    throw new NetworkError(500, "Could not complete action due to mutex timeout.");
-                }
-                throw new NetworkError(500, `Unknown error when trying to run action:  ${e?.message}`);
-            }
-        } else {
-            return action();
-        }
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -22,8 +22,6 @@ import {
 type RepoOperationType = "create" | "open";
 
 export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepositoryManagerFactory {
-    // Cache repositories to allow for reuse
-    private readonly repositoryCache = new Map<string, TRepo>();
     // Map each mutex to one repo. We don't want to block concurrent requests on the mutex if
     // the requests are meant for different repos.
     private readonly mutexes = new Map<string, MutexInterface>();
@@ -36,6 +34,8 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
             lumberjackBaseProperties: Record<string, any>,
         ) => Promise<void> | never,
         repoOperationType: RepoOperationType) => Promise<IRepositoryManager>;
+    // Cache repositories to allow for reuse
+    protected readonly repositoryCache = new Map<string, TRepo>();
     protected abstract initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<TRepo>;
     protected abstract openGitRepo(gitdir: string): Promise<TRepo>;
     protected abstract createRepoManager(

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -1,0 +1,197 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { E_TIMEOUT, Mutex, MutexInterface, withTimeout } from "async-mutex";
+import { NetworkError } from "@fluidframework/server-services-client";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { IExternalStorageManager } from "../externalStorageManager";
+import * as helpers from "./helpers";
+import {
+    IRepositoryManagerFactory,
+    IRepositoryManager,
+    IFileSystemManager,
+    IFileSystemManagerFactory,
+    IRepoManagerParams,
+    IStorageDirectoryConfig,
+    BaseGitRestTelemetryProperties,
+    Constants,
+} from "./definitions";
+
+export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepositoryManagerFactory {
+    // Cache repositories to allow for reuse
+    private readonly repositoryCache = new Map<string, TRepo>();
+    private readonly mutexes = new Map<string, MutexInterface>();
+    private readonly internalHandler: (
+        params: IRepoManagerParams,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
+        shouldUseMutex: boolean) => Promise<IRepositoryManager>;
+    protected abstract initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<TRepo>;
+    protected abstract openGitRepo(gitdir: string): Promise<TRepo>;
+    protected abstract createRepoManager(
+        fileSystemManager: IFileSystemManager,
+        repoOwner: string,
+        repoName: string,
+        repo: TRepo,
+        gitdir: string,
+        externalStorageManager: IExternalStorageManager,
+        lumberjackBaseProperties: Record<string, any>): IRepositoryManager;
+
+    constructor(
+        private readonly storageDirectoryConfig: IStorageDirectoryConfig,
+        private readonly fileSystemManagerFactory: IFileSystemManagerFactory,
+        private readonly externalStorageManager: IExternalStorageManager,
+        repoPerDocEnabled: boolean,
+    ) {
+        if (repoPerDocEnabled) {
+            this.internalHandler = this.repoPerDocInternalHandler.bind(this);
+        } else {
+            this.internalHandler = this.repoPerTenantInternalHandler.bind(this);
+        }
+    }
+
+    public async create(params: IRepoManagerParams): Promise<IRepositoryManager> {
+        const onRepoNotExists = async (args?: any) => {
+            // Create and then cache the repository
+            const repository = await this.initGitRepo(args?.fileSystemManager, args?.directoryPath);
+            this.repositoryCache.set(args?.repoPath, repository);
+            Lumberjack.info(
+                "Created a new repo",
+                {
+                    ...(args?.lumberjackBaseProperties),
+                    [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
+                });
+        };
+
+        return this.internalHandler(params, onRepoNotExists, true);
+    }
+
+    public async open(params: IRepoManagerParams): Promise<IRepositoryManager> {
+        const onRepoNotExists = (args?: any) => {
+            Lumberjack.error(
+                `Repo does not exist ${args?.directoryPath}`,
+                {
+                    ...(args?.lumberjackBaseProperties),
+                    [BaseGitRestTelemetryProperties.directoryPath]: args?.directoryPath,
+                });
+                // services-client/getOrCreateRepository depends on a 400 response code
+                throw new NetworkError(400, `Repo does not exist ${args?.directoryPath}`);
+            };
+
+        return this.internalHandler(params, onRepoNotExists, false);
+    }
+
+    public async openOrCreate(params: IRepoManagerParams): Promise<IRepositoryManager> {
+        try {
+            return await this.open(params);
+        } catch (error: any) {
+            if (error instanceof Error &&
+                error?.name === "NetworkError" &&
+                (error as NetworkError)?.code === 400) {
+                    return this.create(params);
+            }
+            throw error;
+        }
+    }
+
+    private async repoPerDocInternalHandler(
+        params: IRepoManagerParams,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
+        shouldUseMutex: boolean): Promise<IRepositoryManager> {
+        if (!params.storageRoutingId?.tenantId || !params.storageRoutingId?.documentId) {
+            throw new NetworkError(400, `Invalid ${Constants.StorageRoutingIdHeader} header`);
+        }
+
+        const repoPath = helpers.getRepoPath(
+            params.storageRoutingId.tenantId,
+            params.storageRoutingId.documentId,
+            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
+        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
+        const repoName = `${params.storageRoutingId.tenantId}/${params.storageRoutingId.documentId}`;
+
+        return this.internalHandlerCore(
+            params,
+            repoPath,
+            directoryPath,
+            repoName,
+            onRepoNotExists,
+            shouldUseMutex);
+    }
+
+    private async repoPerTenantInternalHandler(
+        params: IRepoManagerParams,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
+        shouldUseMutex: boolean): Promise<IRepositoryManager> {
+        const repoPath = helpers.getRepoPath(
+            params.repoName,
+            undefined,
+            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
+        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
+
+        return this.internalHandlerCore(
+            params,
+            repoPath,
+            directoryPath,
+            params.repoName,
+            onRepoNotExists,
+            shouldUseMutex);
+    }
+
+    private async internalHandlerCore(
+        params: IRepoManagerParams,
+        repoPath: string,
+        directoryPath: string,
+        repoName: string,
+        onRepoNotExists: (args?: any) => Promise<void> | never,
+        shouldUseMutex: boolean): Promise<IRepositoryManager> {
+        const lumberjackBaseProperties = helpers.getLumberjackBasePropertiesFromRepoManagerParams(params);
+        const fileSystemManager = this.fileSystemManagerFactory.create(params.fileSystemManagerParams);
+
+        // We define the function below to be able to call it either on its own or within the mutex.
+        const action = async () => {
+            if (!this.repositoryCache.has(repoPath)) {
+                const repoExists = await helpers.exists(fileSystemManager, directoryPath);
+                if (!repoExists || !repoExists.isDirectory()) {
+                    await onRepoNotExists({
+                        fileSystemManager,
+                        repoPath,
+                        directoryPath,
+                        lumberjackBaseProperties });
+                } else {
+                    const repo = await this.openGitRepo(directoryPath);
+                    this.repositoryCache.set(repoPath, repo);
+                }
+            }
+
+            const repository = this.repositoryCache.get(repoPath);
+            return this.createRepoManager(
+                fileSystemManager,
+                params.repoOwner,
+                repoName,
+                repository,
+                directoryPath,
+                this.externalStorageManager,
+                lumberjackBaseProperties);
+        };
+
+        if (shouldUseMutex) {
+            if (!this.mutexes.has(repoName)) {
+                this.mutexes.set(repoName, withTimeout(new Mutex(), 10000));
+            }
+            const mutex = this.mutexes.get(repoName);
+            try {
+                return mutex.runExclusive(async () => {
+                    return action();
+                });
+            } catch (e: any) {
+                if (e === E_TIMEOUT) {
+                    throw new NetworkError(500, "Could not complete action due to mutex timeout.");
+                }
+                throw new NetworkError(500, `Unknown error when trying to run action:  ${e?.message}`);
+            }
+        } else {
+            return action();
+        }
+    }
+}

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -19,6 +19,7 @@
         "lib": {
             "name": "nodegit"
         },
-        "persistLatestFullSummary": false
+        "persistLatestFullSummary": false,
+        "repoPerDocEnabled": false
     }
 }


### PR DESCRIPTION
# [GitRest] Implementing repo per doc model

For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)

## Description

Currently, GitRest uses a "repo per tenant" model. That means that Git repos are created by GitRest as part of the Fluid server tenant creation flow. What that means is that Fluid “documents” or "containers" get translated into different “Git branches”, each one with a “ref”. One advantage of that approach is that since Git data is content-addressable, different documents within one tenant can share Git objects among them. However, we expect tenants to have thousands, if not millions of documents in FRS, and given how Fluid in general is supposed to handle massive scale traffic, other Fluid server implementations could expect the same scenarios. The problem is that Git was not implemented having thousands/millions of branches into account, and is not optimized for those scenarios, where an increasing number of branches become a bottleneck.

Therefore, this change introduces a new model for GitRest, which we call "repo per document" model. The idea is to create one Git repository per Fluid document instead of per Fluid tenant. That way, each repository will have only one branch. Some advantages of the proposed approach: 

- Performance: Git would only have to handle one branch per repository, and that can dramatically increase performance at scale. 
- Garbage Collection: it is much easier to do garbage collection on a repository with only one branch since all Git objects would only be referenced by that particular branch. It would be very inefficient to perform garbage collection on Git objects if they can be referenced by potentially thousands/millions of branches. 
- Deleting documents: the repo per doc model allows us to centralize all the data associated with a given document with one specific repository, making it easier to delete a document.

This change, on its own, is a breaking change. However, it is being introduced with an associated setting - `repoPerDocEnabled`. The setting is off by default, meaning there is no actual breaking change. Consumers of this repo can opt in by setting `repoPerDocEnabled` as true.

It is out of the scope for this PR, but in the future we aim to make a plan around how to fully transition to this new model and how to announce it as a breaking change. Transitioning to the new model will help make the code cleaner, as currently we have to support 2 scenarios (repo per tenant and repo per doc models).

A note on why this PR also adds a mutex to the `IRepositoryManagerFactory` implementations:
The fact that repositories would now be created just-in-time as part of Write APIs can introduce some complications due to race conditions. That happens, specifically, when we are dealing with “shredded” summaries in `nodegit`. When creating the initial summary, Alfred will try to upload multiple blobs at once. Even though Node.js is single threaded, the asynchronous nature of HTTP request processing can introduce race conditions. And with `nodegit`, that is a problem: when creating a Git repo, `nodegit` will create a `config.lock` file while Git Init is happening, and will fail if the file already exists. During the scenario above, of multiple, concurrent blob uploads, that `config.lock` issue is something that was observed. Therefore, our implementation will have to account for that scenario, and the proposal is to use the [async-mutex](https://www.npmjs.com/package/async-mutex) open-source package, widely used in JavaScript to help with concurrency. We will leverage async-mutex and use its mutex implementation, making sure that only one async execution context gets to try to run Git Init at a given time.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] My code follows the code style of this project.
-   [X] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [X] No (as long as `repoPerDocEnabled` is false, which is the default value).

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.

By switching `repoPerDocEnabled` to true, GitRest will start creating Git repos under `<Repo owner>/<repo name>/<documentId>` instead of `<Repo owner>/<repo name>`. Note that `<repo name>` is equivalent to `<tenantId>`.

## Testing

> -   Instructions for testing and validation of your code so the reviewer can follow those steps and validate code works as expected

Tested the changes by extending unit tests to cover the new setup (`repoPerDocEnable` === `true`) as well as running Clicker against r11s Docker + GitRest, considering all the following combinations of parameters, and verifying GitRest, Historian, Scribe and Alfred summary-related logs.

GitLib | Summary | RepoPerDoc
-- | -- | --
NodeGit | Shredded | False
NodeGit | Shredded | True
NodeGit | Whole | False
NodeGit | Whole | True
Isomorphic-Git | Shredded | False
Isomorphic-Git | Shredded | True
Isomorphic-Git | Whole | False
Isomorphic-Git | Whole | True

## Other information or known dependencies

> -   Any other information or known dependencies that is important to this PR.
> -   TODO that are to be done after this PR.

TODO: plan around how to fully transition to this new model and how to announce it as a breaking change.
