### PR TITLE
Log GC inactive objects events only for data stores and attachment blobs

### DIFF
--- a/api-report/garbage-collector.api.md
+++ b/api-report/garbage-collector.api.md
@@ -55,6 +55,15 @@ export function runGarbageCollection(referenceGraph: {
 }, rootIds: string[], logger: ITelemetryLogger): IGCResult;
 
 // @public
+export function trimLeadingAndTrailingSlashes(str: string): string;
+
+// @public
+export function trimLeadingSlashes(str: string): string;
+
+// @public
+export function trimTrailingSlashes(str: string): string;
+
+// @public
 export function unpackChildNodesGCDetails(gcDetails: IGarbageCollectionDetailsBase): Map<string, IGarbageCollectionDetailsBase>;
 
 // @public

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -100,7 +100,7 @@ import {
     seqFromTree,
     calculateStats,
 } from "@fluidframework/runtime-utils";
-import { GCDataBuilder } from "@fluidframework/garbage-collector";
+import { GCDataBuilder, trimLeadingAndTrailingSlashes } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
 import { ContainerFluidHandleContext } from "./containerHandleContext";
 import { FluidDataStoreRegistry } from "./dataStoreRegistry";
@@ -1401,8 +1401,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
 
         const dataStoreChannel = await dataStoreContext.realize();
+
+        // Remove query params, leading and trailing slashes from the url. This is done to make sure the format is
+        // the same as GC nodes id.
+        const urlWithoutQuery = trimLeadingAndTrailingSlashes(request.url.split("?")[0]);
         this.garbageCollector.nodeUpdated(
-            `/${id}`,
+            `/${urlWithoutQuery}`,
             "Loaded",
             undefined /* timestampMs */,
             dataStoreContext.packagePath,

--- a/packages/runtime/garbage-collector/src/utils.ts
+++ b/packages/runtime/garbage-collector/src/utils.ts
@@ -12,6 +12,33 @@ import {
 } from "@fluidframework/runtime-definitions";
 
 /**
+ * Trims the leading and trailing slashes from the given string.
+ * @param str - A string that may contain leading and / or trailing slashes.
+ * @returns A new string without leading and trailing slashes.
+ */
+export function trimLeadingAndTrailingSlashes(str: string) {
+    return str.replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * Trims the leading slashes from the given string.
+ * @param str - A string that may contain leading slashes.
+ * @returns A new string without leading slashes.
+ */
+export function trimLeadingSlashes(str: string) {
+    return str.replace(/^\/+/g, "");
+}
+
+/**
+ * Trims the trailing slashes from the given string.
+ * @param str - A string that may contain trailing slashes.
+ * @returns A new string without trailing slashes.
+ */
+export function trimTrailingSlashes(str: string) {
+    return str.replace(/\/+$/g, "");
+}
+
+/**
  * Helper function that clones the GC data.
  * @param gcData - The GC data to clone.
  * @returns a clone of the given GC data.
@@ -201,19 +228,12 @@ export class GCDataBuilder implements IGarbageCollectionData {
      */
     public prefixAndAddNodes(prefixId: string, gcNodes: { [ id: string ]: string[]; }) {
         for (const [id, outboundRoutes] of Object.entries(gcNodes)) {
-            let normalizedId = id;
-            // Remove any starting slashes from the id.
-            while (normalizedId.startsWith("/")) {
-                normalizedId = normalizedId.substr(1);
-            }
-
+            // Remove any leading slashes from the id.
+            let normalizedId = trimLeadingSlashes(id);
             // Prefix the given id to the normalized id.
             normalizedId = `/${prefixId}/${normalizedId}`;
-
             // Remove any trailing slashes from the normalized id.
-            while (normalizedId.endsWith("/")) {
-                normalizedId = normalizedId.substr(0, normalizedId.length - 1);
-            }
+            normalizedId = trimTrailingSlashes(normalizedId);
 
             // Add the outbound routes against the normalized and prefixed id without duplicates.
             this.gcNodesSet[normalizedId] = new Set(outboundRoutes);

--- a/packages/runtime/garbage-collector/src/utils.ts
+++ b/packages/runtime/garbage-collector/src/utils.ts
@@ -232,7 +232,8 @@ export class GCDataBuilder implements IGarbageCollectionData {
             let normalizedId = trimLeadingSlashes(id);
             // Prefix the given id to the normalized id.
             normalizedId = `/${prefixId}/${normalizedId}`;
-            // Remove any trailing slashes from the normalized id.
+            // Remove any trailing slashes from the normalized id. Note that the trailing slashes are removed after
+            // adding the prefix for handling the special case where id is "/".
             normalizedId = trimTrailingSlashes(normalizedId);
 
             // Add the outbound routes against the normalized and prefixed id without duplicates.


### PR DESCRIPTION
## Description
This PR does a few things:
1. Filters the inactive objects telemetry in GC to log only for data stores and attachment blobs. We run GC only for these objects today and having these logs for DDSs adds noise and false positives. For example, when a data store is loaded, more often than not it will load one or more of its DDS. That should not result in these events as its false positive - it doesn't mean that a user tried to load something but rather its a side effect of loading a data store.
2. When GC is notified of an object being loaded, container runtime always only sends the data store id. So, even if a DDS is loaded, GC logs it as if its parent data store is loaded. This leads to the false positive described in 1/ above but for data stores.
3. Added the nodeType of the inactive object telemetry which will help us filter logs based on the type of node.

## PR Checklist
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

Part 2 of [AB#515](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/515).