### PR TITLE
Allow deli to extend write clients

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1,4 +1,3 @@
-
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1,3 +1,4 @@
+
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -476,7 +477,6 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
                         if (sequencedMessage.type === MessageType.ClientJoin) {
                             this.addSequencedSignalClient(dataContent as IClientJoin, signalMessage);
-
                         } else {
                             this.sequencedSignalClients.delete(dataContent);
                         }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1690,12 +1690,12 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
     }
 
     /**
-     * Adds a sequenced signal client to the in-memory map
+     * Adds a sequenced signal client to the in-memory map.
+     * Alfred will periodically send ExtendClient control messages, which will extend the client expiration times.
      * @param clientJoinMessage - Client join message (from dataContent)
      * @param signalMessage - Ticketed join signal message
      */
     private addSequencedSignalClient(clientJoinMessage: IClientJoin, signalMessage: ISignalMessageOutput) {
-        // store the read client in-memory, including the signal sequence numbers
         const sequencedSignalClient: ISequencedSignalClient = {
             client: clientJoinMessage.detail,
             referenceSequenceNumber: (signalMessage.message.operation as any).referenceSequenceNumber,

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1200,8 +1200,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
     private checkIdleReadClients() {
         const currentTime = Date.now();
 
-        for (const [clientId, { exp }] of this.sequencedSignalClients) {
-            if (exp < currentTime) {
+        for (const [clientId, { client, exp }] of this.sequencedSignalClients) {
+            if (client.mode === "read" && exp < currentTime) {
                 const leaveMessage = this.createLeaveMessage(clientId);
                 void this.sendToRawDeltas(leaveMessage);
             }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1201,6 +1201,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
         const currentTime = Date.now();
 
         for (const [clientId, { client, exp }] of this.sequencedSignalClients) {
+            // only handle read clients here
+            // write client idle is handled by checkIdleWriteClients
             if (client.mode === "read" && exp < currentTime) {
                 const leaveMessage = this.createLeaveMessage(clientId);
                 void this.sendToRawDeltas(leaveMessage);


### PR DESCRIPTION
Follow up on #9191

Deli has the ability to periodically extend the expiration time for read clients. However, deli is not doing the same for write clients. This means alfred needs separate logic to periodically extend the expiration time for write clients. 

It's simpler if deli treated both clients the same. That's what this PR does.

State before this PR:
- Alfred has to periodically use `ClientManager` to extend write clients AND tell Deli to extend read clients
- Deli processes `ExtendClient` control message and extends those read clients

So both Alfred and deli are modifying the client data structure

State after this PR:
- Alfred has to periodically tell Deli to extend clients (read and write)
- Deli processes `ExtendClient` control message and extends those clients

Now only deli is modifying the client data structure. This is nice and the end result is less calls to Redis throughout the system.

The main change: Rename `readClients` to `sequencedSignalClients` and add write clients to that map too. This allows Alfred to send an `ExtendClient` control message to extend read & write clients in a single message.