### PR TITLE
Typetests cleanup.

### DIFF
--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
@@ -530,7 +530,6 @@ declare function get_old_ClassDeclaration_IntervalCollection():
 declare function use_current_ClassDeclaration_IntervalCollection(
     use: TypeOnly<current.IntervalCollection<any>>);
 use_current_ClassDeclaration_IntervalCollection(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_IntervalCollection());
 
 /*

--- a/packages/runtime/garbage-collector/src/test/types/validateGarbageCollectorPrevious.ts
+++ b/packages/runtime/garbage-collector/src/test/types/validateGarbageCollectorPrevious.ts
@@ -184,6 +184,78 @@ use_old_FunctionDeclaration_runGarbageCollection(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_trimLeadingAndTrailingSlashes": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_trimLeadingAndTrailingSlashes():
+    TypeOnly<typeof old.trimLeadingAndTrailingSlashes>;
+declare function use_current_FunctionDeclaration_trimLeadingAndTrailingSlashes(
+    use: TypeOnly<typeof current.trimLeadingAndTrailingSlashes>);
+use_current_FunctionDeclaration_trimLeadingAndTrailingSlashes(
+    get_old_FunctionDeclaration_trimLeadingAndTrailingSlashes());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_trimLeadingAndTrailingSlashes": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_trimLeadingAndTrailingSlashes():
+    TypeOnly<typeof current.trimLeadingAndTrailingSlashes>;
+declare function use_old_FunctionDeclaration_trimLeadingAndTrailingSlashes(
+    use: TypeOnly<typeof old.trimLeadingAndTrailingSlashes>);
+use_old_FunctionDeclaration_trimLeadingAndTrailingSlashes(
+    get_current_FunctionDeclaration_trimLeadingAndTrailingSlashes());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_trimLeadingSlashes": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_trimLeadingSlashes():
+    TypeOnly<typeof old.trimLeadingSlashes>;
+declare function use_current_FunctionDeclaration_trimLeadingSlashes(
+    use: TypeOnly<typeof current.trimLeadingSlashes>);
+use_current_FunctionDeclaration_trimLeadingSlashes(
+    get_old_FunctionDeclaration_trimLeadingSlashes());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_trimLeadingSlashes": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_trimLeadingSlashes():
+    TypeOnly<typeof current.trimLeadingSlashes>;
+declare function use_old_FunctionDeclaration_trimLeadingSlashes(
+    use: TypeOnly<typeof old.trimLeadingSlashes>);
+use_old_FunctionDeclaration_trimLeadingSlashes(
+    get_current_FunctionDeclaration_trimLeadingSlashes());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_trimTrailingSlashes": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_trimTrailingSlashes():
+    TypeOnly<typeof old.trimTrailingSlashes>;
+declare function use_current_FunctionDeclaration_trimTrailingSlashes(
+    use: TypeOnly<typeof current.trimTrailingSlashes>);
+use_current_FunctionDeclaration_trimTrailingSlashes(
+    get_old_FunctionDeclaration_trimTrailingSlashes());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_trimTrailingSlashes": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_trimTrailingSlashes():
+    TypeOnly<typeof current.trimTrailingSlashes>;
+declare function use_old_FunctionDeclaration_trimTrailingSlashes(
+    use: TypeOnly<typeof old.trimTrailingSlashes>);
+use_old_FunctionDeclaration_trimTrailingSlashes(
+    get_current_FunctionDeclaration_trimTrailingSlashes());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_unpackChildNodesGCDetails": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_unpackChildNodesGCDetails():

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.ts
@@ -40,6 +40,30 @@ use_old_FunctionDeclaration_addBlobToSummary(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_addSummarizeResultToSummary": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_addSummarizeResultToSummary():
+    TypeOnly<typeof old.addSummarizeResultToSummary>;
+declare function use_current_FunctionDeclaration_addSummarizeResultToSummary(
+    use: TypeOnly<typeof current.addSummarizeResultToSummary>);
+use_current_FunctionDeclaration_addSummarizeResultToSummary(
+    get_old_FunctionDeclaration_addSummarizeResultToSummary());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_addSummarizeResultToSummary": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_addSummarizeResultToSummary():
+    TypeOnly<typeof current.addSummarizeResultToSummary>;
+declare function use_old_FunctionDeclaration_addSummarizeResultToSummary(
+    use: TypeOnly<typeof old.addSummarizeResultToSummary>);
+use_old_FunctionDeclaration_addSummarizeResultToSummary(
+    get_current_FunctionDeclaration_addSummarizeResultToSummary());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_addTreeToSummary": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_addTreeToSummary():


### PR DESCRIPTION
Typetests cleanup after 1.0.0 bump.

Earlier error:

/bin/bash /mnt/vss/_work/_temp/91206337-9114-4274-bcf9-b97671eab5a4.sh
	modified:   packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
	modified:   packages/runtime/garbage-collector/src/test/types/validateGarbageCollectorPrevious.ts
	modified:   packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.ts
##[error]Build should not create extraenous files
##[error]Bash exited with code '255'.
Finishing: Check for extraenous modified files
