### PR TITLE
Adding error handling for incomingOpHandler and DeltaQueue.push()

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -271,6 +271,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                 try {
                     this.enqueueMessages(messages, reason);
                 } catch (error) {
+                    this.logger.sendErrorEvent({ eventName: "EnqueueMessages_Exception" }, error);
                     this.close(normalizeError(error));
                 }
             },

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -267,8 +267,13 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     ) {
         super();
         const props: IConnectionManagerFactoryArgs = {
-            incomingOpHandler: (messages: ISequencedDocumentMessage[], reason: string) =>
-                this.enqueueMessages(messages, reason),
+            incomingOpHandler: (messages: ISequencedDocumentMessage[], reason: string) => {
+                try {
+                    this.enqueueMessages(messages, reason);
+                } catch (error) {
+                    this.close(normalizeError(error));
+                }
+            },
             signalHandler: (message: ISignalMessage) => this._inboundSignal.push(message),
             reconnectionDelayHandler: (delayMs: number, error: unknown) =>
                 this.emitDelayInfo(this.deltaStreamDelayId, delayMs, error),

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -85,9 +85,13 @@ export class DeltaQueue<T>
     }
 
     public push(task: T) {
-        this.q.push(task);
-        this.emit("push", task);
-        this.ensureProcessing();
+        try {
+            this.q.push(task);
+            this.emit("push", task);
+            this.ensureProcessing();
+        } catch (error) {
+            this.emit("error", error);
+        }
     }
 
     public async pause(): Promise<void> {


### PR DESCRIPTION
bug 605

## Description

Wrap enqueueMessages call in try catch block, same with DeltaQueue.push()

