### PR TITLE
[next] Deprecate forceAccessTokenViaAuthorizationHeader in odsp host policy

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [routerlicious-host package and ContainerUrlResolver to be removed](#routerlicious-host-package-and-ContainerUrlResolver-to-be-removed)
 - [LocalReference class and method deprecations](#LocalReference-class-and-method-deprecations)
 - [Deprecated properties from ILoaderOptions](#Deprecated-properties-from-ILoaderOptions)
+- [Deprecated forceAccessTokenViaAuthorizationHeader from ICollabSessionOptions](#Deprecated-forceAccessTokenViaAuthorizationHeader-from-ICollabSessionOptions)
 
 ### Remove ICodeLoader interface
 ICodeLoader interface was deprecated a while ago and will be removed in the next release. Please refer to [replace ICodeLoader with ICodeDetailsLoader interface](#Replace-ICodeLoader-with-ICodeDetailsLoader-interface) for more details.
@@ -48,6 +49,9 @@ To support this change the following methods are deprecated with replacements th
 
  ### Deprecated properties from ILoaderOptions
 `noopTimeFrequency` and `noopCountFrequency` from `ILoaderOptions` will be deprecated and moved to `IClientConfiguration` in `@fluidframework/protocol-definitions`.
+
+### Deprecated forceAccessTokenViaAuthorizationHeader from ICollabSessionOptions
+Deprecated forceAccessTokenViaAuthorizationHeader from ICollabSessionOptions as auth token will be supplied as Header by default due to security reasons.
 
 ## 0.59 Breaking changes
 - [Removing Commit from TreeEntry and commits from SnapShotTree](#Removing-Commit-from-TreeEntry-and-commits-from-SnapShotTree)

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -38,6 +38,7 @@ export interface ICacheEntry extends IEntry {
 
 // @public (undocumented)
 export interface ICollabSessionOptions {
+    // @deprecated (undocumented)
     forceAccessTokenViaAuthorizationHeader?: boolean;
     unauthenticatedUserDisplayName?: string;
 }

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -57,6 +57,7 @@ export interface ICollabSessionOptions {
      */
     unauthenticatedUserDisplayName?: string;
     /**
+     * @deprecated - Due to security reasons we will passing the token via Authorization header only.
      * Value indicating session preference to always pass access token via Authorization header.
      * Default behavior is to pass access token via query parameter unless overall href string
      * length exceeds 2048 characters. Using query param is performance optimization which results

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -111,6 +111,10 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
                 isWithSummaryUpload: true,
             },
             async (event) => {
+                this.hostPolicy.sessionOptions = {
+                    forceAccessTokenViaAuthorizationHeader: true,
+                    ...this.hostPolicy.sessionOptions,
+                };
                 odspResolvedUrl = await createNewFluidFile(
                     toInstrumentedOdspTokenFetcher(
                         odspLogger,
@@ -183,6 +187,11 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.nonPersistentCache,
             { resolvedUrl: odspResolvedUrl, docId: odspResolvedUrl.hashedDocumentId },
             odspLogger);
+
+        this.hostPolicy.sessionOptions = {
+            forceAccessTokenViaAuthorizationHeader: true,
+            ...this.hostPolicy.sessionOptions,
+        };
 
         const storageTokenFetcher = toInstrumentedOdspTokenFetcher(
             odspLogger,


### PR DESCRIPTION
This PR will merge #10459 with the next branch.

@jatgarg Since you are the author of the original PR, please review this change. If there are any CI failures, you'll be asked to help resolve them.

**If you want to approve the PR,** please add an "Approve" review.

If the PR requires changes, either to fix CI failures or for other reasons, you can follow the instructions in the GitHub UI to check out this PR, make changes, and push them back to this PR branch.

Once approved, @tylerbutler will merge the change into the next branch.