### PR TITLE
Updated from assert to UsageError

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -15,9 +15,7 @@ import {
     IConnectionDetails,
     ICriticalContainerError,
 } from "@fluidframework/container-definitions";
-import {
-    GenericError, UsageError,
-} from "@fluidframework/container-utils";
+import { GenericError, UsageError } from "@fluidframework/container-utils";
 import {
     IDocumentService,
     IDocumentDeltaConnection,
@@ -370,8 +368,9 @@ export class ConnectionManager implements IConnectionManager {
         this._forceReadonly = readonly;
 
         if (oldValue !== this.readonly) {
-            throw new UsageError("API is not supported for non-connecting or closed container");
-
+            if (this._reconnectMode === ReconnectMode.Never) {
+                throw new UsageError("API is not supported for non-connecting or closed container");
+            }
             let reconnect = false;
             if (this.readonly === true) {
                 // If we switch to readonly while connected, we should disconnect first

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -16,7 +16,7 @@ import {
     ICriticalContainerError,
 } from "@fluidframework/container-definitions";
 import {
-    GenericError,
+    GenericError, UsageError,
 } from "@fluidframework/container-utils";
 import {
     IDocumentService,
@@ -370,8 +370,7 @@ export class ConnectionManager implements IConnectionManager {
         this._forceReadonly = readonly;
 
         if (oldValue !== this.readonly) {
-            assert(this._reconnectMode !== ReconnectMode.Never,
-                0x279 /* "API is not supported for non-connecting or closed container" */);
+            throw new UsageError("API is not supported for non-connecting or closed container");
 
             let reconnect = false;
             if (this.readonly === true) {


### PR DESCRIPTION

[AB#628](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/628) 
Updates test to throw Usage error instead of making an assertion, since we're validating preconditions for an API. 