### PR TITLE
Avoid sliding intervals with pending changes

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1206,7 +1206,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
         const newStart = this.getSlideToSegment(interval.start);
         const newEnd = this.getSlideToSegment(interval.end);
 
-        // TODO: Regression test for this behavior.
         const id = interval.properties[reservedIntervalIdKey];
         const hasPendingStartChange = this.hasPendingChangeStart(id);
         const hasPendingEndChange = this.hasPendingChangeEnd(id);

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1181,7 +1181,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
         const segoff = { segment: lref.segment, offset: lref.offset };
         const newSegoff = this.client.getSlideToSegment(segoff);
         const value: { segment: ISegment | undefined; offset: number | undefined; } | undefined
-            = (segoff === newSegoff) ? undefined : newSegoff;
+            = (segoff.segment === newSegoff.segment && segoff.offset === newSegoff.offset) ? undefined : newSegoff;
         return value;
     }
 
@@ -1205,17 +1205,31 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
             0x2f7 /* start and end must both be StayOnRemove */);
         const newStart = this.getSlideToSegment(interval.start);
         const newEnd = this.getSlideToSegment(interval.end);
-        this.setSlideOnRemove(interval.start);
-        this.setSlideOnRemove(interval.end);
 
-        if (newStart || newEnd) {
+        // TODO: Regression test for this behavior.
+        const id = interval.properties[reservedIntervalIdKey];
+        const hasPendingStartChange = this.hasPendingChangeStart(id);
+        const hasPendingEndChange = this.hasPendingChangeEnd(id);
+
+        if (!hasPendingStartChange) {
+            this.setSlideOnRemove(interval.start);
+        }
+
+        if (!hasPendingEndChange) {
+            this.setSlideOnRemove(interval.end);
+        }
+
+        const needsStartUpdate = newStart !== undefined && !hasPendingStartChange;
+        const needsEndUpdate = newEnd !== undefined && !hasPendingEndChange;
+
+        if (needsStartUpdate || needsEndUpdate) {
             this.localCollection.removeExistingInterval(interval);
-            if (newStart) {
+            if (needsStartUpdate) {
                 const props = interval.start.properties;
                 interval.start = createPositionReferenceFromSegoff(this.client, newStart, interval.start.refType, op);
                 interval.start.addProperties(props);
             }
-            if (newEnd) {
+            if (needsEndUpdate) {
                 const props = interval.end.properties;
                 interval.end = createPositionReferenceFromSegoff(this.client, newEnd, interval.end.refType, op);
                 interval.end.addProperties(props);

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -789,6 +789,21 @@ describe("SharedString interval collections", () => {
             assert.equal(Array.from(collection1).length, 0);
             assert.equal(Array.from(collection2).length, 0);
         });
+
+        it.only("remains consistent on add+change with concurrent remove", () => {
+            // WIP: oddly, doesn't repro.
+            sharedString.insertText(0, "ABCDEF");
+            const collection1 = sharedString.getIntervalCollection("test");
+            const collection2 = sharedString2.getIntervalCollection("test");
+            containerRuntimeFactory.processAllMessages();
+            sharedString.removeRange(3, 6);
+            const interval = collection2.add(3, 4, IntervalType.SlideOnRemove);
+            collection2.change(interval.getIntervalId(), 1, 5);
+            containerRuntimeFactory.processAllMessages();
+            assert.equal(sharedString.getText(), "ABC");
+            assertIntervals(sharedString, collection1, [{ start: 1, end: 2 }]);
+            assertIntervals(sharedString2, collection2, [{ start: 1, end: 2 }]);
+        });
     });
 
     // TODO: Enable this test suite once correctness issues with reconnect are addressed.

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -790,8 +790,7 @@ describe("SharedString interval collections", () => {
             assert.equal(Array.from(collection2).length, 0);
         });
 
-        it.only("remains consistent on add+change with concurrent remove", () => {
-            // WIP: oddly, doesn't repro.
+        it("doesn't slide references on ack if there are pending remote changes", () => {
             sharedString.insertText(0, "ABCDEF");
             const collection1 = sharedString.getIntervalCollection("test");
             const collection2 = sharedString2.getIntervalCollection("test");
@@ -799,10 +798,17 @@ describe("SharedString interval collections", () => {
             sharedString.removeRange(3, 6);
             const interval = collection2.add(3, 4, IntervalType.SlideOnRemove);
             collection2.change(interval.getIntervalId(), 1, 5);
-            containerRuntimeFactory.processAllMessages();
+
+            assert.equal(containerRuntimeFactory.outstandingMessageCount, 3, "Unexpected number of ops");
+            containerRuntimeFactory.processOneMessage();
+            assertIntervals(sharedString2, collection2, [{ start: 1, end: 3 /* hasn't yet been acked */ }]);
+            containerRuntimeFactory.processOneMessage();
+            assertIntervals(sharedString2, collection2, [{ start: 1, end: 3 /* hasn't yet been acked */ }]);
+            containerRuntimeFactory.processOneMessage();
+            assertIntervals(sharedString2, collection2, [{ start: 1, end: 2 }]);
+
             assert.equal(sharedString.getText(), "ABC");
             assertIntervals(sharedString, collection1, [{ start: 1, end: 2 }]);
-            assertIntervals(sharedString2, collection2, [{ start: 1, end: 2 }]);
         });
     });
 


### PR DESCRIPTION
This is in-line with the philosophy of only sliding on ack. Though the previous code wouldn't lead to eventually-inconsistent behavior, it could cause some flickering on a client with local changes to a recently added interval.