### PR TITLE
Fix an issue with eventual consistency of property sets

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -379,7 +379,8 @@ implements ISerializableInterval {
         const newInterval =
             createSequenceInterval(label, startPos, endPos, this.start.getClient(), this.intervalType, op);
         if (this.properties) {
-            newInterval.addProperties(this.properties);
+            newInterval.properties = createMap<any>();
+            this.propertyManager.copyTo(this.properties, newInterval.properties, newInterval.propertyManager);
         }
         return newInterval;
     }

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -198,7 +198,12 @@ export class Interval implements ISerializableInterval {
             // Return undefined to indicate that no change is necessary.
             return;
         }
-        return new Interval(startPos, endPos, this.properties);
+        const newInterval = new Interval(startPos, endPos);
+        if (this.properties) {
+            newInterval.properties = createMap<any>();
+            this.propertyManager.copyTo(this.properties, newInterval.properties, newInterval.propertyManager);
+        }
+        return newInterval;
     }
 }
 


### PR DESCRIPTION
Pending states on property sets weren't properly copied when `IInterval.modify()` was invoked. This fixes that issue (the functionality was already supported in PropertyManager) and adds a regression test.