### PR TITLE
Pipeline: Fix test build version

### DIFF
--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -28,7 +28,7 @@ variables:
 - name: skipComponentGovernanceDetection
   value: true
 - name: testBuild
-  value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
+  value: ${{ lower(startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')) }}
 - name: shouldPublish
   value: ${{
     and(


### PR DESCRIPTION
Fluid-tool's buildVersion is compare against lower case "true" but ADO use "True".
Force the value to use lower case

Fixes [AB#714](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/714)