### PR TITLE
Added option in TestObjectProvider to sync summarizer clients.

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -185,6 +185,7 @@ export interface ITestObjectProvider {
 
 // @public (undocumented)
 export class LoaderContainerTracker implements IOpProcessingController {
+    constructor(syncSummarizerClients?: boolean);
     add<LoaderType extends IHostLoader>(loader: LoaderType): void;
     ensureSynchronized(...containers: IContainer[]): Promise<void>;
     pauseProcessing(...containers: IContainer[]): Promise<void>;
@@ -287,6 +288,8 @@ export class TestObjectProvider implements ITestObjectProvider {
     get opProcessingController(): IOpProcessingController;
     // (undocumented)
     reset(): void;
+    // (undocumented)
+    resetLoaderContainerTracker(syncSummarizerClients?: boolean): void;
     // (undocumented)
     updateDocumentId(resolvedUrl: IResolvedUrl | undefined): void;
     // (undocumented)

--- a/examples/data-objects/webflow/src/test/layout.spec.ts
+++ b/examples/data-objects/webflow/src/test/layout.spec.ts
@@ -46,7 +46,7 @@ describeLoaderCompat("Layout", (getTestObjectProvider) => {
 
     let provider: ITestObjectProvider;
     before(async () => {
-        provider = getTestObjectProvider(/* reset */ false);
+        provider = getTestObjectProvider({ resetAfterEach: false });
         const container = await provider.createContainer(FlowDocument.getFactory());
         doc = await requestFluidObject<FlowDocument>(container, "default");
     });

--- a/examples/data-objects/webflow/src/test/segmentspan.spec.ts
+++ b/examples/data-objects/webflow/src/test/segmentspan.spec.ts
@@ -15,7 +15,7 @@ describeLoaderCompat("SegmentSpan", (getTestObjectProvider) => {
     let doc: FlowDocument;
     let provider: ITestObjectProvider;
     before(async () => {
-        provider = getTestObjectProvider(/* reset */ false);
+        provider = getTestObjectProvider({ resetAfterEach: false });
         const container = await provider.createContainer(FlowDocument.getFactory());
         doc = await requestFluidObject<FlowDocument>(container, "default");
     });

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -125,7 +125,7 @@ async function runAndValidateBatch(
 describeNoCompat("Batching failures", (getTestObjectProvider) => {
     it("working proxy",
     async function() {
-        const provider = getTestObjectProvider(true);
+        const provider = getTestObjectProvider({ resetAfterEach: true });
 
         const proxyDsf = createFunctionOverrideProxy<IDocumentServiceFactory>(
             provider.documentServiceFactory,
@@ -143,7 +143,7 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
     });
     it("working batch",
     async function() {
-        const provider = getTestObjectProvider(true);
+        const provider = getTestObjectProvider({ resetAfterEach: true });
         await runAndValidateBatch(provider, provider.documentServiceFactory, this.timeout());
     });
     describe("client sends invalid batches ", () => {
@@ -152,7 +152,7 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "OpBatchIncomplete" },
         ],
         async function() {
-            const provider = getTestObjectProvider(true);
+            const provider = getTestObjectProvider({ resetAfterEach: true });
 
             const proxyDsf = createFunctionOverrideProxy<IDocumentServiceFactory>(
                 provider.documentServiceFactory,
@@ -191,7 +191,7 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
         [
         ],
         async function() {
-            const provider = getTestObjectProvider(true);
+            const provider = getTestObjectProvider({ resetAfterEach: true });
 
             const proxyDsf = createFunctionOverrideProxy<IDocumentServiceFactory>(
                 provider.documentServiceFactory,
@@ -228,7 +228,7 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
         [
         ],
         async function() {
-            const provider = getTestObjectProvider(true);
+            const provider = getTestObjectProvider({ resetAfterEach: true });
 
             const proxyDsf = createFunctionOverrideProxy<IDocumentServiceFactory>(
                 provider.documentServiceFactory,
@@ -257,7 +257,7 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "0x29a" },
         ],
         async function() {
-            const provider = getTestObjectProvider(true);
+            const provider = getTestObjectProvider({ resetAfterEach: true });
 
             const proxyDsf = createFunctionOverrideProxy<IDocumentServiceFactory>(
                 provider.documentServiceFactory,
@@ -293,7 +293,7 @@ describeNoCompat("Batching failures", (getTestObjectProvider) => {
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "0x29a" },
         ],
         async function() {
-            const provider = getTestObjectProvider(true);
+            const provider = getTestObjectProvider({ resetAfterEach: true });
 
             const proxyDsf = createFunctionOverrideProxy<IDocumentServiceFactory>(
                 provider.documentServiceFactory,

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -104,6 +104,10 @@
   },
   "typeValidation": {
     "version": "1.1.0",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_TestObjectProvider": {
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -33,6 +33,8 @@ export class LoaderContainerTracker implements IOpProcessingController {
     private readonly containers = new Map<IContainer, ContainerRecord>();
     private lastProposalSeqNum: number = 0;
 
+    constructor(private readonly syncSummarizerClients: boolean = false) {}
+
     /**
      * Add a loader to start to track any container created from them
      * @param loader - loader to start tracking any container created.
@@ -61,7 +63,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
      */
     private addContainer(container: IContainer) {
         // ignore summarizer
-        if (!container.deltaManager.clientDetails.capabilities.interactive) { return; }
+        if (!container.deltaManager.clientDetails.capabilities.interactive && !this.syncSummarizerClients) { return; }
 
         // don't add container that is already tracked
         if (this.containers.has(container)) { return; }
@@ -227,7 +229,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
             const quorum = container.getQuorum();
             quorum.getMembers().forEach((client, clientId) => {
                 // ignore summarizer
-                if (!client.client.details.capabilities.interactive) { return; }
+                if (!client.client.details.capabilities.interactive && !this.syncSummarizerClients) { return; }
                 if (!openedClientId.includes(clientId)) {
                     pendingClientId.add(clientId);
                 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.ts
@@ -551,6 +551,7 @@ declare function get_old_ClassDeclaration_TestObjectProvider():
 declare function use_current_ClassDeclaration_TestObjectProvider(
     use: TypeOnly<current.TestObjectProvider>);
 use_current_ClassDeclaration_TestObjectProvider(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestObjectProvider());
 
 /*

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -41,19 +41,15 @@ export const createTestContainerRuntimeFactory = (containerRuntimeCtor: typeof C
         }
 
         public async instantiateFirstTime(runtime: ContainerRuntime): Promise<void> {
-            await runtime.createRootDataStore(this.type, "default");
-
-            // Test detached creation
-            const root2Context = runtime.createDetachedRootDataStore([this.type], "default2");
-            const root2Runtime = await this.dataStoreFactory.instantiateDataStore(root2Context, /* existing */ false);
-            await root2Context.attachRuntime(this.dataStoreFactory, root2Runtime);
+            const rootContext = runtime.createDetachedRootDataStore([this.type], "default");
+            const rootRuntime = await this.dataStoreFactory.instantiateDataStore(rootContext, /* existing */ false);
+            await rootContext.attachRuntime(this.dataStoreFactory, rootRuntime);
         }
 
         public async instantiateFromExisting(runtime: ContainerRuntime): Promise<void> {
             // Validate we can load root data stores.
             // We should be able to load any data store that was created in initializeFirstTime!
             await runtime.getRootDataStore("default");
-            await runtime.getRootDataStore("default2");
         }
 
         async preInitialize(

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -194,7 +194,7 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
  * Shared base class for test object provider.  Contain code for loader and container creation and loading
  */
 export class TestObjectProvider implements ITestObjectProvider {
-    private readonly _loaderContainerTracker = new LoaderContainerTracker();
+    private _loaderContainerTracker = new LoaderContainerTracker();
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
     private _urlResolver: IUrlResolver | undefined;
     private _logger: EventAndErrorTrackingLogger | undefined;
@@ -407,6 +407,11 @@ export class TestObjectProvider implements ITestObjectProvider {
 
     updateDocumentId(resolvedUrl: IResolvedUrl | undefined) {
         this._documentIdStrategy.update(resolvedUrl);
+    }
+
+    public resetLoaderContainerTracker(syncSummarizerClients: boolean = false) {
+        this._loaderContainerTracker.reset();
+        this._loaderContainerTracker = new LoaderContainerTracker(syncSummarizerClients);
     }
 }
 

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -42,12 +42,12 @@ function createCompatSuite(
                     );
                     Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
                 });
-                tests.bind(this)((reset: boolean = true, syncSummarizer: boolean = false) => {
-                    if (reset) {
+                tests.bind(this)((options?: ITestObjectProviderOptions) => {
+                    if (options?.resetAfterEach) {
                         resetAfterEach = true;
                     }
-                    if (syncSummarizer) {
-                        provider.resetLoaderContainerTracker(syncSummarizer);
+                    if (options?.syncSummarizer) {
+                        provider.resetLoaderContainerTracker(true /* syncSummarizerClients */);
                     }
                     return provider;
                 });
@@ -63,16 +63,18 @@ function createCompatSuite(
     };
 }
 
+export interface ITestObjectProviderOptions {
+    /** If true, resets all state after each test completes. */
+    resetAfterEach?: boolean;
+    /** If true, synchronizes summarizer client as well when ensureSynchronized() is called. */
+    syncSummarizer?: boolean;
+}
+
 export type DescribeCompatSuite =
     (name: string,
     tests: (
         this: Mocha.Suite,
-        provider: (
-            /** If true, resets all state after each test completes. */
-            resetAfterEach?: boolean,
-            /** If true, synchronizes summarizer client as well when ensureSynchronized() is called. */
-            syncSummarizerClients?: boolean,
-        ) => ITestObjectProvider) => void
+        provider: (options?: ITestObjectProviderOptions) => ITestObjectProvider) => void
     ) => Mocha.Suite | void;
 
 export type DescribeCompat = DescribeCompatSuite & Record<"skip" | "only" | "noCompat", DescribeCompatSuite>;

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -42,9 +42,12 @@ function createCompatSuite(
                     );
                     Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
                 });
-                tests.bind(this)((reset: boolean = true) => {
+                tests.bind(this)((reset: boolean = true, syncSummarizer: boolean = false) => {
                     if (reset) {
                         resetAfterEach = true;
+                    }
+                    if (syncSummarizer) {
+                        provider.resetLoaderContainerTracker(syncSummarizer);
                     }
                     return provider;
                 });
@@ -64,7 +67,12 @@ export type DescribeCompatSuite =
     (name: string,
     tests: (
         this: Mocha.Suite,
-        provider: (resetAfterEach?: boolean) => ITestObjectProvider) => void
+        provider: (
+            /** If true, resets all state after each test completes. */
+            resetAfterEach?: boolean,
+            /** If true, synchronizes summarizer client as well when ensureSynchronized() is called. */
+            syncSummarizerClients?: boolean,
+        ) => ITestObjectProvider) => void
     ) => Mocha.Suite | void;
 
 export type DescribeCompat = DescribeCompatSuite & Record<"skip" | "only" | "noCompat", DescribeCompatSuite>;

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -43,10 +43,8 @@ function createCompatSuite(
                     Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
                 });
                 tests.bind(this)((options?: ITestObjectProviderOptions) => {
-                    if (options?.resetAfterEach) {
-                        resetAfterEach = true;
-                    }
-                    if (options?.syncSummarizer) {
+                    resetAfterEach = options?.resetAfterEach ?? true;
+                    if (options?.syncSummarizer === true) {
                         provider.resetLoaderContainerTracker(true /* syncSummarizerClients */);
                     }
                     return provider;


### PR DESCRIPTION
Part 1 for [AB#727](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/727).

## Description
Currently, when `ensureSynchronized` is called on `TestObjectProvider`, it does not sync summarizer clients. That's because `LoaderContainerTracker` does not track summarizer clients. Due to this, testing scenarios where we want to wait for a summary to container up-to-date changes is complex and often unreliable.

This change does the following:
- Added an option in `TestObjectProvider` and `LoaderContainerTracker` to track and sync summarizer clients. Note that this is option and not turned on by default. This is because summarizer client starts with a delay and summarizes based on heuristics which can result in tests running for a long times potentially hitting timeouts.
It should be used by tests that control the summarization process, such as summary and GC related tests that summarize on demand. I will have a follow up that will use this for such tests.
- Updated the test data store factory to only create 1 root data store by default instead of 2. The reason for this change is that there are tests that validate things such as count of data stores, DDSes and other related stats which are skewed due to an extra data store. Also, having this extra data store during creation does not any value.


## PR Checklist

> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My code follows the code style of this project.
-   [x] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
