### PR TITLE
Remove ISummaryConfiguration from protocol-definitions

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -87,8 +87,6 @@ export interface IClientConfiguration {
     maxMessageSize: number;
     noopCountFrequency?: number;
     noopTimeFrequency?: number;
-    // (undocumented)
-    summary: ISummaryConfiguration;
 }
 
 // @public (undocumented)
@@ -442,20 +440,6 @@ export interface ISummaryCommitter {
     email: string;
     // (undocumented)
     name: string;
-}
-
-// @public (undocumented)
-export interface ISummaryConfiguration {
-    // (undocumented)
-    disableSummaries?: boolean;
-    // (undocumented)
-    idleTime: number;
-    // (undocumented)
-    maxAckWaitTime: number;
-    // (undocumented)
-    maxOps: number;
-    // (undocumented)
-    maxTime: number;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -56,6 +56,17 @@
   },
   "typeValidation": {
     "version": "0.1029.1000",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_IConnected": {
+               "backCompat": false
+      },
+      "RemovedInterfaceDeclaration_ISummaryConfiguration": {
+              "forwardCompat": false,
+              "backCompat": false
+      },
+      "InterfaceDeclaration_IClientConfiguration": {
+          "backCompat": false
+      }
+    }
   }
 }

--- a/common/lib/protocol-definitions/src/config.ts
+++ b/common/lib/protocol-definitions/src/config.ts
@@ -3,25 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// Summary algorithm configuration
-// A summary will occur either if
-// * idleTime(ms) have passed without activity with pending ops to summarize, or
-// * maxTime(ms) have passed with pending ops to summarize, or
-// * maxOps are waiting to summarize
-// AND
-// * disableSummaries !== true
-export interface ISummaryConfiguration {
-    idleTime: number;
-
-    maxTime: number;
-
-    maxOps: number;
-
-    maxAckWaitTime: number;
-
-    disableSummaries?: boolean;
-}
-
 /**
  * Key value store of service configuration properties provided to the client as part of connection
  */
@@ -31,9 +12,6 @@ export interface IClientConfiguration {
 
     // Server defined ideal block size for storing snapshots
     blockSize: number;
-
-    // Summary algorithm configuration. This is sent to clients when they connect
-    summary: ISummaryConfiguration;
 
     /**
      * noopTimeFrequency & noopCountFrequency control how often a client with "write" connection needs to send

--- a/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.ts
+++ b/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.ts
@@ -251,6 +251,7 @@ declare function get_current_InterfaceDeclaration_IClientConfiguration():
 declare function use_old_InterfaceDeclaration_IClientConfiguration(
     use: TypeOnly<old.IClientConfiguration>);
 use_old_InterfaceDeclaration_IClientConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IClientConfiguration());
 
 /*
@@ -371,6 +372,7 @@ declare function get_current_InterfaceDeclaration_IConnected():
 declare function use_old_InterfaceDeclaration_IConnected(
     use: TypeOnly<old.IConnected>);
 use_old_InterfaceDeclaration_IConnected(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnected());
 
 /*
@@ -1144,26 +1146,14 @@ use_old_InterfaceDeclaration_ISummaryCommitter(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ISummaryConfiguration": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_ISummaryConfiguration": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_ISummaryConfiguration():
-    TypeOnly<old.ISummaryConfiguration>;
-declare function use_current_InterfaceDeclaration_ISummaryConfiguration(
-    use: TypeOnly<current.ISummaryConfiguration>);
-use_current_InterfaceDeclaration_ISummaryConfiguration(
-    get_old_InterfaceDeclaration_ISummaryConfiguration());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ISummaryConfiguration": {"backCompat": false}
+* "RemovedInterfaceDeclaration_ISummaryConfiguration": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_ISummaryConfiguration():
-    TypeOnly<current.ISummaryConfiguration>;
-declare function use_old_InterfaceDeclaration_ISummaryConfiguration(
-    use: TypeOnly<old.ISummaryConfiguration>);
-use_old_InterfaceDeclaration_ISummaryConfiguration(
-    get_current_InterfaceDeclaration_ISummaryConfiguration());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
# [Remove ISummaryConfiguration from Protocol-definitions](https://dev.azure.com/fluidframework/internal/_workitems/edit/546)

## Description

First step from removing the ISummaryConfiguration from protocol. 


## PR Checklist


-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [x] Yes
-   [] No

Removing ISummaryConfiguration from IClientConfiguration will be breaking change. 
