### PR TITLE
Add message size limit on event emission in local server

### DIFF
--- a/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
+++ b/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
@@ -37,6 +37,11 @@ export class LocalWebSocket implements core.IWebSocket {
     }
 
     public emit(event: string, ...args: any[]) {
+        // Disconnect from the "socket" if the message is greater than 1MB
+        if (JSON.stringify(args).length > 1e6) {
+            this.disconnect();
+        }
+
         this.events.emit(event, ...args);
     }
 

--- a/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
+++ b/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
@@ -40,6 +40,7 @@ export class LocalWebSocket implements core.IWebSocket {
         // Disconnect from the "socket" if the message is greater than 1MB
         if (JSON.stringify(args).length > 1e6) {
             this.disconnect();
+            return;
         }
 
         this.events.emit(event, ...args);

--- a/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
+++ b/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
@@ -104,7 +104,7 @@ describe("LocalDeltaConnectionServer", () => {
 
         socket.on(
             "disconnect",
-            (id: string, msgs: ISequencedDocumentMessage[]) => messageP.reject("socket was disconnected"));
+            () => messageP.reject("socket was disconnected"));
 
         return messageP.promise;
     }

--- a/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
+++ b/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
@@ -84,7 +84,7 @@ describe("LocalDeltaConnectionServer", () => {
     }
 
     // Function to add a handler that listens for "op" message on the given socket. It returns a promise that
-    // will be resolved with the op's contents.
+    // will be resolved with the op's contents. It will reject if the socket is disconnected.
     async function addMessagehandler(socket: IWebSocket): Promise<any> {
         const messageP = new Deferred<any>();
 
@@ -101,6 +101,10 @@ describe("LocalDeltaConnectionServer", () => {
         socket.on(
             "op",
             (id: string, msgs: ISequencedDocumentMessage[]) => messageHandler(msgs));
+
+        socket.on(
+            "disconnect",
+            (id: string, msgs: ISequencedDocumentMessage[]) => messageP.reject("socket was disconnected"));
 
         return messageP.promise;
     }
@@ -252,5 +256,34 @@ describe("LocalDeltaConnectionServer", () => {
 
         socket1.disconnect();
         socket2.disconnect();
+    });
+
+    it("disconnects on message over 1mb", async () => {
+        const [socket1, connected1P] = connectNewClient("write", "userId1");
+        const join1P = addJoinHandler(socket1);
+
+        await join1P;
+
+        // Wait for the first client to be connected and joined.
+        const connected1 = await connected1P;
+        assert.equal(connected1.mode, "write", "The first client should be connected in write mode");
+
+        const message1P = addMessagehandler(socket1);
+
+        const content = new Array(1e6).join("0");
+        const message: IDocumentMessage = {
+            clientSequenceNumber: 1,
+            contents: content,
+            metadata: undefined,
+            referenceSequenceNumber: 0,
+            traces: [],
+            type: MessageType.Operation,
+        };
+        socket1.emit("submitOp", connected1.clientId, [message]);
+        try {
+            await message1P;
+        } catch (error) {
+            assert.equal(error, "socket was disconnected");
+        }
     });
 });


### PR DESCRIPTION
# [Task 278](https://dev.azure.com/fluidframework/internal/_workitems/edit/278)

## Description
The local server implementation currently doesn't have a max message size implemented. There is a 1MB message size limit (more info in #7599), so this can lead to situations where tests pass on the local server implementation but not in production. 

I've taken a simple approach of just stringifying the payload, checking if the length is greater than 1MB, and disconnecting the socket if it is. 

Fixes #8888 