### PR TITLE
Preserve the value of isClpCompliantApp on resolved url in odsp

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -40,6 +40,7 @@ import { OdspDriverUrlResolver } from "./odspDriverUrlResolver";
 import { convertCreateNewSummaryTreeToTreeAndBlobs } from "./createNewUtils";
 import { runWithRetry } from "./retryUtils";
 import { pkgVersion as driverVersion } from "./packageVersion";
+import { ClpCompliantAppHeader } from "./contractsPublic";
 
 const isInvalidFileName = (fileName: string): boolean => {
     const invalidCharsRegex = /["*/:<>?\\|]+/g;
@@ -59,6 +60,7 @@ export async function createNewFluidFile(
     fileEntry: IFileEntry,
     createNewCaching: boolean,
     forceAccessTokenViaAuthorizationHeader: boolean,
+    isClpCompliantApp?: boolean,
 ): Promise<IOdspResolvedUrl> {
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
@@ -91,7 +93,10 @@ export async function createNewFluidFile(
 
     const odspUrl = createOdspUrl({ ... newFileInfo, itemId, dataStorePath: "/" });
     const resolver = new OdspDriverUrlResolver();
-    const odspResolvedUrl = await resolver.resolve({ url: odspUrl });
+    const odspResolvedUrl = await resolver.resolve({
+        url: odspUrl,
+        headers: { [ClpCompliantAppHeader.isClpCompliantApp]: isClpCompliantApp },
+    });
     fileEntry.docId = odspResolvedUrl.hashedDocumentId;
     fileEntry.resolvedUrl = odspResolvedUrl;
 

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -129,6 +129,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
                     fileEntry,
                     this.hostPolicy.cacheCreateNewSummary ?? true,
                     !!this.hostPolicy.sessionOptions?.forceAccessTokenViaAuthorizationHeader,
+                    odspResolvedUrl.isClpCompliantApp,
                 );
                 const docService = this.createDocumentServiceCore(odspResolvedUrl, odspLogger,
                     cacheAndTracker, clientIsSummarizer);

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -51,6 +51,22 @@ describe("Create New Utils Tests", () => {
         return summary;
     };
 
+    const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
+    const driveId = "driveId";
+    const itemId = "itemId";
+    const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
+    const filePath = "path";
+    let newFileParams: INewFileInfo;
+
+    beforeEach(async () => {
+        newFileParams = {
+            driveId,
+            siteUrl,
+            filePath,
+            filename: "filename",
+        };
+    });
+
     const test = (snapshot: ISnapshotContents) => {
         const snapshotTree = snapshot.snapshotTree;
         assert.strictEqual(Object.entries(snapshotTree.trees).length, 2, "app and protocol should be there");
@@ -83,11 +99,7 @@ describe("Create New Utils Tests", () => {
     });
 
     it("Should cache converted summary during createNewFluidFile", async () => {
-        const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
-        const driveId = "driveId";
-        const itemId = "itemId";
         const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
-        const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
         const localCache = createUtLocalCache();
         // use null logger here as we expect errors
         const epochTracker = new EpochTracker(
@@ -97,14 +109,6 @@ describe("Create New Utils Tests", () => {
                 resolvedUrl,
             },
             new TelemetryNullLogger());
-
-        const filePath = "path";
-        const newFileParams: INewFileInfo = {
-            driveId,
-            siteUrl: "https://www.localhost.xxx",
-            filePath,
-            filename: "filename",
-        };
 
         const fileEntry: IFileEntry = {
             docId: hashedDocumentId,
@@ -131,12 +135,9 @@ describe("Create New Utils Tests", () => {
     });
 
     it("Should save share link information received during createNewFluidFile", async () => {
-        const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
-        const driveId = "driveId";
-        const itemId = "itemId";
         const createLinkType = ShareLinkTypes.csl;
         const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
-        const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
+
         // use null logger here as we expect errors
         const epochTracker = new EpochTracker(
             createUtLocalCache(),
@@ -146,13 +147,7 @@ describe("Create New Utils Tests", () => {
             },
             new TelemetryNullLogger());
 
-        const newFileParams: INewFileInfo = {
-            driveId,
-            siteUrl: "https://www.localhost.xxx",
-            filePath: "path",
-            filename: "filename",
-            createLinkType,
-        };
+        newFileParams.createLinkType = createLinkType;
 
         const fileEntry: IFileEntry = {
             docId: hashedDocumentId,
@@ -203,5 +198,57 @@ describe("Create New Utils Tests", () => {
             error: mockError,
         });
         await epochTracker.removeEntries().catch(() => {});
+    });
+
+    it("Should set the isClpCompliantApp prop on resolved url if already present", async () => {
+        const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
+        const localCache = createUtLocalCache();
+        // use null logger here as we expect errors
+        const epochTracker = new EpochTracker(
+            localCache,
+            {
+                docId: hashedDocumentId,
+                resolvedUrl,
+            },
+            new TelemetryNullLogger());
+
+        const fileEntry: IFileEntry = {
+            docId: hashedDocumentId,
+            resolvedUrl,
+        };
+
+        const odspResolvedUrl1 = await mockFetchOk(
+                async () => createNewFluidFile(
+                    async (_options) => "token",
+                    newFileParams,
+                    new TelemetryNullLogger(),
+                    createSummary(),
+                    epochTracker,
+                    fileEntry,
+                    true,
+                    false,
+                    true /* isClpCompliantApp */,
+                ),
+                { itemId: "itemId1", id: "Summary handle" },
+                { "x-fluid-epoch": "epoch1" },
+                );
+        assert(odspResolvedUrl1.isClpCompliantApp, "isClpCompliantApp should be set");
+
+        const odspResolvedUrl2 = await mockFetchOk(
+            async () => createNewFluidFile(
+                async (_options) => "token",
+                newFileParams,
+                new TelemetryNullLogger(),
+                createSummary(),
+                epochTracker,
+                fileEntry,
+                true,
+                false,
+                undefined /* isClpCompliantApp */,
+            ),
+            { itemId: "itemId1", id: "Summary handle" },
+            { "x-fluid-epoch": "epoch1" },
+            );
+    assert(!odspResolvedUrl2.isClpCompliantApp, "isClpCompliantApp should be falsy");
     });
 });

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -51,22 +51,6 @@ describe("Create New Utils Tests", () => {
         return summary;
     };
 
-    const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
-    const driveId = "driveId";
-    const itemId = "itemId";
-    const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
-    const filePath = "path";
-    let newFileParams: INewFileInfo;
-
-    beforeEach(async () => {
-        newFileParams = {
-            driveId,
-            siteUrl,
-            filePath,
-            filename: "filename",
-        };
-    });
-
     const test = (snapshot: ISnapshotContents) => {
         const snapshotTree = snapshot.snapshotTree;
         assert.strictEqual(Object.entries(snapshotTree.trees).length, 2, "app and protocol should be there");
@@ -99,7 +83,11 @@ describe("Create New Utils Tests", () => {
     });
 
     it("Should cache converted summary during createNewFluidFile", async () => {
+        const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
+        const driveId = "driveId";
+        const itemId = "itemId";
         const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
+        const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
         const localCache = createUtLocalCache();
         // use null logger here as we expect errors
         const epochTracker = new EpochTracker(
@@ -109,6 +97,14 @@ describe("Create New Utils Tests", () => {
                 resolvedUrl,
             },
             new TelemetryNullLogger());
+
+        const filePath = "path";
+        const newFileParams: INewFileInfo = {
+            driveId,
+            siteUrl: "https://www.localhost.xxx",
+            filePath,
+            filename: "filename",
+        };
 
         const fileEntry: IFileEntry = {
             docId: hashedDocumentId,
@@ -135,9 +131,12 @@ describe("Create New Utils Tests", () => {
     });
 
     it("Should save share link information received during createNewFluidFile", async () => {
+        const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
+        const driveId = "driveId";
+        const itemId = "itemId";
         const createLinkType = ShareLinkTypes.csl;
         const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
-
+        const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
         // use null logger here as we expect errors
         const epochTracker = new EpochTracker(
             createUtLocalCache(),
@@ -147,7 +146,13 @@ describe("Create New Utils Tests", () => {
             },
             new TelemetryNullLogger());
 
-        newFileParams.createLinkType = createLinkType;
+        const newFileParams: INewFileInfo = {
+            driveId,
+            siteUrl: "https://www.localhost.xxx",
+            filePath: "path",
+            filename: "filename",
+            createLinkType,
+        };
 
         const fileEntry: IFileEntry = {
             docId: hashedDocumentId,
@@ -198,57 +203,5 @@ describe("Create New Utils Tests", () => {
             error: mockError,
         });
         await epochTracker.removeEntries().catch(() => {});
-    });
-
-    it("Should set the isClpCompliantApp prop on resolved url if already present", async () => {
-        const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
-        const localCache = createUtLocalCache();
-        // use null logger here as we expect errors
-        const epochTracker = new EpochTracker(
-            localCache,
-            {
-                docId: hashedDocumentId,
-                resolvedUrl,
-            },
-            new TelemetryNullLogger());
-
-        const fileEntry: IFileEntry = {
-            docId: hashedDocumentId,
-            resolvedUrl,
-        };
-
-        const odspResolvedUrl1 = await mockFetchOk(
-                async () => createNewFluidFile(
-                    async (_options) => "token",
-                    newFileParams,
-                    new TelemetryNullLogger(),
-                    createSummary(),
-                    epochTracker,
-                    fileEntry,
-                    true,
-                    false,
-                    true /* isClpCompliantApp */,
-                ),
-                { itemId: "itemId1", id: "Summary handle" },
-                { "x-fluid-epoch": "epoch1" },
-                );
-        assert(odspResolvedUrl1.isClpCompliantApp, "isClpCompliantApp should be set");
-
-        const odspResolvedUrl2 = await mockFetchOk(
-            async () => createNewFluidFile(
-                async (_options) => "token",
-                newFileParams,
-                new TelemetryNullLogger(),
-                createSummary(),
-                epochTracker,
-                fileEntry,
-                true,
-                false,
-                undefined /* isClpCompliantApp */,
-            ),
-            { itemId: "itemId1", id: "Summary handle" },
-            { "x-fluid-epoch": "epoch1" },
-            );
-    assert(!odspResolvedUrl2.isClpCompliantApp, "isClpCompliantApp should be falsy");
     });
 });


### PR DESCRIPTION
(https://dev.azure.com/fluidframework/internal/_workitems/edit/422/)

For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)

Description
Preserve the value of isClpCompliantApp on resolved url in odsp in create new case as it was not getting persisted. Its value was not set on the header of the request to be resolved so it was getting lost.

PR Checklist

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
