### PR TITLE
Fix merge-tree conflict resolution inconsistency

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1960,7 +1960,7 @@ export class MergeTree {
         newSegments: T[],
     ) {
         let segIsLocal = false;
-        const checkSegmentIsLocal = (segment: ISegment, _pos: number, _refSeq: number, _clientId: number) => {
+        const checkSegmentIsLocal = (segment: ISegment) => {
             if (segment.seq === UnassignedSequenceNumber) {
                 segIsLocal = true;
             }
@@ -2110,9 +2110,11 @@ export class MergeTree {
         }
     }
 
-    // Visit segments starting from node's right siblings, then up to node's parent
-    private rightExcursion(node: IMergeNode, leafAction: ISegmentAction<undefined>) {
-        const actions = { leaf: leafAction };
+    /**
+     * Visit segments starting from node's right siblings, then up to node's parent.
+     * All segments past `node` are visited, regardless of their visibility.
+     */
+    private rightExcursion(node: IMergeNode, leafAction: (seg: ISegment) => boolean) {
         let go = true;
         let startNode = node;
         let parent = startNode.parent;
@@ -2126,10 +2128,9 @@ export class MergeTree {
                 if (matchedStart) {
                     if (!_node.isLeaf()) {
                         const childBlock = _node;
-                        go = this.nodeMap(childBlock, actions, 0, UniversalSequenceNumber, this.collabWindow.clientId,
-                            undefined);
+                        go = this.walkAllSegments(childBlock, leafAction);
                     } else {
-                        go = leafAction(_node, 0, UniversalSequenceNumber, this.collabWindow.clientId, 0, 0, undefined);
+                        go = leafAction(_node);
                     }
                     if (!go) {
                         return;

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -260,4 +260,73 @@ describe("MergeTree.insertingWalk", () => {
             });
         });
     });
+
+    it("handles conflicts involving removed segments across block boundaries", () => {
+        let initialText = "0";
+        let seq = 0;
+        const mergeTree = new MergeTree();
+        mergeTree.startCollaboration(localClientId, 0, seq);
+        mergeTree.insertSegments(
+            0,
+            [TextSegment.make(initialText)],
+            UniversalSequenceNumber,
+            localClientId,
+            UniversalSequenceNumber,
+            undefined);
+        for (let i = 1; i < MaxNodesInBlock; i++) {
+            const text = String.fromCharCode(i + 64);
+            insertText(
+                mergeTree,
+                0,
+                UniversalSequenceNumber,
+                localClientId,
+                UnassignedSequenceNumber,
+                text,
+                undefined,
+                undefined);
+            initialText += text;
+        }
+
+        const textHelper = new MergeTreeTextHelper(mergeTree);
+
+        // Two blocks
+        assert.equal(textHelper.getText(0, localClientId), "GFEDCBA0");
+        // Remove "DCBA"
+        mergeTree.markRangeRemoved(
+            3,
+            7,
+            UniversalSequenceNumber,
+            localClientId,
+            UnassignedSequenceNumber,
+            false,
+            undefined as any
+        );
+        assert.equal(textHelper.getText(0, localClientId), "GFE0");
+        // Simulate another client inserting concurrently with the above operations. Because
+        // all segments but the 0 are unacked, this insert should place the segment directly
+        // before the 0. Prior to this regression test, an issue with `rightExcursion` in the
+        // merge conflict logic instead caused the segment to be placed before the removed segments.
+        insertText(
+            mergeTree,
+            0,
+            UniversalSequenceNumber,
+            localClientId + 1,
+            ++seq,
+            "x",
+        );
+
+        const segments: string[] = [];
+        mergeTree.walkAllSegments(mergeTree.root, (seg) => {
+            if (TextSegment.is(seg)) {
+                if (seg.localRemovedSeq !== undefined || seg.removedSeq !== undefined) {
+                    segments.push(`(${seg.text})`);
+                } else {
+                    segments.push(seg.text);
+                }
+            }
+            return true;
+        });
+
+        assert.deepStrictEqual(segments, ["G", "F", "E", "(D)", "(C)", "(B)", "(A)", "x", "0"]);
+    });
 });

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -289,7 +289,7 @@ describe("MergeTree.insertingWalk", () => {
 
         const textHelper = new MergeTreeTextHelper(mergeTree);
 
-        // Two blocks
+        assert.equal(mergeTree.root.childCount, 2);
         assert.equal(textHelper.getText(0, localClientId), "GFEDCBA0");
         // Remove "DCBA"
         mergeTree.markRangeRemoved(
@@ -299,7 +299,7 @@ describe("MergeTree.insertingWalk", () => {
             localClientId,
             UnassignedSequenceNumber,
             false,
-            undefined as any
+            undefined as any,
         );
         assert.equal(textHelper.getText(0, localClientId), "GFE0");
         // Simulate another client inserting concurrently with the above operations. Because


### PR DESCRIPTION
Resolves an issue with consistency of where a segment gets inserted when its insertion point conflicts with locally-removed segments across a merge-tree block boundary. Add a merge-tree regression test with more details.