### PR TITLE
Remove invalid early-exit in interval modification

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -371,11 +371,6 @@ implements ISerializableInterval {
         const startPos = start ?? this.start.toPosition();
         const endPos = end ?? this.end.toPosition();
 
-        if (this.start.toPosition() === startPos && this.end.toPosition() === endPos) {
-            // Return undefined to indicate that no change is necessary.
-            return;
-        }
-
         const newInterval =
             createSequenceInterval(label, startPos, endPos, this.start.getClient(), this.intervalType, op);
         if (this.properties) {


### PR DESCRIPTION
## Description

Removes an invalid optimization in interval modification and adds a regression test demonstrating the issue. This problem was found via fuzz testing.