### PR TITLE
Fixed Tinylicious link on FF.com

### DIFF
--- a/docs/content/docs/build/packages.md
+++ b/docs/content/docs/build/packages.md
@@ -22,7 +22,7 @@ contained within itself, as well as to inspect the state of the collaboration se
 
 ### Shared object packages
 
-You'll use one or more shared objects in your container to model your collaborative data.  The `fluid-framework` package includes
+You'll use one or more shared objects in your container to model your collaborative data. The `fluid-framework` package includes
 three data structures that cover a broad range of scenarios:
 
 1. [SharedMap]({{< relref "/docs/data-structures/map.md" >}}), a map-like data structure for storing key/value pair data.
@@ -38,7 +38,7 @@ Fluid Framework packages are published under one of the following npm scopes:
 - @fluid-internal
 - @fluid-tools
 
-In addition to the scoped packages, two unscoped packages are published: the `fluid-framework` package, described earlier, and the `tinylicious` package, which contains a minimal Fluid server. For more information, see [Tinylicious]({{< relref "tinylicious.md" >}}.
+In addition to the scoped packages, two unscoped packages are published: the `fluid-framework` package, described earlier, and the `tinylicious` package, which contains a minimal Fluid server. For more information, see [Tinylicious]({{< relref "tinylicious.md" >}}).
 
 Unless you are contributing to the Fluid Framework, you should only need the unscoped packages and packages from the **@fluidframework** scope.
 You can [read more about the scopes and their intent][scopes] in the Fluid Framework wiki.


### PR DESCRIPTION
# Fixed Tinylicious link on FF.com

## Description

This PR fixes the broken link by a syntax error on page; https://fluidframework.com/docs/build/packages/

## Steps to Reproduce Bug and Validate Solution

Go to the website and see that the link doesn't work.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [X] My code follows the code style of this project.
-   [X] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

## Testing
Ran server locally and tested.

## Other information or known dependencies
[AB#614](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/614)
