### PR TITLE
Remove extra version and semver code

### DIFF
--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -27,13 +27,10 @@ import {
     gcTreeKey,
     IGarbageCollectionRuntime,
     IGarbageCollector,
-    trackGCStateMinimumVersionKey,
     runSessionExpiryKey,
     disableSessionExpiryKey,
-    semverCompare,
 } from "../garbageCollection";
 import { IContainerRuntimeMetadata } from "../summaryFormat";
-import { pkgVersion } from "../packageVersion";
 
 describe("Garbage Collection Tests", () => {
     // Nodes in the reference graph.
@@ -987,27 +984,6 @@ describe("Garbage Collection Tests", () => {
             );
         };
 
-        /**
-         * The client package version on the server is likely to be [major].[minor].[patch]-[pre-release], i.e 1.0.0-1
-         * This does conversions like this as minimumVersion needs to be [major].[minor].[patch] where [x] is a number.
-         * 1.0.0-1 to 1.0.0
-         * 1.0.0 to 1.0.0
-         * 1.0.0-pre1+12 to 1.0.0
-         * 1.0.0+a123-a123 to 1.0.0
-         */
-        const getRegularSemverVersion = () => {
-            let lastRegularIndex = pkgVersion.length;
-            const firstHyphen = pkgVersion.indexOf("-");
-            const firstPlus = pkgVersion.indexOf("+");
-            if (firstHyphen > 0 && (firstHyphen <= firstPlus || firstPlus <= 0)) {
-                lastRegularIndex = firstHyphen;
-            } else if (firstPlus > 0 && (firstPlus < firstHyphen || firstHyphen <= 0)) {
-                lastRegularIndex = firstPlus;
-            }
-
-            return pkgVersion.substring(0, lastRegularIndex);
-        };
-
         it("No changes to GC between summaries creates a blob handle when no version specified", async () => {
             garbageCollector = createGarbageCollector();
 
@@ -1026,70 +1002,5 @@ describe("Garbage Collection Tests", () => {
 
             checkGCSummaryType(tree2, SummaryType.Handle, "second");
         });
-
-        it("No changes to GC between summaries creates a blob handle when greater than minimum version", async () => {
-            settings[trackGCStateMinimumVersionKey] = "0.59.1000";
-            garbageCollector = createGarbageCollector();
-
-            await garbageCollector.collectGarbage({ runGC: true });
-            const tree1 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree1, SummaryType.Tree, "first");
-
-            await garbageCollector.latestSummaryStateRefreshed(
-                { wasSummaryTracked: true, latestSummaryUpdated: true },
-                parseNothing,
-            );
-
-            await garbageCollector.collectGarbage({ runGC: true });
-            const tree2 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree2, SummaryType.Handle, "second");
-        });
-
-        it("No changes to GC between summaries creates a blob when less than minimum version", async () => {
-            settings[trackGCStateMinimumVersionKey] = `1${getRegularSemverVersion()}`;
-            garbageCollector = createGarbageCollector();
-
-            await garbageCollector.collectGarbage({ runGC: true });
-            const tree1 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree1, SummaryType.Tree, "first");
-
-            await garbageCollector.latestSummaryStateRefreshed(
-                { wasSummaryTracked: true, latestSummaryUpdated: true },
-                parseNothing,
-            );
-
-            await garbageCollector.collectGarbage({ runGC: true });
-            const tree2 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree2, SummaryType.Tree, "second");
-        });
-    });
-
-    describe("Semver comparison tests", () => {
-        const test = (current: string, minimum: string, expected: number) => {
-            it(`Current: ${current} ${expected === 1 ? ">" : expected === 0 ? "=" : "<" } Minimum: ${minimum}`, () => {
-                const actual = semverCompare(current, minimum);
-                assert(actual === expected, `Semver compare failed, expected ${expected}, got ${actual}`);
-            });
-        };
-        test("0.0.0", "0.0.0", 0);
-        test("0.0.1", "0.0.0", 1);
-        test("0.0.0", "0.0.1", -1);
-        test("0.1.0", "0.1.0", 0);
-        test("0.1.0", "0.0.1", 1);
-        test("0.0.0", "0.1.0", -1);
-        test("1.0.0", "1.0.0", 0);
-        test("1.0.0", "0.1.1", 1);
-        test("0.1.1", "1.0.0", -1);
-        test("0.0.0-123", "0.0.0", -1);
-        test("0.0.12-123", "0.0.0", 1);
-        test("10.2.3-DEV-SNAPSHOT", "10.2.3", -1);
-        test("1.1.2-prerelease+meta", "1.1.2", -1);
-        test("0.59.4000", "0.59.4001", -1);
-        test("1.0.0", "0.59.4001", 1);
-        test("0.59.4000-123123", "0.59.4000", -1);
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -32,13 +32,9 @@ import { wrapDocumentServiceFactory } from "./gcDriverWrappers";
 import { mockConfigProvider } from "./mockConfigProivder";
 
 /**
- * Validates that unchanged Fluid objects are not resummarized again. Basically, only objects that have changed since
- * the previous summary should be resummarized and for the rest, we add handles that refer to the previous summary.
- * A Fluid object is considered changed since the last summary if either or both of the following is true:
- * - It received an op.
- * - Its reference state changed, i.e., it was referenced and became unreferenced or vice-versa.
+ * Validates whether or not a GC Tree Summary Handle should be written to the summary.
  */
-describeNoCompat("GC Blob stored in summaries", (getTestObjectProvider) => {
+describeNoCompat("GC Tree stored as a handle in summaries", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const dataObjectFactory = new DataObjectFactory("TestDataObject", TestDataObject, [], []);
     const runtimeOptions: IContainerRuntimeOptions = {


### PR DESCRIPTION
[AB#641](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/641)

Removes the extra code we created by trying to come up with the ability to ship a feature with a minFeatureVersion

To sum everything up
>If a version of a feature turns out to be bad and we need to turn it off, it seems a lot simpler to just make a new feature flag for v.Next rather than having the feature flag + minFeatureVersion.