### PR TITLE
Fix bundle size test after webpack 5 update

### DIFF
--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -40,7 +40,8 @@ module.exports = {
     extensions: ['.tsx', '.ts', '.js'],
   },
   output: {
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
+    library: 'bundle',
   },
   node: false,
   plugins: [


### PR DESCRIPTION
PR #10186 upgraded to webpack 5, which caused the output of the bundle-size-test to be all 23 bytes with all export removed.

See https://github.com/microsoft/FluidFramework/pull/10186#issuecomment-1121833208

Adding `output.library` in the webpack config fixes the issue.