### PR TITLE
Fix reconnection threshold for the container runtime progress tracking

### DIFF
--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -639,12 +639,17 @@ describe("Runtime", () => {
                 return runtime as ContainerRuntime;
             }
 
+            const toggleConnection = (runtime: ContainerRuntime) => {
+                runtime.setConnectionState(false);
+                runtime.setConnectionState(true);
+            };
+
             it(`No progress for ${maxReconnects} connection state changes and pending state will ` +
                 "close the container", async () => {
                     patchRuntime(getMockPendingStateManager(true /* always has pending messages */));
 
                     for (let i = 0; i < maxReconnects; i++) {
-                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                        toggleConnection(containerRuntime);
                     }
 
                     const error = getFirstContainerError();
@@ -661,7 +666,7 @@ describe("Runtime", () => {
                     patchRuntime(getMockPendingStateManager(true /* always has pending messages */));
 
                     for (let i = 0; i < maxReconnects / 2; i++) {
-                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                        toggleConnection(containerRuntime);
                     }
 
                     assert.equal(containerErrors.length, 0);
@@ -678,7 +683,7 @@ describe("Runtime", () => {
                         -1 /* maxConsecutiveReplays */);
 
                     for (let i = 0; i < maxReconnects; i++) {
-                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                        toggleConnection(containerRuntime);
                     }
 
                     assert.equal(containerErrors.length, 0);
@@ -690,7 +695,7 @@ describe("Runtime", () => {
                     patchRuntime(getMockPendingStateManager(false /* always has no pending messages */));
 
                     for (let i = 0; i < maxReconnects; i++) {
-                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                        toggleConnection(containerRuntime);
                     }
 
                     assert.equal(containerErrors.length, 0);
@@ -722,8 +727,7 @@ describe("Runtime", () => {
                     patchRuntime(getMockPendingStateManager(true /* always has pending messages */));
 
                     for (let i = 0; i < maxReconnects; i++) {
-                        containerRuntime.setConnectionState(false);
-                        containerRuntime.setConnectionState(true);
+                        toggleConnection(containerRuntime);
                         containerRuntime.process({
                             type: "op",
                             clientId: "clientId",


### PR DESCRIPTION
# [ADO:357](https://dev.azure.com/fluidframework/internal/_workitems/edit/357/)

## Description

The existing code was tracking _any_ connection transition, instead of actual reconnections. So, for example if the reconnection threshold was 15, the container would close after only 8 reconnections. This PR fixes it, thus 'increasing' the threshold to the actual default value of 15.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

