### PR TITLE
fix: Correct relative path for api-extractor output

### DIFF
--- a/azure/packages/azure-client/api-extractor.json
+++ b/azure/packages/azure-client/api-extractor.json
@@ -8,4 +8,5 @@
   "docModel": {
     "enabled": true,
     "apiJsonFilePath": "<projectFolder>/../../_api-extractor-temp/doc-models/<unscopedPackageName>.api.json"
-  }}
+  }
+}

--- a/azure/packages/azure-service-utils/api-extractor.json
+++ b/azure/packages/azure-service-utils/api-extractor.json
@@ -7,6 +7,6 @@
   },
   "docModel": {
     "enabled": true,
-    "apiJsonFilePath": "<projectFolder>/../../_api-extractor-temp/doc-models/<unscopedPackageName>.api.json"
+    "apiJsonFilePath": "<projectFolder>/../../../_api-extractor-temp/doc-models/<unscopedPackageName>.api.json"
   }
 }


### PR DESCRIPTION
The current config was outputting the `_api-extractor-temp` contents under the `azure` directory, rather than at the root. Our fluidframework.com API docs build expects all of the api-extractor reports to be generated in the `_api-extractor-temp` directory under the repo root, and was failing when generating API docs.