### PR TITLE
Method should be optional for back-compat

### DIFF
--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -153,7 +153,7 @@ export interface IDb {
      * Removes a collection or view from the database.
      * The method also removes any indexes associated with the dropped collection.
      */
-    dropCollection(name: string): Promise<boolean>;
+    dropCollection?(name: string): Promise<boolean>;
 }
 
 export interface IDbFactory {


### PR DESCRIPTION
## Description

See the error [here](https://dev.azure.com/fluidframework/public/_build/results?buildId=73310&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=3e8a0811-333e-5612-55d7-750fabab9520). The new method is not optional; therefore, it is a breaking change.

`IDb` is the type of a property inside `LocalSessionStorageDbFactory` which is exported by `@fluidframework/local-driver`. A new method on the interface would make existing objects incompatible.