### PR TITLE
Fix processing of unversioned ops

### DIFF
--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -1093,10 +1093,10 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 		};
 		this.cachingLogViewer.setMinimumSequenceNumber(typedMessage.minimumSequenceNumber);
 		const op = typedMessage.contents;
-        if (op.version === undefined) {
-            // Back-compat: some legacy documents may contain trailing ops with an unstamped version; normalize them.
+		if (op.version === undefined) {
+			// Back-compat: some legacy documents may contain trailing ops with an unstamped version; normalize them.
 			(op as { version: WriteFormat | undefined }).version = WriteFormat.v0_0_2;
-        }
+		}
 		const { type, version } = op;
 		const sameVersion = version === this.writeFormat;
 

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -1093,9 +1093,12 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 		};
 		this.cachingLogViewer.setMinimumSequenceNumber(typedMessage.minimumSequenceNumber);
 		const op = typedMessage.contents;
+        if (op.version === undefined) {
+            // Back-compat: some legacy documents may contain trailing ops with an unstamped version; normalize them.
+			(op as { version: WriteFormat | undefined }).version = WriteFormat.v0_0_2;
+        }
 		const { type, version } = op;
-		const resolvedVersion = version ?? WriteFormat.v0_0_2;
-		const sameVersion = resolvedVersion === this.writeFormat;
+		const sameVersion = version === this.writeFormat;
 
 		// Edit and handle ops should only be processed if they're the same version as the tree write version.
 		// Update ops should only be processed if they're not the same version.
@@ -1128,7 +1131,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 			}
 		} else if (type === SharedTreeOpType.Update) {
 			this.processVersionUpdate(op.version);
-		} else if (compareSummaryFormatVersions(resolvedVersion, this.writeFormat) === 1) {
+		} else if (compareSummaryFormatVersions(version, this.writeFormat) === 1) {
 			// An op version newer than our current version should not be received. If this happens, either an
 			// incorrect op version has been written or an update op was skipped.
 			const error = 'Newer op version received by a client that has yet to be updated.';

--- a/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
@@ -401,7 +401,7 @@ export function runSharedTreeOperationsTests(
 				};
 			}
 
-            if (writeFormat === WriteFormat.v0_0_2) {
+			if (writeFormat === WriteFormat.v0_0_2) {
 				it('applies unversioned ops in the 0.0.2 format', () => {
 					const { tree: sharedTree1, containerRuntimeFactory } = setUpTestSharedTree(tree1Options);
 					const { sharedTree: sharedTree2, testTree: testTree2 } = createSimpleTestTree(
@@ -411,12 +411,12 @@ export function runSharedTreeOperationsTests(
 					containerRuntimeFactory.processAllMessages();
 					const originalPushMessage = containerRuntimeFactory.pushMessage.bind(containerRuntimeFactory);
 					containerRuntimeFactory.pushMessage = (msg) => {
-                        // Drop the version property to replicate ops created before the version property existed
+						// Drop the version property to replicate ops created before the version property existed
 						msg.contents.version = undefined;
 						originalPushMessage(msg);
 					};
 
-                    // Ensure that an edit can be passed and processed between two trees as normal
+					// Ensure that an edit can be passed and processed between two trees as normal
 					sharedTree2.applyEdit(Change.delete(StableRange.only(testTree2.right)));
 
 					const getTestTreeRoot = (sharedTree: SharedTree) =>

--- a/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeTests.ts
@@ -401,6 +401,45 @@ export function runSharedTreeOperationsTests(
 				};
 			}
 
+            if (writeFormat === WriteFormat.v0_0_2) {
+				it('applies unversioned ops in the 0.0.2 format', () => {
+					const { tree: sharedTree1, containerRuntimeFactory } = setUpTestSharedTree(tree1Options);
+					const { sharedTree: sharedTree2, testTree: testTree2 } = createSimpleTestTree(
+						createSecondTreeOptions(containerRuntimeFactory)
+					);
+
+					containerRuntimeFactory.processAllMessages();
+					const originalPushMessage = containerRuntimeFactory.pushMessage.bind(containerRuntimeFactory);
+					containerRuntimeFactory.pushMessage = (msg) => {
+                        // Drop the version property to replicate ops created before the version property existed
+						msg.contents.version = undefined;
+						originalPushMessage(msg);
+					};
+
+                    // Ensure that an edit can be passed and processed between two trees as normal
+					sharedTree2.applyEdit(Change.delete(StableRange.only(testTree2.right)));
+
+					const getTestTreeRoot = (sharedTree: SharedTree) =>
+						new TreeNodeHandle(
+							sharedTree.currentView,
+							sharedTree.convertToNodeId(sharedTree2.convertToStableNodeId(testTree2.identifier))
+						);
+
+					let root1 = getTestTreeRoot(sharedTree1);
+					let root2 = getTestTreeRoot(sharedTree2);
+
+					expect(Array.from(root1.traits[testTree2.right.traitLabel])).to.have.length(1);
+					expect(Array.from(root2.traits[testTree2.right.traitLabel] ?? [])).to.have.length(0);
+
+					containerRuntimeFactory.processAllMessages();
+
+					root1 = getTestTreeRoot(sharedTree1);
+					root2 = getTestTreeRoot(sharedTree2);
+					expect(Array.from(root1.traits[testTree2.right.traitLabel] ?? [])).to.have.length(0);
+					expect(Array.from(root2.traits[testTree2.right.traitLabel] ?? [])).to.have.length(0);
+				});
+			}
+
 			it('should apply remote changes and converge', () => {
 				const { tree: sharedTree1, containerRuntimeFactory } = setUpTestSharedTree(tree1Options);
 				const { tree: sharedTree2 } = setUpTestSharedTree(createSecondTreeOptions(containerRuntimeFactory));


### PR DESCRIPTION
Very old SharedTree ops did not have a version property, but op processing currently assumes that the property is present. Thanks @Abe27342 for the original diagnosis and fix.