### PR TITLE
[bump] package version for driver-definitions (patch)

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -228,13 +228,13 @@
       "integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.46.2000-68089",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.2000-68089.tgz",
-      "integrity": "sha512-AaLZEEw1EtyDVwSjh5+Zo/GY/D71nI95Ml/L8l3ZLy2xD+hnFopUH6V3YwZu/LiyanOrPJ/Y1UGecJzN+FpG4g==",
+      "version": "0.46.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.2000.tgz",
+      "integrity": "sha512-I0NzrWuU638M5OyeQGHKO+5kjUbNHeSt0XsI7f0/rwz2sygvAVJcYyyqt0NWLK/CvxWvZZwvexSPyFdmLo3E1g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/core-interfaces": "^0.43.1000",
-        "@fluidframework/protocol-definitions": "^0.1028.2000-0"
+        "@fluidframework/protocol-definitions": "^0.1028.2000"
       }
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000"
   },
   "devDependencies": {

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/driver-definitions",
-  "version": "0.46.2000",
+  "version": "0.46.2001",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/driver-definitions",
-  "version": "0.46.2000",
+  "version": "0.46.2001",
   "description": "Fluid driver definitions",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/register-collection": "^0.59.4000",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/iframe-driver": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/data-object-base": "^0.59.4000",
     "@fluidframework/datastore": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/merge-tree": "^0.59.4000",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-experimental/property-common": "^0.59.4000",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/local-driver": "^0.59.4000",
     "@fluidframework/mocha-test-setup": "^0.59.4000",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/local-driver": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2573,16 +2573,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -2607,18 +2597,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/odsp-driver": "^0.59.3000",
 				"@fluidframework/odsp-driver-definitions": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
@@ -2664,16 +2642,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
@@ -3097,16 +3065,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -3143,16 +3101,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -3187,16 +3135,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -3389,16 +3327,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3446,16 +3374,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
@@ -3512,16 +3430,6 @@
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3564,16 +3472,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -3599,16 +3497,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -3646,16 +3534,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
@@ -3699,16 +3577,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -3732,16 +3600,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -3808,16 +3666,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -3852,16 +3700,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
@@ -3907,16 +3745,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -3942,16 +3770,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -3988,16 +3806,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
@@ -4042,18 +3850,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/replay-driver": "^0.59.3000",
 				"jsonschema": "^1.2.6"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/driver-base": {
@@ -4067,18 +3863,6 @@
 				"@fluidframework/driver-utils": "^0.59.3003",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/telemetry-utils": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/driver-base-previous": {
@@ -4092,28 +3876,16 @@
 				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/telemetry-utils": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.46.2000-68089",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.2000-68089.tgz",
-			"integrity": "sha512-AaLZEEw1EtyDVwSjh5+Zo/GY/D71nI95Ml/L8l3ZLy2xD+hnFopUH6V3YwZu/LiyanOrPJ/Y1UGecJzN+FpG4g==",
+			"version": "0.46.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.2000.tgz",
+			"integrity": "sha512-I0NzrWuU638M5OyeQGHKO+5kjUbNHeSt0XsI7f0/rwz2sygvAVJcYyyqt0NWLK/CvxWvZZwvexSPyFdmLo3E1g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/protocol-definitions": "^0.1028.2000-0"
+				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/driver-utils": {
@@ -4133,16 +3905,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -4178,16 +3940,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -4272,18 +4024,6 @@
 				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/replay-driver": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/fluid-static": {
@@ -4313,16 +4053,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -4355,16 +4085,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -4408,18 +4128,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"comlink": "^4.3.0"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/ink": {
@@ -4473,16 +4181,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -4757,16 +4455,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -5159,16 +4847,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -5197,16 +4875,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -5866,18 +5534,6 @@
 				"@fluidframework/odsp-driver-definitions": "^0.59.3003",
 				"@fluidframework/telemetry-utils": "^0.59.3003",
 				"node-fetch": "^2.6.1"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
@@ -5892,18 +5548,6 @@
 				"@fluidframework/odsp-driver-definitions": "^0.59.3000",
 				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"node-fetch": "^2.6.1"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/odsp-driver": {
@@ -5929,16 +5573,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -5963,18 +5597,6 @@
 			"integrity": "sha512-nxlvq+74IhRy1ztIfTreWnsY7cY3jm0LWx0NappDl0ifT/ZdLI9rbHN4NdQsUiXHr76QUgJWSLyj+sVjJpQmXA==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
@@ -5983,18 +5605,6 @@
 			"integrity": "sha512-XwuBIl27el8b9a+xBuGHeOwI4DKwSta++mlpJMG4ZYfoSulCtJ/JUVx/TqoNt8CG0qQvHvqMVr/a1G9bWoWqtQ==",
 			"requires": {
 				"@fluidframework/driver-definitions": "^0.46.1000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
@@ -6020,16 +5630,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -6057,18 +5657,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/odsp-driver": "^0.59.3003",
 				"@fluidframework/odsp-driver-definitions": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
@@ -6080,18 +5668,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/odsp-driver": "^0.59.3000",
 				"@fluidframework/odsp-driver-definitions": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/ordered-collection": {
@@ -6225,18 +5801,6 @@
 				"@fluidframework/driver-utils": "^0.59.3003",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/telemetry-utils": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
@@ -6250,18 +5814,6 @@
 				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/telemetry-utils": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/request-handler": {
@@ -6310,16 +5862,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -6384,16 +5926,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -6445,18 +5977,6 @@
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"axios": "^0.26.0"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
@@ -6469,18 +5989,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"nconf": "^0.11.4"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/runtime-definitions": {
@@ -6505,16 +6013,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -6542,16 +6040,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -6583,16 +6071,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
@@ -6640,16 +6118,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				},
@@ -7616,16 +7084,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -7657,16 +7115,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -7740,18 +7188,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
@@ -7764,18 +7200,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-drivers": {
@@ -7805,16 +7229,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -8097,16 +7511,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -8372,18 +7776,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/driver-utils": "^0.59.3000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000"
-			},
-			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
@@ -8436,16 +7828,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -8479,16 +7861,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -8541,16 +7913,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -8593,16 +7955,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -8652,16 +8004,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -8695,16 +8037,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -8723,16 +8055,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -8790,16 +8112,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -8977,16 +8289,6 @@
 						"@fluidframework/driver-definitions": "^0.46.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
 				}
 			}
 		},
@@ -9008,16 +8310,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}
@@ -29528,16 +28820,6 @@
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-					"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.1000"
 					}
 				}

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/replay-driver": "^0.59.4000",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000"

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/replay-driver": "^0.59.4000"

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/odsp-driver": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000"
   },

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-base": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -36,7 +36,7 @@
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "dependencies": {
-    "@fluidframework/driver-definitions": "^0.46.2000-0"
+    "@fluidframework/driver-definitions": "^0.46.2000"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-base": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/gitresources": "^0.1036.4000-0",
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/odsp-driver": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000"
   },

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000"

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-base": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/gitresources": "^0.1036.4000-0",
     "@fluidframework/protocol-base": "^0.1036.4000-0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "axios": "^0.26.0"
   },
   "devDependencies": {

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "nconf": "^0.11.4"
   },

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/container-loader": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/fluid-static": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/container-utils": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/gitresources": "^0.1036.4000-0",
     "@fluidframework/protocol-base": "^0.1036.4000-0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000"
   },

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",
     "@types/node": "^14.18.0"

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/container-utils": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/garbage-collector": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/container-utils": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/garbage-collector": "^0.59.4000",
     "@fluidframework/protocol-base": "^0.1036.4000-0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@types/node": "^14.18.0"
   },

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/routerlicious-driver": "^0.59.4000",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/datastore": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-base": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/ink": "^0.59.4000",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/file-driver": "^0.59.4000",
     "@fluidframework/ink": "^0.59.4000",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "uuid": "^8.3.1"
   },

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/local-driver": "^0.59.4000",
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/counter": "^0.59.4000",
     "@fluidframework/datastore": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/garbage-collector": "^0.59.4000",
     "@fluidframework/ink": "^0.59.4000",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/local-driver": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/ink": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/datastore": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",
     "@fluidframework/odsp-driver": "^0.59.4000",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/file-driver": "^0.59.4000",
     "@fluidframework/ink": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/container-definitions": "^0.48.2000-0",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/local-driver": "^0.59.4000",
     "@fluidframework/odsp-doclib-utils": "^0.59.4000",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.46.2000-0",
+    "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",
     "@fluidframework/odsp-driver-definitions": "^0.59.4000",
     "@fluidframework/telemetry-utils": "^0.59.4000",


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:  0.28.3000 (unchanged)
      @fluidframework/common-definitions:  0.21.1000 (unchanged)
            @fluidframework/common-utils:  0.33.1000 (unchanged)
         @fluidframework/core-interfaces:  0.43.2000 (unchanged)
    @fluidframework/protocol-definitions: 0.1028.2001 (unchanged)
      @fluidframework/driver-definitions:  0.46.2000 -> 0.46.2001
   @fluidframework/container-definitions:  0.48.2000 (unchanged)
                                   Azure:  0.59.3000 (unchanged)
                                  Server: 0.1036.4000 (unchanged)
                                  Client:  0.59.4000 (unchanged)
                  @fluid-tools/benchmark:     0.41.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)

Also remove pre-release dependencies for driver-definitions
      @fluidframework/driver-definitions -> ^0.46.2000