### PR TITLE
Add mocha configuration for Tree workspace

### DIFF
--- a/packages/dds/tree/.vscode/Tree.code-workspace
+++ b/packages/dds/tree/.vscode/Tree.code-workspace
@@ -1,0 +1,15 @@
+{
+    "folders": [
+      {
+        "name": "FluidFramework",
+        "path": "../../../../"
+      },
+      {
+        "name": "@fluid-internal/tree",
+        "path": ".."
+      }
+    ],
+    "settings": {
+      "terminal.integrated.cwd": "../../.."
+    }
+  }

--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"mochaExplorer.files": ["dist/**/*.spec.js"],
+	"mochaExplorer.pruneFiles": true,
+	"mochaExplorer.require": "node_modules/@fluidframework/mocha-test-setup",
+	"mochaExplorer.timeout": 999999
+}

--- a/packages/dds/tree/src/test/.mocharc.js
+++ b/packages/dds/tree/src/test/.mocharc.js
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+'use strict';
+
+const config = {
+	require: ['@fluidframework/mocha-test-setup'],
+};
+
+module.exports = config;


### PR DESCRIPTION
## Description

Provides a VS Code workspace file for the dds/tree package. Using this workspace directs vs code to use a settings file local to the tree package, which now sets up the Mocha Test Explorer extension properly.

## Does this introduce a breaking change?

-   [ ] Yes
-   [X] No
