### PR TITLE
skip sequence number check when loading with stashed ops

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -896,7 +896,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         // Verify summary runtime sequence number matches protocol sequence number.
         const runtimeSequenceNumber = metadata?.message?.sequenceNumber;
-        if (runtimeSequenceNumber !== undefined) {
+        // When we load with pending state, we reuse an old snapshot so we don't expect these numbers to match
+        if (!pendingRuntimeState && runtimeSequenceNumber !== undefined) {
             const protocolSequenceNumber = context.deltaManager.initialSequenceNumber;
             // Unless bypass is explicitly set, then take action when sequence numbers mismatch.
             if (loadSequenceNumberVerification !== "bypass" && runtimeSequenceNumber !== protocolSequenceNumber) {

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -28,6 +28,7 @@ import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils"
 import { ConnectionState } from "@fluidframework/container-loader";
 import { bufferToString, Deferred, stringToBuffer } from "@fluidframework/common-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
+import { DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
 
 const mapId = "map";
 const stringId = "sharedStringKey";
@@ -37,6 +38,19 @@ const testContainerConfig: ITestContainerConfig = {
     registry,
     runtimeOptions: {
         enableOfflineLoad: true,
+        summaryOptions: {
+            initialSummarizerDelayMs: 20, // Previous Containers had this property under SummaryOptions.
+            summaryConfigOverrides: {
+                ...DefaultSummaryConfiguration,
+                ...{
+                    idleTime: 5000,
+                    maxTime: 5000 * 12,
+                    maxAckWaitTime: 120000,
+                    maxOps: 1,
+                    initialSummarizerDelayMs: 20,
+                },
+            },
+        },
     },
 };
 
@@ -134,6 +148,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
     let container1: IContainer;
     let map1: SharedMap;
     let string1: SharedString;
+    let waitForSummary: () => Promise<void>;
 
     beforeEach(async () => {
         provider = getTestObjectProvider();
@@ -148,6 +163,21 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         map1 = await dataStore1.getSharedObject<SharedMap>(mapId);
         string1 = await dataStore1.getSharedObject<SharedString>(stringId);
         string1.insertText(0, "hello");
+
+        waitForSummary = async () => {
+            await new Promise<void>((resolve, reject) => {
+                let summarized = false;
+                container1.on("op", (op) => {
+                    if (op.type === "summarize") {
+                        summarized = true;
+                    } else if (summarized && op.type === "summaryAck") {
+                        resolve();
+                    } else if (op.type === "summaryNack") {
+                        reject(new Error("summaryNack"));
+                    }
+                });
+            });
+        };
     });
 
     it("resends op", async function() {
@@ -773,5 +803,26 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         const map3 = await dataStore3.getSharedObject<SharedMap>(mapId);
         assert.strictEqual(map3.get(testKey), testValue);
         assert.strictEqual(map3.get(testKey2), testValue);
+    });
+
+    it("works with summary while offline", async function() {
+        map1.set("test op 1", "test op 1");
+        await waitForSummary();
+
+        const pendingOps = await getPendingOps(provider, false, (c, d, map) => {
+            map.set(testKey, testValue);
+        });
+
+        map1.set("test op 2", "test op 2");
+        await waitForSummary();
+
+        // load container with pending ops, which should resend the op not sent by previous container
+        const container2 = await loader.resolve({ url }, pendingOps);
+        const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+        const map2 = await dataStore2.getSharedObject<SharedMap>(mapId);
+        await ensureContainerConnected(container2);
+        await provider.ensureSynchronized();
+        assert.strictEqual(map1.get(testKey), testValue);
+        assert.strictEqual(map2.get(testKey), testValue);
     });
 });


### PR DESCRIPTION
There is a check in runtime that ensures the sequence number from the metadata blob in the snapshot from which runtime was loaded matches the initial sequence number given to DeltaManager from which to begin processing new ops. When stashing ops, we save the snapshot we originally loaded from so the metadata blob will be the same, but we supply DeltaManager with the sequence number when the container was closed. Therefore, this check is not relevant when we are loading with stashed ops. The reason this error was not encountered before is because the metadata blob was not present in the saved snapshot in tests, so the check was skipped. I believe it is not included in the summary created when attaching a detached container because it is generated by the runtime.

The test added covers this by waiting for a summary before stashing ops. Without the fix in runtime, it results in errors like this:
```
"eventName": "fluid:telemetry:Container:ContainerClose",
    "category": "error",
    "stack": "Error\n    at Function.load (/home/wes/fluid/packages/runtime/container-runtime/dist/containerRuntime.js:642:31)\n    at async Object.preInitialize (/home/wes/fluid/packages/test/test-utils/dist/testContainerRuntimeFactory.js:44:29)\n    at async Object.instantiateRuntime (/home/wes/fluid/packages/runtime/runtime-utils/dist/runtimeFactoryHelper.js:14:25)\n    at async ContainerContext.instantiateRuntime (/home/wes/fluid/packages/loader/container-loader/dist/containerContext.js:192:25)\n    at async Function.createOrLoad (/home/wes/fluid/packages/loader/container-loader/dist/containerContext.js:37:9)\n    at async Container.instantiateContext (/home/wes/fluid/packages/loader/container-loader/dist/container.js:1270:25)\n    at async Container.load (/home/wes/fluid/packages/loader/container-loader/dist/container.js:798:9)",
    "error": "Summary metadata mismatch",
    "errorType": "dataCorruptionError",
    "fluidErrorCode": "-",
    "runtimeSequenceNumber": 4,
    "protocolSequenceNumber": 37,
```
In this case, `runtimeSequenceNumber`, 4, is the sequence number of the snapshot from which the original container was loaded, and `protocolSequenceNumber`, 37, is the sequence number when the original container was closed (and stashed ops retrieved). This gap is by design and should not result in an error.