### PR TITLE
tools: Enable `unicorn/prefer-switch` rule

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -120,6 +120,7 @@ module.exports = {
         ],
         "unicorn/no-new-buffer": "error",
         "unicorn/no-unsafe-regex": "error",
+        "unicorn/prefer-switch": "error",
 
         // DISABLED INTENTIONALLY
         // Disabled because we don't require that all variable declarations be explicitly typed.

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -913,6 +913,9 @@
         "unicorn/no-unsafe-regex": [
             "error"
         ],
+        "unicorn/prefer-switch": [
+            "error"
+        ],
         "unused-imports/no-unused-imports": [
             "error"
         ],

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -913,6 +913,9 @@
         "unicorn/no-unsafe-regex": [
             "error"
         ],
+        "unicorn/prefer-switch": [
+            "error"
+        ],
         "unused-imports/no-unused-imports": [
             "error"
         ],


### PR DESCRIPTION
From the [rule documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-switch.md):

> A switch statement is easier to read than multiple if statements with simple equality comparisons.

Note: there were no existing violations in the repo, so no code changes were required.