### PR TITLE
common def type tests cleanup

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1657,7 +1657,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -2640,31 +2640,14 @@
 			}
 		},
 		"@fluidframework/container-definitions-previous": {
-			"version": "npm:@fluidframework/container-definitions@0.48.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.1000.tgz",
-			"integrity": "sha512-ko0XEL/vG3+czcNVeFFjF/N52wetQaUfEhluas82RdHpHUg4V/NU2lyvBvmybwF1gpGJOe608cCfUlyyCf1Hfw==",
+			"version": "npm:@fluidframework/container-definitions@1.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.0.0.tgz",
+			"integrity": "sha512-Sw11DOaGZE8b6CfSfkGsdzvEGRAJ5OQahHqhEg2wtBg7i9ZMwgU8KP6hJCuKmJz0MhPYofauyA0l/xer4ZHR7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/driver-definitions": "^0.46.1000",
-				"@fluidframework/protocol-definitions": "^0.1028.1000"
-			},
-			"dependencies": {
-				"@fluidframework/core-interfaces": {
-					"version": "0.43.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
-					"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.46.2000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.2000.tgz",
-					"integrity": "sha512-I0NzrWuU638M5OyeQGHKO+5kjUbNHeSt0XsI7f0/rwz2sygvAVJcYyyqt0NWLK/CvxWvZZwvexSPyFdmLo3E1g==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.1",
-						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/protocol-definitions": "^0.1028.2000"
-					}
-				}
+				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/container-loader": {
@@ -2887,9 +2870,9 @@
 			"integrity": "sha512-zn8apmBV/SKJAGGSKqbmYLeJHflb95Gmym1U7T95loAuqk5ffhpwH72GGuLvpiYJ8DpWgmkzYcCQZQimw/j6jA=="
 		},
 		"@fluidframework/core-interfaces-previous": {
-			"version": "npm:@fluidframework/core-interfaces@0.43.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
-			"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
+			"version": "npm:@fluidframework/core-interfaces@1.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.0.0.tgz",
+			"integrity": "sha512-zn8apmBV/SKJAGGSKqbmYLeJHflb95Gmym1U7T95loAuqk5ffhpwH72GGuLvpiYJ8DpWgmkzYcCQZQimw/j6jA=="
 		},
 		"@fluidframework/counter": {
 			"version": "1.0.0",
@@ -3109,20 +3092,13 @@
 			}
 		},
 		"@fluidframework/driver-definitions-previous": {
-			"version": "npm:@fluidframework/driver-definitions@0.46.1000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.46.1000.tgz",
-			"integrity": "sha512-GfWXV0kQCuJPz7TRg8p5AHOlId5fI2957vsT4Am20uwAUPx5t6/CRYDzD6O3fcfOevMcMRNuZtypGwStMTOrCw==",
+			"version": "npm:@fluidframework/driver-definitions@1.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.0.0.tgz",
+			"integrity": "sha512-aezc684mM5p47hNpQp3+0NOnDQ9SpO6pdHuGJZcBbWSDHBW6iAVBXuBH8Cw5Imz0DRGBs1S4yrg+EgK5oj59Vw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^0.43.1000",
-				"@fluidframework/protocol-definitions": "^0.1028.1000"
-			},
-			"dependencies": {
-				"@fluidframework/core-interfaces": {
-					"version": "0.43.1000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.43.1000.tgz",
-					"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
-				}
+				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/driver-utils": {
@@ -19487,7 +19463,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
 			"dev": true
 		},
 		"auto-bind": {
@@ -20956,7 +20932,7 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"dev": true
 		},
 		"buffer": {
@@ -20997,7 +20973,7 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
 		},
 		"buffer-fill": {
 			"version": "1.0.0",
@@ -25829,7 +25805,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
 		},
 		"es6-promise": {
 			"version": "4.2.8",
@@ -25839,7 +25815,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -26771,7 +26747,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -27842,7 +27818,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="
 		},
 		"fs-extra": {
 			"version": "9.1.0",
@@ -28182,7 +28158,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -29510,7 +29486,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
 				}
 			}
@@ -29595,7 +29571,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
+			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -29684,7 +29660,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
 		},
 		"immutable": {
 			"version": "3.7.6",
@@ -30035,7 +30011,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
 		},
 		"internal-slot": {
 			"version": "1.0.3",
@@ -30308,7 +30284,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -30414,7 +30390,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -33480,7 +33456,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
+			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -34163,7 +34139,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
 			"dev": true
 		},
 		"lodash.flatten": {
@@ -34189,7 +34165,7 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -34199,7 +34175,7 @@
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
@@ -34214,7 +34190,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -34225,23 +34201,23 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -34251,19 +34227,19 @@
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -34274,12 +34250,12 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
 		},
 		"lodash.snakecase": {
 			"version": "4.1.1",
@@ -34289,7 +34265,7 @@
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
 			"dev": true
 		},
 		"lodash.template": {
@@ -34314,7 +34290,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -36285,7 +36261,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
 			"requires": {
 				"event-lite": "^0.1.1",
 				"ieee754": "^1.1.8",
@@ -36296,7 +36272,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 				}
 			}
 		},
@@ -36613,7 +36589,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
 			"dev": true
 		},
 		"node-dir": {
@@ -38716,7 +38692,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
+			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
 			"dev": true
 		},
 		"p-all": {
@@ -39201,7 +39177,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="
 		},
 		"parse-path": {
 			"version": "4.0.3",
@@ -39457,7 +39433,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
+			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
 			"dev": true
 		},
 		"pirates": {
@@ -44960,7 +44936,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
 					"dev": true
 				},
 				"supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -3722,7 +3722,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
 			"dev": true
 		},
 		"available-typed-arrays": {
@@ -3796,13 +3796,13 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"dev": true
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"dev": true
 		},
 		"buffer-from": {
@@ -5424,7 +5424,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
 			"dev": true
 		},
 		"es6-promise": {
@@ -5436,7 +5436,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
 			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
@@ -5496,7 +5496,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -5680,7 +5680,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
 			"dev": true
 		},
 		"fs-extra": {
@@ -5988,7 +5988,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -6358,7 +6358,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
 				}
 			}
@@ -6407,7 +6407,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
+			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -6449,7 +6449,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
 			"dev": true
 		},
 		"import-fresh": {
@@ -6748,7 +6748,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM=",
+			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==",
 			"dev": true
 		},
 		"internal-slot": {
@@ -6858,7 +6858,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true
 		},
 		"is-extglob": {
@@ -6910,7 +6910,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -7584,7 +7584,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
+			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -7760,7 +7760,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
 			"dev": true
 		},
 		"lodash.get": {
@@ -7772,13 +7772,13 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
 			"dev": true
 		},
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
 			"dev": true
 		},
 		"lodash.isequal": {
@@ -7790,7 +7790,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
 			"dev": true
 		},
 		"lodash.ismatch": {
@@ -7802,43 +7802,43 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
 			"dev": true
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
 			"dev": true
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"dev": true
 		},
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -7850,19 +7850,19 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
 			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
 			"dev": true
 		},
 		"lodash.template": {
@@ -7887,7 +7887,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
 			"dev": true
 		},
 		"log-symbols": {
@@ -8633,7 +8633,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
 			"dev": true,
 			"requires": {
 				"event-lite": "^0.1.1",
@@ -8645,7 +8645,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 					"dev": true
 				}
 			}
@@ -8704,7 +8704,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
 			"dev": true
 		},
 		"node-fetch": {
@@ -9260,7 +9260,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
+			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
 			"dev": true
 		},
 		"p-finally": {
@@ -9548,7 +9548,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
 			"dev": true
 		},
 		"parse-path": {
@@ -9648,7 +9648,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
+			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
 			"dev": true
 		},
 		"plur": {
@@ -10694,7 +10694,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
 					"dev": true
 				}
 			}

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.71273",
-    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@0.48.1000",
+    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@^1.0.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -60,52 +60,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.49.1000",
-    "broken": {
-      "InterfaceDeclaration_IRuntime": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_IContainerContext": {
-        "backCompat": false,
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_IContainer": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IDeltaManager": {
-        "backCompat": false
-      },
-      "TypeAliasDeclaration_ConnectionState": {
-        "backCompat": false
-      },
-      "RemovedVariableDeclaration_IDeltaSender": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IDeltaSender": {
-        "backCompat": false
-      },
-      "RemovedVariableDeclaration_IFluidTokenProvider": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedInterfaceDeclaration_IFluidTokenProvider": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedInterfaceDeclaration_IProvideDeltaSender": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedInterfaceDeclaration_IProvideFluidTokenProvider": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedInterfaceDeclaration_IProxyLoaderFactory": {
-        "backCompat": false,
-        "forwardCompat": false
-      }
-    }
+    "version": "1.1.0",
+    "broken": {}
   }
 }

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -83,8 +83,31 @@ declare function get_current_TypeAliasDeclaration_ConnectionState():
 declare function use_old_TypeAliasDeclaration_ConnectionState(
     use: TypeOnly<old.ConnectionState>);
 use_old_TypeAliasDeclaration_ConnectionState(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_ConnectionState());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ConnectionState.CatchingUp": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ConnectionState_CatchingUp():
+    TypeOnly<old.ConnectionState.CatchingUp>;
+declare function use_current_TypeAliasDeclaration_ConnectionState_CatchingUp(
+    use: TypeOnly<current.ConnectionState.CatchingUp>);
+use_current_TypeAliasDeclaration_ConnectionState_CatchingUp(
+    get_old_TypeAliasDeclaration_ConnectionState_CatchingUp());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ConnectionState.CatchingUp": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ConnectionState_CatchingUp():
+    TypeOnly<current.ConnectionState.CatchingUp>;
+declare function use_old_TypeAliasDeclaration_ConnectionState_CatchingUp(
+    use: TypeOnly<old.ConnectionState.CatchingUp>);
+use_old_TypeAliasDeclaration_ConnectionState_CatchingUp(
+    get_current_TypeAliasDeclaration_ConnectionState_CatchingUp());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -157,6 +180,30 @@ declare function use_old_TypeAliasDeclaration_ConnectionState_Disconnected(
     use: TypeOnly<old.ConnectionState.Disconnected>);
 use_old_TypeAliasDeclaration_ConnectionState_Disconnected(
     get_current_TypeAliasDeclaration_ConnectionState_Disconnected());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ConnectionState.EstablishingConnection": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ConnectionState_EstablishingConnection():
+    TypeOnly<old.ConnectionState.EstablishingConnection>;
+declare function use_current_TypeAliasDeclaration_ConnectionState_EstablishingConnection(
+    use: TypeOnly<current.ConnectionState.EstablishingConnection>);
+use_current_TypeAliasDeclaration_ConnectionState_EstablishingConnection(
+    get_old_TypeAliasDeclaration_ConnectionState_EstablishingConnection());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ConnectionState.EstablishingConnection": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ConnectionState_EstablishingConnection():
+    TypeOnly<current.ConnectionState.EstablishingConnection>;
+declare function use_old_TypeAliasDeclaration_ConnectionState_EstablishingConnection(
+    use: TypeOnly<old.ConnectionState.EstablishingConnection>);
+use_old_TypeAliasDeclaration_ConnectionState_EstablishingConnection(
+    get_current_TypeAliasDeclaration_ConnectionState_EstablishingConnection());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -336,7 +383,6 @@ declare function get_old_InterfaceDeclaration_IContainer():
 declare function use_current_InterfaceDeclaration_IContainer(
     use: TypeOnly<current.IContainer>);
 use_current_InterfaceDeclaration_IContainer(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainer());
 
 /*
@@ -349,7 +395,6 @@ declare function get_current_InterfaceDeclaration_IContainer():
 declare function use_old_InterfaceDeclaration_IContainer(
     use: TypeOnly<old.IContainer>);
 use_old_InterfaceDeclaration_IContainer(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainer());
 
 /*
@@ -362,7 +407,6 @@ declare function get_old_InterfaceDeclaration_IContainerContext():
 declare function use_current_InterfaceDeclaration_IContainerContext(
     use: TypeOnly<current.IContainerContext>);
 use_current_InterfaceDeclaration_IContainerContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerContext());
 
 /*
@@ -375,7 +419,6 @@ declare function get_current_InterfaceDeclaration_IContainerContext():
 declare function use_old_InterfaceDeclaration_IContainerContext(
     use: TypeOnly<old.IContainerContext>);
 use_old_InterfaceDeclaration_IContainerContext(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerContext());
 
 /*
@@ -496,7 +539,6 @@ declare function get_current_InterfaceDeclaration_IDeltaManager():
 declare function use_old_InterfaceDeclaration_IDeltaManager(
     use: TypeOnly<old.IDeltaManager<any,any>>);
 use_old_InterfaceDeclaration_IDeltaManager(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaManager());
 
 /*
@@ -574,18 +616,6 @@ use_old_InterfaceDeclaration_IDeltaQueueEvents(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IDeltaSender": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IDeltaSender": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IDeltaSender": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IDeltaSender():
@@ -605,7 +635,6 @@ declare function get_current_InterfaceDeclaration_IDeltaSender():
 declare function use_old_InterfaceDeclaration_IDeltaSender(
     use: TypeOnly<old.IDeltaSender>);
 use_old_InterfaceDeclaration_IDeltaSender(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaSender());
 
 /*
@@ -1091,18 +1120,6 @@ use_old_InterfaceDeclaration_IPendingLocalState(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideDeltaSender": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideDeltaSender": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProvideFluidCodeDetailsComparer": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidCodeDetailsComparer():
@@ -1199,18 +1216,6 @@ use_old_InterfaceDeclaration_IProvideRuntimeFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProxyLoaderFactory": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProxyLoaderFactory": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IResolvedFluidCodeDetails": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IResolvedFluidCodeDetails():
@@ -1242,7 +1247,6 @@ declare function get_old_InterfaceDeclaration_IRuntime():
 declare function use_current_InterfaceDeclaration_IRuntime(
     use: TypeOnly<current.IRuntime>);
 use_current_InterfaceDeclaration_IRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRuntime());
 
 /*
@@ -1376,6 +1380,30 @@ declare function use_old_VariableDeclaration_isFluidPackage(
     use: TypeOnly<typeof old.isFluidPackage>);
 use_old_VariableDeclaration_isFluidPackage(
     get_current_VariableDeclaration_isFluidPackage());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISnapshotTreeWithBlobContents": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISnapshotTreeWithBlobContents():
+    TypeOnly<old.ISnapshotTreeWithBlobContents>;
+declare function use_current_InterfaceDeclaration_ISnapshotTreeWithBlobContents(
+    use: TypeOnly<current.ISnapshotTreeWithBlobContents>);
+use_current_InterfaceDeclaration_ISnapshotTreeWithBlobContents(
+    get_old_InterfaceDeclaration_ISnapshotTreeWithBlobContents());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISnapshotTreeWithBlobContents": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISnapshotTreeWithBlobContents():
+    TypeOnly<current.ISnapshotTreeWithBlobContents>;
+declare function use_old_InterfaceDeclaration_ISnapshotTreeWithBlobContents(
+    use: TypeOnly<old.ISnapshotTreeWithBlobContents>);
+use_old_InterfaceDeclaration_ISnapshotTreeWithBlobContents(
+    get_current_InterfaceDeclaration_ISnapshotTreeWithBlobContents());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.71273",
-    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@0.43.1000",
+    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@^1.0.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -53,13 +53,13 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.44.1000",
+    "version": "1.1.0",
     "broken": {
-      "RemovedVariableDeclaration_IFluidSerializer": {
+      "RemovedInterfaceDeclaration_IFluidSerializer": {
         "backCompat": false,
         "forwardCompat": false
       },
-      "RemovedInterfaceDeclaration_IFluidSerializer": {
+      "RemovedVariableDeclaration_IFluidSerializer": {
         "backCompat": false,
         "forwardCompat": false
       },

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -54,23 +54,6 @@
   },
   "typeValidation": {
     "version": "1.1.0",
-    "broken": {
-      "RemovedInterfaceDeclaration_IFluidSerializer": {
-        "backCompat": false,
-        "forwardCompat": false
-      },
-      "RemovedVariableDeclaration_IFluidSerializer": {
-        "backCompat": false,
-        "forwardCompat": false
-      },
-      "RemovedInterfaceDeclaration_IProvideFluidSerializer": {
-        "backCompat": false,
-        "forwardCompat": false
-      },
-      "RemovedInterfaceDeclaration_ISerializedHandle": {
-        "backCompat": false,
-        "forwardCompat": false
-      }
-    }
+    "broken": {}
   }
 }

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.ts
@@ -496,30 +496,6 @@ use_old_InterfaceDeclaration_IFluidRunnable(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IFluidSerializer": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IFluidSerializer": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidSerializer": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidSerializer": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProvideFluidCodeDetailsComparer": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProvideFluidCodeDetailsComparer():
@@ -664,18 +640,6 @@ use_old_InterfaceDeclaration_IProvideFluidRunnable(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideFluidSerializer": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideFluidSerializer": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IRequest": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IRequest():
@@ -744,18 +708,6 @@ declare function use_old_InterfaceDeclaration_IResponse(
     use: TypeOnly<old.IResponse>);
 use_old_InterfaceDeclaration_IResponse(
     get_current_InterfaceDeclaration_IResponse());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISerializedHandle": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISerializedHandle": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.71273",
-    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@0.46.1000",
+    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@^1.0.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -56,11 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.47.1000",
-    "broken": {
-      "InterfaceDeclaration_IDocumentStorageService": {
-        "backCompat": false
-      }
-    }
+    "version": "1.1.0",
+    "broken": {}
   }
 }

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.ts
@@ -371,7 +371,6 @@ declare function get_current_InterfaceDeclaration_IDocumentStorageService():
 declare function use_old_InterfaceDeclaration_IDocumentStorageService(
     use: TypeOnly<old.IDocumentStorageService>);
 use_old_InterfaceDeclaration_IDocumentStorageService(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDocumentStorageService());
 
 /*


### PR DESCRIPTION
It seems that our typetests tools did not cover common def packages that got moved to client release group with 1.0. Bumped them manually and regenerated tests.