### PR TITLE
Add telemetry in odsp driver for server_disconnect and nack

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -560,7 +560,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                         if (nackContent !== undefined) {
                             this.logger.sendTelemetryEvent({
                                 eventName: "ServerNack",
-                                ...nackContent,
+                                nackDetails: JSON.stringify(nackContent),
                             });
                         }
                         this.emit("nack", clientIdOrDocumentId, message);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -558,9 +558,11 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                         (this.hasDetails && clientIdOrDocumentId === this.clientId)) {
                         const nackContent = message[0]?.content;
                         if (nackContent !== undefined) {
+                            const { code, type, message, retryAfter } = nackContent;
                             this.logger.sendTelemetryEvent({
                                 eventName: "ServerNack",
-                                nackDetails: JSON.stringify(nackContent),
+                                details: JSON.stringify({ code, type, message }),
+                                retryAfterSeconds: retryAfter,
                             });
                         }
                         this.emit("nack", clientIdOrDocumentId, message);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -552,11 +552,11 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 
             case "nack":
                 // per client / document nack handling
-                super.addTrackedListener(event, (clientIdOrDocumentId: string, message: INack[]) => {
+                super.addTrackedListener(event, (clientIdOrDocumentId: string, nacks: INack[]) => {
                     if (clientIdOrDocumentId.length === 0 ||
                         clientIdOrDocumentId === this.documentId ||
                         (this.hasDetails && clientIdOrDocumentId === this.clientId)) {
-                        const nackContent = message[0]?.content;
+                        const nackContent = nacks[0]?.content;
                         if (nackContent !== undefined) {
                             const { code, type, message, retryAfter } = nackContent;
                             this.logger.sendTelemetryEvent({
@@ -567,7 +567,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                                 retryAfterSeconds: retryAfter,
                             });
                         }
-                        this.emit("nack", clientIdOrDocumentId, message);
+                        this.emit("nack", clientIdOrDocumentId, nacks);
                     }
                 });
                 break;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -561,7 +561,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                             const { code, type, message, retryAfter } = nackContent;
                             this.logger.sendTelemetryEvent({
                                 eventName: "ServerNack",
-                                details: JSON.stringify({ code, type, message }),
+                                code,
+                                type,
+                                message,
                                 retryAfterSeconds: retryAfter,
                             });
                         }

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -440,7 +440,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     }
 
     protected serverDisconnectHandler = (error: IFluidErrorBase & OdspError) => {
-        this.logger.sendTelemetryEvent({eventName: "ServerDisconnectOdsp"}, error);
+        this.logger.sendTelemetryEvent({ eventName: "ServerDisconnectOdsp" }, error);
         this.disposeCore(true, error);
     };
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -440,7 +440,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     }
 
     protected serverDisconnectHandler = (error: IFluidErrorBase & OdspError) => {
-        this.logger.sendTelemetryEvent({ eventName: "ServerDisconnectOdsp" }, error);
+        this.logger.sendTelemetryEvent({ eventName: "ServerDisconnect" }, error);
         this.disposeCore(true, error);
     };
 
@@ -559,7 +559,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                         const nackContent = message[0]?.content;
                         if (nackContent !== undefined) {
                             this.logger.sendTelemetryEvent({
-                                eventName: "ServerNackOdsp",
+                                eventName: "ServerNack",
                                 ...nackContent,
                             });
                         }

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -440,6 +440,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     }
 
     protected serverDisconnectHandler = (error: IFluidErrorBase & OdspError) => {
+        this.logger.sendTelemetryEvent({eventName: "ServerDisconnectOdsp"}, error);
         this.disposeCore(true, error);
     };
 
@@ -555,6 +556,13 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                     if (clientIdOrDocumentId.length === 0 ||
                         clientIdOrDocumentId === this.documentId ||
                         (this.hasDetails && clientIdOrDocumentId === this.clientId)) {
+                        const nackContent = message[0]?.content;
+                        if (nackContent !== undefined) {
+                            this.logger.sendTelemetryEvent({
+                                eventName: "ServerNackOdsp",
+                                ...nackContent,
+                            });
+                        }
                         this.emit("nack", clientIdOrDocumentId, message);
                     }
                 });


### PR DESCRIPTION
https://dev.azure.com/fluidframework/internal/_boards/board/t/Team%20Vlad/Features/?workitem=238

## Description
Add telemetry for "server_disconnect" and "nack" inside the odsp driver to see the correlation with Transport close disconnects from the server. This could help to see if we are indeed seeing these disconnect reasons in loader telemetry before the Transport close by the socket.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
