### PR TITLE
Added an event with GC options and state when garbage collector loads.

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -612,7 +612,7 @@ export class GarbageCollector implements IGarbageCollector {
 
         // Log all the GC options and the state determined by the garbage collector. This is interesting only for the
         // summarizer client since it is the only one that runs GC. It also helps keep the telemetry less noisy.
-        const telemetryProps = {
+        const gcConfigProps = JSON.stringify({
             gcEnabled: this.gcEnabled,
             sweepEnabled: this.sweepEnabled,
             runGC: this.shouldRunGC,
@@ -623,9 +623,12 @@ export class GarbageCollector implements IGarbageCollector {
             inactiveTimeout: this.inactiveTimeoutMs,
             existing,
             ...this.gcOptions,
-        };
+        });
         if (this.isSummarizerClient) {
-            this.mc.logger.sendTelemetryEvent({ eventName: "GarbageCollectorLoaded", ...telemetryProps });
+            this.mc.logger.sendTelemetryEvent({
+                eventName: "GarbageCollectorLoaded",
+                gcConfigs: gcConfigProps,
+            });
         }
 
         // Initialize the base state that is used to detect when inactive objects are used.
@@ -635,7 +638,7 @@ export class GarbageCollector implements IGarbageCollector {
                     error,
                     "FailedToInitializeGC",
                 );
-                dpe.addTelemetryProperties(telemetryProps);
+                dpe.addTelemetryProperties({ gcConfigs: gcConfigProps });
                 throw dpe;
             });
         }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -610,6 +610,24 @@ export class GarbageCollector implements IGarbageCollector {
             return baseGCDetailsMap;
         });
 
+        // Log all the GC options and the state determined by the garbage collector. This is interesting only for the
+        // summarizer client since it is the only one that runs GC. It also helps keep the telemetry less noisy.
+        const telemetryProps = {
+            gcEnabled: this.gcEnabled,
+            sweepEnabled: this.sweepEnabled,
+            runGC: this.shouldRunGC,
+            runSweep: this.shouldRunSweep,
+            writeAtRoot: this._writeDataAtRoot,
+            testMode: this.testMode,
+            sessionExpiry: this.sessionExpiryTimeoutMs,
+            inactiveTimeout: this.inactiveTimeoutMs,
+            existing,
+            ...this.gcOptions,
+        };
+        if (this.isSummarizerClient) {
+            this.mc.logger.sendTelemetryEvent({ eventName: "GarbageCollectorLoaded", ...telemetryProps });
+        }
+
         // Initialize the base state that is used to detect when inactive objects are used.
         if (this.shouldRunGC) {
             this.initializeBaseStateP.catch((error) => {
@@ -617,16 +635,7 @@ export class GarbageCollector implements IGarbageCollector {
                     error,
                     "FailedToInitializeGC",
                 );
-                dpe.addTelemetryProperties({
-                    gcEnabled: this.gcEnabled,
-                    sweepEnabled: this.sweepEnabled,
-                    runGC: this.shouldRunGC,
-                    runSweep: this.shouldRunSweep,
-                    writeAtRoot: this._writeDataAtRoot,
-                    testMode: this.testMode,
-                    sessionExpiry: this.sessionExpiryTimeoutMs,
-                    inactiveTimeout: this.inactiveTimeoutMs,
-                });
+                dpe.addTelemetryProperties(telemetryProps);
                 throw dpe;
             });
         }


### PR DESCRIPTION
## Description
Added an event after the garbage collector is loaded. This contains the GC options that are provided to the container runtime as well as the state determined by GC based on feature flags and / or the metadata blob in the base summary. This will help in debugging when looking at telemetry. For example, we found a bug in the past which was due to the GC data moved to the root of the summary tree and it would have helped to know which summarizer clients had this option on vs off.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
