### PR TITLE
unregister server_disconnect from the correct object

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -586,7 +586,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
         const socket = this.socketReference;
         assert(socket !== undefined, 0x0a2 /* "reentrancy not supported!" */);
 
-        this.socketReference!.off("server_disconnect", this.serverDisconnectHandler);
+        this.socketReference?.off("server_disconnect", this.serverDisconnectHandler);
         this.socketReference = undefined;
 
         if (!socketProtocolError && this.hasDetails) {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -460,7 +460,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
             };
         }
 
-        this.socketReference!.once("server_disconnect", this.serverDisconnectHandler);
+        this.socketReference!.on("server_disconnect", this.serverDisconnectHandler);
 
         this.socket.on("get_ops_response", (result: IGetOpsResponse) => {
             const messages = result.messages;
@@ -585,9 +585,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     protected disconnect(socketProtocolError: boolean, reason: IAnyDriverError) {
         const socket = this.socketReference;
         assert(socket !== undefined, 0x0a2 /* "reentrancy not supported!" */);
-        this.socketReference = undefined;
 
-        this.socket.off("server_disconnect", this.serverDisconnectHandler);
+        this.socketReference!.off("server_disconnect", this.serverDisconnectHandler);
+        this.socketReference = undefined;
 
         if (!socketProtocolError && this.hasDetails) {
             // tell the server we are disconnecting this client from the document


### PR DESCRIPTION
Fixes Bug 598

## Description
changing `once` to `on` when registering disconnect, and unregister from the same object `this.socketReference`
