### PR TITLE
Revert "Fix a consistency issue with single-endpoint interval modification"

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -393,31 +393,11 @@ implements ISerializableInterval {
     }
 
     public modify(label: string, start: number, end: number, op?: ISequencedDocumentMessage) {
-        const getRefType = (baseType: ReferenceType): ReferenceType => {
-            let refType = baseType;
-            if (op === undefined) {
-                refType &= ~ReferenceType.SlideOnRemove;
-                refType |= ReferenceType.StayOnRemove;
-            }
-            return refType;
-        };
+        const startPos = start ?? this.start.toPosition();
+        const endPos = end ?? this.end.toPosition();
 
-        let startRef = this.start;
-        if (start !== undefined) {
-            startRef = createPositionReference(this.start.getClient(), start, getRefType(this.start.refType), op);
-            startRef.addProperties(this.start.properties);
-        }
-
-        let endRef = this.end;
-        if (end !== undefined) {
-            endRef = createPositionReference(this.end.getClient(), end, getRefType(this.end.refType), op);
-            endRef.addProperties(this.end.properties);
-        }
-
-        startRef.pairedRef = endRef;
-        endRef.pairedRef = startRef;
-
-        const newInterval = new SequenceInterval(startRef, endRef, this.intervalType);
+        const newInterval =
+            createSequenceInterval(label, startPos, endPos, this.start.getClient(), this.intervalType, op);
         if (this.properties) {
             newInterval.properties = createMap<any>();
             this.propertyManager.copyTo(this.properties, newInterval.properties, newInterval.propertyManager);

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -931,21 +931,6 @@ describe("SharedString interval collections", () => {
             assert.equal(Array.from(collection2).length, 0);
         });
 
-        it("Can correctly interpret ack of single-endpoint changes", () => {
-            sharedString.insertText(0, "ABCDEF");
-            const collection1 = sharedString.getIntervalCollection("test");
-            const collection2 = sharedString2.getIntervalCollection("test");
-            containerRuntimeFactory.processAllMessages();
-            const interval = collection1.add(2, 5, IntervalType.SlideOnRemove);
-            sharedString2.removeRange(4, 6);
-            collection1.change(interval.getIntervalId(), 1 /* only change start */);
-            sharedString2.insertText(2, "123");
-            containerRuntimeFactory.processAllMessages();
-            assert.equal(sharedString.getText(), "AB123CD");
-            assertIntervals(sharedString, collection1, [{ start: 1, end: 6 }]);
-            assertIntervals(sharedString2, collection2, [{ start: 1, end: 6 }]);
-        });
-
         it("doesn't slide references on ack if there are pending remote changes", () => {
             sharedString.insertText(0, "ABCDEF");
             const collection1 = sharedString.getIntervalCollection("test");


### PR DESCRIPTION
This reverts commit b6c034324e6eb500a3a684aae2581749800a175c (#10644). The combination of that and #10639 caused issues. Fix will be re-applied once it's rebased to include #10639.
