### PR TITLE
Fix a consistency issue with single-endpoint interval modification

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -387,11 +387,13 @@ implements ISerializableInterval {
         let startRef = this.start;
         if (start !== undefined) {
             startRef = createPositionReference(this.start.getClient(), start, getRefType(this.start.refType), op);
+            startRef.addProperties(this.start.properties);
         }
 
         let endRef = this.end;
         if (end !== undefined) {
             endRef = createPositionReference(this.end.getClient(), end, getRefType(this.end.refType), op);
+            endRef.addProperties(this.end.properties);
         }
 
         startRef.pairedRef = endRef;

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -375,23 +375,23 @@ implements ISerializableInterval {
     }
 
     public modify(label: string, start: number, end: number, op?: ISequencedDocumentMessage) {
-        const getRefType = (baseType: ReferenceType, op?: ISequencedDocumentMessage): ReferenceType => {
+        const getRefType = (baseType: ReferenceType): ReferenceType => {
             let refType = baseType;
             if (op === undefined) {
                 refType &= ~ReferenceType.SlideOnRemove;
                 refType |= ReferenceType.StayOnRemove;
             }
             return refType;
-        }
+        };
 
         let startRef = this.start;
         if (start !== undefined) {
-            startRef = createPositionReference(this.start.getClient(), start, getRefType(this.start.refType, op), op);
+            startRef = createPositionReference(this.start.getClient(), start, getRefType(this.start.refType), op);
         }
 
         let endRef = this.end;
         if (end !== undefined) {
-            endRef = createPositionReference(this.end.getClient(), end, getRefType(this.end.refType, op), op);
+            endRef = createPositionReference(this.end.getClient(), end, getRefType(this.end.refType), op);
         }
 
         startRef.pairedRef = endRef;

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -931,6 +931,21 @@ describe("SharedString interval collections", () => {
             assert.equal(Array.from(collection2).length, 0);
         });
 
+        it("Can correctly interpret ack of single-endpoint changes", () => {
+            sharedString.insertText(0, "ABCDEF");
+            const collection1 = sharedString.getIntervalCollection("test");
+            const collection2 = sharedString2.getIntervalCollection("test");
+            containerRuntimeFactory.processAllMessages();
+            const interval = collection1.add(2, 5, IntervalType.SlideOnRemove);
+            sharedString2.removeRange(4, 6);
+            collection1.change(interval.getIntervalId(), 1 /* only change start */);
+            sharedString2.insertText(2, "123");
+            containerRuntimeFactory.processAllMessages();
+            assert.equal(sharedString.getText(), "AB123CD");
+            assertIntervals(sharedString, collection1, [{ start: 1, end: 6 }]);
+            assertIntervals(sharedString2, collection2, [{ start: 1, end: 6 }]);
+        });
+
         it("doesn't slide references on ack if there are pending remote changes", () => {
             sharedString.insertText(0, "ABCDEF");
             const collection1 = sharedString.getIntervalCollection("test");


### PR DESCRIPTION
Previous code to modify intervals attempted to always create new endpoints, even if the requesting API call or op only attempted to change one of start/end. This is problematic as the perspective of the position is dependent on whether or not it came from the caller or from the current value.

This adjusts the logic to only update start/end references if necessary. This is more in line with the approach taken elsewhere in IntervalCollection code, by tracking start and end separately.