### PR TITLE
Move `ILocalSequencedClient` to protocol definitions

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -196,6 +196,11 @@ export interface IHelpMessage {
 }
 
 // @public (undocumented)
+export interface ILocalSequencedClient extends ISequencedClient {
+    shouldHaveLeft?: boolean;
+}
+
+// @public (undocumented)
 export interface INack {
     // (undocumented)
     content: INackContent;

--- a/common/lib/protocol-definitions/src/clients.ts
+++ b/common/lib/protocol-definitions/src/clients.ts
@@ -41,6 +41,13 @@ export interface ISequencedClient {
     sequenceNumber: number;
 }
 
+export interface ILocalSequencedClient extends ISequencedClient {
+    /**
+     * True if the client should have left the quorum, false otherwise
+     */
+    shouldHaveLeft?: boolean;
+}
+
 export interface ISignalClient {
 
     clientId: string;


### PR DESCRIPTION
# [261](https://dev.azure.com/fluidframework/internal/_workitems/edit/261/)

## Description

Part of https://github.com/microsoft/FluidFramework/pull/10412/

This is needed by both the protocol handler and the loader, as the former will check the flag and the latter will set it via the connection handler.

It currently resides in `packages/loader/container-loader/src/connectionStateHandler.ts` and will be removed once the protocol definitions package is upgraded.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [x] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
