### PR TITLE
Throw for non retriable error in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -43,8 +43,8 @@ export async function runWithRetry<T>(
 
             const coherencyError = error?.[Odsp409Error] === true;
             const serviceReadonlyError = error?.errorType === OdspErrorType.serviceReadOnly;
-            // Retry for 409 coherency errors or serviceReadOnly errors.
-            if (!(coherencyError || serviceReadonlyError)) {
+            // Retry for retriable 409 coherency errors or serviceReadOnly errors.
+            if (!(coherencyError || serviceReadonlyError || canRetry)) {
                 throw error;
             }
 
@@ -66,7 +66,6 @@ export async function runWithRetry<T>(
                 throw error;
             }
 
-            assert(canRetry, 0x24d /* "can retry" */);
             await delay(Math.floor(retryAfter));
             retryAfter += retryAfter / 4 * (1 + Math.random());
             lastError = error;

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert, delay, performance } from "@fluidframework/common-utils";
+import { delay, performance } from "@fluidframework/common-utils";
 import { canRetryOnError } from "@fluidframework/driver-utils";
 import { OdspErrorType } from "@fluidframework/odsp-driver-definitions";
 import { Odsp409Error } from "./epochTracker";


### PR DESCRIPTION
## Description
Throw the error for non-retriable error. We expect the 409s to be retriable, but it seems that we are hitting assert in some cases where canRetry is not true. This also leads to hiding the error. So throw the error and then we can see what the actual error was.
