### PR TITLE
Updated GC state to be written at the root of summary tree by default

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -507,7 +507,7 @@ export class GarbageCollector implements IGarbageCollector {
             // The GC state needs to be reset if the base snapshot contains GC tree and GC is disabled or it doesn't
             // contain GC tree and GC is enabled.
             const gcTreePresent = baseSnapshot?.trees[gcTreeKey] !== undefined;
-            this.initialStateNeedsReset = gcTreePresent === !this.shouldRunGC;
+            this.initialStateNeedsReset = gcTreePresent !== this.shouldRunGC;
         }
 
         // Get the GC state from the GC blob in the base snapshot. Use LazyPromise because we only want to do

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -73,8 +73,6 @@ const writeAtRootKey = "Fluid.GarbageCollection.WriteDataAtRoot";
 export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
 // Feature gate key to disable expiring session after a set period of time, even if expiry value is present
 export const disableSessionExpiryKey = "Fluid.GarbageCollection.DisableSessionExpiry";
-// Feature gate key to log error messages if GC reference validation fails.
-export const logUnknownOutboundReferencesKey = "Fluid.GarbageCollection.LogUnknownOutboundReferences";
 // Feature gate key to write the gc blob as a handle if the data is the same.
 export const trackGCStateKey = "Fluid.GarbageCollection.TrackGCState";
 // Feature gate key to limit which versions can write the gc blob as a handle if the data is the same.
@@ -332,7 +330,7 @@ export class GarbageCollector implements IGarbageCollector {
     /**
      * Tells whether the GC data should be written to the root of the summary tree.
      */
-    private _writeDataAtRoot: boolean = false;
+    private _writeDataAtRoot: boolean = true;
     public get writeDataAtRoot(): boolean {
         return this._writeDataAtRoot;
     }
@@ -502,19 +500,15 @@ export class GarbageCollector implements IGarbageCollector {
         // Whether we are running in test mode. In this mode, unreferenced nodes are immediately deleted.
         this.testMode = this.mc.config.getBoolean(gcTestModeKey) ?? gcOptions.runGCInTestMode === true;
 
-        /**
-         * Enable resetting initial state once the following issue is resolved:
-         * https://github.com/microsoft/FluidFramework/issues/8878.
-         * Currently, the GC tree is not written at root, so we don't know if the base snapshot contains GC tree or not.
-         */
+        // GC state is written into root of the summary tree by default. Can be overridden via feature flag for now.
+        this._writeDataAtRoot = this.mc.config.getBoolean(writeAtRootKey) ?? true;
+
         // The GC state needs to be reset if the base snapshot contains GC tree and GC is disabled or it doesn't contain
         // GC tree and GC is enabled.
-        // const gcTreePresent = baseSnapshot?.trees[gcTreeKey] !== undefined;
-        // this.initialStateNeedsReset = gcTreePresent ? !this.shouldRunGC : this.shouldRunGC;
-
-        // If `writeDataAtRoot` setting is true, write the GC data into the root of the summary tree. We do this so that
-        // the roll out can be staged. Once its rolled out everywhere, we will start writing at root by default.
-        this._writeDataAtRoot = this.mc.config.getBoolean(writeAtRootKey) ?? this.gcOptions.writeDataAtRoot === true;
+        if (this._writeDataAtRoot) {
+            const gcTreePresent = baseSnapshot?.trees[gcTreeKey] !== undefined;
+            this.initialStateNeedsReset = gcTreePresent ? !this.shouldRunGC : this.shouldRunGC;
+        }
 
         // Get the GC state from the GC blob in the base snapshot. Use LazyPromise because we only want to do
         // this once since it involves fetching blobs from storage which is expensive.
@@ -1007,10 +1001,7 @@ export class GarbageCollector implements IGarbageCollector {
             this.newReferencesSinceLastRun,
         );
 
-        // The following log will be enabled once this issue is resolved:
-        // https://github.com/microsoft/FluidFramework/issues/8878.
-        if (this.mc.config.getBoolean(logUnknownOutboundReferencesKey) === true
-            && missingExplicitReferences.length > 0) {
+        if (this.writeDataAtRoot && missingExplicitReferences.length > 0) {
             missingExplicitReferences.forEach((missingExplicitReference) => {
                 const event: ITelemetryPerformanceEvent = {
                     eventName: "gcUnknownOutboundReferences",

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -503,11 +503,11 @@ export class GarbageCollector implements IGarbageCollector {
         // GC state is written into root of the summary tree by default. Can be overridden via feature flag for now.
         this._writeDataAtRoot = this.mc.config.getBoolean(writeAtRootKey) ?? true;
 
-        // The GC state needs to be reset if the base snapshot contains GC tree and GC is disabled or it doesn't contain
-        // GC tree and GC is enabled.
         if (this._writeDataAtRoot) {
+            // The GC state needs to be reset if the base snapshot contains GC tree and GC is disabled or it doesn't
+            // contain GC tree and GC is enabled.
             const gcTreePresent = baseSnapshot?.trees[gcTreeKey] !== undefined;
-            this.initialStateNeedsReset = gcTreePresent ? !this.shouldRunGC : this.shouldRunGC;
+            this.initialStateNeedsReset = gcTreePresent === !this.shouldRunGC;
         }
 
         // Get the GC state from the GC blob in the base snapshot. Use LazyPromise because we only want to do

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -30,7 +30,6 @@ import {
     trackGCStateMinimumVersionKey,
     runSessionExpiryKey,
     disableSessionExpiryKey,
-    logUnknownOutboundReferencesKey,
     semverCompare,
 } from "../garbageCollection";
 import { IContainerRuntimeMetadata } from "../summaryFormat";
@@ -635,7 +634,6 @@ describe("Garbage Collection Tests", () => {
 
         beforeEach(() => {
             closeCalled = false;
-            injectedSettings[logUnknownOutboundReferencesKey] = "true";
             defaultGCData.gcNodes = {};
             garbageCollector = createGarbageCollector();
         });

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -449,7 +449,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
         const gcContainerConfig: ITestContainerConfig = {
             runtimeOptions: {
                 gcOptions: {
-                    gcAllowed: true, runGCInTestMode: deleteUnreferencedContent, writeDataAtRoot: true,
+                    gcAllowed: true, runGCInTestMode: deleteUnreferencedContent,
                 },
             },
         };

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -64,8 +64,7 @@ describeFullCompat.skip("GC summary compatibility tests", (getTestObjectProvider
     const logger = new TelemetryNullLogger();
 
     // Enable config provider setting to write GC data at the root.
-    const settings = { "Fluid.GarbageCollection.WriteDataAtRoot": "true" };
-    const configProvider = mockConfigProvider(settings);
+    const configProvider = mockConfigProvider({});
 
     // Stores the latest summary uploaded to the server.
     let latestUploadedSummary: ISummaryTree | undefined;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -47,7 +47,7 @@ describeFullCompat.skip("GC summary compatibility tests", (getTestObjectProvider
                 state: "disabled",
             },
         },
-        gcOptions: { gcAllowed: true, writeDataAtRoot: true },
+        gcOptions: { gcAllowed: true },
     };
 
     const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -59,11 +59,7 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
         runtimeOptions,
     );
 
-    const settings = {
-        "Fluid.GarbageCollection.LogUnknownOutboundRoutes": "true",
-        "Fluid.GarbageCollection.WriteDataAtRoot": "true",
-    };
-    const configProvider = mockConfigProvider(settings);
+    const configProvider = mockConfigProvider({});
 
     let mainContainer: IContainer;
     let mainDataStore: TestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -38,7 +38,7 @@ describeFullCompat("GC delete objects in test mode", (getTestObjectProvider) => 
                     state: "disabled",
                 },
              },
-            gcOptions: { gcAllowed: true, runGCInTestMode: deleteUnreferencedContent, writeDataAtRoot: true },
+            gcOptions: { gcAllowed: true, runGCInTestMode: deleteUnreferencedContent },
         };
         const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
             runtime.IFluidHandleContext.resolveHandle(request);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -51,9 +51,7 @@ describeFullCompat("GC delete objects in test mode", (getTestObjectProvider) => 
             [innerRequestHandler],
             runtimeOptions,
         );
-        // Enable config provider setting to write GC data at the root.
-        const settings = { "Fluid.GarbageCollection.WriteDataAtRoot": "true" };
-        const configProvider = mockConfigProvider(settings);
+        const configProvider = mockConfigProvider({});
 
         let provider: ITestObjectProvider;
         let containerRuntime: ContainerRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
@@ -148,8 +148,20 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
         unreferencedDataStoreIds: string[] = [],
     ) {
         const channelsTree = await getSummaryChannelsTree(summarizerClient);
-        assert(latestUploadedSummary !== undefined, "Did not get a summary");
+        for (const [id, summaryObject] of Object.entries(channelsTree)) {
+            if (summaryObject.type !== SummaryType.Tree) {
+                assert(!shouldRegenerateSummary, `DataStore ${id}'s entry should be a tree if summary was regenerated`);
+                continue;
+            }
 
+            if (unreferencedDataStoreIds.includes(id)) {
+                assert(summaryObject.unreferenced === true, `DataStore ${id} should be unreferenced`);
+            } else {
+                assert(summaryObject.unreferenced !== true, `DataStore ${id} should be referenced`);
+            }
+        }
+
+        assert(latestUploadedSummary !== undefined, "Did not get a summary");
         const gcState = getGCStateFromSummary(latestUploadedSummary);
         if (gcState === undefined) {
             assert(!shouldGCRun, `If GC tree is not present in summary, GC should not have run.`);
@@ -172,31 +184,16 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
                 );
             }
         }
-
-        for (const [id, summaryObject] of Object.entries(channelsTree)) {
-            if (summaryObject.type !== SummaryType.Tree) {
-                assert(!shouldRegenerateSummary, `DataStore ${id}'s entry should be a tree if summary was regenerated`);
-                continue;
-            }
-
-            if (unreferencedDataStoreIds.includes(id)) {
-                assert(summaryObject.unreferenced === true, `DataStore ${id} should be unreferenced`);
-            } else {
-                assert(summaryObject.unreferenced !== true, `DataStore ${id} should be referenced`);
-            }
-        }
     }
 
-    before(function() {
+    beforeEach(async function() {
         provider = getTestObjectProvider();
         // These tests validate the end-to-end behavior of summaries when GC is enabled / disabled. This behavior
         // is not affected by the service. So, it doesn't need to run against real services.
         if (provider.driver.type !== "local") {
             this.skip();
         }
-    });
 
-    beforeEach(async () => {
         // Wrap the document service factory in the driver so that the `uploadSummaryCb` function is called every
         // time the summarizer client uploads a summary.
         (provider as any)._documentServiceFactory = wrapDocumentServiceFactory(
@@ -256,18 +253,19 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
             false /* shouldRegenerateSummary */,
         );
 
-        // Load a new summarizer from the last summary with GC still disabled.
+        // Load a new summarizer from the last summary with GC enabled.
         const summarizerClient3 = await getNewSummarizer(
-            true /* disableGC */,
+            false /* disableGC */,
             undefined /* gcAllowed */,
             latestAckedSummary.summaryAck.contents.handle,
         );
-        // Validate that GC does not run and the summary is not regenerated again in a new client as well. The
-        // summary is regenerated only the first time GC is disabled after it was enabled before.
+        // Validate that GC runs and the summary is regenerated because GC was disabled in the previous summary and
+        // is now enabled. Also, the unreferenced data stores should be marked as such.
         await validateGCState(
             summarizerClient3,
-            false /* shouldGCRun */,
-            false /* shouldRegenerateSummary */,
+            true /* shouldGCRun */,
+            true /* shouldRegenerateSummary */,
+            [newDataStore.id],
         );
     });
 
@@ -306,7 +304,7 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
         const newDataStore = await dataObjectFactory.createInstance(mainDataStore.containerRuntime);
         mainDataStore._root.set("newDataStore", newDataStore.handle);
 
-        // Validate that GC did not run even though gcAllowed is set to ture. Whether GC runs or not is determined by
+        // Validate that GC did not run even though gcAllowed is set to true. Whether GC runs or not is determined by
         // the gcAllowed flag when the document was created.
         await validateGCState(
             summarizerClient,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
@@ -49,9 +49,7 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
          },
     };
     const logger = new TelemetryNullLogger();
-    // Enable config provider setting to write GC data at the root.
-    const settings = { "Fluid.GarbageCollection.WriteDataAtRoot": "true" };
-    const configProvider = mockConfigProvider(settings);
+    const configProvider = mockConfigProvider({});
 
     // Stores the latest summary uploaded to the server.
     let latestUploadedSummary: ISummaryTree | undefined;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
@@ -74,7 +74,7 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
             ],
             undefined,
             [innerRequestHandler],
-            { ...defaultRuntimeOptions, gcOptions: { gcAllowed, writeDataAtRoot: true } },
+            { ...defaultRuntimeOptions, gcOptions: { gcAllowed } },
         );
         return provider.createContainer(runtimeFactory, { configProvider });
     };
@@ -88,7 +88,7 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
             ],
             undefined,
             [innerRequestHandler],
-            { ...defaultRuntimeOptions, gcOptions: { gcAllowed, disableGC, writeDataAtRoot: true } },
+            { ...defaultRuntimeOptions, gcOptions: { gcAllowed, disableGC } },
         );
         return loadSummarizer(
             provider,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -67,7 +67,7 @@ describeFullCompat("GC unknown handles", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: { disableSummaries: true },
-        gcOptions: { gcAllowed: true, writeDataAtRoot: true },
+        gcOptions: { gcAllowed: true },
     };
     let mainContainer: IContainer;
     let dataStoreA: ITestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -83,7 +83,7 @@ describeFullCompat("GC unknown handles", (getTestObjectProvider) => {
     const loadContainer = async () => {
         return provider.loadTestContainer({
             runtimeOptions,
-            loaderProps: { configProvider: mockConfigProvider({}) },
+            loaderProps: { configProvider: mockConfigProvider({ "Fluid.GarbageCollection.WriteDataAtRoot": "true" }) },
         });
     };
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -43,7 +43,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
                 state: "disabled",
             },
          },
-        gcOptions: { gcAllowed: true, writeDataAtRoot: true },
+        gcOptions: { gcAllowed: true },
     };
     const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
         runtime.IFluidHandleContext.resolveHandle(request);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -57,10 +57,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         runtimeOptions,
     );
     const logger = new TelemetryNullLogger();
-
-    // Enable config provider setting to write GC data at the root.
-    const settings = { "Fluid.GarbageCollection.WriteDataAtRoot": "true" };
-    const configProvider = mockConfigProvider(settings);
+    const configProvider = mockConfigProvider({});
 
     // Stores the latest summary uploaded to the server.
     let latestUploadedSummary: ISummaryTree | undefined;

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
@@ -7,7 +7,6 @@ import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-util
 
 export const mockConfigProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => {
     settings["Fluid.ContainerRuntime.UseDataStoreAliasing"] = "true";
-    settings["Fluid.GarbageCollection.WriteDataAtRoot"] = "true";
     settings["Fluid.GarbageCollection.TrackGCState"] = "true";
     return {
         getRawConfig: (name: string): ConfigTypes => settings[name],

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -146,7 +146,6 @@ export async function loadContainer(
                 state: "disabled",
             },
         },
-        gcOptions: { writeDataAtRoot: true },
     };
     const codeLoader = new ReplayCodeLoader(
         new ReplayRuntimeFactory(runtimeOptions, dataStoreRegistries, requestHandlers),


### PR DESCRIPTION
[AB#366](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/366) and [AB#368](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/368)

## Description
The GC state is now written at the root of summary tree by default. This was behind a feature flag which was enabled for a while now for most of Fluid apps.
This can still be disabled via the same feature flag if any issue is observed.

## PR Checklist

-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
