### PR TITLE
build-tools: bundle size test sanity check

### DIFF
--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = {
       analyzerMode: 'static',
       reportFilename: path.resolve(process.cwd(), 'bundleAnalysis/report.html'),
       openAnalyzer: false,
-      generateStatsFile: false,
+      generateStatsFile: true,
       statsFilename: path.resolve(process.cwd(), 'bundleAnalysis/report.json')
     }),
     // Plugin that generates a compressed version of the stats file that can be uploaded to blob storage

--- a/tools/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
+++ b/tools/build-tools/src/bundleSizeAnalysis/collectBundleAnalyses.ts
@@ -7,25 +7,23 @@ import * as child_process from "child_process";
 import * as fse from "fs-extra";
 import * as path from "path";
 
+// The smallest asset size that we deems to be correct. Adjust if we are testing for assets that are smaller.
+const smallestAssetSize = 100;
+
 // Find all bundle analysis artifacts and copy them into a central
 // location to upload as build artifacts for later consumption
 function main() {
     // Get all the package locations
-    let lernaOutput;
-    try {
-        lernaOutput = JSON.parse(child_process.execSync("npx lerna list --all --json").toString());
-        if (!Array.isArray(lernaOutput)) {
-            throw new Error("failed to get package information");
-        }
-    } catch (e) {
-        console.error(e);
-        process.exit(-1);
+    const lernaOutput = JSON.parse(child_process.execSync("npx lerna list --all --json").toString());
+    if (!Array.isArray(lernaOutput)) {
+        throw new Error("failed to get package information");
     }
 
     // Check each package location for a bundleAnalysis folder
     // and copy it to a central location
+    let hasSmallAssetError = false;
     const analysesDestPath = path.join(process.cwd(), "artifacts/bundleAnalysis");
-    lernaOutput.forEach((pkg: {name: string, location: string}) => {
+    lernaOutput.forEach((pkg: { name: string, location: string }) => {
         if (pkg.location === undefined) {
             console.error("missing location in lerna package entry");
             process.exit(-1);
@@ -33,15 +31,40 @@ function main() {
 
         const packageAnalysisPath = path.join(pkg.location, "bundleAnalysis");
         if (fse.existsSync(packageAnalysisPath)) {
-            try {
-                console.log(`found bundleAnalysis for ${pkg.name}`);
-                fse.copySync(packageAnalysisPath, path.join(analysesDestPath, pkg.name), {recursive: true});
-            } catch (e) {
-                console.error(e);
-                process.exit(-1);
+            console.log(`found bundleAnalysis for ${pkg.name}`);
+
+            // Check if we successfully generated any assets
+            const reportPath = path.join(packageAnalysisPath, "report.json");
+            if (!fse.existsSync(reportPath)) {
+                throw new Error(`${reportPath} is missing, cannot verify bundel analysis correctness`);
             }
+
+            const report = fse.readJSONSync(reportPath);
+            if (!report.assets?.length) {
+                throw new Error(`${reportPath} doesn't have any assets info`);
+            }
+            for (const asset of report.assets) {
+                if (!asset.chunkNames?.length) {
+                    // Assets without chunkNAmes are not code files
+                    continue;
+                }
+                if (asset.size < smallestAssetSize) {
+                    console.warn(`${pkg.name}: asset ${asset.name} (${asset.size}) is too small`);
+                    hasSmallAssetError = true;
+                }
+            }
+            fse.copySync(packageAnalysisPath, path.join(analysesDestPath, pkg.name), { recursive: true });
         }
     });
+
+    if (hasSmallAssetError) {
+        throw new Error(`Found assets are too small (<${smallestAssetSize} bytes). Webpack bundle analysis is probably not correct.`);
+    }
 }
 
-main();
+try {
+    main();
+} catch (e) {
+    console.error(e);
+    process.exit(-1);
+}


### PR DESCRIPTION
Follow up to PR #10502, where we broke the bundle size test.

This change updates the tools to include some sanity check by processing the generated stats file and error if the asset size being tested is smaller than certain threshold (currently set at 100 bytes).

Note that the build tool package will need to be published and updated in the core packages mono repo before this will take effect.

Example output of the tool if the fix for #10502 is removed:
```
found bundleAnalysis for @fluid-example/bundle-size-tests
@fluid-example/bundle-size-tests: asset aqueduct.js (23) is too small
@fluid-example/bundle-size-tests: asset connectionState.js (23) is too small
@fluid-example/bundle-size-tests: asset containerRuntime.js (23) is too small
@fluid-example/bundle-size-tests: asset loader.js (23) is too small
@fluid-example/bundle-size-tests: asset map.js (23) is too small
@fluid-example/bundle-size-tests: asset matrix.js (23) is too small
@fluid-example/bundle-size-tests: asset odspDriver.js (23) is too small
@fluid-example/bundle-size-tests: asset odspPrefetchSnapshot.js (23) is too small
@fluid-example/bundle-size-tests: asset sharedString.js (23) is too small
Error: Found assets are too small (<100 bytes). Webpack bundle analysis is probably not correct.
```