### PR TITLE
Integrate Local Reference Deprecations

### DIFF
--- a/examples/data-objects/shared-text/src/client-ui-lib/controls/flowView.ts
+++ b/examples/data-objects/shared-text/src/client-ui-lib/controls/flowView.ts
@@ -15,6 +15,7 @@ import { performance } from "@fluidframework/common-utils";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import * as types from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
+import { refHasRangeLabel, refHasTileLabel } from "@fluidframework/merge-tree";
 import { IClient, ISequencedDocumentMessage, IUser } from "@fluidframework/protocol-definitions";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import * as Sequence from "@fluidframework/sequence";
@@ -248,8 +249,8 @@ function showPositionInLine(
 }
 
 function endRenderSegments(marker: MergeTree.Marker) {
-    return (marker.hasTileLabel("pg") ||
-        ((marker.hasRangeLabel("cell") &&
+    return (refHasTileLabel(marker, "pg") ||
+        ((refHasRangeLabel(marker, "cell") &&
             (marker.refType & MergeTree.ReferenceType.NestEnd))));
 }
 
@@ -1125,7 +1126,7 @@ function renderFlow(layoutContext: ILayoutContext): IRenderOutput {
             ? segoff.segment
             : undefined;
 
-        if (asMarker && asMarker.hasRangeLabel("table")) {
+        if (asMarker && refHasRangeLabel(asMarker, "table")) {
             let tableView: Table.Table;
             if (asMarker.removedSeq === undefined) {
                 renderTable(asMarker, docContext, layoutContext);
@@ -1197,7 +1198,7 @@ function renderFlow(layoutContext: ILayoutContext): IRenderOutput {
                     segoff = getContainingSegment(flowView.sharedString, currentPos);
                     if (MergeTree.Marker.is(segoff.segment)) {
                         // eslint-disable-next-line max-len
-                        if (segoff.segment.hasRangeLabel("cell") && (segoff.segment.refType & MergeTree.ReferenceType.NestEnd)) {
+                        if (refHasRangeLabel(segoff.segment, "cell") && (segoff.segment.refType & MergeTree.ReferenceType.NestEnd)) {
                             break;
                         }
                     }
@@ -1464,8 +1465,8 @@ interface IRemotePresenceBase {
     type: string;
 }
 interface ILocalPresenceInfo {
-    localRef?: MergeTree.LocalReference;
-    markLocalRef?: MergeTree.LocalReference;
+    localRef?: MergeTree.LocalReferencePosition;
+    markLocalRef?: MergeTree.LocalReferencePosition;
     xformPos?: number;
     markXformPos?: number;
     clientId: string;
@@ -1561,8 +1562,8 @@ function getCurrentWord(pos: number, sharedString: Sequence.SharedString) {
     }
 }
 
-function getLocalRefPos(sharedString: Sequence.SharedString, localRef: MergeTree.LocalReference) {
-    return sharedString.getPosition(localRef.segment!) + localRef.offset;
+function getLocalRefPos(sharedString: Sequence.SharedString, localRef: MergeTree.LocalReferencePosition) {
+    return sharedString.localReferencePositionToPosition(localRef);
 }
 
 function getContainingSegment(sharedString: Sequence.SharedString, pos: number): ISegmentOffset {
@@ -1915,9 +1916,9 @@ export class FlowView extends ui.Component {
                 localPresenceInfo.cursor!.presenceInfoUpdated = true;
             }
             if (presentPresence.markLocalRef) {
-                this.sharedString.removeLocalReference(presentPresence.markLocalRef);
+                this.sharedString.removeLocalReferencePosition(presentPresence.markLocalRef);
             }
-            this.sharedString.removeLocalReference(presentPresence.localRef);
+            this.sharedString.removeLocalReferencePosition(presentPresence.localRef);
             tempXformPos = presentPresence.xformPos;
             tempMarkXformPos = presentPresence.markXformPos;
         }
@@ -2188,12 +2189,12 @@ export class FlowView extends ui.Component {
             if (MergeTree.Marker.is(segoff.segment)) {
                 const marker = segoff.segment;
                 if (marker.refType & MergeTree.ReferenceType.Tile) {
-                    if (marker.hasTileLabel("pg")) {
-                        if (marker.hasRangeLabel("table") && (marker.refType & MergeTree.ReferenceType.NestEnd)) {
+                    if (refHasTileLabel(marker, "pg")) {
+                        if (refHasRangeLabel(marker, "table") && (marker.refType & MergeTree.ReferenceType.NestEnd)) {
                             this.cursorRev();
                         }
                     }
-                } else if ((marker.refType === MergeTree.ReferenceType.NestEnd) && (marker.hasRangeLabel("cell"))) {
+                } else if ((marker.refType === MergeTree.ReferenceType.NestEnd) && (refHasRangeLabel(marker, "cell"))) {
                     const cellMarker = marker as Table.ICellMarker;
                     const endId = cellMarker.getId();
                     let beginMarker: Table.ICellMarker | undefined;
@@ -2222,19 +2223,19 @@ export class FlowView extends ui.Component {
                 // REVIEW: assume marker for now
                 const marker = segoff.segment;
                 if (marker.refType & MergeTree.ReferenceType.Tile) {
-                    if (marker.hasTileLabel("pg")) {
-                        if (marker.hasRangeLabel("table") && (marker.refType & MergeTree.ReferenceType.NestEnd)) {
+                    if (refHasTileLabel(marker, "pg")) {
+                        if (refHasRangeLabel(marker, "table") && (marker.refType & MergeTree.ReferenceType.NestEnd)) {
                             this.cursorFwd();
                         } else {
                             return;
                         }
                     }
                 } else if (marker.refType & MergeTree.ReferenceType.NestBegin) {
-                    if (marker.hasRangeLabel("table")) {
+                    if (refHasRangeLabel(marker, "table")) {
                         this.cursor.pos += 3;
-                    } else if (marker.hasRangeLabel("row")) {
+                    } else if (refHasRangeLabel(marker, "row")) {
                         this.cursor.pos += 2;
-                    } else if (marker.hasRangeLabel("cell")) {
+                    } else if (refHasRangeLabel(marker, "cell")) {
                         if (Table.cellIsMoribund(marker)) {
                             this.tryMoveCell(this.cursor.pos);
                         } else {
@@ -2244,9 +2245,9 @@ export class FlowView extends ui.Component {
                         this.cursorFwd();
                     }
                 } else if (marker.refType & MergeTree.ReferenceType.NestEnd) {
-                    if (marker.hasRangeLabel("row")) {
+                    if (refHasRangeLabel(marker, "row")) {
                         this.cursorFwd();
-                    } else if (marker.hasRangeLabel("table")) {
+                    } else if (refHasRangeLabel(marker, "table")) {
                         this.cursor.pos += 2;
                     } else {
                         this.cursorFwd();
@@ -2634,7 +2635,7 @@ export class FlowView extends ui.Component {
         if (tileInfo) {
             const tile = tileInfo.tile as Paragraph.IParagraphMarker;
             let listStatus = false;
-            if (tile.hasTileLabel("list")) {
+            if (refHasTileLabel(tile, "list")) {
                 listStatus = true;
             }
             const curLabels = tile.properties![MergeTree.reservedTileLabelsKey] as string[];
@@ -3194,8 +3195,8 @@ export class FlowView extends ui.Component {
                 const localPresenceInfo = {
                     clientId,
                     fresh: true,
-                    localRef: this.sharedString.createPositionReference(
-                        segoff.segment, segoff.offset, MergeTree.ReferenceType.SlideOnRemove),
+                    localRef: this.sharedString.createLocalReferencePosition(
+                        segoff.segment, segoff.offset, MergeTree.ReferenceType.SlideOnRemove, undefined),
                     presenceColor: this.presenceVector.has(clientId) ?
                         this.presenceVector.get(clientId)!.presenceColor :
                         presenceColors[this.presenceVector.size % presenceColors.length],
@@ -3207,8 +3208,8 @@ export class FlowView extends ui.Component {
                     const markSegoff = this.sharedString.getContainingSegment(remotePresenceInfo.origMark);
                     if (markSegoff.segment) {
                         localPresenceInfo.markLocalRef =
-                            this.sharedString.createPositionReference(markSegoff.segment,
-                                markSegoff.offset, MergeTree.ReferenceType.SlideOnRemove);
+                            this.sharedString.createLocalReferencePosition(markSegoff.segment,
+                                markSegoff.offset, MergeTree.ReferenceType.SlideOnRemove, undefined);
                     }
                 }
                 this.updatePresenceVector(localPresenceInfo);

--- a/examples/data-objects/shared-text/src/client-ui-lib/controls/flowView.ts
+++ b/examples/data-objects/shared-text/src/client-ui-lib/controls/flowView.ts
@@ -1465,8 +1465,8 @@ interface IRemotePresenceBase {
     type: string;
 }
 interface ILocalPresenceInfo {
-    localRef?: MergeTree.LocalReferencePosition;
-    markLocalRef?: MergeTree.LocalReferencePosition;
+    localRef?: MergeTree.ReferencePosition;
+    markLocalRef?: MergeTree.ReferencePosition;
     xformPos?: number;
     markXformPos?: number;
     clientId: string;
@@ -1562,7 +1562,7 @@ function getCurrentWord(pos: number, sharedString: Sequence.SharedString) {
     }
 }
 
-function getLocalRefPos(sharedString: Sequence.SharedString, localRef: MergeTree.LocalReferencePosition) {
+function getLocalRefPos(sharedString: Sequence.SharedString, localRef: MergeTree.ReferencePosition) {
     return sharedString.localReferencePositionToPosition(localRef);
 }
 

--- a/examples/data-objects/shared-text/src/client-ui-lib/text/paragraph.ts
+++ b/examples/data-objects/shared-text/src/client-ui-lib/text/paragraph.ts
@@ -11,6 +11,7 @@ eslint-disable
 */
 
 import * as MergeTree from "@fluidframework/merge-tree";
+import { refHasRangeLabel, refHasTileLabel } from "@fluidframework/merge-tree";
 import * as Sequence from "@fluidframework/sequence";
 import { CharacterCodes } from "./characterCodes";
 
@@ -288,7 +289,7 @@ function getPrecedingTile(
     }
 }
 
-export const isListTile = (tile: IParagraphMarker) => tile.hasTileLabel("list");
+export const isListTile = (tile: IParagraphMarker) => refHasTileLabel(tile, "list");
 
 export interface ISymbol {
     font?: string;
@@ -506,7 +507,7 @@ export function textTokenToItems(
 
 // eslint-disable-next-line no-bitwise
 export const isEndBox = (marker: MergeTree.Marker) => (marker.refType & MergeTree.ReferenceType.NestEnd) &&
-    marker.hasRangeLabel("box");
+    refHasRangeLabel(marker, "box");
 
 export const referenceProperty = "ref";
 
@@ -520,7 +521,7 @@ export function segmentToItems(
     } else if (MergeTree.Marker.is(segment)) {
         if (isReference(segment)) {
             context.paragraphLexer.mark(segment);
-        } else if (segment.hasTileLabel("pg") || isEndBox(segment)) {
+        } else if (refHasTileLabel(segment, "pg") || isEndBox(segment)) {
             context.nextPGPos = segpos;
             return false;
         }

--- a/examples/data-objects/shared-text/src/client-ui-lib/text/table.ts
+++ b/examples/data-objects/shared-text/src/client-ui-lib/text/table.ts
@@ -11,6 +11,7 @@ eslint-disable
 */
 
 import * as MergeTree from "@fluidframework/merge-tree";
+import { refGetRangeLabels, refHasRangeLabel, refHasRangeLabels, refHasTileLabel } from "@fluidframework/merge-tree";
 import * as Sequence from "@fluidframework/sequence";
 import * as Paragraph from "./paragraph";
 
@@ -351,7 +352,7 @@ export function createTable(pos: number, sharedString: SharedString, idBase: str
     if (pos > 0) {
         const segoff = sharedString.getContainingSegment(pos - 1);
         if (MergeTree.Marker.is(segoff.segment)) {
-            if (segoff.segment.hasTileLabel("pg")) {
+            if (refHasTileLabel(segoff.segment, "pg")) {
                 pgAtStart = false;
             }
         }
@@ -618,7 +619,7 @@ function parseCell(cellStartPos: number, sharedString: SharedString, fontInfo?: 
             const segment = segoff.segment;
             if (MergeTree.Marker.is(segment)) {
                 const marker = <MergeTree.Marker>segoff.segment;
-                if (marker.hasRangeLabel("table")) {
+                if (refHasRangeLabel(marker, "table")) {
                     const tableMarker = <ITableMarker>marker;
                     parseTable(tableMarker, nextPos, sharedString, fontInfo);
                     if (tableMarker.table!.minContentWidth > cellMarker.cell.minContentWidth) {
@@ -737,8 +738,8 @@ export function succinctPrintTable(tableMarker: ITableMarker, tableMarkerPos: nu
                 lineBuf += `${segpos}:`;
                 reqPos = false;
             }
-            if (marker.hasRangeLabels()) {
-                const rangeLabel = marker.getRangeLabels()![0];
+            if (refHasRangeLabels(marker)) {
+                const rangeLabel = refGetRangeLabels(marker)![0];
                 if (marker.refType === MergeTree.ReferenceType.NestEnd) {
                     lineBuf += "E";
                     if ((rangeLabel === "table") || (rangeLabel === "row")) {

--- a/examples/data-objects/table-document/src/cellrange.ts
+++ b/examples/data-objects/table-document/src/cellrange.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { LocalReference } from "@fluidframework/merge-tree";
+import { LocalReferencePosition } from "@fluidframework/merge-tree";
 import { SequenceInterval } from "@fluidframework/sequence";
 
 const rangeExpr = /([A-Za-z]+)(\d+):([A-Za-z]+)(\d+)/;
@@ -43,7 +43,7 @@ export function parseRange(range: string) {
 export class CellRange {
     constructor(
         private readonly interval: SequenceInterval,
-        private readonly resolve: (localRef: LocalReference) => { row: number; col: number; },
+        private readonly resolve: (localRef: LocalReferencePosition) => { row: number; col: number; },
     ) {
         // Ensure CellInterval was not created with a null/undefined interval.
         assert(!!interval, "CellInterval created with bad interval!");

--- a/examples/data-objects/table-document/src/cellrange.ts
+++ b/examples/data-objects/table-document/src/cellrange.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { LocalReferencePosition } from "@fluidframework/merge-tree";
+import { ReferencePosition } from "@fluidframework/merge-tree";
 import { SequenceInterval } from "@fluidframework/sequence";
 
 const rangeExpr = /([A-Za-z]+)(\d+):([A-Za-z]+)(\d+)/;
@@ -43,7 +43,7 @@ export function parseRange(range: string) {
 export class CellRange {
     constructor(
         private readonly interval: SequenceInterval,
-        private readonly resolve: (localRef: LocalReferencePosition) => { row: number; col: number; },
+        private readonly resolve: (localRef: ReferencePosition) => { row: number; col: number; },
     ) {
         // Ensure CellInterval was not created with a null/undefined interval.
         assert(!!interval, "CellInterval created with bad interval!");

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -6,7 +6,7 @@
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { ICombiningOp, LocalReference, PropertySet } from "@fluidframework/merge-tree";
+import { ICombiningOp, LocalReferencePosition, PropertySet } from "@fluidframework/merge-tree";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
     positionToRowCol,
@@ -162,8 +162,8 @@ export class TableDocument extends DataObject<{ Events: ITableDocumentEvents; }>
         this.forwardEvent(this.matrix, "op", "sequenceDelta");
     }
 
-    private readonly localRefToRowCol = (localRef: LocalReference) => {
-        const position = localRef.toPosition();
+    private readonly localRefToRowCol = (localRef: LocalReferencePosition) => {
+        const position = this.matrix.localReferencePositionToPosition(localRef);
         return positionToRowCol(position);
     };
 }

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -6,7 +6,7 @@
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { ICombiningOp, LocalReferencePosition, PropertySet } from "@fluidframework/merge-tree";
+import { ICombiningOp, ReferencePosition, PropertySet } from "@fluidframework/merge-tree";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
     positionToRowCol,
@@ -162,7 +162,7 @@ export class TableDocument extends DataObject<{ Events: ITableDocumentEvents; }>
         this.forwardEvent(this.matrix, "op", "sequenceDelta");
     }
 
-    private readonly localRefToRowCol = (localRef: LocalReferencePosition) => {
+    private readonly localRefToRowCol = (localRef: ReferencePosition) => {
         const position = this.matrix.localReferencePositionToPosition(localRef);
         return positionToRowCol(position);
     };

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -132,7 +132,7 @@ const endOfTextReference: ReferencePosition = {
     addProperties(props) {
         addProperties(this.properties, props);
     },
-};
+} as any as ReferencePosition;
 
 export interface IFlowDocumentEvents extends IEvent {
     (event: "sequenceDelta", listener: (event: SequenceDeltaEvent, target: SharedString) => void);

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -11,7 +11,6 @@ import {
     createRemoveRangeOp,
     IMergeTreeRemoveMsg,
     ISegment,
-    LocalReferencePosition,
     Marker,
     MergeTreeDeltaType,
     PropertySet,
@@ -47,7 +46,7 @@ export const enum DocSegmentKind {
     beginTags = "<t>",
     endTags = "</>",
 
-    // Special case for LocalReferencePosition to end of document.  (See comments on 'endOfTextSegment').
+    // Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
     endOfText = "eot",
 }
 
@@ -61,7 +60,7 @@ export const enum DocTile {
 }
 
 export const getDocSegmentKind = (segment: ISegment): DocSegmentKind => {
-    // Special case for LocalReferencePosition to end of document.  (See comments on 'endOfTextSegment').
+    // Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
     if (segment === endOfTextSegment) {
         return DocSegmentKind.endOfText;
     }
@@ -114,7 +113,7 @@ const accumAsLeafAction = (
 ) => (accum)(position, segment, startOffset, endOffset);
 
 // TODO: We need the ability to create LocalReferences to the end of the document. Our
-//       workaround creates a LocalReferencePosition with an 'undefined' segment that is never
+//       workaround creates a ReferencePosition with an 'undefined' segment that is never
 //       inserted into the MergeTree.  We then special case this segment in localRefToPosition,
 //       addLocalRef, removeLocalRef, etc.
 //
@@ -185,21 +184,21 @@ export class FlowDocument extends LazyLoadedDataObject<ISharedDirectory, IFlowDo
     }
 
     public getSegmentAndOffset(position: number) {
-        // Special case for LocalReferencePosition to end of document.  (See comments on 'endOfTextSegment').
+        // Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
         return position === this.length
             ? { segment: endOfTextSegment, offset: 0 }
             : this.sharedString.getContainingSegment(position);
     }
 
     public getPosition(segment: ISegment) {
-        // Special case for LocalReferencePosition to end of document.  (See comments on 'endOfTextSegment').
+        // Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
         return segment === endOfTextSegment
             ? this.length
             : this.sharedString.getPosition(segment);
     }
 
     public addLocalRef(position: number) {
-        // Special case for LocalReferencePosition to end of document.  (See comments on 'endOfTextSegment').
+        // Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
         if (position >= this.length) {
             return this.sharedString.createLocalReferencePosition(endOfTextSegment, 0, ReferenceType.Transient, undefined);
         }
@@ -210,17 +209,17 @@ export class FlowDocument extends LazyLoadedDataObject<ISharedDirectory, IFlowDo
         return localRef;
     }
 
-    public removeLocalRef(localRef: LocalReferencePosition) {
+    public removeLocalRef(localRef: ReferencePosition) {
         const segment = localRef.getSegment();
 
-        // Special case for LocalReferencePosition to end of document.  (See comments on 'endOfTextSegment').
+        // Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
         if (segment !== endOfTextSegment) {
             this.sharedString.removeLocalReferencePosition(localRef);
         }
     }
 
-    public localRefToPosition(localRef: LocalReferencePosition) {
-        // Special case for LocalReferencePosition to end of document.  (See comments on 'endOfTextSegment').
+    public localRefToPosition(localRef: ReferencePosition) {
+        // Special case for ReferencePosition to end of document.  (See comments on 'endOfTextSegment').
         if (localRef.getSegment() === endOfTextSegment) {
             return this.length;
         }

--- a/examples/data-objects/webflow/src/editor/caret.ts
+++ b/examples/data-objects/webflow/src/editor/caret.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { LocalReferencePosition } from "@fluidframework/merge-tree";
+import { ReferencePosition } from "@fluidframework/merge-tree";
 import { DocSegmentKind, getDocSegmentKind } from "../document";
 import { clamp, Dom, hasTagName, TagName } from "../util";
 import { updateRef } from "../util/localref";
@@ -30,8 +30,8 @@ export class Caret {
             ? { start, end }
             : { start: end, end: start };
     }
-    private startRef: LocalReferencePosition;
-    private endRef: LocalReferencePosition;
+    private startRef: ReferencePosition;
+    private endRef: ReferencePosition;
 
     public constructor(private readonly layout: Layout) {
         this.startRef = this.doc.addLocalRef(0);
@@ -90,7 +90,7 @@ export class Caret {
         this.setSelection(start, end);
     };
 
-    private positionToNodeOffset(ref: LocalReferencePosition) {
+    private positionToNodeOffset(ref: ReferencePosition) {
         let result: { node: Node; nodeOffset: number; };
 
         const position = this.doc.localRefToPosition(ref);

--- a/examples/data-objects/webflow/src/editor/caret.ts
+++ b/examples/data-objects/webflow/src/editor/caret.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { LocalReference } from "@fluidframework/merge-tree";
+import { LocalReferencePosition } from "@fluidframework/merge-tree";
 import { DocSegmentKind, getDocSegmentKind } from "../document";
 import { clamp, Dom, hasTagName, TagName } from "../util";
 import { updateRef } from "../util/localref";
@@ -30,8 +30,8 @@ export class Caret {
             ? { start, end }
             : { start: end, end: start };
     }
-    private startRef: LocalReference;
-    private endRef: LocalReference;
+    private startRef: LocalReferencePosition;
+    private endRef: LocalReferencePosition;
 
     public constructor(private readonly layout: Layout) {
         this.startRef = this.doc.addLocalRef(0);
@@ -90,12 +90,12 @@ export class Caret {
         this.setSelection(start, end);
     };
 
-    private positionToNodeOffset(ref: LocalReference) {
+    private positionToNodeOffset(ref: LocalReferencePosition) {
         let result: { node: Node; nodeOffset: number; };
 
         const position = this.doc.localRefToPosition(ref);
         const { segment: rightSegment, offset: rightOffset } = this.doc.getSegmentAndOffset(position);
-        const rightKind = getDocSegmentKind(ref.segment);
+        const rightKind = getDocSegmentKind(ref.getSegment());
 
         // The position -> { node, offset } mapping places the caret "just before" the content at the given
         // position.  For text nodes, an offset of 0 is "just before" the first character.

--- a/examples/data-objects/webflow/src/test/flowdocument.spec.ts
+++ b/examples/data-objects/webflow/src/test/flowdocument.spec.ts
@@ -111,7 +111,7 @@ describeLoaderCompat("FlowDocument", (getTestObjectProvider) => {
                 });
             });
         });
-        describe("LocalReferencePosition after last position", () => {
+        describe("ReferencePosition after last position", () => {
             it("can create", () => {
                 const localRef = doc.addLocalRef(doc.length);
                 assert.strictEqual(doc.localRefToPosition(localRef), doc.length);

--- a/examples/data-objects/webflow/src/test/flowdocument.spec.ts
+++ b/examples/data-objects/webflow/src/test/flowdocument.spec.ts
@@ -111,7 +111,7 @@ describeLoaderCompat("FlowDocument", (getTestObjectProvider) => {
                 });
             });
         });
-        describe("LocalReference after last position", () => {
+        describe("LocalReferencePosition after last position", () => {
             it("can create", () => {
                 const localRef = doc.addLocalRef(doc.length);
                 assert.strictEqual(doc.localRefToPosition(localRef), doc.length);

--- a/examples/data-objects/webflow/src/util/localref.ts
+++ b/examples/data-objects/webflow/src/util/localref.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { LocalReference } from "@fluidframework/merge-tree";
+import { LocalReferencePosition } from "@fluidframework/merge-tree";
 import { debug } from "../document/debug";
 import { FlowDocument } from "../document/index";
 
-export function updateRef(doc: FlowDocument, ref: LocalReference, position: number) {
+export function updateRef(doc: FlowDocument, ref: LocalReferencePosition, position: number) {
     if (isNaN(position)) {
         debug(`      ${position} (ignored)`);
         return ref;
@@ -30,7 +30,7 @@ export function updateRef(doc: FlowDocument, ref: LocalReference, position: numb
     return doc.addLocalRef(position);
 }
 
-export function extractRef(doc: FlowDocument, ref: LocalReference) {
+export function extractRef(doc: FlowDocument, ref: LocalReferencePosition) {
     const position = doc.localRefToPosition(ref);
     doc.removeLocalRef(ref);
     return position;

--- a/examples/data-objects/webflow/src/util/localref.ts
+++ b/examples/data-objects/webflow/src/util/localref.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { LocalReferencePosition } from "@fluidframework/merge-tree";
+import { ReferencePosition } from "@fluidframework/merge-tree";
 import { debug } from "../document/debug";
 import { FlowDocument } from "../document/index";
 
-export function updateRef(doc: FlowDocument, ref: LocalReferencePosition, position: number) {
+export function updateRef(doc: FlowDocument, ref: ReferencePosition, position: number) {
     if (isNaN(position)) {
         debug(`      ${position} (ignored)`);
         return ref;
@@ -30,7 +30,7 @@ export function updateRef(doc: FlowDocument, ref: LocalReferencePosition, positi
     return doc.addLocalRef(position);
 }
 
-export function extractRef(doc: FlowDocument, ref: LocalReferencePosition) {
+export function extractRef(doc: FlowDocument, ref: ReferencePosition) {
     const position = doc.localRefToPosition(ref);
     doc.removeLocalRef(ref);
     return position;

--- a/examples/data-objects/webflow/src/view/layout.ts
+++ b/examples/data-objects/webflow/src/view/layout.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { EventEmitter } from "events";
-import { ISegment, LocalReferencePosition, MergeTreeMaintenanceType } from "@fluidframework/merge-tree";
+import { ISegment, ReferencePosition, MergeTreeMaintenanceType } from "@fluidframework/merge-tree";
 import { SequenceEvent } from "@fluidframework/sequence";
 import { FlowDocument } from "../document";
 import { clamp, Dom, done, emptyObject, getSegmentRange, hasTagName, isTextNode, TagName } from "../util";
@@ -82,8 +82,8 @@ export class Layout extends EventEmitter {
     private _segmentStart = NaN;
     private _segmentEnd = NaN;
 
-    private startInvalid: LocalReferencePosition;
-    private endInvalid: LocalReferencePosition;
+    private startInvalid: ReferencePosition;
+    private endInvalid: ReferencePosition;
 
     private readonly scheduleRender: () => void;
 
@@ -543,7 +543,7 @@ export class Layout extends EventEmitter {
         this.invalidate(e.first.position, e.last.position + e.last.segment.cachedLength);
     };
 
-    private unionRef(doc: FlowDocument, position: number | undefined, ref: LocalReferencePosition | undefined, fn: (a: number, b: number) => number, limit: number) {
+    private unionRef(doc: FlowDocument, position: number | undefined, ref: ReferencePosition | undefined, fn: (a: number, b: number) => number, limit: number) {
         return fn(
             position === undefined
                 ? limit

--- a/examples/data-objects/webflow/src/view/layout.ts
+++ b/examples/data-objects/webflow/src/view/layout.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { EventEmitter } from "events";
-import { ISegment, LocalReference, MergeTreeMaintenanceType } from "@fluidframework/merge-tree";
+import { ISegment, LocalReferencePosition, MergeTreeMaintenanceType } from "@fluidframework/merge-tree";
 import { SequenceEvent } from "@fluidframework/sequence";
 import { FlowDocument } from "../document";
 import { clamp, Dom, done, emptyObject, getSegmentRange, hasTagName, isTextNode, TagName } from "../util";
@@ -82,8 +82,8 @@ export class Layout extends EventEmitter {
     private _segmentStart = NaN;
     private _segmentEnd = NaN;
 
-    private startInvalid: LocalReference;
-    private endInvalid: LocalReference;
+    private startInvalid: LocalReferencePosition;
+    private endInvalid: LocalReferencePosition;
 
     private readonly scheduleRender: () => void;
 
@@ -543,7 +543,7 @@ export class Layout extends EventEmitter {
         this.invalidate(e.first.position, e.last.position + e.last.segment.cachedLength);
     };
 
-    private unionRef(doc: FlowDocument, position: number | undefined, ref: LocalReference | undefined, fn: (a: number, b: number) => number, limit: number) {
+    private unionRef(doc: FlowDocument, position: number | undefined, ref: LocalReferencePosition | undefined, fn: (a: number, b: number) => number, limit: number) {
         return fn(
             position === undefined
                 ? limit

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -17,7 +17,6 @@ import {
     MergeTreeDeltaType,
     IMergeTreeMaintenanceCallbackArgs,
     MergeTreeMaintenanceType,
-    LocalReference,
     ReferenceType,
 } from "@fluidframework/merge-tree";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -177,7 +176,7 @@ export class PermutationVector extends Client {
 
         return {
             op: this.insertAtReferencePositionLocal(
-                    new LocalReference(this, segment, /* offset: */ 0, ReferenceType.Transient),
+                    this.createLocalReferencePosition(segment, 0, ReferenceType.Transient, undefined),
                     inserted),
             inserted,
         };

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2549,8 +2549,9 @@ export class MergeTree {
         client: Client,
     ): ReferencePosition {
         if (isRemoved(segment)) {
-            if (!refTypeIncludesFlag(refType, ReferenceType.SlideOnRemove)) {
-                throw new UsageError("Can only create SlideOnRemove local reference position on a removed segment");
+            if (!refTypeIncludesFlag(refType, ReferenceType.SlideOnRemove | ReferenceType.Transient)) {
+                throw new UsageError(
+                    "Can only create SlideOnRemove or Transient local reference position on a removed segment");
             }
         }
         const localRefs = segment.localRefs ?? new LocalReferenceCollection(segment);

--- a/packages/dds/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.ts
@@ -9,13 +9,13 @@
 import path from "path";
 import random from "random-js";
 import { Trace } from "@fluidframework/common-utils";
-import { LocalReference } from "../localReference";
 import { ReferenceType } from "../ops";
 import {
     createMap,
     extend,
     MapLike,
 } from "../properties";
+import { ReferencePosition } from "../referencePositions";
 import { TestClient } from "./testClient";
 import { loadTextFromFileWithMarkers } from "./testUtils";
 
@@ -115,7 +115,7 @@ export function propertyCopy() {
 function makeBookmarks(client: TestClient, bookmarkCount: number) {
     const mt = random.engines.mt19937();
     mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
-    const bookmarks: LocalReference[] = [];
+    const bookmarks: ReferencePosition[] = [];
     const len = client.getLength();
     for (let i = 0; i < bookmarkCount; i++) {
         const pos = random.integer(0, len - 1)(mt);
@@ -124,8 +124,8 @@ function makeBookmarks(client: TestClient, bookmarkCount: number) {
         if (i & 1) {
             refType = ReferenceType.SlideOnRemove;
         }
-        const lref = new LocalReference(client, segoff.segment!, segoff.offset, refType);
-        client.mergeTree.addLocalReference(lref);
+        const lref = client.mergeTree.createLocalReferencePosition(
+             segoff.segment!, segoff.offset!, refType, undefined, client);
         bookmarks.push(lref);
     }
     return bookmarks;

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -8,6 +8,7 @@ import { BaseSegment, ISegment, Marker, MergeTree } from "./mergeTree";
 import { IJSONSegment } from "./ops";
 import { PropertySet } from "./properties";
 import { LocalReferenceCollection } from "./localReference";
+import { refHasTileLabel } from "./referencePositions";
 
 // Maximum length of text segment to be considered to be merged with other segment.
 // Maximum segment length is at least 2x of it (not taking into account initial segment creation).
@@ -266,7 +267,7 @@ export class MergeTreeTextHelper {
                 }
             } else if (isTextAndMarkerAccumulator(accumText)) {
                 const marker = segment as Marker;
-                if (marker.hasTileLabel(accumText.parallelMarkerLabel)) {
+                if (refHasTileLabel(marker, accumText.parallelMarkerLabel)) {
                     accumText.parallelMarkers.push(marker);
                     accumText.parallelText.push(accumText.textSegment.text);
                     accumText.textSegment.text = "";

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -314,15 +314,15 @@ function assertConsistent(sharedStrings: SharedString[]): void {
             );
             for (const interval of intervals1) {
                 const otherInterval = collection2.getIntervalById(interval.getIntervalId());
-                const firstStart = first.localRefToPos(interval.start);
-                const otherStart = other.localRefToPos(otherInterval.start);
+                const firstStart = first.localReferencePositionToPosition(interval.start);
+                const otherStart = other.localReferencePositionToPosition(otherInterval.start);
                 assert.equal(firstStart, otherStart,
                     `Startpoints of interval ${interval.getIntervalId()} different:\n` +
                     `\tfull text:${first.getText()}\n` +
                     `\tclient ${first.id} char:${first.getText(firstStart, firstStart + 1)}\n` +
                     `\tclient ${other.id} char:${other.getText(otherStart, otherStart + 1)}`);
-                const firstEnd = first.localRefToPos(interval.end);
-                const otherEnd = other.localRefToPos(otherInterval.end);
+                const firstEnd = first.localReferencePositionToPosition(interval.end);
+                const otherEnd = other.localReferencePositionToPosition(otherInterval.end);
                 assert.equal(firstEnd, otherEnd,
                     `Endpoints of interval ${interval.getIntervalId()} different:\n` +
                     `\tfull text:${first.getText()}\n` +

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -32,8 +32,8 @@ const assertIntervals = (
         `findOverlappingIntervals() must return the expected number of intervals`);
 
     const actualPos = actual.map((interval) => {
-        const start = sharedString.localRefToPos(interval.start);
-        const end = sharedString.localRefToPos(interval.end);
+        const start = sharedString.localReferencePositionToPosition(interval.start);
+        const end = sharedString.localReferencePositionToPosition(interval.end);
         return { start, end };
     });
     assert.deepEqual(actualPos, expected, "intervals are not as expected");
@@ -44,8 +44,8 @@ function assertIntervalEquals(
     interval: SequenceInterval,
     endpoints: { start: number; end: number; },
 ): void {
-    assert.equal(string.localRefToPos(interval.start), endpoints.start, "mismatched start");
-    assert.equal(string.localRefToPos(interval.end), endpoints.end, "mismatched end");
+    assert.equal(string.localReferencePositionToPosition(interval.start), endpoints.start, "mismatched start");
+    assert.equal(string.localReferencePositionToPosition(interval.end), endpoints.end, "mismatched end");
 }
 
 describe("SharedString interval collections", () => {
@@ -668,8 +668,8 @@ describe("SharedString interval collections", () => {
             const collection1 = sharedString.getIntervalCollection("test");
             const endpointsForCollection1: { start: number; end: number; }[] = [];
             const sequenceIntervalToEndpoints = (interval: SequenceInterval): { start: number; end: number; } => ({
-                start: sharedString.localRefToPos(interval.start),
-                end: sharedString.localRefToPos(interval.end),
+                start: sharedString.localReferencePositionToPosition(interval.start),
+                end: sharedString.localReferencePositionToPosition(interval.end),
             });
 
             collection1.on("addInterval", (interval) => {

--- a/packages/dds/sequence/src/test/testFarm.ts
+++ b/packages/dds/sequence/src/test/testFarm.ts
@@ -14,13 +14,14 @@
 import path from "path";
 import { Trace } from "@fluidframework/common-utils";
 import * as MergeTree from "@fluidframework/merge-tree";
-// eslint-disable-next-line @typescript-eslint/no-duplicate-imports
+
 import {
     TextSegment,
     createGroupOp,
     PropertySet,
     MergeTreeTextHelper,
     IMergeTreeDeltaOp,
+    ReferenceType,
 } from "@fluidframework/merge-tree";
 import {
     LocalClientId,
@@ -114,17 +115,11 @@ function makeBookmarks(client: TestClient, bookmarkCount: number) {
         if (segoff1?.segment && segoff2?.segment) {
             const baseSegment1 = <MergeTree.BaseSegment>segoff1.segment;
             const baseSegment2 = <MergeTree.BaseSegment>segoff2.segment;
-            const lref1 = new MergeTree.LocalReference(client, baseSegment1, segoff1.offset);
-            const lref2 = new MergeTree.LocalReference(client, baseSegment2, segoff2.offset);
-            lref1.refType = MergeTree.ReferenceType.RangeBegin;
+            const lref1 = client.createLocalReferencePosition(baseSegment1, segoff1.offset, MergeTree.ReferenceType.RangeBegin, undefined);
+            const lref2 = client.createLocalReferencePosition(baseSegment2, segoff2.offset, MergeTree.ReferenceType.RangeEnd, undefined);
             lref1.addProperties({ [MergeTree.reservedRangeLabelsKey]: ["bookmark"] });
-            // Can do this locally; for shared refs need to use id/index to ref end
-            lref1.pairedRef = lref2;
-            lref2.refType = MergeTree.ReferenceType.RangeEnd;
             lref2.addProperties({ [MergeTree.reservedRangeLabelsKey]: ["bookmark"] });
-            client.addLocalReference(lref1);
-            client.addLocalReference(lref2);
-            bookmarks.push(new SharedString.SequenceInterval(lref1, lref2, SharedString.IntervalType.Simple));
+            bookmarks.push(new SharedString.SequenceInterval(client, lref1, lref2, SharedString.IntervalType.Simple));
         } else {
             i--;
         }
@@ -135,18 +130,17 @@ function makeBookmarks(client: TestClient, bookmarkCount: number) {
 function makeReferences(client: TestClient, referenceCount: number) {
     const mt = random.engines.mt19937();
     mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
-    const refs = <MergeTree.LocalReference[]>[];
+    const refs = <MergeTree.LocalReferencePosition[]>[];
     const len = client.mergeTree.getLength(UniversalSequenceNumber, NonCollabClient);
     for (let i = 0; i < referenceCount; i++) {
         const pos = random.integer(0, len - 1)(mt);
         const segoff = client.getContainingSegment(pos);
         if (segoff?.segment) {
             const baseSegment = <MergeTree.BaseSegment>segoff.segment;
-            const lref = new MergeTree.LocalReference(client, baseSegment, segoff.offset);
+            const lref = client.createLocalReferencePosition(baseSegment, segoff.offset, MergeTree.ReferenceType.Simple, undefined);
             if (i & 1) {
                 lref.refType = MergeTree.ReferenceType.SlideOnRemove;
             }
-            client.addLocalReference(lref);
             refs.push(lref);
         } else {
             i--;
@@ -229,7 +223,7 @@ export function TestPack(verbose = true) {
         const measureRanges = true;
         const referenceCount = 2000;
         const bookmarkCount = 5000;
-        let references: MergeTree.LocalReference[];
+        let references: MergeTree.LocalReferencePosition[];
         let refReads = 0;
         let refReadTime = 0;
         let posContextChecks = 0;
@@ -405,7 +399,7 @@ export function TestPack(verbose = true) {
                 const segOff = client.getContainingSegment(pos);
                 const insertOp = !insertAsRefPos && segOff.segment
                     ? client.insertAtReferencePositionLocal(
-                        new MergeTree.LocalReference(client, segOff.segment, segOff.offset, MergeTree.ReferenceType.Transient),
+                        client.createLocalReferencePosition(segOff.segment, segOff.offset, MergeTree.ReferenceType.Transient, undefined),
                         TextSegment.make(word1.text))
                     : client.insertTextLocal(pos, word1.text);
 
@@ -524,7 +518,7 @@ export function TestPack(verbose = true) {
                 const rangeChecksPerRound = 200;
                 let clockStart = clock();
                 for (let i = 0; i < refReadsPerRound; i++) {
-                    references[i].toPosition();
+                    testServer.localReferencePositionToPosition(references[i]);
                     refReads++;
                 }
                 refReadTime += elapsedMicroseconds(clockStart);
@@ -575,9 +569,9 @@ export function TestPack(verbose = true) {
                         const segoff1 = testServer.getContainingSegment(checkPos[i]);
                         const segoff2 = testServer.getContainingSegment(checkPos[i] + 1);
                         if (segoff1?.segment && segoff2?.segment) {
-                            const lrefPos1 = new MergeTree.LocalReference(testServer, <MergeTree.BaseSegment>segoff1.segment, segoff1.offset);
-                            const lrefPos2 = new MergeTree.LocalReference(testServer, <MergeTree.BaseSegment>segoff2.segment, segoff2.offset);
-                            checkPosRanges[i] = new SharedString.SequenceInterval(lrefPos1, lrefPos2, SharedString.IntervalType.Simple);
+                            const lrefPos1 = testServer.createLocalReferencePosition(<MergeTree.BaseSegment>segoff1.segment, segoff1.offset, ReferenceType.Simple, undefined);
+                            const lrefPos2 = testServer.createLocalReferencePosition(<MergeTree.BaseSegment>segoff2.segment, segoff2.offset, ReferenceType.Simple, undefined);
+                            checkPosRanges[i] = new SharedString.SequenceInterval(testServer, lrefPos1, lrefPos2, SharedString.IntervalType.Simple);
                         } else {
                             i--;
                         }
@@ -593,9 +587,9 @@ export function TestPack(verbose = true) {
                         const segoff1 = testServer.getContainingSegment(checkRange[i][0]);
                         const segoff2 = testServer.getContainingSegment(checkRange[i][1]);
                         if (segoff1?.segment && segoff2?.segment) {
-                            const lrefPos1 = new MergeTree.LocalReference(testServer, <MergeTree.BaseSegment>segoff1.segment, segoff1.offset);
-                            const lrefPos2 = new MergeTree.LocalReference(testServer, <MergeTree.BaseSegment>segoff2.segment, segoff2.offset);
-                            checkRangeRanges[i] = new SharedString.SequenceInterval(lrefPos1, lrefPos2, SharedString.IntervalType.Simple);
+                            const lrefPos1 = testServer.createLocalReferencePosition(<MergeTree.BaseSegment>segoff1.segment, segoff1.offset, ReferenceType.Simple, undefined);
+                            const lrefPos2 = testServer.createLocalReferencePosition(<MergeTree.BaseSegment>segoff2.segment, segoff2.offset, ReferenceType.Simple, undefined);
+                            checkRangeRanges[i] = new SharedString.SequenceInterval(testServer, lrefPos1, lrefPos2, SharedString.IntervalType.Simple);
                         } else {
                             i--;
                         }
@@ -877,8 +871,10 @@ export function TestPack(verbose = true) {
         }
         cli.insertTextRemote(0, "abcde", undefined, 1, 0, "2");
         const segoff = cli.getContainingSegment(0);
-        const lref1 = new MergeTree.LocalReference(cli, <MergeTree.BaseSegment>(segoff.segment),
-            segoff.offset);
+        const lref1 = cli.createLocalReferencePosition(<MergeTree.BaseSegment>(segoff.segment),
+            segoff.offset,
+            ReferenceType.Simple,
+            undefined);
         cli.insertTextRemote(0, "yyy", undefined, 2, 0, "1");
         cli.insertTextRemote(2, "zzz", undefined, 3, 1, "3");
         cli.insertTextRemote(1, "EAGLE", undefined, 4, 1, "4");

--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -107,7 +107,7 @@ export class SharedSegmentSequenceRevertible implements IRevertible {
                         case MergeTreeDeltaType.REMOVE:
                             const insertSegment = this.sequence.segmentFromSpec(sg.toJSONObject() as IJSONSegment);
                             this.sequence.insertAtReferencePosition(
-                                this.sequence.createPositionReference(sg, 0, ReferenceType.Transient),
+                                this.sequence.createLocalReferencePosition(sg, 0, ReferenceType.Transient, undefined),
                                 insertSegment);
                             sg.trackingCollection.trackingGroups.forEach((tg) => {
                                 tg.link(insertSegment);

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { LocalReference, PropertySet } from "@fluidframework/merge-tree";
+import { DetachedReferencePosition, PropertySet } from "@fluidframework/merge-tree";
 import { ISummaryBlob } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
@@ -40,8 +40,8 @@ const assertIntervalsHelper = (
         `findOverlappingIntervals() must return the expected number of intervals`);
 
     for (const actualInterval of actual) {
-        const start = sharedString.localRefToPos(actualInterval.start);
-        const end = sharedString.localRefToPos(actualInterval.end);
+        const start = sharedString.localReferencePositionToPosition(actualInterval.start);
+        const end = sharedString.localReferencePositionToPosition(actualInterval.end);
         let found = false;
 
         // console.log(`[${start},${end}): ${sharedString.getText().slice(start, end)}`);
@@ -250,7 +250,7 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 
             sharedString.removeRange(0, len);
             await provider.ensureSynchronized();
-            assertIntervals([{ start: LocalReference.DetachedPosition, end: LocalReference.DetachedPosition }]);
+            assertIntervals([{ start: DetachedReferencePosition, end: DetachedReferencePosition }]);
         });
 
         it("replace before is excluded", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -178,7 +178,8 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 
                 const segInfo = sharedString.getContainingSegment(3);
                 sharedString.insertAtReferencePosition(
-                    sharedString.createPositionReference(segInfo.segment, segInfo.offset, ReferenceType.SlideOnRemove),
+                    sharedString.createLocalReferencePosition(
+                        segInfo.segment, segInfo.offset, ReferenceType.SlideOnRemove, undefined),
                     new TextSegment(text));
 
                 sharedString.removeRange(0, 5);


### PR DESCRIPTION
# Integrate Local Reference Deprecations

## Description

There are a number of deprecations related to local references. This change brings in all the changes necessary to consume the replacements in preparation for the removal of that deprecations in a follow up pr.