### PR TITLE
Cherry-pick PR #10686 to 1.0 release branch

### DIFF
--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -5,8 +5,11 @@
 ```ts
 
 import { AttachState } from '@fluidframework/container-definitions';
+import { ConnectionState } from '@fluidframework/container-loader';
 
 export { AttachState }
+
+export { ConnectionState }
 
 
 export * from "@fluidframework/fluid-static";

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^1.0.0",
+    "@fluidframework/container-loader": "^1.0.0",
     "@fluidframework/fluid-static": "^1.0.0",
     "@fluidframework/map": "^1.0.0",
     "@fluidframework/sequence": "^1.0.0"

--- a/packages/framework/fluid-framework/src/containerLoader.ts
+++ b/packages/framework/fluid-framework/src/containerLoader.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { ConnectionState } from "@fluidframework/container-loader";

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 export * from "./containerDefinitions";
+export * from "./containerLoader";
 export * from "./fluidStatic";
 export * from "./map";
 export * from "./sequence";


### PR DESCRIPTION
Ports PR #10686 (_Re-export `ConnectionState` from fluid-framework to prevent the need to import from container-loader_) to the 1.0 release branch so we can release it in a patch release.