### PR TITLE
protocol defs bumped down to 0.1028.3000

### DIFF
--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/protocol-definitions",
-  "version": "0.1029.1000",
+  "version": "0.1028.3000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2599,21 +2599,6 @@
         "semver": "^7.3.5",
         "strip-indent": "^3.0.0"
       }
-    },
-    "eslint-plugin-unused-imports": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
-      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
-      "dev": true,
-      "requires": {
-        "eslint-rule-composer": "^0.3.0"
-      }
-    },
-    "eslint-rule-composer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/protocol-definitions",
-  "version": "0.1029.1000",
+  "version": "0.1028.3000",
   "description": "Fluid protocol definitions",
   "homepage": "https://fluidframework.com",
   "repository": {
@@ -55,7 +55,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.1029.1000",
+    "version": "0.1028.3000",
     "broken": {}
   }
 }


### PR DESCRIPTION
1. Similar reasoning to https://github.com/microsoft/FluidFramework/pull/10624/files#diff-eeac13eef21a75f495cac3b93af5a0071c6e19ca57f2bbf64a7d7dd02a1851e6. protocol-definitions should have been propagated from "next" as minor version bump.
2. We have just pre-released 0.1029.1000 from next, therefore this seems a good step to enable pre-release from both branches.

General post 1.0 cleanup objective:
main / protocol-def: ⁠0.1029.1000 ->  ⁠0.1028.3000
next / protocol-def: (stays ⁠0.1029.1000)