### PR TITLE
Pending local state CI test

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1170,6 +1170,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // ...load in the existing quorum
         // Initialize the protocol handler
+        if (pendingLocalState !== undefined) {
+            throw new Error("TEST");
+        }
+
         this._protocolHandler =
             await this.initializeProtocolStateFromSnapshot(attributes, this.storageService, snapshot);
 


### PR DESCRIPTION
This is a test CI run of a regression that happened during a bad merge of `main` -> `next`. The result caused any use of pending local state in a container runtime to unconditionally fail. The only test failures manifested in the @fluid-experimental/tree package. A unit test should probably be added higher up to catch this.