### PR TITLE
Comment cleanup

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1789,11 +1789,10 @@ export class MergeTree {
         if (pendingSegmentGroup !== undefined) {
             const deltaSegments: IMergeTreeSegmentDelta[] = [];
             pendingSegmentGroup.segments.map((pendingSegment) => {
-                const modified = pendingSegment.ack(pendingSegmentGroup, opArgs, this);
-                // This computation of overwrite appears incorrect. Leaving as is to avoid breaking something.
-                overwrite = !modified || overwrite;
+                const overlappingRemove = !pendingSegment.ack(pendingSegmentGroup, opArgs, this);
+                overwrite = overlappingRemove || overwrite;
 
-                if (modified && opArgs.op.type === MergeTreeDeltaType.REMOVE) {
+                if (!overlappingRemove && opArgs.op.type === MergeTreeDeltaType.REMOVE) {
                     this.updateSegmentRefsAfterMarkRemoved(pendingSegment, false);
                 }
                 if (MergeTree.options.zamboniSegments) {


### PR DESCRIPTION
# Remove comment and change variable name

## Description

This cleans up a comment left from a previous PR and renames a variable and changes its polarity.
Previously overwrite was being set when there was no modification. This was logically confusing, so
I had left a comment to review further.
On review, it is consistent with how `markRangeRemoved` computes overwrite, so I removed the comment
and changed the variable naming to make it more clear.

## PR Checklist

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [X ] All new and existing tests passed.
-   [X] My code follows the code style of this project.
-   [X ] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [X ] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

## Testing

covered by `packages\dds\merge-tree\src\test\client.localReference.spec.ts`
