### PR TITLE
Change Local Reference Event Emitter to Callback

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -5,14 +5,12 @@
 ```ts
 
 import { IChannelStorageService } from '@fluidframework/datastore-definitions';
-import { IEvent } from '@fluidframework/common-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
-import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public (undocumented)
 export function addProperties(oldProps: PropertySet | undefined, newProps: PropertySet, op?: ICombiningOp, seq?: number): PropertySet;
@@ -116,7 +114,7 @@ export class Client {
     // (undocumented)
     cloneFromSegments(): Client;
     // (undocumented)
-    createLocalReferencePosition(segment: ISegment, offset: number, refType: ReferenceType, properties: PropertySet | undefined): ReferencePosition;
+    createLocalReferencePosition(segment: ISegment, offset: number, refType: ReferenceType, properties: PropertySet | undefined): LocalReferencePosition;
     // (undocumented)
     createTextHelper(): MergeTreeTextHelper;
     protected findReconnectionPosition(segment: ISegment, localSeq: number): number;
@@ -200,9 +198,9 @@ export class Client {
     rebasePosition(pos: number, seqNumberFrom: number, localSeq: number): number;
     regeneratePendingOp(resetOp: IMergeTreeOp, segmentGroup: SegmentGroup | SegmentGroup[]): IMergeTreeOp;
     // @deprecated (undocumented)
-    removeLocalReference(lref: LocalReference): ReferencePosition | undefined;
+    removeLocalReference(lref: LocalReference): LocalReferencePosition | undefined;
     // (undocumented)
-    removeLocalReferencePosition(lref: ReferencePosition): ReferencePosition | undefined;
+    removeLocalReferencePosition(lref: LocalReferencePosition): LocalReferencePosition | undefined;
     removeRangeLocal(start: number, end: number): IMergeTreeRemoveMsg | undefined;
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number | undefined;
     serializeGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void;
@@ -696,12 +694,6 @@ export interface IRBMatcher<TKey, TData> {
 }
 
 // @public
-export interface IReferencePositionEvents extends IEvent {
-    // (undocumented)
-    (event: "beforeSlide" | "afterSlide", listener: () => void): any;
-}
-
-// @public
 export interface IRelativePosition {
     before?: boolean;
     id?: string;
@@ -820,12 +812,14 @@ export function ListRemoveEntry<U>(entry: List<U>): List<U> | undefined;
 export const LocalClientId = -1;
 
 // @public @deprecated (undocumented)
-export class LocalReference extends TypedEventEmitter<IReferencePositionEvents> implements ReferencePosition {
+export class LocalReference implements LocalReferencePosition {
     // @deprecated
     constructor(client: Client, initSegment: ISegment,
     offset?: number, refType?: ReferenceType, properties?: PropertySet);
     // (undocumented)
     addProperties(newProps: PropertySet, op?: ICombiningOp): void;
+    // (undocumented)
+    callbacks?: Partial<Record<"beforeSlide" | "afterSlide", () => void>> | undefined;
     // @deprecated (undocumented)
     compare(b: LocalReference): number;
     // @deprecated (undocumented)
@@ -908,6 +902,12 @@ export class LocalReferenceCollection {
 
 // @public (undocumented)
 export type LocalReferenceMapper = (id: string) => LocalReference;
+
+// @public (undocumented)
+export interface LocalReferencePosition extends ReferencePosition {
+    // (undocumented)
+    callbacks?: Partial<Record<"beforeSlide" | "afterSlide", () => void>>;
+}
 
 // @public (undocumented)
 export interface LRUSegment {
@@ -1030,7 +1030,7 @@ export class MergeTree {
     // (undocumented)
     readonly collabWindow: CollaborationWindow;
     // (undocumented)
-    createLocalReferencePosition(segment: ISegment, offset: number, refType: ReferenceType, properties: PropertySet | undefined, client: Client): ReferencePosition;
+    createLocalReferencePosition(segment: ISegment, offset: number, refType: ReferenceType, properties: PropertySet | undefined, client: Client): LocalReferencePosition;
     // (undocumented)
     findTile(startPos: number, clientId: number, tileLabel: string, posPrecedesTile?: boolean): {
         tile: ReferencePosition;
@@ -1100,7 +1100,7 @@ export class MergeTree {
     // @deprecated (undocumented)
     removeLocalReference(segment: ISegment, lref: LocalReference): void;
     // (undocumented)
-    removeLocalReferencePosition(lref: ReferencePosition): ReferencePosition | undefined;
+    removeLocalReferencePosition(lref: LocalReferencePosition): LocalReferencePosition | undefined;
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: number): number | undefined;
     // (undocumented)
     root: IMergeBlock;

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -547,7 +547,7 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     // (undocumented)
     protected client: Client;
     // (undocumented)
-    createLocalReferencePosition(segment: T, offset: number, refType: ReferenceType, properties: PropertySet | undefined): ReferencePosition;
+    createLocalReferencePosition(segment: T, offset: number, refType: ReferenceType, properties: PropertySet | undefined): LocalReferencePosition;
     // @deprecated (undocumented)
     createPositionReference(segment: T, offset: number, refType: ReferenceType): LocalReference;
     // (undocumented)
@@ -603,7 +603,7 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     // @deprecated (undocumented)
     removeLocalReference(lref: LocalReference): LocalReferencePosition;
     // (undocumented)
-    removeLocalReferencePosition(lref: ReferencePosition): LocalReferencePosition;
+    removeLocalReferencePosition(lref: LocalReferencePosition): LocalReferencePosition;
     // (undocumented)
     removeRange(start: number, end: number): IMergeTreeRemoveMsg;
     protected replaceRange(start: number, end: number, segment: ISegment): void;

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -37,6 +37,7 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { Jsonable } from '@fluidframework/datastore-definitions';
 import { LocalReference } from '@fluidframework/merge-tree';
+import { LocalReferencePosition } from '@fluidframework/merge-tree';
 import { Marker } from '@fluidframework/merge-tree';
 import { MergeTreeDeltaOperationType } from '@fluidframework/merge-tree';
 import { MergeTreeDeltaOperationTypes } from '@fluidframework/merge-tree';
@@ -600,9 +601,9 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     protected processGCDataCore(serializer: SummarySerializer): void;
     // @deprecated (undocumented)
-    removeLocalReference(lref: LocalReference): ReferencePosition;
+    removeLocalReference(lref: LocalReference): LocalReferencePosition;
     // (undocumented)
-    removeLocalReferencePosition(lref: ReferencePosition): ReferencePosition;
+    removeLocalReferencePosition(lref: ReferencePosition): LocalReferencePosition;
     // (undocumented)
     removeRange(start: number, end: number): IMergeTreeRemoveMsg;
     protected replaceRange(start: number, end: number, segment: ISegment): void;

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -102,9 +102,6 @@
     "broken": {
       "ClassDeclaration_Client": {
         "forwardCompat": false
-      },
-      "ClassDeclaration_LocalReference": {
-        "forwardCompat": false
       }
     }
   }

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -16,7 +16,7 @@ import { LoggingError } from "@fluidframework/telemetry-utils";
 import { IIntegerRange } from "./base";
 import { RedBlackTree } from "./collections";
 import { UnassignedSequenceNumber, UniversalSequenceNumber } from "./constants";
-import { LocalReference } from "./localReference";
+import { LocalReference, LocalReferencePosition } from "./localReference";
 import {
     CollaborationWindow,
     compareStrings,
@@ -334,11 +334,11 @@ export class Client {
 
     public createLocalReferencePosition(
         segment: ISegment, offset: number, refType: ReferenceType, properties: PropertySet | undefined,
-    ): ReferencePosition {
+    ): LocalReferencePosition {
         return this.mergeTree.createLocalReferencePosition(segment, offset, refType, properties, this);
     }
 
-    public removeLocalReferencePosition(lref: ReferencePosition) {
+    public removeLocalReferencePosition(lref: LocalReferencePosition) {
         return this.mergeTree.removeLocalReferencePosition(lref);
     }
 

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -7,7 +7,7 @@ export * from "./base";
 export * from "./client";
 export * from "./collections";
 export * from "./constants";
-export { LocalReference, LocalReferenceCollection } from "./localReference";
+export { LocalReference, LocalReferencePosition, LocalReferenceCollection } from "./localReference";
 export * from "./mergeTree";
 export * from "./mergeTreeDeltaCallback";
 export * from "./mergeTreeTracking";

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
+import { assert } from "@fluidframework/common-utils";
 import { UsageError } from "@fluidframework/container-utils";
 import { Client } from "./client";
 import { List, ListMakeHead, ListRemoveEntry } from "./collections";
@@ -24,7 +24,6 @@ import {
     refHasRangeLabel,
     refHasTileLabel,
     refTypeIncludesFlag,
-    IReferencePositionEvents,
 } from "./referencePositions";
 
 /**
@@ -47,11 +46,14 @@ export function _validateReferenceType(refType: ReferenceType) {
     }
 }
 
+export interface LocalReferencePosition extends ReferencePosition {
+    callbacks?: Partial<Record<"beforeSlide" | "afterSlide", () => void>>;
+}
+
 /**
- * @deprecated - Use ReferencePosition
+ * @deprecated - Use LocalReferencePosition
  */
-export class LocalReference
-extends TypedEventEmitter<IReferencePositionEvents> implements ReferencePosition {
+export class LocalReference implements LocalReferencePosition {
     /**
      * @deprecated - use DetachedReferencePosition
      */
@@ -67,6 +69,8 @@ extends TypedEventEmitter<IReferencePositionEvents> implements ReferencePosition
      */
     public segment: ISegment | undefined;
 
+    public callbacks?: Partial<Record<"beforeSlide" | "afterSlide", () => void>> | undefined;
+
     /**
      * @deprecated - use createReferencePosition
      */
@@ -80,7 +84,6 @@ extends TypedEventEmitter<IReferencePositionEvents> implements ReferencePosition
         public refType = ReferenceType.Simple,
         properties?: PropertySet,
     ) {
-        super();
         _validateReferenceType(refType);
         this.segment = initSegment;
         this.properties = properties;

--- a/packages/dds/merge-tree/src/referencePositions.ts
+++ b/packages/dds/merge-tree/src/referencePositions.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent } from "@fluidframework/common-definitions";
 import { Stack } from "./collections";
 import { ISegment } from "./mergeTree";
 import { ReferenceType, ICombiningOp } from "./ops";
@@ -55,14 +54,6 @@ export function refHasTileLabels(refPos: ReferencePosition): boolean {
 }
 export function refHasRangeLabels(refPos: ReferencePosition): boolean {
     return refGetRangeLabels(refPos) !== undefined;
-}
-
-/**
- * IReferencePositionEvents are emitted before and after  a local reference slides.
- * Currently the event emitter is only implemented on LocalReferences.
- */
-export interface IReferencePositionEvents extends IEvent {
-    (event: "beforeSlide" | "afterSlide", listener: () => void);
 }
 
 export interface ReferencePosition {

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.ts
@@ -1872,7 +1872,6 @@ declare function get_old_ClassDeclaration_LocalReference():
 declare function use_current_ClassDeclaration_LocalReference(
     use: TypeOnly<current.LocalReference>);
 use_current_ClassDeclaration_LocalReference(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalReference());
 
 /*

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -252,14 +252,18 @@ implements ISerializableInterval {
             switch (event) {
                 case "beforePositionChange":
                     if (super.listenerCount(event) === 0) {
-                        this.start.on("beforeSlide", beforeSlide);
-                        this.end.on("beforeSlide", beforeSlide);
+                        const startCb = this.start.callbacks ??= {};
+                        startCb.beforeSlide = beforeSlide;
+                        const endCb = this.end.callbacks ??= {};
+                        endCb.beforeSlide = beforeSlide;
                     }
                     break;
                 case "afterPositionChange":
                     if (super.listenerCount(event) === 0) {
-                        this.start.on("afterSlide", afterSlide);
-                        this.end.on("afterSlide", afterSlide);
+                        const startCb = this.start.callbacks ??= {};
+                        startCb.afterSlide = afterSlide;
+                        const endCb = this.end.callbacks ??= {};
+                        endCb.afterSlide = afterSlide;
                     }
                     break;
                 default:
@@ -269,14 +273,22 @@ implements ISerializableInterval {
             switch (event) {
                 case "beforePositionChange":
                     if (super.listenerCount(event) === 0) {
-                        this.start.off("beforeSlide", beforeSlide);
-                        this.end.off("beforeSlide", beforeSlide);
+                        if (this.start.callbacks) {
+                            this.start.callbacks.beforeSlide = undefined;
+                        }
+                        if (this.end.callbacks) {
+                            this.end.callbacks.beforeSlide = undefined;
+                        }
                     }
                     break;
                 case "afterPositionChange":
                     if (super.listenerCount(event) === 0) {
-                        this.start.off("afterSlide", afterSlide);
-                        this.end.off("afterSlide", afterSlide);
+                        if (this.start.callbacks) {
+                            this.start.callbacks.afterSlide = undefined;
+                        }
+                        if (this.end.callbacks) {
+                            this.end.callbacks.afterSlide = undefined;
+                        }
                     }
                     break;
                 default:

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -30,6 +30,7 @@ import {
     ISegment,
     ISegmentAction,
     LocalReference,
+    LocalReferencePosition,
     matchProperties,
     MergeTreeDeltaType,
     PropertySet,
@@ -312,7 +313,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
         segment: T,
         offset: number,
         refType: ReferenceType,
-        properties: PropertySet | undefined): ReferencePosition {
+        properties: PropertySet | undefined): LocalReferencePosition {
         return this.client.createLocalReferencePosition(
             segment,
             offset,
@@ -387,7 +388,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
         return this.client.removeLocalReferencePosition(lref);
     }
 
-    public removeLocalReferencePosition(lref: ReferencePosition) {
+    public removeLocalReferencePosition(lref: LocalReferencePosition) {
         return this.client.removeLocalReferencePosition(lref);
     }
 


### PR DESCRIPTION
# Change Local Reference Event Emitter to Callback

The primary impetus for this change is in terms of memory usage. Event emitter is a large class, and making all local references, regardless of usage, an even emitter will result in lots of unnecessary memory being used. this change simplifies the design and uses an optional callback, so when not needed the callbacks will not even be defined, and checking if they are defined or not is a done via a very cheap null coalescing operator.