### PR TITLE
Remove semver import and replace the algorithm

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -77,7 +77,6 @@
     "@fluidframework/runtime-utils": "^1.0.0",
     "@fluidframework/telemetry-utils": "^1.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "semver": "^7.3.4",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -40,7 +40,6 @@ import {
     TelemetryDataTag,
 } from "@fluidframework/telemetry-utils";
 
-import * as semver from "semver";
 import { IGCRuntimeOptions, RuntimeHeaders } from "./containerRuntime";
 import { getSummaryForDatastores } from "./dataStores";
 import { pkgVersion } from "./packageVersion";
@@ -1331,5 +1330,56 @@ function setLongTimeout(
  * @param minimumVersion - the function to execute when the timer ends
  */
 function meetsMinimumVersionRequirement(currentVersion: string, minimumVersion: string | undefined) {
-    return minimumVersion === undefined || semver.compare(currentVersion, minimumVersion) >= 0;
+    return minimumVersion === undefined || semverCompare(currentVersion, minimumVersion) >= 0;
+}
+
+/**
+ * Compare semver versions.
+ * @param currentVersion - assumed to be any valid semver version
+ * @param minimumVersion - must be [major].[minor].[patch], where major, minor, and patch are all numbers
+ *  as it complicates the algorithm if we allow comparisons against minimum pre-release versions.
+ * @returns
+ *  0 if the currentVersion equals the minimumVersion
+ *  1 if the currentVersion is greater than the minimumVersion
+ *  -1 if the minimumVersion is greater than the currentVersion
+ */
+export function semverCompare(currentVersion: string, minimumVersion: string): number {
+    const minimumValues = minimumVersion.split(".").map((value): number => {
+        assert(isNaN(+value) === false, `Expected real numbers in minimum version!`);
+        return Number.parseInt(value, 10);
+    });
+    assert(minimumValues.length === 3, `Expected minimumVersion ${minimumVersion} `);
+    const [minMajor, minMinor, minPatch] = minimumValues;
+
+    const currentValuesString = currentVersion.split(/\W/);
+    assert(currentValuesString.length >= 3, `Expected version to match semver rules!`);
+    const currentValues = currentValuesString.slice(0, 3).map((value) => {
+        assert(isNaN(+value) === false, `Expected real numbers in minimum version!`);
+        return Number.parseInt(value, 10);
+    });
+    const [cMajor, cMinor, cPatch] = currentValues;
+
+    if (cMajor > minMajor) {
+        return 1;
+    } else if (minMajor > cMajor) {
+        return -1;
+    }
+
+    if (cMinor > minMinor) {
+        return 1;
+    } else if (minMinor > cMinor) {
+        return -1;
+    }
+
+    if (cPatch > minPatch) {
+        return 1;
+    } else if (minPatch > cPatch) {
+        return -1;
+    }
+
+    if (currentValuesString.length === 3) {
+        return 0;
+    }
+
+    return -1;
 }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1345,16 +1345,16 @@ function meetsMinimumVersionRequirement(currentVersion: string, minimumVersion: 
  */
 export function semverCompare(currentVersion: string, minimumVersion: string): number {
     const minimumValues = minimumVersion.split(".").map((value): number => {
-        assert(isNaN(+value) === false, `Expected real numbers in minimum version!`);
+        assert(isNaN(+value) === false, "Expected real numbers in minimum version!");
         return Number.parseInt(value, 10);
     });
-    assert(minimumValues.length === 3, `Expected minimumVersion ${minimumVersion} `);
+    assert(minimumValues.length === 3, "Expected minimumVersion to be [major].[minor].[patch]");
     const [minMajor, minMinor, minPatch] = minimumValues;
 
     const currentValuesString = currentVersion.split(/\W/);
-    assert(currentValuesString.length >= 3, `Expected version to match semver rules!`);
+    assert(currentValuesString.length >= 3, "Expected version to match semver rules!");
     const currentValues = currentValuesString.slice(0, 3).map((value) => {
-        assert(isNaN(+value) === false, `Expected real numbers in minimum version!`);
+        assert(isNaN(+value) === false, "Expected real numbers in minimum version!");
         return Number.parseInt(value, 10);
     });
     const [cMajor, cMinor, cPatch] = currentValues;

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -989,7 +989,14 @@ describe("Garbage Collection Tests", () => {
             );
         };
 
-        // On the server we may get something like 1.0.0-1 - handle that situation
+        /**
+         * The client package version on the server is likely to be [major].[minor].[patch]-[pre-release], i.e 1.0.0-1
+         * This does conversions like this as minimumVersion needs to be [major].[minor].[patch] where [x] is a number.
+         * 1.0.0-1 to 1.0.0
+         * 1.0.0 to 1.0.0
+         * 1.0.0-pre1+12 to 1.0.0
+         * 1.0.0+a123-a123 to 1.0.0
+         */
         const getRegularSemverVersion = () => {
             let lastRegularIndex = pkgVersion.length;
             const firstHyphen = pkgVersion.indexOf("-");

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -31,6 +31,7 @@ import {
     runSessionExpiryKey,
     disableSessionExpiryKey,
     logUnknownOutboundReferencesKey,
+    semverCompare,
 } from "../garbageCollection";
 import { IContainerRuntimeMetadata } from "../summaryFormat";
 import { pkgVersion } from "../packageVersion";
@@ -988,6 +989,20 @@ describe("Garbage Collection Tests", () => {
             );
         };
 
+        // On the server we may get something like 1.0.0-1 - handle that situation
+        const getRegularSemverVersion = () => {
+            let lastRegularIndex = pkgVersion.length;
+            const firstHyphen = pkgVersion.indexOf("-");
+            const firstPlus = pkgVersion.indexOf("+");
+            if (firstHyphen > 0 && (firstHyphen <= firstPlus || firstPlus <= 0)) {
+                lastRegularIndex = firstHyphen;
+            } else if (firstPlus > 0 && (firstPlus < firstHyphen || firstHyphen <= 0)) {
+                lastRegularIndex = firstPlus;
+            }
+
+            return pkgVersion.substring(0, lastRegularIndex);
+        };
+
         it("No changes to GC between summaries creates a blob handle when no version specified", async () => {
             garbageCollector = createGarbageCollector();
 
@@ -1028,7 +1043,7 @@ describe("Garbage Collection Tests", () => {
         });
 
         it("No changes to GC between summaries creates a blob when less than minimum version", async () => {
-            settings[trackGCStateMinimumVersionKey] = `1${pkgVersion}`;
+            settings[trackGCStateMinimumVersionKey] = `1${getRegularSemverVersion()}`;
             garbageCollector = createGarbageCollector();
 
             await garbageCollector.collectGarbage({ runGC: true });
@@ -1046,25 +1061,30 @@ describe("Garbage Collection Tests", () => {
 
             checkGCSummaryType(tree2, SummaryType.Tree, "second");
         });
+    });
 
-        it("No changes to GC between summaries creates a blob handle when equal to minimum version", async () => {
-            settings[trackGCStateMinimumVersionKey] = `${pkgVersion}`;
-            garbageCollector = createGarbageCollector();
-
-            await garbageCollector.collectGarbage({ runGC: true });
-            const tree1 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree1, SummaryType.Tree, "first");
-
-            await garbageCollector.latestSummaryStateRefreshed(
-                { wasSummaryTracked: true, latestSummaryUpdated: true },
-                parseNothing,
-            );
-
-            await garbageCollector.collectGarbage({ runGC: true });
-            const tree2 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree2, SummaryType.Handle, "second");
-        });
+    describe("Semver comparison tests", () => {
+        const test = (current: string, minimum: string, expected: number) => {
+            it(`Current: ${current} ${expected === 1 ? ">" : expected === 0 ? "=" : "<" } Minimum: ${minimum}`, () => {
+                const actual = semverCompare(current, minimum);
+                assert(actual === expected, `Semver compare failed, expected ${expected}, got ${actual}`);
+            });
+        };
+        test("0.0.0", "0.0.0", 0);
+        test("0.0.1", "0.0.0", 1);
+        test("0.0.0", "0.0.1", -1);
+        test("0.1.0", "0.1.0", 0);
+        test("0.1.0", "0.0.1", 1);
+        test("0.0.0", "0.1.0", -1);
+        test("1.0.0", "1.0.0", 0);
+        test("1.0.0", "0.1.1", 1);
+        test("0.1.1", "1.0.0", -1);
+        test("0.0.0-123", "0.0.0", -1);
+        test("0.0.12-123", "0.0.0", 1);
+        test("10.2.3-DEV-SNAPSHOT", "10.2.3", -1);
+        test("1.1.2-prerelease+meta", "1.1.2", -1);
+        test("0.59.4000", "0.59.4001", -1);
+        test("1.0.0", "0.59.4001", 1);
+        test("0.59.4000-123123", "0.59.4000", -1);
     });
 });


### PR DESCRIPTION
Remove semver import as it increases bundle size.

Replace the semver import with a new comparison algorithm.

[AB#622](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/622)