### PR TITLE
Fix Early Container Close Exception

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1629,7 +1629,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         }
 
         const state = this.connectionState === ConnectionState.Connected;
-        if (!this.context.disposed) {
+        if (this._context?.disposed === false) {
             this.context.setConnectionState(state, this.clientId);
         }
         assert(this.protocolHandler !== undefined, 0x0dc /* "Protocol handler should be set here" */);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1629,7 +1629,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         }
 
         const state = this.connectionState === ConnectionState.Connected;
-        if (!this.closed && !this.context.disposed) {
+        if (this._context?.disposed === false) {
             this.context.setConnectionState(state, this.clientId);
         }
         assert(this.protocolHandler !== undefined, 0x0dc /* "Protocol handler should be set here" */);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1629,7 +1629,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         }
 
         const state = this.connectionState === ConnectionState.Connected;
-        if (this._context?.disposed === false) {
+        if (!this.closed && !this.context.disposed) {
             this.context.setConnectionState(state, this.clientId);
         }
         assert(this.protocolHandler !== undefined, 0x0dc /* "Protocol handler should be set here" */);


### PR DESCRIPTION
# Fix Early Container Close Exception

## Description

If the container closes before the context is setup we can get a container close exception from the context getter


## PR Checklist
-  [x] I have updated the documentation accordingly.
-  [ ]  I have added tests to cover my changes.
-  [x]  All new and existing tests passed.
-  [x]  My code follows the code style of this project.
-  [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-  [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

[AB#625](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/625)