### PR TITLE
Re-export ConnectionState from fluid-framework

### DIFF
--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -5,8 +5,11 @@
 ```ts
 
 import { AttachState } from '@fluidframework/container-definitions';
+import { ConnectionState } from '@fluidframework/container-loader';
 
 export { AttachState }
+
+export { ConnectionState }
 
 
 export * from "@fluidframework/fluid-static";

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^1.1.0",
+    "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/fluid-static": "^1.1.0",
     "@fluidframework/map": "^1.1.0",
     "@fluidframework/sequence": "^1.1.0"

--- a/packages/framework/fluid-framework/src/containerLoader.ts
+++ b/packages/framework/fluid-framework/src/containerLoader.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { ConnectionState } from "@fluidframework/container-loader";

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 export * from "./containerDefinitions";
+export * from "./containerLoader";
 export * from "./fluidStatic";
 export * from "./map";
 export * from "./sequence";


### PR DESCRIPTION
# [Re-export ConnectionState from fluid-framework](https://github.com/microsoft/FluidFramework/issues/10681)

## Description

This PR re-exports `ConnectionState` from fluid-framework to prevent the need to import container-loader. 

Note: We don't re-export from container-definitions since it would then be exported as a namespace (instead of enum from container-loader).

## Testing

Manually tested by importing `ConnectionState` from fluid-framework in existing e2e tests

## Other information or known dependencies

[AB#716](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/716)
Closes #10681 
Relevant PR: https://github.com/microsoft/FluidExamples/pull/491#discussion_r897516803
