### PR TITLE
Fixed the first summary for a container logging incremental summary violation error

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -221,7 +221,7 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
     /**
      * Defines the maximum allowed time in between summarizations.
      */
-     idleTime: number;
+    idleTime: number;
     /**
      * Defines the maximum allowed time, since the last received Ack,  before running the summary
      * with reason maxTime.
@@ -231,9 +231,9 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
      * Defines the maximum number of Ops, since the last received Ack, that can be allowed
      * before running the summary with reason maxOps.
      */
-     maxOps: number;
+    maxOps: number;
     /**
-     * Defnines the minimum number of Ops, since the last received Ack, that can be allowed
+     * Defines the minimum number of Ops, since the last received Ack, that can be allowed
      * before running the last summary.
      */
     minOpsForLastSummaryAttempt: number;
@@ -334,7 +334,7 @@ export interface ISummaryRuntimeOptions {
      * @deprecated - use `summaryConfigOverrides.maxOpsSinceLastSummary` instead.
      * Defaults to 7000 ops
      */
-     maxOpsSinceLastSummary?: number;
+    maxOpsSinceLastSummary?: number;
 
      /**
      * @deprecated - use `summaryConfigOverrides.summarizerClientElection` instead.

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1154,11 +1154,12 @@ export class GarbageCollector implements IGarbageCollector {
 
         const updateNodeStats = (nodeId: string, referenced: boolean) => {
             gcStats.nodeCount++;
-            /**
-             * `this.unreferencedNodesState` has the previous unreferenced state of all nodes. `referenced` flag passed
-             * here is current state of the give node. Check if the reference state of the changed.
-             */
-            const stateUpdated = this.unreferencedNodesState.has(nodeId) ? referenced : !referenced;
+            // If there is no previous GC data, every node's state is generated and is considered as updated.
+            // Otherwise, find out if any node went from referenced to unreferenced or vice-versa.
+            const stateUpdated = this.previousGCDataFromLastRun === undefined
+                ? true
+                : (this.unreferencedNodesState.has(nodeId) ? referenced : !referenced);
+
             if (stateUpdated) {
                 gcStats.updatedNodeCount++;
             }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1156,10 +1156,8 @@ export class GarbageCollector implements IGarbageCollector {
             gcStats.nodeCount++;
             // If there is no previous GC data, every node's state is generated and is considered as updated.
             // Otherwise, find out if any node went from referenced to unreferenced or vice-versa.
-            const stateUpdated = this.previousGCDataFromLastRun === undefined
-                ? true
-                : (this.unreferencedNodesState.has(nodeId) ? referenced : !referenced);
-
+            const stateUpdated = this.previousGCDataFromLastRun === undefined ||
+                this.unreferencedNodesState.has(nodeId) === referenced;
             if (stateUpdated) {
                 gcStats.updatedNodeCount++;
             }

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -105,13 +105,13 @@ describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         const expectedGCStats: IGCStats = {
             nodeCount: 9,
             unrefNodeCount: 0,
-            updatedNodeCount: 0,
+            updatedNodeCount: 9,
             dataStoreCount: 3,
             unrefDataStoreCount: 0,
-            updatedDataStoreCount: 0,
+            updatedDataStoreCount: 3,
             attachmentBlobCount: 2,
             unrefAttachmentBlobCount: 0,
-            updatedAttachmentBlobCount: 0,
+            updatedAttachmentBlobCount: 2,
         };
 
         // Add both data store handles in default data store to mark them referenced.
@@ -142,13 +142,13 @@ describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         const expectedGCStats: IGCStats = {
             nodeCount: 9,
             unrefNodeCount: 0,
-            updatedNodeCount: 0,
+            updatedNodeCount: 9,
             dataStoreCount: 3,
             unrefDataStoreCount: 0,
-            updatedDataStoreCount: 0,
+            updatedDataStoreCount: 3,
             attachmentBlobCount: 2,
             unrefAttachmentBlobCount: 0,
-            updatedAttachmentBlobCount: 0,
+            updatedAttachmentBlobCount: 2,
         };
 
         // Add both data store handles in default data store to mark them referenced.
@@ -165,6 +165,9 @@ describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 
         await provider.ensureSynchronized();
 
+        let gcStats = await containerRuntime.collectGarbage({});
+        assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+
         // Remove dataStore1 and blob1's handles to mark them unreferenced.
         defaultDataStore._root.delete("dataStore1");
         defaultDataStore._root.delete("blob1");
@@ -179,7 +182,7 @@ describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         expectedGCStats.unrefAttachmentBlobCount = 1;
         expectedGCStats.updatedAttachmentBlobCount = 1;
 
-        let gcStats = await containerRuntime.collectGarbage({});
+        gcStats = await containerRuntime.collectGarbage({});
         assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
         let summarizeResult = await containerRuntime.summarize({ trackState: false });
@@ -222,13 +225,13 @@ describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         const expectedGCStats: IGCStats = {
             nodeCount: 9,
             unrefNodeCount: 0,
-            updatedNodeCount: 0,
+            updatedNodeCount: 9,
             dataStoreCount: 3,
             unrefDataStoreCount: 0,
-            updatedDataStoreCount: 0,
+            updatedDataStoreCount: 3,
             attachmentBlobCount: 2,
             unrefAttachmentBlobCount: 0,
-            updatedAttachmentBlobCount: 0,
+            updatedAttachmentBlobCount: 2,
         };
 
         // Add both data store handles in default data store to mark them referenced.
@@ -272,10 +275,10 @@ describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         const expectedGCStats: IGCStats = {
             nodeCount: 7,
             unrefNodeCount: 0,
-            updatedNodeCount: 0,
+            updatedNodeCount: 7,
             dataStoreCount: 3,
             unrefDataStoreCount: 0,
-            updatedDataStoreCount: 0,
+            updatedDataStoreCount: 3,
             attachmentBlobCount: 0,
             unrefAttachmentBlobCount: 0,
             updatedAttachmentBlobCount: 0,

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerRuntimeFactoryWithDefaultDataStore, DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { assert, bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import {
@@ -11,37 +10,27 @@ import {
     Summarizer,
     ISummarizer,
     ISummarizeResults,
-    ISummaryRuntimeOptions, DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
-import { SharedDirectory, SharedMap } from "@fluidframework/map";
-import { SharedMatrix } from "@fluidframework/matrix";
+    ISummaryRuntimeOptions, DefaultSummaryConfiguration, SummaryCollection } from "@fluidframework/container-runtime";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
-import { channelsTreeName, IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { SharedObjectSequence } from "@fluidframework/sequence";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
-import { createLoader, ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
-import { IRequest } from "@fluidframework/core-interfaces";
+import { describeFullCompat, ITestDataObject, TestDataObjectType } from "@fluidframework/test-version-utils";
+import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
+import { ConnectionState } from "@fluidframework/container-loader";
 
-const defaultDataStoreId = "default";
 let summarizer: ISummarizer;
-
-class TestDataObject extends DataObject {
-    public static readonly dataObjectName = "TestDataObject";
-    public readonly getRoot = () => this.root;
-    public readonly getRuntime = () => this.runtime;
-    public readonly getContext = () => this.context;
-}
+const defaultDataStoreId = "default";
 
 const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));
-const maxOps = 10;
 const testContainerConfig: ITestContainerConfig = {
     runtimeOptions: {
         summaryOptions: {
             summaryConfigOverrides: {
                 ...DefaultSummaryConfiguration,
                 ...{
-                    maxOps,
+                    maxOps: 10,
                     initialSummarizerDelayMs: 0,
+                    idleTime: 10,
                 },
              },
         },
@@ -52,44 +41,19 @@ async function createContainer(
     provider: ITestObjectProvider,
     summaryOpt: ISummaryRuntimeOptions,
 ): Promise<IContainer> {
-    const factory = new DataObjectFactory(TestDataObject.dataObjectName, TestDataObject, [
-        SharedMap.getFactory(),
-        SharedDirectory.getFactory(),
-        SharedMatrix.getFactory(),
-        SharedObjectSequence.getFactory(),
-    ], []);
-
     // Force generateSummaries to false.
-    const summaryOptions: ISummaryRuntimeOptions = { ...summaryOpt,
+    const summaryOptions: ISummaryRuntimeOptions = {
+        ...summaryOpt,
         summaryConfigOverrides: {
             ...summaryOpt.summaryConfigOverrides,
             state: "disabled",
         } };
 
-    const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-        runtime.IFluidHandleContext.resolveHandle(request);
-
-    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-        factory,
-        [
-            [defaultDataStoreId, Promise.resolve(factory)],
-            [TestDataObject.dataObjectName, Promise.resolve(factory)],
-        ],
-        undefined,
-        [innerRequestHandler],
-        { summaryOptions },
-    );
-
-    return provider.createContainer(runtimeFactory);
+    return provider.makeTestContainer({ runtimeOptions: { summaryOptions } });
 }
 
 async function createSummarizer(provider: ITestObjectProvider): Promise<ISummarizer> {
-    const loader = createLoader(
-        [[provider.defaultCodeDetails, provider.createFluidEntryPoint(testContainerConfig)]],
-        provider.documentServiceFactory,
-        provider.urlResolver,
-    );
-
+    const loader = provider.makeTestLoader(testContainerConfig);
     const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
     await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
     const absoluteUrl = await container.getAbsoluteUrl("");
@@ -105,7 +69,7 @@ function readBlobContent(content: ISummaryBlob["content"]): unknown {
 }
 
 // REVIEW: enable compat testing?
-describeNoCompat("Summaries", (getTestObjectProvider) => {
+describeFullCompat("Summaries", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     beforeEach(() => {
         provider = getTestObjectProvider();
@@ -159,8 +123,8 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 
     it("Should generate summary tree", async () => {
         const container = await createContainer(provider, { disableIsolatedChannels: false });
-        const defaultDataStore = await requestFluidObject<TestDataObject>(container, defaultDataStoreId);
-        const containerRuntime = defaultDataStore.getContext().containerRuntime as ContainerRuntime;
+        const defaultDataStore = await requestFluidObject<ITestDataObject>(container, defaultDataStoreId);
+        const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
 
         await provider.ensureSynchronized();
 
@@ -211,8 +175,8 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 
     it("Should generate summary tree with isolated channels disabled", async () => {
         const container = await createContainer(provider, { disableIsolatedChannels: true });
-        const defaultDataStore = await requestFluidObject<TestDataObject>(container, defaultDataStoreId);
-        const containerRuntime = defaultDataStore.getContext().containerRuntime as ContainerRuntime;
+        const defaultDataStore = await requestFluidObject<ITestDataObject>(container, defaultDataStoreId);
+        const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
 
         await provider.ensureSynchronized();
 
@@ -278,5 +242,45 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
         assert(!defaultDdsNode.unreferenced, "Default root DDS should be referenced.");
         assert(defaultDdsNode.tree[".attributes"]?.type === SummaryType.Blob,
             "Expected .attributes blob in default root DDS summary tree.");
+    });
+
+    /**
+     * This test validates that the first summary for a container by the first summarizer client does not violate
+     * incremental summary principles, i.e. we should not get "IncrementalSummaryViolation" error log.
+     * In the first summary all data stores are summarized because GC hasn't run yet so it has to summarize every data
+     * store to update "unreferenced" flag in its summary.
+     */
+    it.only("should not violate incremental summary principles on first summary", async () => {
+        const loader = provider.makeTestLoader(testContainerConfig);
+        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        const summaryCollection = new SummaryCollection(container.deltaManager, new TelemetryNullLogger());
+
+        const defaultDataStore = await requestFluidObject<ITestDataObject>(container, defaultDataStoreId);
+        const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
+
+        // Create a bunch of data stores before the container is attached so that they are part of the summary that the
+        // first summarizer client loads from.
+        const dataStore = await containerRuntime.createDataStore(TestDataObjectType);
+        const testDataObject = await requestFluidObject<ITestDataObject>(dataStore, "");
+        defaultDataStore._root.set("ds2", testDataObject.handle);
+
+        const dataStore2 = await containerRuntime.createDataStore(TestDataObjectType);
+        const testDataObject2 = await requestFluidObject<ITestDataObject>(dataStore2, "");
+        defaultDataStore._root.set("ds3", testDataObject2.handle);
+
+        const dataStore3 = await containerRuntime.createDataStore(TestDataObjectType);
+        const testDataObject3 = await requestFluidObject<ITestDataObject>(dataStore3, "");
+        defaultDataStore._root.set("ds4", testDataObject3.handle);
+
+        await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+        if (container.connectionState !== ConnectionState.Connected) {
+            await new Promise<void>((resolve) => container.once("connected", () => resolve()));
+        }
+
+        // Send an op to trigger summary. We should not get the "IncrementalSummaryViolation" error log.
+        defaultDataStore._root.set("key", "value");
+        await provider.ensureSynchronized();
+        await summaryCollection.waitSummaryAck(container.deltaManager.lastSequenceNumber);
     });
 });


### PR DESCRIPTION
[AB#644](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/644)

## Description
The `IncrementalSummaryViolation` error is sometimes seen during the first summary by the first summarizer client. This error is logged if `summarizedDataStoreCount > opsSinceLastSummary + gcStateUpdatedDataStoreCount`. Basically, only data stores that received an op or had their GC state updated should summarize.

### Root-cause
However, in the first summary by the first summarizer, all data stores are summarized even if they don't have changes. This is because it loads from the summary created by detached container that does not have GC data. So, GC cannot run incrementally this time and has to re-summarize every data stores to update their "unreferenced" flag. Now, if the number of ops is less than the number of data stores, this throws an error.

### Fix
The data stores summarized because of the absence of GC data in previous summary are considered as "updated". This is correct because their GC state was generated in this summary, so it was updated from not having GC data.
In the scenario where its failing now, the `gcStateUpdatedDataStoreCount` will now be equal to `summarizedDataStoreCount`, so this error won't be logged anymore.

## Steps to Reproduce Bug and Validate Solution
1. Create a detached container and create 4-5 data stores in it.
2. Attach the container.
3. Send only 1 op to trigger a summary.
4. The `IncrementalSummaryViolation` error will be seen.
Note that even though 1 op is sent in step 3, there may be few system ops that can contribute to `opsSinceLastSummary`. If that happens, create more data stores in step 1 until it exceeds the op count during summary.

Added a test that follows these steps and validates that the error is not seen anymore.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Testing

Added a test to validate this scenario does not log the error event anymore.

## Other information
Removed a bunch of unnecessary setup from the `summaries.spec.ts` file.