### PR TITLE
Event BatchStats - Set duration as undefined when Data_interruped == false 

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -606,7 +606,7 @@ class ScheduleManagerCore {
 
     private resumeQueue(startBatch: number, messageEndBatch: ISequencedDocumentMessage) {
         const endBatch = messageEndBatch.sequenceNumber;
-        const duration = performance.now() - this.timePaused;
+        const duration = this.localPaused ? (performance.now() - this.timePaused) : undefined;
 
         this.batchCount++;
         if (this.batchCount % 1000 === 1) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -629,7 +629,7 @@ class ScheduleManagerCore {
         this.localPaused = false;
 
         // Random round number - we want to know when batch waiting paused op processing.
-        if (duration > latencyThreshold) {
+        if (duration !== undefined && duration > latencyThreshold) {
             this.logger.sendErrorEvent({
                 eventName: "MaxBatchWaitTimeExceeded",
                 duration,


### PR DESCRIPTION
# [BatchStats duration is wrong #10397](https://dev.azure.com/fluidframework/internal/_workitems/edit/415)

For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)

## Description

> Event BatchStats is being triggered with invalid duration when the queue has not been paused. 

## Steps to Reproduce Bug and Validate Solution

Just simple telemetry inspection. 

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] My code follows the code style of this project.
-   [X] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No


## Testing

Existing unit tests will make sure we are setting undefined properly when the queue has not been paused.

## Any relevant logs or outputs

N/A

## Other information or known dependencies
N/A
