### PR TITLE
Add breaking note for ConnectionState changes

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -48,11 +48,12 @@ For more details on GC and options for controlling its behavior, please see [thi
 - [`ISummarizerOptions` is deprecated](#isummarizerOptions-is-deprecated)
 - [connect() and disconnect() made mandatory on IContainer and IFluidContainer](#connect-and-disconnect-made-mandatory-on-icontainer-and-ifluidcontainer)
 - [Remove Const Enums from Merge Tree, Sequence, and Shared String](#Remove-Const-Enums-from-Merge-Tree-Sequence-and-Shared-String)
-- [Remove Container.setAutoReconnect() and Container.resume()](#Remove-Container-setAutoReconnect-and-resume)
-- [Remove IContainer.connected and IFluidContainer.connected](#Remove-IContainer-connected-and-IFluidContainer-connected)
+- [Remove Container.setAutoReconnect() and Container.resume()](#remove-containersetautoreconnect-and-containerresume)
+- [Remove IContainer.connected and IFluidContainer.connected](#remove-icontainerconnected-and-ifluidcontainerconnected)
 - [All IFluidObject Augmentations Removed](#All-IFluidObject-Augmentations-Removed)
 - [Remove `noopTimeFrequency` and `noopCountFrequency` from ILoaderOptions](#remove-nooptimefrequency-and-noopcountfrequency-from-iloaderoptions)
-- [proxyLoaderFactories members removed from ILoaderProps and ILoaderServices](#proxyLoaderFactories-members-removed-from-ILoaderProps-and-ILoaderServices)
+- [proxyLoaderFactories members removed from ILoaderProps and ILoaderServices](#proxyloaderfactories-members-to-be-removed-from-iloaderprops-and-iloaderservices)
+- [IContainer.connectionState yields finer-grained ConnectionState values](#icontainerconnectionstate-yields-finer-grained-connectionstate-values)
 
 ### Changed AzureConnectionConfig API
 - Added a `type` field that's used to differentiate between remote and local connections.
@@ -140,6 +141,19 @@ The properties `IContainer.connected` and `IFluidContainer.connected` were depre
 
 ### proxyLoaderFactories members to be removed from ILoaderProps and ILoaderServices
 The `proxyLoaderFactories` member on `ILoaderProps` and `ILoaderServices` was deprecated in 0.59 and has now been removed.
+
+### IContainer.connectionState yields finer-grained ConnectionState values
+In both `@fluidframework/container-definitions` and `@fluidframework/container-loader` packages,
+the `ConnectionState` types have been updated to include a new state which previously was
+encompassed by the `Disconnected` state. The new state is `EstablishingConnection` and indicates that the container is
+attempting to connect to the ordering service, but is not yet connected.
+
+Any logic based on the `Disconnected` state (e.g. checking the value of `connectionState` on either `IContainer` and `Container`)
+should be updated depending on how you want to treat this new `EstablishingConnection` state.
+
+Additionally, please note that the `Connecting` state is being renamed to `CatchingUp`.
+`ConnectionState.Connecting` is marked as deprecated, please use `ConnectionState.CatchingUp` instead.
+`ConnectionState.Connecting` will be removed in the following major release.
 
 # 0.59
 


### PR DESCRIPTION
## Description

PR [#10447](https://github.com/microsoft/FluidFramework/pull/10447/files/db270d943c73aa894e0383224c2c97d6680ea93b) was included in #10468 (by necessity during a large integrate merge) in an incomplete state - it was missing BREAKING.md notes.  This PR is adding those notes.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [x] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [x] Yes
-   [x] No

## Testing

N/A

## Any relevant logs or outputs

N/A

## Other information or known dependencies

N/A