### PR TITLE
[bump] package version for protocol-definitions (patch)

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -286,9 +286,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1028.2000-68027",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000-68027.tgz",
-      "integrity": "sha512-nwOwcxq8EDN2vC26gvX/9/x75cz6/+40mTSrOud+UojI2alJ1kYXfPGy/cOjBRpLE7nS4VsFYlz+GONq+Jua0g==",
+      "version": "0.1028.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
+      "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1"
       }

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0"
+    "@fluidframework/protocol-definitions": "^0.1028.2000"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -264,9 +264,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1028.2000-68027",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000-68027.tgz",
-      "integrity": "sha512-nwOwcxq8EDN2vC26gvX/9/x75cz6/+40mTSrOud+UojI2alJ1kYXfPGy/cOjBRpLE7nS4VsFYlz+GONq+Jua0g==",
+      "version": "0.1028.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
+      "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1"
       }

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0"
+    "@fluidframework/protocol-definitions": "^0.1028.2000"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/protocol-definitions",
-  "version": "0.1028.2000",
+  "version": "0.1028.2001",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/protocol-definitions",
-  "version": "0.1028.2000",
+  "version": "0.1028.2001",
   "description": "Fluid protocol definitions",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/merge-tree": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/merge-tree": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/sequence": "^0.59.4000",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/test-runtime-utils": "^0.59.4000",
     "@fluidframework/view-interfaces": "^0.59.4000",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/iframe-driver": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/test-runtime-utils": "^0.59.4000",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/merge-tree": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/merge-tree": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000"
   },

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/shared-object-base": "^0.59.4000",
     "ot-json1": "^1.0.1"
   },

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/local-driver": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/server-local-server": "^0.1036.4000-0",
     "@fluidframework/test-runtime-utils": "^0.59.4000",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-summary-block": "^0.59.4000"
   },

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2201,7 +2201,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -2583,14 +2583,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -2625,14 +2617,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -2707,14 +2691,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
@@ -3131,14 +3107,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -3185,14 +3153,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -3238,14 +3198,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -3353,16 +3305,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3003",
 				"@fluidframework/shared-object-base": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/cell-previous": {
@@ -3377,16 +3319,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -3482,14 +3414,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -3549,14 +3473,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -3621,14 +3537,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -3666,14 +3574,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -3710,14 +3610,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -3782,14 +3674,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -3824,14 +3708,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -3868,14 +3744,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -3896,16 +3764,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3003",
 				"@fluidframework/shared-object-base": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/counter-previous": {
@@ -3920,16 +3778,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
@@ -3969,14 +3817,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -4040,14 +3880,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4085,14 +3917,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4129,14 +3953,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -4200,14 +4016,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4245,14 +4053,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4278,14 +4078,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4310,14 +4102,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -4374,14 +4158,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4426,14 +4202,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -4515,14 +4283,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4565,14 +4325,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4614,14 +4366,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -4675,14 +4419,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -4699,16 +4435,6 @@
 				"@fluidframework/runtime-definitions": "^0.59.3003",
 				"@fluidframework/shared-object-base": "^0.59.3003",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/ink-previous": {
@@ -4724,16 +4450,6 @@
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/local-driver": {
@@ -4781,14 +4497,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
@@ -5075,14 +4783,6 @@
 						"lodash": "^4.17.21"
 					}
 				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				},
 				"@fluidframework/server-lambdas": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.3000.tgz",
@@ -5336,16 +5036,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3003",
 				"@fluidframework/shared-object-base": "^0.59.3003",
 				"path-browserify": "^1.0.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/map-previous": {
@@ -5364,16 +5054,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000",
 				"path-browserify": "^1.0.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/matrix": {
@@ -5410,14 +5090,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -5456,14 +5128,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -5505,14 +5169,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -5552,14 +5208,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -6229,14 +5877,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6262,14 +5902,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -6322,14 +5954,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6350,14 +5974,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6377,14 +5993,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -6437,14 +6045,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6467,14 +6067,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -6499,14 +6091,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6523,16 +6107,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3003",
 				"@fluidframework/shared-object-base": "^0.59.3003",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
@@ -6548,16 +6122,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/protocol-base": {
@@ -6579,9 +6143,9 @@
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1028.2000-68027",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000-68027.tgz",
-			"integrity": "sha512-nwOwcxq8EDN2vC26gvX/9/x75cz6/+40mTSrOud+UojI2alJ1kYXfPGy/cOjBRpLE7nS4VsFYlz+GONq+Jua0g==",
+			"version": "0.1028.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
+			"integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1"
 			}
@@ -6615,14 +6179,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6655,14 +6211,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6688,14 +6236,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6720,14 +6260,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -6804,14 +6336,6 @@
 						"lodash": "^4.17.21"
 					}
 				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				},
 				"@fluidframework/server-services-client": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.3000.tgz",
@@ -6886,14 +6410,6 @@
 						"lodash": "^4.17.21"
 					}
 				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				},
 				"@fluidframework/server-services-client": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.3000.tgz",
@@ -6940,14 +6456,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -6971,14 +6479,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -7017,14 +6517,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -7061,14 +6553,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -7127,14 +6611,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -7192,14 +6668,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -7219,16 +6687,6 @@
 				"@fluidframework/shared-object-base": "^0.59.3003",
 				"@fluidframework/telemetry-utils": "^0.59.3003",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/sequence-previous": {
@@ -7247,16 +6705,6 @@
 				"@fluidframework/shared-object-base": "^0.59.3000",
 				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/server-lambdas": {
@@ -8178,14 +7626,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -8229,14 +7669,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -8252,16 +7684,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/synthesize": {
@@ -8306,16 +7728,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/test-runtime-utils": "^0.59.3000",
 				"sillyname": "^0.1.0"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
@@ -8338,14 +7750,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -8370,14 +7774,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -8433,14 +7829,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
@@ -8735,14 +8123,6 @@
 						"lodash": "^4.17.21"
 					}
 				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				},
 				"@fluidframework/server-lambdas": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.3000.tgz",
@@ -9003,14 +8383,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -9074,14 +8446,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -9126,14 +8490,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -9195,14 +8551,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -9256,14 +8604,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -9322,14 +8662,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -9373,14 +8705,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -9423,14 +8747,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
@@ -9500,14 +8816,6 @@
 						"lodash": "^4.17.21"
 					}
 				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
-				},
 				"@fluidframework/server-services-client": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.3000.tgz",
@@ -9564,14 +8872,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -9604,14 +8904,6 @@
 						"@fluidframework/gitresources": "^0.1036.3000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000",
 						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -9695,14 +8987,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -9735,14 +9019,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
 					}
 				}
 			}
@@ -22350,7 +21626,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
 		"auto-bind": {
@@ -23797,7 +23073,7 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
 			"dev": true
 		},
 		"buffer": {
@@ -23824,7 +23100,7 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -28226,7 +27502,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
 		},
 		"es6-promise": {
 			"version": "4.2.8",
@@ -28236,7 +27512,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -29510,7 +28786,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -30264,14 +29540,6 @@
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1028.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-					"integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1"
-					}
 				}
 			}
 		},
@@ -30604,7 +29872,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
 		},
 		"fs-extra": {
 			"version": "9.1.0",
@@ -30926,7 +30194,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
+			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -32211,7 +31479,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -32339,7 +31607,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
+			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -32429,7 +31697,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"immutable": {
 			"version": "3.7.6",
@@ -32780,7 +32048,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
+			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
 		},
 		"internal-ip": {
 			"version": "6.2.0",
@@ -33069,7 +32337,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -33183,7 +32451,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
+			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -36760,7 +36028,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
+			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -37438,7 +36706,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
 			"dev": true
 		},
 		"lodash.flatten": {
@@ -37464,7 +36732,7 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -37474,7 +36742,7 @@
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
@@ -37489,7 +36757,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -37500,23 +36768,23 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -37526,19 +36794,19 @@
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -37549,12 +36817,12 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
 		},
 		"lodash.snakecase": {
 			"version": "4.1.1",
@@ -37564,7 +36832,7 @@
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.template": {
 			"version": "4.5.0",
@@ -37588,7 +36856,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -39561,7 +38829,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
 			"requires": {
 				"event-lite": "^0.1.1",
 				"ieee754": "^1.1.8",
@@ -39572,7 +38840,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
 		},
@@ -39877,7 +39145,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
+			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
 			"dev": true
 		},
 		"node-dir": {
@@ -41673,7 +40941,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
+			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
 			"dev": true
 		},
 		"p-all": {
@@ -42141,7 +41409,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parse-path": {
 			"version": "4.0.3",
@@ -42383,7 +41651,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
+			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
 			"dev": true
 		},
 		"pirates": {
@@ -47975,7 +47243,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
 					"dev": true
 				},
 				"supports-color": {
@@ -47990,7 +47258,7 @@
 						"has-flag": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-							"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 							"dev": true
 						}
 					}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -3677,7 +3677,7 @@
     "atob-lite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
       "dev": true
     },
     "available-typed-arrays": {
@@ -3751,13 +3751,13 @@
     "btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true
     },
     "buffer-from": {
@@ -5378,7 +5378,7 @@
     "es6-object-assign": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "dev": true
     },
     "es6-promise": {
@@ -5390,7 +5390,7 @@
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
@@ -5450,7 +5450,7 @@
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -5634,7 +5634,7 @@
     "fs-exists-sync": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
     "fs-extra": {
@@ -5942,7 +5942,7 @@
     "git-config-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-      "integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
+      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -6312,7 +6312,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -6361,7 +6361,7 @@
     "humps": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
       "dev": true
     },
     "hyperlinker": {
@@ -6403,7 +6403,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "import-fresh": {
@@ -6702,7 +6702,7 @@
     "int64-buffer": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-      "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==",
+      "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM=",
       "dev": true
     },
     "internal-slot": {
@@ -6812,7 +6812,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
@@ -6864,7 +6864,7 @@
     "is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-      "integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
       "dev": true
     },
     "is-negative-zero": {
@@ -7538,7 +7538,7 @@
     "li": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-      "integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
+      "integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
       "dev": true
     },
     "libnpmaccess": {
@@ -7714,7 +7714,7 @@
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
       "dev": true
     },
     "lodash.get": {
@@ -7726,13 +7726,13 @@
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "dev": true
     },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "dev": true
     },
     "lodash.isequal": {
@@ -7744,7 +7744,7 @@
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
       "dev": true
     },
     "lodash.ismatch": {
@@ -7756,43 +7756,43 @@
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "dev": true
     },
     "lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-      "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
       "dev": true
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.merge": {
@@ -7804,19 +7804,19 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.template": {
@@ -7841,7 +7841,7 @@
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "log-symbols": {
@@ -8587,7 +8587,7 @@
     "msgpack-lite": {
       "version": "0.1.26",
       "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-      "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+      "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
       "dev": true,
       "requires": {
         "event-lite": "^0.1.1",
@@ -8599,7 +8599,7 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
       }
@@ -8658,7 +8658,7 @@
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-      "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
+      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
       "dev": true
     },
     "node-fetch": {
@@ -9214,7 +9214,7 @@
     "override-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-      "integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
+      "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
       "dev": true
     },
     "p-finally": {
@@ -9502,7 +9502,7 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "parse-path": {
@@ -9602,7 +9602,7 @@
     "pinpoint": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-      "integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
+      "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
       "dev": true
     },
     "plur": {
@@ -10665,7 +10665,7 @@
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
@@ -10680,7 +10680,7 @@
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
               "dev": true
             }
           }

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000"
   },

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000"
   },

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",
     "uuid": "^8.3.1"

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/merge-tree": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",

--- a/packages/dds/quorum/package.json
+++ b/packages/dds/quorum/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000"
   },

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000"
   },

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/merge-tree": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000"
   },

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/shared-object-base": "^0.59.4000"
   },

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/replay-driver": "^0.59.4000",
     "jsonschema": "^1.2.6"
   },

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000"
   },
   "devDependencies": {

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/replay-driver": "^0.59.4000"
   },
   "devDependencies": {

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000",
     "comlink": "^4.3.0"
   },

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/driver-base": "^0.59.4000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/server-local-server": "^0.1036.4000-0",
     "@fluidframework/server-services-client": "^0.1036.4000-0",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-tools": "^0.2.70857",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@0.59.3000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000"
   },
   "devDependencies": {

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/gitresources": "^0.1036.4000-0",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.4000-0",
     "@fluidframework/telemetry-utils": "^0.59.4000",
     "cross-fetch": "^3.1.5",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.70857",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@0.59.3000",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "nconf": "^0.11.4"
   },
   "devDependencies": {

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/server-services-client": "^0.1036.4000-0",
     "jsrsasign": "^10.2.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000"

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -37,7 +37,7 @@
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/test-runtime-utils": "^0.59.4000",
     "sillyname": "^0.1.0"
   },

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/fluid-static": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/tinylicious-driver": "^0.59.4000",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000",
     "abort-controller": "^3.0.0",
     "double-ended-queue": "^2.1.0-0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.2000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000"
   },
   "devDependencies": {

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/gitresources": "^0.1036.4000-0",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000",
     "axios": "^0.26.0",
     "uuid": "^8.3.1"

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0"
+    "@fluidframework/protocol-definitions": "^0.1028.2000"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@0.59.3000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@types/node": "^14.18.0"
   },

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/garbage-collector": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@types/node": "^14.18.0"
   },

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/garbage-collector": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@types/node": "^14.18.0"
   },
   "devDependencies": {

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/garbage-collector": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000"
   },

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/driver-utils": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/sequence": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000",
     "@fluidframework/test-loader-utils": "^0.59.4000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/mocha-test-setup": "^0.59.4000",
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",
     "@fluidframework/ordered-collection": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/register-collection": "^0.59.4000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/matrix": "^0.59.4000",
     "@fluidframework/ordered-collection": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/register-collection": "^0.59.4000",
     "@fluidframework/replay-driver": "^0.59.4000",
     "@fluidframework/sequence": "^0.59.4000",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/odsp-driver": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000",
     "@fluidframework/odsp-urlresolver": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/server-local-server": "^0.1036.4000-0",
     "@fluidframework/test-driver-definitions": "^0.59.4000",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -91,7 +91,7 @@
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000",
     "@fluidframework/ordered-collection": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/register-collection": "^0.59.4000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-definitions": "^0.46.2000-0",
     "@fluidframework/map": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/local-driver": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/request-handler": "^0.59.4000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/matrix": "^0.59.4000",
     "@fluidframework/mocha-test-setup": "^0.59.4000",
     "@fluidframework/ordered-collection": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/register-collection": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/sequence": "^0.59.4000",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/odsp-driver": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000",
     "@fluidframework/odsp-urlresolver": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/routerlicious-urlresolver": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/matrix": "^0.59.4000",
     "@fluidframework/ordered-collection": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/register-collection": "^0.59.4000",
     "@fluidframework/replay-driver": "^0.59.4000",
     "@fluidframework/request-handler": "^0.59.4000",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",
     "@fluidframework/odsp-driver": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "async-mutex": "^0.3.1",
     "debug": "^4.1.1",
     "jwt-decode": "^2.2.0",

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -3865,7 +3865,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true
     },
     "buffer-from": {
@@ -7968,13 +7968,13 @@
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "dev": true
     },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "dev": true
     },
     "lodash.isequal": {
@@ -7986,7 +7986,7 @@
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
       "dev": true
     },
     "lodash.ismatch": {
@@ -7998,7 +7998,7 @@
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "dev": true
     },
     "lodash.isobject": {
@@ -8010,13 +8010,13 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.keys": {
@@ -8046,7 +8046,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "lodash.set": {
@@ -8058,7 +8058,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.template": {

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-core": "^0.1036.4000"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-memory-orderer": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-kafka-orderer": "^0.1036.4000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-kafka-orderer": "^0.1036.4000",
     "@fluidframework/server-lambdas": "^0.1036.4000",
     "@fluidframework/server-lambdas-driver": "^0.1036.4000",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "axios": "^0.26.0",
     "crc-32": "1.2.0",
     "debug": "^4.1.1",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",
     "@types/nconf": "^0.10.2",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1036.4000",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000",
     "@fluidframework/protocol-base": "^0.1036.4000",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.4000",
     "@fluidframework/server-services-core": "^0.1036.4000",
     "@fluidframework/server-services-telemetry": "^0.1036.4000",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -465,9 +465,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1028.2000-68027",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000-68027.tgz",
-      "integrity": "sha512-nwOwcxq8EDN2vC26gvX/9/x75cz6/+40mTSrOud+UojI2alJ1kYXfPGy/cOjBRpLE7nS4VsFYlz+GONq+Jua0g==",
+      "version": "0.1028.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
+      "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1"
       }

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1036.4000-0",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000-0",
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-lambdas": "^0.1036.4000-0",
     "@fluidframework/server-local-server": "^0.1036.4000-0",
     "@fluidframework/server-memory-orderer": "^0.1036.4000-0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:  0.28.3000 (unchanged)
      @fluidframework/common-definitions:  0.21.1000 (unchanged)
            @fluidframework/common-utils:  0.33.1000 (unchanged)
         @fluidframework/core-interfaces:  0.43.2000 (unchanged)
    @fluidframework/protocol-definitions: 0.1028.2000 -> 0.1028.2001
      @fluidframework/driver-definitions:  0.46.2000 (unchanged)
   @fluidframework/container-definitions:  0.48.2000 (unchanged)
                                   Azure:  0.59.3000 (unchanged)
                                  Server: 0.1036.4000 (unchanged)
                                  Client:  0.59.4000 (unchanged)
                  @fluid-tools/benchmark:     0.41.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)

Also remove pre-release dependencies for protocol-definitions
    @fluidframework/protocol-definitions -> ^0.1028.2000