### PR TITLE
Remove telemetryContext parameter

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,6 +14,26 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
+# 2.0.0
+
+## 2.0.0 Upcoming changes
+
+TBD
+
+## 2.0.0 Breaking changes
+
+- [Remove parameter in SharedObject.summarizeCore](#Remove-parameter-in-SharedObject.summarizeCore)
+
+### Remove parameter in SharedObject.summarizeCore
+
+The second parameter of the `summarizeCore()` method in `SharedObject` was not used so it was removed. The method
+signature was unchanged besides that, so it now looks like this:
+
+```typescript
+protected abstract summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats
+```
+
+
 # 1.0.0
 
 ## 1.0.0 Upcoming changes

--- a/api-report/map.api.md
+++ b/api-report/map.api.md
@@ -19,7 +19,6 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
 
 // @public @sealed
@@ -216,7 +215,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     // @internal
     submitDirectoryMessage(op: IDirectoryOperation, localOpMetadata: unknown): void;
     // @internal (undocumented)
-    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
     values(): IterableIterator<any>;
 }
 
@@ -247,7 +246,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     set(key: string, value: any): this;
     get size(): number;
     // @internal (undocumented)
-    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
     values(): IterableIterator<any>;
 }
 

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -34,7 +34,6 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { Jsonable } from '@fluidframework/datastore-definitions';
 import { LocalReference } from '@fluidframework/merge-tree';
 import { Marker } from '@fluidframework/merge-tree';
@@ -600,7 +599,7 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     // (undocumented)
     submitSequenceMessage(message: IMergeTreeOp): void;
     // (undocumented)
-    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
     // @deprecated (undocumented)
     waitIntervalCollection(label: string): Promise<IntervalCollection<SequenceInterval>>;
     walkSegments<TClientData>(handler: ISegmentAction<TClientData>, start?: number, end?: number, accum?: TClientData, splitRange?: boolean): void;

--- a/api-report/shared-object-base.api.md
+++ b/api-report/shared-object-base.api.md
@@ -93,7 +93,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     protected get serializer(): IFluidSerializer;
     // (undocumented)
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    protected abstract summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
 }
 
 // @public

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -523,7 +523,6 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
      */
     protected summarizeCore(
         serializer: IFluidSerializer,
-        telemetryContext?: ITelemetryContext,
     ): ISummaryTreeWithStats {
         return this.serializeDirectory(this.root, serializer);
     }

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -11,7 +11,7 @@ import {
     IChannelServices,
     IChannelFactory,
 } from "@fluidframework/datastore-definitions";
-import { ISummaryTreeWithStats, ITelemetryContext } from "@fluidframework/runtime-definitions";
+import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import {
     IFluidSerializer,
@@ -247,7 +247,6 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
      */
     protected summarizeCore(
         serializer: IFluidSerializer,
-        telemetryContext?: ITelemetryContext,
     ): ISummaryTreeWithStats {
         let currentSize = 0;
         let counter = 0;

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -48,7 +48,7 @@ import {
     SummarySerializer,
 } from "@fluidframework/shared-object-base";
 import { IEventThisPlaceHolder } from "@fluidframework/common-definitions";
-import { ISummaryTreeWithStats, ITelemetryContext } from "@fluidframework/runtime-definitions";
+import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 
 import {
     IntervalCollection,
@@ -465,7 +465,6 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 
     protected summarizeCore(
         serializer: IFluidSerializer,
-        telemetryContext?: ITelemetryContext,
     ): ISummaryTreeWithStats {
         const builder = new SummaryTreeBuilder();
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -500,7 +500,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
         trackState: boolean = false,
         telemetryContext?: ITelemetryContext,
     ): ISummaryTreeWithStats {
-        const result = this.summarizeCore(this.serializer, telemetryContext);
+        const result = this.summarizeCore(this.serializer);
         this.incrementTelemetryMetric(blobCountPropertyName, result.stats.blobNodeCount, telemetryContext);
         this.incrementTelemetryMetric(totalBlobSizePropertyName, result.stats.totalBlobSize, telemetryContext);
         return result;
@@ -514,7 +514,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
         trackState: boolean = false,
         telemetryContext?: ITelemetryContext,
     ): Promise<ISummaryTreeWithStats> {
-        const result = this.summarizeCore(this.serializer, telemetryContext);
+        const result = this.summarizeCore(this.serializer);
         this.incrementTelemetryMetric(blobCountPropertyName, result.stats.blobNodeCount, telemetryContext);
         this.incrementTelemetryMetric(totalBlobSizePropertyName, result.stats.totalBlobSize, telemetryContext);
         return result;
@@ -564,7 +564,6 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
      */
     protected abstract summarizeCore(
         serializer: IFluidSerializer,
-        telemetryContext?: ITelemetryContext,
     ): ISummaryTreeWithStats;
 
     private incrementTelemetryMetric(propertyName: string, incrementBy: number, telemetryContext?: ITelemetryContext) {


### PR DESCRIPTION
## Description

Removes a seemingly unused parameter. At least within the framework codebase itself it's not used, so I'd suspect that's probably also true in consumer codebases? The intention of the PR is to get the discussion going to decide if this parameter should stay (are there plans for it? A specific use case?) or if it can be removed.

## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [x] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.

Implementations of `protected abstract summarizeCore()` in the `SharedObject` class will need to remove the second parameter. **If the parameter was being used somehow, that won't be possible anymore**.
