### PR TITLE
Patch bump 1654291562361

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -189,37 +189,15 @@
       "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/container-definitions-previous": {
-      "version": "npm:@fluidframework/container-definitions@0.48.1000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-      "integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
+      "version": "npm:@fluidframework/container-definitions@0.48.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.2000.tgz",
+      "integrity": "sha512-rumdYGROmLzy94vth/twugAF1aveb2YDZDXqRJW+nwHbAF3WrIZ37rdlI3P3rQDO2+B4Hd1RQM13hMa1KA1VDQ==",
       "dev": true,
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/core-interfaces": "^0.43.1000",
-        "@fluidframework/driver-definitions": "^0.46.1000",
-        "@fluidframework/protocol-definitions": "^0.1028.1000"
-      },
-      "dependencies": {
-        "@fluidframework/driver-definitions": {
-          "version": "0.46.1000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-          "integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
-          "dev": true,
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^0.43.1000",
-            "@fluidframework/protocol-definitions": "^0.1028.1000"
-          }
-        },
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.1000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-          "integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
-          "dev": true,
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        }
+        "@fluidframework/driver-definitions": "^0.46.2000",
+        "@fluidframework/protocol-definitions": "^0.1028.2000"
       }
     },
     "@fluidframework/core-interfaces": {

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/container-definitions",
-  "version": "0.48.2000",
+  "version": "0.48.2001",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.70857",
-    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@0.48.1000",
+    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@0.48.2000",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -73,7 +73,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.48.2000",
+    "version": "0.48.2001",
     "broken": {}
   }
 }

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/container-definitions",
-  "version": "0.48.2000",
+  "version": "0.48.2001",
   "description": "Fluid container definitions",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.59.4000",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/merge-tree": "^0.59.4000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -45,7 +45,7 @@
     "@fluid-example/example-utils": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -45,7 +45,7 @@
     "@fluid-example/table-document": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/matrix": "^0.59.4000",
     "@fluidframework/runtime-utils": "^0.59.4000",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/request-handler": "^0.59.4000",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/get-container": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/cell": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-utils": "^0.59.4000",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluid-example/todo": "^0.59.4000",
     "@fluid-experimental/get-container": "^0.59.4000",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/schemas": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -38,7 +38,7 @@
     "@fluid-experimental/property-changeset": "^0.59.4000",
     "@fluid-experimental/property-properties": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -46,7 +46,7 @@
     "@fluid-example/example-utils": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -47,7 +47,7 @@
     "@fluid-experimental/sharejs-json1": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -47,7 +47,7 @@
     "@fluid-experimental/tree": "^0.59.4000",
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -30,7 +30,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2561,19 +2561,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluid-tools/benchmark": {
@@ -2634,17 +2621,6 @@
 				"webpack-dev-server": "4.0.0"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3053,19 +3029,6 @@
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/runtime-utils": "^0.59.3000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/aqueduct": {
@@ -3089,19 +3052,6 @@
 				"@fluidframework/synthesize": "^0.59.3003",
 				"@fluidframework/view-interfaces": "^0.59.3003",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
@@ -3125,19 +3075,6 @@
 				"@fluidframework/synthesize": "^0.59.3000",
 				"@fluidframework/view-interfaces": "^0.59.3000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/build-common": {
@@ -3285,14 +3222,14 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.48.2000-68107",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.2000-68107.tgz",
-			"integrity": "sha512-aZow3+D+Dv7i1nPWjyL+Ye4z0ia1jZXjFXkcTn5fIe61xJzNoXP1ksdCe3rtZu9YtPocN5fkvDTKMMhSInZedQ==",
+			"version": "0.48.2000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.2000.tgz",
+			"integrity": "sha512-rumdYGROmLzy94vth/twugAF1aveb2YDZDXqRJW+nwHbAF3WrIZ37rdlI3P3rQDO2+B4Hd1RQM13hMa1KA1VDQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-definitions": "^0.46.2000-0",
-				"@fluidframework/protocol-definitions": "^0.1028.2000-0"
+				"@fluidframework/driver-definitions": "^0.46.2000",
+				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/container-loader": {
@@ -3316,17 +3253,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3366,17 +3292,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3419,17 +3334,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3460,19 +3364,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3003",
 				"@types/node": "^14.18.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
@@ -3487,19 +3378,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@types/node": "^14.18.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
@@ -3526,17 +3404,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3565,19 +3432,6 @@
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/telemetry-utils": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/container-utils-previous": {
@@ -3590,19 +3444,6 @@
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/telemetry-utils": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/core-interfaces": {
@@ -3654,19 +3495,6 @@
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/runtime-utils": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/datastore": {
@@ -3692,17 +3520,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -3733,19 +3550,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3003",
 				"@types/node": "^14.18.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
@@ -3760,19 +3564,6 @@
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@types/node": "^14.18.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/datastore-previous": {
@@ -3798,17 +3589,6 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -4043,19 +3823,6 @@
 				"@fluidframework/request-handler": "^0.59.3003",
 				"@fluidframework/runtime-definitions": "^0.59.3003",
 				"@fluidframework/runtime-utils": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
@@ -4075,19 +3842,6 @@
 				"@fluidframework/request-handler": "^0.59.3000",
 				"@fluidframework/runtime-definitions": "^0.59.3000",
 				"@fluidframework/runtime-utils": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/garbage-collector": {
@@ -4835,19 +4589,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3003",
 				"@fluidframework/shared-object-base": "^0.59.3003",
 				"@fluidframework/telemetry-utils": "^0.59.3003"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
@@ -4865,19 +4606,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3000",
 				"@fluidframework/shared-object-base": "^0.59.3000",
 				"@fluidframework/telemetry-utils": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
@@ -6003,19 +5731,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@types/node": "^14.18.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
@@ -6030,19 +5745,6 @@
 				"@fluidframework/driver-definitions": "^0.46.1000",
 				"@fluidframework/protocol-definitions": "^0.1028.1000",
 				"@types/node": "^14.18.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/runtime-utils": {
@@ -6063,17 +5765,6 @@
 				"@fluidframework/telemetry-utils": "^0.59.3003"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -6110,17 +5801,6 @@
 				"@fluidframework/telemetry-utils": "^0.59.3000"
 			},
 			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.3000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.3000.tgz",
@@ -7072,19 +6752,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3003",
 				"@fluidframework/telemetry-utils": "^0.59.3003",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
@@ -7105,19 +6772,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3000",
 				"@fluidframework/telemetry-utils": "^0.59.3000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
@@ -7816,19 +7470,6 @@
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
@@ -7851,19 +7492,6 @@
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-tools": {
@@ -7901,19 +7529,6 @@
 				"@fluidframework/test-runtime-utils": "^0.59.3003",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-utils-previous": {
@@ -7945,19 +7560,6 @@
 				"@fluidframework/test-runtime-utils": "^0.59.3000",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
@@ -7992,19 +7594,6 @@
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
@@ -8025,19 +7614,6 @@
 				"@fluidframework/runtime-utils": "^0.59.3000",
 				"@fluidframework/tinylicious-driver": "^0.59.3000",
 				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
@@ -8277,19 +7853,6 @@
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"isomorphic-fetch": "^3.0.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
@@ -8300,19 +7863,6 @@
 				"@fluidframework/container-definitions": "^0.48.1000",
 				"@fluidframework/core-interfaces": "^0.43.1000",
 				"isomorphic-fetch": "^3.0.0"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"@gar/promisify": {
@@ -28810,19 +28360,6 @@
 				"@fluidframework/fluid-static": "^0.59.3000",
 				"@fluidframework/map": "^0.59.3000",
 				"@fluidframework/sequence": "^0.59.3000"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.48.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-					"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/driver-definitions": "^0.46.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.1000"
-					}
-				}
 			}
 		},
 		"flush-write-stream": {

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-utils": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",
     "@fluidframework/datastore-definitions": "^0.59.4000",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore": "^0.59.4000",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -35,7 +35,7 @@
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/fluid-static": "^0.59.4000",
     "@fluidframework/map": "^0.59.4000",
     "@fluidframework/sequence": "^0.59.4000"

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/driver-utils": "^0.59.4000",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-utils": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^0.59.4000"
   },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/container-utils": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^0.59.4000",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-utils": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/datastore-definitions": "^0.59.4000",
     "@fluidframework/driver-definitions": "^0.46.2000",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -60,7 +60,7 @@
     "@fluid-internal/replay-tool": "^0.59.4000",
     "@fluidframework/cell": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/counter": "^0.59.4000",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/cell": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/cell": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/cell": "^0.59.4000",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/container-runtime": "^0.59.4000",
     "@fluidframework/container-runtime-definitions": "^0.59.4000",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.59.4000",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.48.2000-0",
+    "@fluidframework/container-definitions": "^0.48.2000",
     "@fluidframework/container-loader": "^0.59.4000",
     "@fluidframework/core-interfaces": "^0.43.1000",
     "@fluidframework/driver-definitions": "^0.46.2000",


### PR DESCRIPTION
 @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:  0.28.3000 (unchanged)
      @fluidframework/common-definitions:  0.21.1000 (unchanged)
            @fluidframework/common-utils:  0.33.1000 (unchanged)
         @fluidframework/core-interfaces:  0.43.2000 (unchanged)
    @fluidframework/protocol-definitions: 0.1028.2001 (unchanged)
      @fluidframework/driver-definitions:  0.46.2001 (unchanged)
   @fluidframework/container-definitions:  0.48.2000 -> 0.48.2001
                                   Azure:  0.59.3000 (unchanged)
                                  Server: 0.1036.4000 (unchanged)
                                  Client:  0.59.4000 (unchanged)
                  @fluid-tools/benchmark:     0.41.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)

Also remove pre-release dependencies for container-definitions
   @fluidframework/container-definitions -> ^0.48.2000