### PR TITLE
fluid-framework typetests fixes

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1950,20 +1950,20 @@
 			}
 		},
 		"@fluid-experimental/task-manager-previous": {
-			"version": "npm:@fluid-experimental/task-manager@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-1.0.0.tgz",
-			"integrity": "sha512-BiJyKfY0jY/7KNQIhmDN8aSEUby0NZrI6RS3THfbKmO7CYDGw8XTW/kmYq6cgE+1Qbm7B2pN2ZZSgWK1jhANKw==",
+			"version": "npm:@fluid-experimental/task-manager@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-1.0.1.tgz",
+			"integrity": "sha512-f3TdetE+E+txRITOTe+9LbtOJCCnMLGWWQmB2cjnNz437a2WDEQ6bqv5V7p5KvwzT5q5r3SpLh7FpkU+bQnrRw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluid-tools/benchmark": {
@@ -2214,44 +2214,44 @@
 			}
 		},
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-1.0.0.tgz",
-			"integrity": "sha512-0/XLCYwV9hRF4QE1VwUP2CToAl54CHUBWacdXd2Y/Y3YqwTe3jOpiL3hqzAqpM3gNAmxFQ4vWFM5BTy6VlRAHg==",
+			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-1.0.1.tgz",
+			"integrity": "sha512-Lw45k5XCzG8hPT3Tlf6a0eZnuqFUQwDW/dWY0RGlwLlCNHaePFwz54f4trp1vH57nFrA0DCmcXncUm9qO7uvJg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/odsp-driver": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0"
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/odsp-driver": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1"
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.0.0.tgz",
-			"integrity": "sha512-TDiQ9wfvcue1NqHtOz27tX7Pw1gM+7y8R3f4vni48B7JuOBM0sG63iid0Tfd1xNfBrktIW8gQsgwC+zfSksIdQ==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.0.1.tgz",
+			"integrity": "sha512-xzbeHss7tPDonC9SOYxndR2E475IvTfsLx9JU8hPtPwIReqbP3JKqPGnn0nso4HUgO8CmpcxBGONsQeIlLsYpQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.0",
+				"@fluidframework/aqueduct": "^1.0.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/local-driver": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": "^1.0.0",
-				"@fluidframework/odsp-driver": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/local-driver": "^1.0.1",
+				"@fluidframework/odsp-doclib-utils": "^1.0.1",
+				"@fluidframework/odsp-driver": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/server-local-server": "^0.1036.4000",
 				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/test-runtime-utils": "^1.0.0",
-				"@fluidframework/tool-utils": "^1.0.0",
-				"@fluidframework/view-adapters": "^1.0.0",
-				"@fluidframework/view-interfaces": "^1.0.0",
-				"@fluidframework/web-code-loader": "^1.0.0",
+				"@fluidframework/test-runtime-utils": "^1.0.1",
+				"@fluidframework/tool-utils": "^1.0.1",
+				"@fluidframework/view-adapters": "^1.0.1",
+				"@fluidframework/view-interfaces": "^1.0.1",
+				"@fluidframework/web-code-loader": "^1.0.1",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
 				"nconf": "^0.11.4",
@@ -2261,66 +2261,66 @@
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.0.0.tgz",
-			"integrity": "sha512-pjWMLiMQwWspYp6FjxO9SsGbIfdsdsLmdGT9wRZ4/32Pbi9UCYNVIafxHHpwlPZIPUi2uPpEacdeArxCunvmtw==",
+			"version": "npm:@fluidframework/agent-scheduler@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.0.1.tgz",
+			"integrity": "sha512-iYEGq/C8fLFNSitpBhqg+yFxeGl0jjoXmYKKvqJ93mc2ip7CppMM67AOHHbny+cfyJQRq6alK2RBq40IK5Y1Ag==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
-				"@fluidframework/register-collection": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/register-collection": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.0.0.tgz",
-			"integrity": "sha512-XrW+0kn79KkNhyk92dpW2Z7EuWKJvkve0Tt65ByIFbAaiUouP2SV1VKZXDHGZ/bJNDe3ok29ehT1Sxqk6SUYeg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.0.1.tgz",
+			"integrity": "sha512-mr5uuioC8qN6PrQLpSj0dFQnbjEnb0xVPGW9erocD8KuT+8MJ3WJ4PE/O1RUqWglUf0rWhul6fhmt6hqHNQdvA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
-				"@fluidframework/request-handler": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/synthesize": "^1.0.0",
-				"@fluidframework/view-interfaces": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/request-handler": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/synthesize": "^1.0.1",
+				"@fluidframework/view-interfaces": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.0.0.tgz",
-			"integrity": "sha512-XrW+0kn79KkNhyk92dpW2Z7EuWKJvkve0Tt65ByIFbAaiUouP2SV1VKZXDHGZ/bJNDe3ok29ehT1Sxqk6SUYeg==",
+			"version": "npm:@fluidframework/aqueduct@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.0.1.tgz",
+			"integrity": "sha512-mr5uuioC8qN6PrQLpSj0dFQnbjEnb0xVPGW9erocD8KuT+8MJ3WJ4PE/O1RUqWglUf0rWhul6fhmt6hqHNQdvA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
-				"@fluidframework/request-handler": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/synthesize": "^1.0.0",
-				"@fluidframework/view-interfaces": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/request-handler": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/synthesize": "^1.0.1",
+				"@fluidframework/view-interfaces": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -2416,31 +2416,31 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.0.0.tgz",
-			"integrity": "sha512-TxDKyMK6XKgGTlJRWQhRPCYeD5+o4Jt3OTZ2O+1xl/yhRpSAZqyeG5QiOnFGeEjL5CZxvkWOpEZmGOXsxsnMIA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.0.1.tgz",
+			"integrity": "sha512-yv4kPoSje3EIkKxeadjzNoh4Gm9sVvVoz78wCxoQgUGzW9IbhSfC4B6FxTl7SP+mti3+Rmit5pwBLVPswEyg7g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.0.0.tgz",
-			"integrity": "sha512-TxDKyMK6XKgGTlJRWQhRPCYeD5+o4Jt3OTZ2O+1xl/yhRpSAZqyeG5QiOnFGeEjL5CZxvkWOpEZmGOXsxsnMIA==",
+			"version": "npm:@fluidframework/cell@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.0.1.tgz",
+			"integrity": "sha512-yv4kPoSje3EIkKxeadjzNoh4Gm9sVvVoz78wCxoQgUGzW9IbhSfC4B6FxTl7SP+mti3+Rmit5pwBLVPswEyg7g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -2469,42 +2469,42 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.0.0.tgz",
-			"integrity": "sha512-Sw11DOaGZE8b6CfSfkGsdzvEGRAJ5OQahHqhEg2wtBg7i9ZMwgU8KP6hJCuKmJz0MhPYofauyA0l/xer4ZHR7A==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.0.1.tgz",
+			"integrity": "sha512-C8r6rNzA3nmsKelK3nFVr7AF5NCDM6a0zgUxWLO2/uTH5XPWir+s1b8qbnvWXIWrbgriEJFLUh22SWz1EXv9ow==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/container-definitions-previous": {
-			"version": "npm:@fluidframework/container-definitions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.0.0.tgz",
-			"integrity": "sha512-Sw11DOaGZE8b6CfSfkGsdzvEGRAJ5OQahHqhEg2wtBg7i9ZMwgU8KP6hJCuKmJz0MhPYofauyA0l/xer4ZHR7A==",
+			"version": "npm:@fluidframework/container-definitions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.0.1.tgz",
+			"integrity": "sha512-C8r6rNzA3nmsKelK3nFVr7AF5NCDM6a0zgUxWLO2/uTH5XPWir+s1b8qbnvWXIWrbgriEJFLUh22SWz1EXv9ow==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.0.0.tgz",
-			"integrity": "sha512-hQiav8wvNDiu6QIqzdC+sHcUc/75ypsPhOTPh3K0g+OjNmw2qPl7i65vBVZTqJpAcOwetuAFEQ8slT/3O/bKBQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.0.1.tgz",
+			"integrity": "sha512-0FzdCNLKcldyD8xheiMJemnKy+5HXTMMMnWcaIaLUgqi+TnIpNFZ/jMYFh9LG83LPPXsOA0hMY6KvY87SCZvTQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2512,20 +2512,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.0.0.tgz",
-			"integrity": "sha512-hQiav8wvNDiu6QIqzdC+sHcUc/75ypsPhOTPh3K0g+OjNmw2qPl7i65vBVZTqJpAcOwetuAFEQ8slT/3O/bKBQ==",
+			"version": "npm:@fluidframework/container-loader@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.0.1.tgz",
+			"integrity": "sha512-0FzdCNLKcldyD8xheiMJemnKy+5HXTMMMnWcaIaLUgqi+TnIpNFZ/jMYFh9LG83LPPXsOA0hMY6KvY87SCZvTQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2533,348 +2533,348 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.0.0.tgz",
-			"integrity": "sha512-ebRoi6a+z2s+bQHdXoTnsorAobwrAlXSMaTDHHJ16MZcTlcnHrHuMLlh9uCnCvszjZUzRR6ZHJbG+QEUbchQCg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.0.1.tgz",
+			"integrity": "sha512-OCkTXpgOW0XhqrXu9je6V0qhAut3+SmKI5p/wV4uK7rzyxrbk18ItiZ9s43zOTvD7/X8s38JO2rtGSEkCFgqMw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/garbage-collector": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/garbage-collector": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.0.0.tgz",
-			"integrity": "sha512-yQ3hDWRK36Hp2n5QCgmGvjhiPyieNTkBPmTJQ1zTsWvRk7er/qmks/fLNy8ZBrD6qzFngmS5YUAgGU5aJUulsw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.0.1.tgz",
+			"integrity": "sha512-scJoGh/aLCiA+VSH0Oc+MRPx3KkpX1B3GrKDLOwY2VHrW4UtyLaMLQTq+nlUZiw9EQRo42A7B1NQqQwdUQpfAw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.0.0.tgz",
-			"integrity": "sha512-yQ3hDWRK36Hp2n5QCgmGvjhiPyieNTkBPmTJQ1zTsWvRk7er/qmks/fLNy8ZBrD6qzFngmS5YUAgGU5aJUulsw==",
+			"version": "npm:@fluidframework/container-runtime-definitions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.0.1.tgz",
+			"integrity": "sha512-scJoGh/aLCiA+VSH0Oc+MRPx3KkpX1B3GrKDLOwY2VHrW4UtyLaMLQTq+nlUZiw9EQRo42A7B1NQqQwdUQpfAw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.0.0.tgz",
-			"integrity": "sha512-ebRoi6a+z2s+bQHdXoTnsorAobwrAlXSMaTDHHJ16MZcTlcnHrHuMLlh9uCnCvszjZUzRR6ZHJbG+QEUbchQCg==",
+			"version": "npm:@fluidframework/container-runtime@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.0.1.tgz",
+			"integrity": "sha512-OCkTXpgOW0XhqrXu9je6V0qhAut3+SmKI5p/wV4uK7rzyxrbk18ItiZ9s43zOTvD7/X8s38JO2rtGSEkCFgqMw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/garbage-collector": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/garbage-collector": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.0.0.tgz",
-			"integrity": "sha512-4FPjsW0Ff8ciXk0jhWGl0S93t6hHQUhkYHyDMV6r7JmauuoOJZtQOQ1tfwZIMQT8OVN+L7/wlCCwtaSMb0FzpQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.0.1.tgz",
+			"integrity": "sha512-LmNsG79MjD9AFi2oZTxHjfp1M1VF4XKX02bNqe2mCplShO4Cldd0Zo0w68St5Nrro4eWFIE3STapwE8/kdzC3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.0.0.tgz",
-			"integrity": "sha512-4FPjsW0Ff8ciXk0jhWGl0S93t6hHQUhkYHyDMV6r7JmauuoOJZtQOQ1tfwZIMQT8OVN+L7/wlCCwtaSMb0FzpQ==",
+			"version": "npm:@fluidframework/container-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.0.1.tgz",
+			"integrity": "sha512-LmNsG79MjD9AFi2oZTxHjfp1M1VF4XKX02bNqe2mCplShO4Cldd0Zo0w68St5Nrro4eWFIE3STapwE8/kdzC3A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.0.0.tgz",
-			"integrity": "sha512-zn8apmBV/SKJAGGSKqbmYLeJHflb95Gmym1U7T95loAuqk5ffhpwH72GGuLvpiYJ8DpWgmkzYcCQZQimw/j6jA=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.0.1.tgz",
+			"integrity": "sha512-Bt6ONbZJgKSK0WQcV6od9xqa6t4VcAKX6tRIwougvm/YJSc7YLz3itKR6g+ILaO0yH8+GnMHt6l11Bjsl44NBw=="
 		},
 		"@fluidframework/core-interfaces-previous": {
-			"version": "npm:@fluidframework/core-interfaces@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.0.0.tgz",
-			"integrity": "sha512-zn8apmBV/SKJAGGSKqbmYLeJHflb95Gmym1U7T95loAuqk5ffhpwH72GGuLvpiYJ8DpWgmkzYcCQZQimw/j6jA=="
+			"version": "npm:@fluidframework/core-interfaces@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.0.1.tgz",
+			"integrity": "sha512-Bt6ONbZJgKSK0WQcV6od9xqa6t4VcAKX6tRIwougvm/YJSc7YLz3itKR6g+ILaO0yH8+GnMHt6l11Bjsl44NBw=="
 		},
 		"@fluidframework/counter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.0.0.tgz",
-			"integrity": "sha512-7WgyOelPUb5QpRELoS9hHgsNk9HkOx/ELuslQnPJni/svTqQIQSsrR0xlb2wJ8xDwhUkS1uVJI7Qoa34IB9x5w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.0.1.tgz",
+			"integrity": "sha512-kYM5tbxEH9tMobsu+9DCBicgDbFSj/UGLxBH+8Lumw3SdqY1afW0kgDXoJ39yiLQmIRsEJVe2/kZqqyVbJR6Mw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.0.0.tgz",
-			"integrity": "sha512-7WgyOelPUb5QpRELoS9hHgsNk9HkOx/ELuslQnPJni/svTqQIQSsrR0xlb2wJ8xDwhUkS1uVJI7Qoa34IB9x5w==",
+			"version": "npm:@fluidframework/counter@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.0.1.tgz",
+			"integrity": "sha512-kYM5tbxEH9tMobsu+9DCBicgDbFSj/UGLxBH+8Lumw3SdqY1afW0kgDXoJ39yiLQmIRsEJVe2/kZqqyVbJR6Mw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.0.0.tgz",
-			"integrity": "sha512-UCTpMyqjfaRY3I6tJi7taH6vV49lsMf+I4Ood6d2qFlcgTA8g4Ao5pgSUvlKxRZfZrIeMA2LRXPnOcL7Uazdyw==",
+			"version": "npm:@fluidframework/data-object-base@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.0.1.tgz",
+			"integrity": "sha512-gXpP7hZ95zUuBdQFypnWEl2BvYGQnX4hfd+fdXXdEPk/Y4Dtoy9V6j379Mb3XUeRQCWUkkk6WvLNnUbHcU45vQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/request-handler": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/request-handler": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.0.0.tgz",
-			"integrity": "sha512-NcXt1Ex1XCFW8l6aUvzNssaQYI2Zoym6NOajyKMXs+4yGw5K4TcvDjlJ9xGknqvgWvaAG1emAxxmTzhlbWfepQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.0.1.tgz",
+			"integrity": "sha512-bo4qqiZUXGd4SzmMeQgCIbcMiPo6uTWJe4/jFHwrj24gWmY8VFjcHNIdX1VFe1SS9hTIbJS9L93zcz2vr0yhfA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/garbage-collector": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/garbage-collector": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.0.0.tgz",
-			"integrity": "sha512-mlOb42QtHc5WWRjbzFPvwMpp/o09eCccv9ttFxxxPGQZz8jWU5vvn7Ff/vB0atvwMRkjk0nUYhBCOVyb5ATd1w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.0.1.tgz",
+			"integrity": "sha512-3knrsvPUzcdf6VwEBzLFdDbKBH7cz9YZn1QtCkamr4skrHWTP9bknzpQCT9PrKPdk5D9gJxUQsJXYYs+SITYVA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.0.0.tgz",
-			"integrity": "sha512-mlOb42QtHc5WWRjbzFPvwMpp/o09eCccv9ttFxxxPGQZz8jWU5vvn7Ff/vB0atvwMRkjk0nUYhBCOVyb5ATd1w==",
+			"version": "npm:@fluidframework/datastore-definitions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.0.1.tgz",
+			"integrity": "sha512-3knrsvPUzcdf6VwEBzLFdDbKBH7cz9YZn1QtCkamr4skrHWTP9bknzpQCT9PrKPdk5D9gJxUQsJXYYs+SITYVA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.0.0.tgz",
-			"integrity": "sha512-NcXt1Ex1XCFW8l6aUvzNssaQYI2Zoym6NOajyKMXs+4yGw5K4TcvDjlJ9xGknqvgWvaAG1emAxxmTzhlbWfepQ==",
+			"version": "npm:@fluidframework/datastore@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.0.1.tgz",
+			"integrity": "sha512-bo4qqiZUXGd4SzmMeQgCIbcMiPo6uTWJe4/jFHwrj24gWmY8VFjcHNIdX1VFe1SS9hTIbJS9L93zcz2vr0yhfA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/garbage-collector": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/garbage-collector": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.0.0.tgz",
-			"integrity": "sha512-3aVvm9zKHOhrTe80aO5IpIrCIRL+lfE3eBvuRA0bSGYUwiS1oR3Gkp1eThSSaLmVPSbj952HYl77nOOZMbze8w==",
+			"version": "npm:@fluidframework/dds-interceptions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.0.1.tgz",
+			"integrity": "sha512-V+XN4+aOVqrEv9M0+HxC9Qq9lwrgLj40LpNK7s2SWGCtERcVIPzNEeCKYnpjGbL5TJ6cfHCDuybr/STBreBKlA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^1.0.0",
-				"@fluidframework/merge-tree": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/sequence": "^1.0.0"
+				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/merge-tree": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/sequence": "^1.0.1"
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.0.0.tgz",
-			"integrity": "sha512-OAgSwBKpeEucSgFNmJBJFpnUsD+LdOo1x1M/1jPcZv23F2Bq/VrD5lo4tKDLDrn8hNh858QWf7brzRfJ5Kd8XA==",
+			"version": "npm:@fluidframework/debugger@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.0.1.tgz",
+			"integrity": "sha512-IAmLd1myBpLRZvvuE9iQ8NF4i4BPMvJy7lDpWBUkqoOHc3gxlyG2WCJHEf+86kO+TAVxYi07vr4mXBQpPccZ5w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.0.0",
+				"@fluidframework/replay-driver": "^1.0.1",
 				"jsonschema": "^1.2.6"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.0.0.tgz",
-			"integrity": "sha512-BramsL9VT+wn5viOw7MQSecBAXG/D2ti49RdazrDDl59nC+oh9GLaEgfLMMLT4rUbsOL2hMV6hjog8XBi9G+vQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.0.1.tgz",
+			"integrity": "sha512-QVWhz0eqeJar//hNTfdLJ+mnuTv9hV2DhxjnnTU+ZsxJ6w3fvW+5nj4yKxyWM+k6CF9XKNBVn1Kh3tOA3e08IQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.0.0.tgz",
-			"integrity": "sha512-BramsL9VT+wn5viOw7MQSecBAXG/D2ti49RdazrDDl59nC+oh9GLaEgfLMMLT4rUbsOL2hMV6hjog8XBi9G+vQ==",
+			"version": "npm:@fluidframework/driver-base@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.0.1.tgz",
+			"integrity": "sha512-QVWhz0eqeJar//hNTfdLJ+mnuTv9hV2DhxjnnTU+ZsxJ6w3fvW+5nj4yKxyWM+k6CF9XKNBVn1Kh3tOA3e08IQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.0.0.tgz",
-			"integrity": "sha512-aezc684mM5p47hNpQp3+0NOnDQ9SpO6pdHuGJZcBbWSDHBW6iAVBXuBH8Cw5Imz0DRGBs1S4yrg+EgK5oj59Vw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.0.1.tgz",
+			"integrity": "sha512-WlcfXUsslcm5egApzpKmTOMawIsneYiTIG9LwVaY0yNvE5I/xVg54Z5SIqKc7Ov4kA/jxRPp/PLjsARGvHuWnQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/driver-definitions-previous": {
-			"version": "npm:@fluidframework/driver-definitions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.0.0.tgz",
-			"integrity": "sha512-aezc684mM5p47hNpQp3+0NOnDQ9SpO6pdHuGJZcBbWSDHBW6iAVBXuBH8Cw5Imz0DRGBs1S4yrg+EgK5oj59Vw==",
+			"version": "npm:@fluidframework/driver-definitions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.0.1.tgz",
+			"integrity": "sha512-WlcfXUsslcm5egApzpKmTOMawIsneYiTIG9LwVaY0yNvE5I/xVg54Z5SIqKc7Ov4kA/jxRPp/PLjsARGvHuWnQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.0.0.tgz",
-			"integrity": "sha512-yl+LNlkxJeaDCHYl9x9QMpl00mVAIHDyvXe6omx2oERXc5vcd7Q8ohnocw1whO7vKByrQaaux3Z3E32DhotuBQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.0.1.tgz",
+			"integrity": "sha512-k53mRghyr0+tzLca/353AZAAHTzphgwTmhRucwtXP3RXWMucpCEJN+9BL5TP0YGlvW7aceFkwgrY2pOTQ4Bm4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/gitresources": "^0.1036.4000",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.0.0.tgz",
-			"integrity": "sha512-yl+LNlkxJeaDCHYl9x9QMpl00mVAIHDyvXe6omx2oERXc5vcd7Q8ohnocw1whO7vKByrQaaux3Z3E32DhotuBQ==",
+			"version": "npm:@fluidframework/driver-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.0.1.tgz",
+			"integrity": "sha512-k53mRghyr0+tzLca/353AZAAHTzphgwTmhRucwtXP3RXWMucpCEJN+9BL5TP0YGlvW7aceFkwgrY2pOTQ4Bm4A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/gitresources": "^0.1036.4000",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.0.0.tgz",
-			"integrity": "sha512-+fN48ej1//f3OLuvEfMtV/b0yWY7UG9uo4BMqDb9DNi/bpKSL2uFGZRbgvIp6v1AS4imXqKddEzI2kSYc/wPPA==",
+			"version": "npm:@fluidframework/driver-web-cache@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.0.1.tgz",
+			"integrity": "sha512-tTdthVkg2qgk60I0arPwQhmaL8lKuZXLDxzdesXly7H6pfp9iVp9mPs19EzC1V2iXJ5oVmLdEMNRHFGmVWj5Pg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"idb": "^6.1.2"
 			}
 		},
@@ -2898,74 +2898,74 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.0.0.tgz",
-			"integrity": "sha512-BOwY8hBSd5hlqOnDKs/3z1BMjt0fJfiBC9Nomg2SxXCLBCpre7LeH4x1fdKBl2Rx89Ry1S942x3TK8jCh9TRfw==",
+			"version": "npm:@fluidframework/file-driver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.0.1.tgz",
+			"integrity": "sha512-8aBLyiD1npigMEz4GkgsY09UwQsEXDjAeRRhFfWS0vQBjSEDP9R6zLrqnMQHJmn4zSXfc9ul+RaNXdjT3jBRDA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.0.0"
+				"@fluidframework/replay-driver": "^1.0.1"
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.0.0.tgz",
-			"integrity": "sha512-tHKqTX9pi+4QlECzMdR7xoI0DUQ/uyUwuISk1Z+U8tfcqRJaX6uURLghxTFJHvc7lGDzzE8oqRwYfsNFqgDgWA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.0.1.tgz",
+			"integrity": "sha512-7YD22HbWmtNBZSwVYrBMU9W6A/6TGpI7TrV2aqTHm8NTbQ/BfFzPKqvBKstGOQhmkd5HXHXuq8XgsMQg56BiHQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.0",
+				"@fluidframework/aqueduct": "^1.0.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0"
+				"@fluidframework/request-handler": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.0.0.tgz",
-			"integrity": "sha512-tHKqTX9pi+4QlECzMdR7xoI0DUQ/uyUwuISk1Z+U8tfcqRJaX6uURLghxTFJHvc7lGDzzE8oqRwYfsNFqgDgWA==",
+			"version": "npm:@fluidframework/fluid-static@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.0.1.tgz",
+			"integrity": "sha512-7YD22HbWmtNBZSwVYrBMU9W6A/6TGpI7TrV2aqTHm8NTbQ/BfFzPKqvBKstGOQhmkd5HXHXuq8XgsMQg56BiHQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.0",
+				"@fluidframework/aqueduct": "^1.0.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0"
+				"@fluidframework/request-handler": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.0.0.tgz",
-			"integrity": "sha512-CXzn6ljc8gYefykgHZtwfxduSp2Z/n3J/fmhQdLkcT7eDw6YZOk7tDTIyIvR0d6qcHJbyn0FLtC+lgmTAcplFQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.0.1.tgz",
+			"integrity": "sha512-1QyuKdcAcyaFiVCtn7NU/sMAoo2cHKxWwA0oi8LEbXCf5k9aSo+bPWvDItsqx2Am0xGJ+DAZArD5LtD0wm1KsQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.0.0.tgz",
-			"integrity": "sha512-CXzn6ljc8gYefykgHZtwfxduSp2Z/n3J/fmhQdLkcT7eDw6YZOk7tDTIyIvR0d6qcHJbyn0FLtC+lgmTAcplFQ==",
+			"version": "npm:@fluidframework/garbage-collector@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.0.1.tgz",
+			"integrity": "sha512-1QyuKdcAcyaFiVCtn7NU/sMAoo2cHKxWwA0oi8LEbXCf5k9aSo+bPWvDItsqx2Am0xGJ+DAZArD5LtD0wm1KsQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -2974,63 +2974,63 @@
 			"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.0.0.tgz",
-			"integrity": "sha512-i5n3yyDZMe3lsV4ZEWWhpHZUoVYw8KkOIDv8X8J5xwJu/7chi/qf87Dra76DgVHgsv0pKRcyMvyb6EVoSRQTLA==",
+			"version": "npm:@fluidframework/iframe-driver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.0.1.tgz",
+			"integrity": "sha512-3XqLQKOgvq4R8LOyLvb4FLFnTfhIpkgZYQ00eWjUj4ZWgtFymkCaU1mg9DiNJi1p2AAFMrFiFEC3BUoOp6M/XA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"comlink": "^4.3.0"
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.0.0.tgz",
-			"integrity": "sha512-ASDSMnCRAzf3wCbY/8Myzj827T/UhmA/APt+x3SlgliGBAm8LhRqZbj5YL+rCqB8HFGzqadKWaHlaXTX8qRskg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.0.1.tgz",
+			"integrity": "sha512-bphRTjyDnValhS/SXUPpg9cbYzBh256S3zOgG0hP0GO7e9dMR63lrZDO4ysAEZ+rc+JrMJJ4BiASThMRwhrSIw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.0.0.tgz",
-			"integrity": "sha512-ASDSMnCRAzf3wCbY/8Myzj827T/UhmA/APt+x3SlgliGBAm8LhRqZbj5YL+rCqB8HFGzqadKWaHlaXTX8qRskg==",
+			"version": "npm:@fluidframework/ink@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.0.1.tgz",
+			"integrity": "sha512-bphRTjyDnValhS/SXUPpg9cbYzBh256S3zOgG0hP0GO7e9dMR63lrZDO4ysAEZ+rc+JrMJJ4BiASThMRwhrSIw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.0.0.tgz",
-			"integrity": "sha512-0SpW+lwPKBs0aIRlhiK6KZ5ylZqYmCWFtieri40GRCv5FDN8es0GghtZs0ejW8VPRGt4BKjYpAauUPNaLHkcoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.0.1.tgz",
+			"integrity": "sha512-wOR5tNksImVAnikpU5DU5+VcmisYT+2Aaq1BB1PJpr8ly0nPccggTb3qs+iL1JsHrvHmyG3WQqZi/KzcObg7mw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-base": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-base": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
 				"@fluidframework/server-local-server": "^0.1036.4000",
 				"@fluidframework/server-services-client": "^0.1036.4000",
 				"@fluidframework/server-services-core": "^0.1036.4000",
@@ -3040,18 +3040,18 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.0.0.tgz",
-			"integrity": "sha512-0SpW+lwPKBs0aIRlhiK6KZ5ylZqYmCWFtieri40GRCv5FDN8es0GghtZs0ejW8VPRGt4BKjYpAauUPNaLHkcoA==",
+			"version": "npm:@fluidframework/local-driver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.0.1.tgz",
+			"integrity": "sha512-wOR5tNksImVAnikpU5DU5+VcmisYT+2Aaq1BB1PJpr8ly0nPccggTb3qs+iL1JsHrvHmyG3WQqZi/KzcObg7mw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-base": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-base": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
 				"@fluidframework/server-local-server": "^0.1036.4000",
 				"@fluidframework/server-services-client": "^0.1036.4000",
 				"@fluidframework/server-services-core": "^0.1036.4000",
@@ -3061,182 +3061,182 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.0.0.tgz",
-			"integrity": "sha512-Nfm7TKS4jPg2pll5V29McrXOzuaDbshcJAi3+vTjvsEEAfMvRVylDCRTk/7cWPLpnjGuMpgWdMwJRtyDEfzdSw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.0.1.tgz",
+			"integrity": "sha512-GunY9b1lNqacwTWN4LGkeyUFb5liZLGN21X29KRmt4AO1LysACIfylBd/zUejerci1F20773+Ao491DeMHaF3g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.0.0.tgz",
-			"integrity": "sha512-Nfm7TKS4jPg2pll5V29McrXOzuaDbshcJAi3+vTjvsEEAfMvRVylDCRTk/7cWPLpnjGuMpgWdMwJRtyDEfzdSw==",
+			"version": "npm:@fluidframework/map@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.0.1.tgz",
+			"integrity": "sha512-GunY9b1lNqacwTWN4LGkeyUFb5liZLGN21X29KRmt4AO1LysACIfylBd/zUejerci1F20773+Ao491DeMHaF3g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.0.0.tgz",
-			"integrity": "sha512-zoRqyHmSWp4TIuV+2b2K6nAoJ+xx7kZVM5yTtkkMdRgkAKKiEV+j86cNbNQAb8+Q6d7oOhh1xjV2Q9MJqlwx2w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.0.1.tgz",
+			"integrity": "sha512-yyL2DQZnlt/Hg/O+Trszy8yNKFvaUDcHI7HpsD1czaWln9qTUIIsKa6Nas+JNte6VbylWze9ySr8r+JidoFftQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/merge-tree": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/merge-tree": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.0.0.tgz",
-			"integrity": "sha512-zoRqyHmSWp4TIuV+2b2K6nAoJ+xx7kZVM5yTtkkMdRgkAKKiEV+j86cNbNQAb8+Q6d7oOhh1xjV2Q9MJqlwx2w==",
+			"version": "npm:@fluidframework/matrix@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.0.1.tgz",
+			"integrity": "sha512-yyL2DQZnlt/Hg/O+Trszy8yNKFvaUDcHI7HpsD1czaWln9qTUIIsKa6Nas+JNte6VbylWze9ySr8r+JidoFftQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/merge-tree": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/merge-tree": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.0.0.tgz",
-			"integrity": "sha512-Y76cmut8mNAI9t7vvLn4Q5UDfwxxjQPxLReY56IkHYaCCoJVyrLscP1PAQmnRq00GT3HxyjAcZPRC0I05JG7Wg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.0.1.tgz",
+			"integrity": "sha512-QgDvz75hkBV3dZ+5zHLvKZLk40h3qTdarztrXxRl0b0dQd4q7gA5Vpg+0f1AEZKECMCGPPBdkpZ3Cn1BNBH7yw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.0.0.tgz",
-			"integrity": "sha512-Y76cmut8mNAI9t7vvLn4Q5UDfwxxjQPxLReY56IkHYaCCoJVyrLscP1PAQmnRq00GT3HxyjAcZPRC0I05JG7Wg==",
+			"version": "npm:@fluidframework/merge-tree@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.0.1.tgz",
+			"integrity": "sha512-QgDvz75hkBV3dZ+5zHLvKZLk40h3qTdarztrXxRl0b0dQd4q7gA5Vpg+0f1AEZKECMCGPPBdkpZ3Cn1BNBH7yw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.0.0.tgz",
-			"integrity": "sha512-vk5lia4TXtsT2OtSAiFpC1JrIdurRKLjvUK8KuGGxC6hhNZZFJMcgrpcP2cobPBXSeATlP5anHNg9bxCH9vDng==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.0.1.tgz",
+			"integrity": "sha512-vCOEXQ3uokayRaYfO69+VVESGcL0z7iIKxOjRHPNGtiJRvV/kIze6bsp8nBGba4K/45CJPqIKo3kX1+PWa8SjQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.0.0",
+				"@fluidframework/test-driver-definitions": "^1.0.1",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.0.0.tgz",
-			"integrity": "sha512-vk5lia4TXtsT2OtSAiFpC1JrIdurRKLjvUK8KuGGxC6hhNZZFJMcgrpcP2cobPBXSeATlP5anHNg9bxCH9vDng==",
+			"version": "npm:@fluidframework/mocha-test-setup@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.0.1.tgz",
+			"integrity": "sha512-vCOEXQ3uokayRaYfO69+VVESGcL0z7iIKxOjRHPNGtiJRvV/kIze6bsp8nBGba4K/45CJPqIKo3kX1+PWa8SjQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.0.0",
+				"@fluidframework/test-driver-definitions": "^1.0.1",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.0.0.tgz",
-			"integrity": "sha512-cYL7kHUSNzftwD4XNaC8LZhmsCWNRJuC4oup0XMA8sq6yiDsUU5EYZZ6orYEjg5qnR6DfxQpclsmp96t2VCQ2w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.0.1.tgz",
+			"integrity": "sha512-MF3v2f1jTphvic2GoHmXg+oFG8ttAsGzNdCJB7LEfLG5P5EVJyFB2BUOxsGnh3EIbB0o7un8bJ09qLSxRMzaKA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.0.0.tgz",
-			"integrity": "sha512-cYL7kHUSNzftwD4XNaC8LZhmsCWNRJuC4oup0XMA8sq6yiDsUU5EYZZ6orYEjg5qnR6DfxQpclsmp96t2VCQ2w==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.0.1.tgz",
+			"integrity": "sha512-MF3v2f1jTphvic2GoHmXg+oFG8ttAsGzNdCJB7LEfLG5P5EVJyFB2BUOxsGnh3EIbB0o7un8bJ09qLSxRMzaKA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.0.0.tgz",
-			"integrity": "sha512-g/Kk3fbFtwdV+p4M7xtMBb34UXI/pdkI7G7xM0rDM9Q+h1eNmwwgnnn7LaC20X1tm/bhlTXiUuJgL5iofnSXLA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.0.1.tgz",
+			"integrity": "sha512-zXGD4UH6+ddi/ekcYrJ68HpAYj6QI2L/19+b3jM6NcTYSXoyusdBLRUhC1vBNL6sBEV75ATzGYP/kmJI2YroNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-base": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-base": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/odsp-doclib-utils": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
+				"@fluidframework/odsp-doclib-utils": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -3244,38 +3244,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.0.0.tgz",
-			"integrity": "sha512-Nh26+1iOY5nIYQthvdP6Dg2qJGYc9N+O3y3f/liD9nd9jg3GhIZuwejgocp7TdFOsjOKH7swuAiMSVnsVBxVrg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.0.1.tgz",
+			"integrity": "sha512-bFJTbZtdWSO1CMhVwmcTsx65VFMq1qA3DFPhI2OGsDV1dWH3rCSuxceTSIIlrDILgI0EzCdK8rYdM6mDWXEDMg==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.0.0"
+				"@fluidframework/driver-definitions": "^1.0.1"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.0.0.tgz",
-			"integrity": "sha512-Nh26+1iOY5nIYQthvdP6Dg2qJGYc9N+O3y3f/liD9nd9jg3GhIZuwejgocp7TdFOsjOKH7swuAiMSVnsVBxVrg==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.0.1.tgz",
+			"integrity": "sha512-bFJTbZtdWSO1CMhVwmcTsx65VFMq1qA3DFPhI2OGsDV1dWH3rCSuxceTSIIlrDILgI0EzCdK8rYdM6mDWXEDMg==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.0.0"
+				"@fluidframework/driver-definitions": "^1.0.1"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.0.0.tgz",
-			"integrity": "sha512-g/Kk3fbFtwdV+p4M7xtMBb34UXI/pdkI7G7xM0rDM9Q+h1eNmwwgnnn7LaC20X1tm/bhlTXiUuJgL5iofnSXLA==",
+			"version": "npm:@fluidframework/odsp-driver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.0.1.tgz",
+			"integrity": "sha512-zXGD4UH6+ddi/ekcYrJ68HpAYj6QI2L/19+b3jM6NcTYSXoyusdBLRUhC1vBNL6sBEV75ATzGYP/kmJI2YroNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-base": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-base": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/odsp-doclib-utils": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
+				"@fluidframework/odsp-doclib-utils": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -3283,54 +3283,54 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.0.0.tgz",
-			"integrity": "sha512-yTNTygITfq5iMwh+LY+qIvgPB0RndnTuQTxcv8aIl32W2scRBb5+Cz5sFFx7TfKSLhBUu9JdKooVkJ3PKecZsQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.0.1.tgz",
+			"integrity": "sha512-Zhe3HJaXMGnSRieMwPmTOhrHbWdu6QD9MqFxd2bmOK/l5M02YGJwMHG9nRsiJsLA7QZJ5RCviBLAyraAA6BnUA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/odsp-driver": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0"
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/odsp-driver": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.0.0.tgz",
-			"integrity": "sha512-yTNTygITfq5iMwh+LY+qIvgPB0RndnTuQTxcv8aIl32W2scRBb5+Cz5sFFx7TfKSLhBUu9JdKooVkJ3PKecZsQ==",
+			"version": "npm:@fluidframework/odsp-urlresolver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.0.1.tgz",
+			"integrity": "sha512-Zhe3HJaXMGnSRieMwPmTOhrHbWdu6QD9MqFxd2bmOK/l5M02YGJwMHG9nRsiJsLA7QZJ5RCviBLAyraAA6BnUA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/odsp-driver": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0"
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/odsp-driver": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.0.0.tgz",
-			"integrity": "sha512-UsSf4uIpZyuJzQU3Nd4I09esPY0LehSya5Bq4U2R8lJQbmkxngLeXG7gY/TDbmRuP7iIGgv5PpTvm7/lK0Pyrw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.0.1.tgz",
+			"integrity": "sha512-6jlLzi3+ktpbSnbYpdAD+/uOhEcF9kXfozR5I9aPhgavgKA1pHNo8qkpx62ZbmXUoM09RhArmXqgxbf9bLFKlA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.0.0.tgz",
-			"integrity": "sha512-UsSf4uIpZyuJzQU3Nd4I09esPY0LehSya5Bq4U2R8lJQbmkxngLeXG7gY/TDbmRuP7iIGgv5PpTvm7/lK0Pyrw==",
+			"version": "npm:@fluidframework/ordered-collection@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.0.1.tgz",
+			"integrity": "sha512-6jlLzi3+ktpbSnbYpdAD+/uOhEcF9kXfozR5I9aPhgavgKA1pHNo8qkpx62ZbmXUoM09RhArmXqgxbf9bLFKlA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3354,98 +3354,98 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.0.0.tgz",
-			"integrity": "sha512-voOkIhdpxyMy6QZ66EpwkhLiXnxuJbxmUxUrhXFxO6aza/R8M/em7a7qiOfC7W0SvSE3nugHEmBCw9sLi5aI7g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.0.1.tgz",
+			"integrity": "sha512-I2LytiwJBtuYqisJBUg0VQPyLWNTdHw9Le6b4XmgG+oRUPFI/Dfv/RR3rph3t9/vFpAIwu3qnSSMZH/BEk5ptA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.0.0.tgz",
-			"integrity": "sha512-voOkIhdpxyMy6QZ66EpwkhLiXnxuJbxmUxUrhXFxO6aza/R8M/em7a7qiOfC7W0SvSE3nugHEmBCw9sLi5aI7g==",
+			"version": "npm:@fluidframework/register-collection@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.0.1.tgz",
+			"integrity": "sha512-I2LytiwJBtuYqisJBUg0VQPyLWNTdHw9Le6b4XmgG+oRUPFI/Dfv/RR3rph3t9/vFpAIwu3qnSSMZH/BEk5ptA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.0.0.tgz",
-			"integrity": "sha512-Ny3Vdh0temP5ycYf8m9/nkKlLDGhpnDLMXOjDyU87NfezT2GiEwiOuJNjF8jnfNMG9XijwDKoIvxjCSq5KdQvA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.0.1.tgz",
+			"integrity": "sha512-6dWFUw2K+ZZxxU4cYy0jQ82uToXp2RARMB/5evH1e2coRMd8/Mz/HZp6XDgkKI/VujsF2Y36yDtLVB4ZhiOCQw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.0.0.tgz",
-			"integrity": "sha512-Ny3Vdh0temP5ycYf8m9/nkKlLDGhpnDLMXOjDyU87NfezT2GiEwiOuJNjF8jnfNMG9XijwDKoIvxjCSq5KdQvA==",
+			"version": "npm:@fluidframework/replay-driver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.0.1.tgz",
+			"integrity": "sha512-6dWFUw2K+ZZxxU4cYy0jQ82uToXp2RARMB/5evH1e2coRMd8/Mz/HZp6XDgkKI/VujsF2Y36yDtLVB4ZhiOCQw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.0.0.tgz",
-			"integrity": "sha512-pNSFnwho9z3sO911+LYhXyXrpuGgz6M0tOHMY1C/4XHtUcnN4v4Eb8HjYQpABDt9WMj1RL1uahRTm9j4AbgLRA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.0.1.tgz",
+			"integrity": "sha512-j3b/p8qqdqOZ5Xm5UuXMAKJ0e0KIaedzTePNr/DOku9+DZuWfWRankYB2cArdZwfYmOmarEg3GTu/4pNK9iDrg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0"
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.0.0.tgz",
-			"integrity": "sha512-pNSFnwho9z3sO911+LYhXyXrpuGgz6M0tOHMY1C/4XHtUcnN4v4Eb8HjYQpABDt9WMj1RL1uahRTm9j4AbgLRA==",
+			"version": "npm:@fluidframework/request-handler@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.0.1.tgz",
+			"integrity": "sha512-j3b/p8qqdqOZ5Xm5UuXMAKJ0e0KIaedzTePNr/DOku9+DZuWfWRankYB2cArdZwfYmOmarEg3GTu/4pNK9iDrg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0"
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.0.0.tgz",
-			"integrity": "sha512-vSJr27ZagXuyUl2cDythRF9S8TuzHW+5R0/Aax1A0kW4+xRD9D8aMF7//adY42FsWVOe36+QNcAzh7HZv18huw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.0.1.tgz",
+			"integrity": "sha512-wgxyOzV+NfsjmvPAGmGMdro8jgbQhsB8PrVkgNvZjkofY9JbVNNDdISgUeQ+Kw8jE9FMqlwUPPPpWTuGgCI2CA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-base": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/gitresources": "^0.1036.4000",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -3455,20 +3455,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.0.0.tgz",
-			"integrity": "sha512-vSJr27ZagXuyUl2cDythRF9S8TuzHW+5R0/Aax1A0kW4+xRD9D8aMF7//adY42FsWVOe36+QNcAzh7HZv18huw==",
+			"version": "npm:@fluidframework/routerlicious-driver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.0.1.tgz",
+			"integrity": "sha512-wgxyOzV+NfsjmvPAGmGMdro8jgbQhsB8PrVkgNvZjkofY9JbVNNDdISgUeQ+Kw8jE9FMqlwUPPPpWTuGgCI2CA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-base": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/gitresources": "^0.1036.4000",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -3478,116 +3478,116 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.0.0.tgz",
-			"integrity": "sha512-wFWok90qUySTv6wQ3uf/0FjFQO3xzugGUuiF9x5h6sXabKNlw1EIGN2HwVEhMxWgNvTDt2DYRuY9k/yp0Za4zw==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.0.1.tgz",
+			"integrity": "sha512-6xPToCcCaEqTV7fmJ82X08WjXwf4atB55BMZZZgvZTSszm7caZ+rqKH33OGtu3KvcOtIqYj+P5xDYPuXPVBi+w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"nconf": "^0.11.4"
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.0.0.tgz",
-			"integrity": "sha512-OAiBVVoZi8wl984HrFdmNDgeFVfpoTF9vAqgIhTmsyRceI2+JBafcSLn0Z6XHUVSD0f4ARDN5qEw1X8Ry0ODTQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.0.1.tgz",
+			"integrity": "sha512-G1zLa/qMYOioeDx7v7R/c32A9qZMOdF697OK9pGVo1goXgIyNkPa0Tz9s3kuZvzDmubyYNZvDP8SynI7wnS9eA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.0.0.tgz",
-			"integrity": "sha512-OAiBVVoZi8wl984HrFdmNDgeFVfpoTF9vAqgIhTmsyRceI2+JBafcSLn0Z6XHUVSD0f4ARDN5qEw1X8Ry0ODTQ==",
+			"version": "npm:@fluidframework/runtime-definitions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.0.1.tgz",
+			"integrity": "sha512-G1zLa/qMYOioeDx7v7R/c32A9qZMOdF697OK9pGVo1goXgIyNkPa0Tz9s3kuZvzDmubyYNZvDP8SynI7wnS9eA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.0.0.tgz",
-			"integrity": "sha512-0iEeYPJpFcJCO/JDV+sdir1MBDTc1SMcCfJkQmuzzNYzOK25qbFrAJ793isCLrFj+6xgq2I7pL8Q2F7de3fTZQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.0.1.tgz",
+			"integrity": "sha512-2Y8WgH5RldOigzegU+xMqhmXY6HhJEseb5TGPD1tu3qy0UJSkE7CJLbVGP70lySdG2wYrq9ckp3rkvWMzcIHnA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/garbage-collector": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/garbage-collector": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.0.0.tgz",
-			"integrity": "sha512-0iEeYPJpFcJCO/JDV+sdir1MBDTc1SMcCfJkQmuzzNYzOK25qbFrAJ793isCLrFj+6xgq2I7pL8Q2F7de3fTZQ==",
+			"version": "npm:@fluidframework/runtime-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.0.1.tgz",
+			"integrity": "sha512-2Y8WgH5RldOigzegU+xMqhmXY6HhJEseb5TGPD1tu3qy0UJSkE7CJLbVGP70lySdG2wYrq9ckp3rkvWMzcIHnA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/garbage-collector": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/garbage-collector": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1"
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.0.0.tgz",
-			"integrity": "sha512-XR9y5IuGyhHSADa+dnHRpIMvuXnCVgGqWic4lgNV5ffIj6l2jWxIwVgyB9as39ahHMr4/mdchTG4/zFqGrUn7Q==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.0.1.tgz",
+			"integrity": "sha512-46VC/p4HoSh/Je5ivYaoa+u0znD/Wv+IFfxmmopqwnvU2YnjHkto1cT37BRjaHtFFY0mbs+TQb9tOTktaBuXuQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/merge-tree": "^1.0.0",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/merge-tree": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.0.0.tgz",
-			"integrity": "sha512-XR9y5IuGyhHSADa+dnHRpIMvuXnCVgGqWic4lgNV5ffIj6l2jWxIwVgyB9as39ahHMr4/mdchTG4/zFqGrUn7Q==",
+			"version": "npm:@fluidframework/sequence@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.0.1.tgz",
+			"integrity": "sha512-46VC/p4HoSh/Je5ivYaoa+u0znD/Wv+IFfxmmopqwnvU2YnjHkto1cT37BRjaHtFFY0mbs+TQb9tOTktaBuXuQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/merge-tree": "^1.0.0",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/merge-tree": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4195,73 +4195,73 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.0.0.tgz",
-			"integrity": "sha512-R7xrl+Npyjx9pm6mngtzk+u7/Yp0ET0SyilHBsA8etJaIap4wuyrCp36aZrAX0IWj4DjVefSIc17c5w+tYh0Fw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.0.1.tgz",
+			"integrity": "sha512-MLJFK3zfTLYJlu2zVXiENHMCcRnh90BLnpzMl41hC+NM1dJ4uU4MbiYe8IP/7zt1T7TVoH6+GuFGsJa3PX8mQA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.0.0.tgz",
-			"integrity": "sha512-R7xrl+Npyjx9pm6mngtzk+u7/Yp0ET0SyilHBsA8etJaIap4wuyrCp36aZrAX0IWj4DjVefSIc17c5w+tYh0Fw==",
+			"version": "npm:@fluidframework/shared-object-base@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.0.1.tgz",
+			"integrity": "sha512-MLJFK3zfTLYJlu2zVXiENHMCcRnh90BLnpzMl41hC+NM1dJ4uU4MbiYe8IP/7zt1T7TVoH6+GuFGsJa3PX8mQA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/container-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/container-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.0.0.tgz",
-			"integrity": "sha512-MJn0aJ5iLnJm76rD6Aq585Roc5TrC45yTtWQNaeJQFle6vtHs3NnWBcfnSxXyEW+jf5c+U5Fc4PB+dhCSDv14w==",
+			"version": "npm:@fluidframework/shared-summary-block@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.0.1.tgz",
+			"integrity": "sha512-eTktyzjE1NcDNBwmcvF6zX8598i38KQe/wReJveLVqpEI0AJXEHOa8WVJ/Np2ipK8eS48EGVTJ8bxJgqDvlW2g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/shared-object-base": "^1.0.0"
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/shared-object-base": "^1.0.1"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.0.0.tgz",
-			"integrity": "sha512-lCPXkBuX/6iARBgbg/MNYOpuWazywJVFqIuMZ9LNrxwQ/YVBymZQ6qQ765mfgps/RNcB5uA4mG0hQt49UbdPWw=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.0.1.tgz",
+			"integrity": "sha512-wi7vJCT7eMAzgmoWxMPM8+7XQMqLJ//lNvhyvZtSajhBVmnVXi/yfVuqTMUXoC6KkcWFjAp6EAgw+CWt2YtoUw=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.0.0.tgz",
-			"integrity": "sha512-lCPXkBuX/6iARBgbg/MNYOpuWazywJVFqIuMZ9LNrxwQ/YVBymZQ6qQ765mfgps/RNcB5uA4mG0hQt49UbdPWw=="
+			"version": "npm:@fluidframework/synthesize@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.0.1.tgz",
+			"integrity": "sha512-wi7vJCT7eMAzgmoWxMPM8+7XQMqLJ//lNvhyvZtSajhBVmnVXi/yfVuqTMUXoC6KkcWFjAp6EAgw+CWt2YtoUw=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.0.0.tgz",
-			"integrity": "sha512-ygqwX32pVjvM5HpW3QvMxPglgjmktpQrr9QpJbXT+bWWJJmDjYn7HxtuTdDNKVDBSeR94Z1v3hRUUOfdAq4dCQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.0.1.tgz",
+			"integrity": "sha512-IaroFRAAhPx39cy/66hy33WcnXGz/6S/PGUaG1ut4aMaskRumMmt1aJmLaN1wUGjl2i+GNqn2optrl4myk37wA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -4271,9 +4271,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.0.0.tgz",
-			"integrity": "sha512-ygqwX32pVjvM5HpW3QvMxPglgjmktpQrr9QpJbXT+bWWJJmDjYn7HxtuTdDNKVDBSeR94Z1v3hRUUOfdAq4dCQ==",
+			"version": "npm:@fluidframework/telemetry-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.0.1.tgz",
+			"integrity": "sha512-IaroFRAAhPx39cy/66hy33WcnXGz/6S/PGUaG1ut4aMaskRumMmt1aJmLaN1wUGjl2i+GNqn2optrl4myk37wA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -4283,162 +4283,162 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.0.0.tgz",
-			"integrity": "sha512-+oiVSxA2T9liC6KUfgyhESL8GNASTC2LHKW1XZcWnMU3zjn9gGozebPvexm2H0yssOgnQ7zQJ//ZjOWFkA1w+w==",
+			"version": "npm:@fluidframework/test-client-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.0.1.tgz",
+			"integrity": "sha512-GvxmERKcGiFW4mND6dkB7O/nLKkiQwAMsP2Y1n5MtpdttW8mtwUE4j9It0o9skOGcRljcSVtalxhqPuV6pFCIA==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/test-runtime-utils": "^1.0.0",
+				"@fluidframework/test-runtime-utils": "^1.0.1",
 				"sillyname": "^0.1.0"
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.0.0.tgz",
-			"integrity": "sha512-2yFeq7rhHqkI/n0rnollxKMuW6m8AYganyEJzqfjVWRIF28xiioV8tMtaxYhdLqdgxO9bPh8QiIAHN1BnJY3bQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.0.1.tgz",
+			"integrity": "sha512-k/4lc61H9mXk3wNFWPr665OUafbWPw9v84mvMU4honx7oPCGlhrjoZZFNQF2k7k2MUoR7xsmwZGlH9Lc4J/x+g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "npm:@fluidframework/test-driver-definitions@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.0.0.tgz",
-			"integrity": "sha512-2yFeq7rhHqkI/n0rnollxKMuW6m8AYganyEJzqfjVWRIF28xiioV8tMtaxYhdLqdgxO9bPh8QiIAHN1BnJY3bQ==",
+			"version": "npm:@fluidframework/test-driver-definitions@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.0.1.tgz",
+			"integrity": "sha512-k/4lc61H9mXk3wNFWPr665OUafbWPw9v84mvMU4honx7oPCGlhrjoZZFNQF2k7k2MUoR7xsmwZGlH9Lc4J/x+g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.0.0.tgz",
-			"integrity": "sha512-0VnuniWmgtfGpmbDoFHmfn39mLSKUpsalPES03MQ9UyQ1tvVweuBdRcdPLLS0XQIXf3Do/C9JygZiNQTGyyLUQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.0.1.tgz",
+			"integrity": "sha512-GXpFJls0cv9CKgG2U1znuvLATySA2B+/7ffFIj6jU19AQATJyAXRa7eZgklb79RfzNnftldoBVIr15JY1/Jl4Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/local-driver": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": "^1.0.0",
-				"@fluidframework/odsp-driver": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
-				"@fluidframework/odsp-urlresolver": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/local-driver": "^1.0.1",
+				"@fluidframework/odsp-doclib-utils": "^1.0.1",
+				"@fluidframework/odsp-driver": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
+				"@fluidframework/odsp-urlresolver": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
 				"@fluidframework/server-local-server": "^0.1036.4000",
-				"@fluidframework/test-driver-definitions": "^1.0.0",
-				"@fluidframework/test-pairwise-generator": "^1.0.0",
-				"@fluidframework/test-runtime-utils": "^1.0.0",
-				"@fluidframework/tinylicious-driver": "^1.0.0",
-				"@fluidframework/tool-utils": "^1.0.0",
+				"@fluidframework/test-driver-definitions": "^1.0.1",
+				"@fluidframework/test-pairwise-generator": "^1.0.1",
+				"@fluidframework/test-runtime-utils": "^1.0.1",
+				"@fluidframework/tinylicious-driver": "^1.0.1",
+				"@fluidframework/tool-utils": "^1.0.1",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.0.0.tgz",
-			"integrity": "sha512-0VnuniWmgtfGpmbDoFHmfn39mLSKUpsalPES03MQ9UyQ1tvVweuBdRcdPLLS0XQIXf3Do/C9JygZiNQTGyyLUQ==",
+			"version": "npm:@fluidframework/test-drivers@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.0.1.tgz",
+			"integrity": "sha512-GXpFJls0cv9CKgG2U1znuvLATySA2B+/7ffFIj6jU19AQATJyAXRa7eZgklb79RfzNnftldoBVIr15JY1/Jl4Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/local-driver": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": "^1.0.0",
-				"@fluidframework/odsp-driver": "^1.0.0",
-				"@fluidframework/odsp-driver-definitions": "^1.0.0",
-				"@fluidframework/odsp-urlresolver": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/local-driver": "^1.0.1",
+				"@fluidframework/odsp-doclib-utils": "^1.0.1",
+				"@fluidframework/odsp-driver": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.0.1",
+				"@fluidframework/odsp-urlresolver": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
 				"@fluidframework/server-local-server": "^0.1036.4000",
-				"@fluidframework/test-driver-definitions": "^1.0.0",
-				"@fluidframework/test-pairwise-generator": "^1.0.0",
-				"@fluidframework/test-runtime-utils": "^1.0.0",
-				"@fluidframework/tinylicious-driver": "^1.0.0",
-				"@fluidframework/tool-utils": "^1.0.0",
+				"@fluidframework/test-driver-definitions": "^1.0.1",
+				"@fluidframework/test-pairwise-generator": "^1.0.1",
+				"@fluidframework/test-runtime-utils": "^1.0.1",
+				"@fluidframework/tinylicious-driver": "^1.0.1",
+				"@fluidframework/tool-utils": "^1.0.1",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.0.0.tgz",
-			"integrity": "sha512-+XjUJ6nHRd8IUoEto7ZX1sUcSkByHW2/9tCAFNwfyMBKPawGkgQ+0sL4rxKaX0w9/Kygm6gjyZVPQNtv/+LxBQ==",
+			"version": "npm:@fluidframework/test-loader-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.0.1.tgz",
+			"integrity": "sha512-4Ro+NjVYuAcsLdHrJ4Y9zjaK+c8BY0BC4meXehrof9JrXl2vxzSzBfHewNG8sV2W5qXKMGhMEuWCPiibvj0nAg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.0.0.tgz",
-			"integrity": "sha512-kYBWjU6AYslJowGe0wnBSreQO6DL7+DAaXxmUbFhlY7yhPYqfh8JvsaAzk+dNaf8SJCcMVxhFhazIDcgpwyg7Q==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.0.1.tgz",
+			"integrity": "sha512-or+wTZ/NEYxoaouflIvth9CxPr6e+W7doHrAGYDyEoUayOMNo3DzkSLNm/ct8dtL1RkPt5aWyfN96KrmQpBGww==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.0.0.tgz",
-			"integrity": "sha512-kYBWjU6AYslJowGe0wnBSreQO6DL7+DAaXxmUbFhlY7yhPYqfh8JvsaAzk+dNaf8SJCcMVxhFhazIDcgpwyg7Q==",
+			"version": "npm:@fluidframework/test-pairwise-generator@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.0.1.tgz",
+			"integrity": "sha512-or+wTZ/NEYxoaouflIvth9CxPr6e+W7doHrAGYDyEoUayOMNo3DzkSLNm/ct8dtL1RkPt5aWyfN96KrmQpBGww==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.0.0.tgz",
-			"integrity": "sha512-ooozbNA2aNip28wTECWoGapOgnTHNgK1xWbUsBYgk3XlDXovmohXYaRVwSOIlJqFkFolRzKcw6wKoaTR6aURBA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.0.1.tgz",
+			"integrity": "sha512-ODs6IhU/Ah4sr7OBENff59rSdecBFJjS3ZRVDoaQRcK5xLwS9az82Hzvfe5zXSHSEbfmdXoBIPSbQRKgSr9cSw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.0.0.tgz",
-			"integrity": "sha512-ooozbNA2aNip28wTECWoGapOgnTHNgK1xWbUsBYgk3XlDXovmohXYaRVwSOIlJqFkFolRzKcw6wKoaTR6aURBA==",
+			"version": "npm:@fluidframework/test-runtime-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.0.1.tgz",
+			"integrity": "sha512-ODs6IhU/Ah4sr7OBENff59rSdecBFJjS3ZRVDoaQRcK5xLwS9az82Hzvfe5zXSHSEbfmdXoBIPSbQRKgSr9cSw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
@@ -4451,158 +4451,158 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.0.0.tgz",
-			"integrity": "sha512-0McMxcd889LD9YJVZRZf1AXmErBIUaMkSlV1SOCKFsVH0mxRX/bA7WKIX19KOHjEKbdRMoLVjsg5lJYr+C4ytg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.0.1.tgz",
+			"integrity": "sha512-LHlBNMkzc9RoEVden1pnjyGpWdVVgaMhJ19CSJ41PPIt0OxseUo2u523Uen3FBJKR/V6/aBJ37Kvm3sU8WNUnQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.0",
+				"@fluidframework/aqueduct": "^1.0.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/local-driver": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/local-driver": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.0",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
-				"@fluidframework/test-driver-definitions": "^1.0.0",
-				"@fluidframework/test-runtime-utils": "^1.0.0",
+				"@fluidframework/request-handler": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/test-driver-definitions": "^1.0.1",
+				"@fluidframework/test-runtime-utils": "^1.0.1",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.0.0.tgz",
-			"integrity": "sha512-0McMxcd889LD9YJVZRZf1AXmErBIUaMkSlV1SOCKFsVH0mxRX/bA7WKIX19KOHjEKbdRMoLVjsg5lJYr+C4ytg==",
+			"version": "npm:@fluidframework/test-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.0.1.tgz",
+			"integrity": "sha512-LHlBNMkzc9RoEVden1pnjyGpWdVVgaMhJ19CSJ41PPIt0OxseUo2u523Uen3FBJKR/V6/aBJ37Kvm3sU8WNUnQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.0",
+				"@fluidframework/aqueduct": "^1.0.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/datastore": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/local-driver": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/container-runtime-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/datastore": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/local-driver": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.0",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/telemetry-utils": "^1.0.0",
-				"@fluidframework/test-driver-definitions": "^1.0.0",
-				"@fluidframework/test-runtime-utils": "^1.0.0",
+				"@fluidframework/request-handler": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/test-driver-definitions": "^1.0.1",
+				"@fluidframework/test-runtime-utils": "^1.0.1",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.0.0.tgz",
-			"integrity": "sha512-UqZfqogURBtEvtV26u9hwwGpQ9HRREIkS4/LkC30n0bTD7lpjHh94brEYcYdqFG86bOyfD1uc9xJzXNRmH10Bg==",
+			"version": "npm:@fluidframework/test-version-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.0.1.tgz",
+			"integrity": "sha512-xH351nBi9LCKu1U9wGE+a02CjPCofnBjTwpZExfoGXpvlh2tVc8oA5decYzXFV1YJrWkx4rfbg5hlBfditBpYg==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.0",
-				"@fluidframework/cell": "^1.0.0",
+				"@fluidframework/aqueduct": "^1.0.1",
+				"@fluidframework/cell": "^1.0.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/container-runtime": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/counter": "^1.0.0",
-				"@fluidframework/datastore-definitions": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/ink": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
-				"@fluidframework/matrix": "^1.0.0",
-				"@fluidframework/mocha-test-setup": "^1.0.0",
-				"@fluidframework/ordered-collection": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/container-runtime": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/counter": "^1.0.1",
+				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/ink": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/matrix": "^1.0.1",
+				"@fluidframework/mocha-test-setup": "^1.0.1",
+				"@fluidframework/ordered-collection": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/register-collection": "^1.0.0",
-				"@fluidframework/runtime-definitions": "^1.0.0",
-				"@fluidframework/sequence": "^1.0.0",
-				"@fluidframework/test-driver-definitions": "^1.0.0",
-				"@fluidframework/test-drivers": "^1.0.0",
-				"@fluidframework/test-utils": "^1.0.0",
+				"@fluidframework/register-collection": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/sequence": "^1.0.1",
+				"@fluidframework/test-driver-definitions": "^1.0.1",
+				"@fluidframework/test-drivers": "^1.0.1",
+				"@fluidframework/test-utils": "^1.0.1",
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.0.0.tgz",
-			"integrity": "sha512-8+3soPGGp3dQVC2kT3S44sb/SjtqBuBTlMUtpw4dDQTsD6BU5QfLtqx26OhLuduHUqNQuZcs0/L0F022+9GZsA==",
+			"version": "npm:@fluidframework/tinylicious-client@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.0.1.tgz",
+			"integrity": "sha512-o+RwCFMR6xpJLE9BAjD1hedJ9nKoeGvHPjeLIwzhxXHO5OARdbRJuMZWJGqyIe/WM7h/gYLSOMrnChc+eZvDHA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/container-loader": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
-				"@fluidframework/fluid-static": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/fluid-static": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
-				"@fluidframework/runtime-utils": "^1.0.0",
-				"@fluidframework/tinylicious-driver": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
+				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/tinylicious-driver": "^1.0.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.0.0.tgz",
-			"integrity": "sha512-9Ru5AFGXrHPC8Fm1a4ZUc1Qchs/ag8OG5ffHQt7sdDUIknqpwUk7yYn1DLnSAXkJXYGrexSpsIm2k0aYaG0jvA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.0.1.tgz",
+			"integrity": "sha512-PzrHYukjzMMJNWa5AbX6szYCY0LNowi8W2XxEWvkJgbFaz2gfAbbbLCBnvCrZQ4DLxOpmjcIID6GSZTVfJQ5tA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
 				"@fluidframework/server-services-client": "^0.1036.4000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.0.0.tgz",
-			"integrity": "sha512-9Ru5AFGXrHPC8Fm1a4ZUc1Qchs/ag8OG5ffHQt7sdDUIknqpwUk7yYn1DLnSAXkJXYGrexSpsIm2k0aYaG0jvA==",
+			"version": "npm:@fluidframework/tinylicious-driver@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.0.1.tgz",
+			"integrity": "sha512-PzrHYukjzMMJNWa5AbX6szYCY0LNowi8W2XxEWvkJgbFaz2gfAbbbLCBnvCrZQ4DLxOpmjcIID6GSZTVfJQ5tA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/driver-definitions": "^1.0.0",
-				"@fluidframework/driver-utils": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.0",
+				"@fluidframework/routerlicious-driver": "^1.0.1",
 				"@fluidframework/server-services-client": "^0.1036.4000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.0.0.tgz",
-			"integrity": "sha512-/6VDifIeLof3TYSElkPuygGcnbvopI9gRQtnil4c7cwWoi6K7/UzVQWsuU7HLiVsagb36yKA+GwlUrQdhHhUfQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.0.1.tgz",
+			"integrity": "sha512-e2FFqI1JJk6ZQUTtKEWyxANIGEOrACdiARs1ub0maD//wK+DVSbsrNxwyKjRno13Z7PKJA5KD7leFoB3+3XHYQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.0.0",
+				"@fluidframework/odsp-doclib-utils": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -4612,12 +4612,12 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.0.0.tgz",
-			"integrity": "sha512-/6VDifIeLof3TYSElkPuygGcnbvopI9gRQtnil4c7cwWoi6K7/UzVQWsuU7HLiVsagb36yKA+GwlUrQdhHhUfQ==",
+			"version": "npm:@fluidframework/tool-utils@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.0.1.tgz",
+			"integrity": "sha512-e2FFqI1JJk6ZQUTtKEWyxANIGEOrACdiARs1ub0maD//wK+DVSbsrNxwyKjRno13Z7PKJA5KD7leFoB3+3XHYQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.0.0",
+				"@fluidframework/odsp-doclib-utils": "^1.0.1",
 				"@fluidframework/protocol-base": "^0.1036.4000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -4627,71 +4627,71 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.0.0.tgz",
-			"integrity": "sha512-J3PqXsqLHpkqAJMutCKTxc9pLe6B6tuequrI2/+xm4/i912yfyIL3OiktJ//oNbknjbVG9ceWHmSg73IHbJ85Q==",
+			"version": "npm:@fluidframework/undo-redo@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.0.1.tgz",
+			"integrity": "sha512-COutsHG0qZ7twvEsgRC2AbYe4w2eAJCn8a4WR2h6hUxVmIAxuw+vKXxKkrjhJE9pUsaqlEl1UXNXOhxZ8RijVg==",
 			"requires": {
-				"@fluidframework/map": "^1.0.0",
-				"@fluidframework/matrix": "^1.0.0",
-				"@fluidframework/merge-tree": "^1.0.0",
-				"@fluidframework/sequence": "^1.0.0"
+				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/matrix": "^1.0.1",
+				"@fluidframework/merge-tree": "^1.0.1",
+				"@fluidframework/sequence": "^1.0.1"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.0.0.tgz",
-			"integrity": "sha512-eauFj5zpGyh2O0/TNheW9zhuvGD7O5R0EfOzCdyz1FwkqfxP902XCHBuGFVeZ7EmpQvttm9phejm1ZnWr9T1AQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.0.1.tgz",
+			"integrity": "sha512-KFSXgTds64ZlUtrPvA9LWGldLGsFiLIAhkkE/pg4bXtUq9F3gMzJWfrsHazXrQPc+xO4f8ypEFz793Xs+oAumQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/view-interfaces": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/view-interfaces": "^1.0.1",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.0.0.tgz",
-			"integrity": "sha512-eauFj5zpGyh2O0/TNheW9zhuvGD7O5R0EfOzCdyz1FwkqfxP902XCHBuGFVeZ7EmpQvttm9phejm1ZnWr9T1AQ==",
+			"version": "npm:@fluidframework/view-adapters@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.0.1.tgz",
+			"integrity": "sha512-KFSXgTds64ZlUtrPvA9LWGldLGsFiLIAhkkE/pg4bXtUq9F3gMzJWfrsHazXrQPc+xO4f8ypEFz793Xs+oAumQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0",
-				"@fluidframework/view-interfaces": "^1.0.0",
+				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/view-interfaces": "^1.0.1",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.0.0.tgz",
-			"integrity": "sha512-a0l2pz96iMv2qOOWj38soANF0jOiIOI85ex4DEJwK8MeiajTdVIrcrZ+mjNfTq/+cHVlHaBgoTbiYlpyUJ+Q3g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.0.1.tgz",
+			"integrity": "sha512-OLup6/jkBkHfHwQBi5YrhZhTIJKrrrFZpZkP820wBxq9+qzaneRZo7IhsCEYnqBCLKX9zuHHO9l8wxeNKafTlQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0"
+				"@fluidframework/core-interfaces": "^1.0.1"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.0.0.tgz",
-			"integrity": "sha512-a0l2pz96iMv2qOOWj38soANF0jOiIOI85ex4DEJwK8MeiajTdVIrcrZ+mjNfTq/+cHVlHaBgoTbiYlpyUJ+Q3g==",
+			"version": "npm:@fluidframework/view-interfaces@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.0.1.tgz",
+			"integrity": "sha512-OLup6/jkBkHfHwQBi5YrhZhTIJKrrrFZpZkP820wBxq9+qzaneRZo7IhsCEYnqBCLKX9zuHHO9l8wxeNKafTlQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.0"
+				"@fluidframework/core-interfaces": "^1.0.1"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.0.0.tgz",
-			"integrity": "sha512-oPB6Dv94FtxVT0Bs69V/TmR+f/hTgv4gKwJZbskRKYn1cYDNWqS4eNZFo2sjnKdmxbbm374etPnQQ1hpK+WGNA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.0.1.tgz",
+			"integrity": "sha512-RgMpoOyvfnM7L6aWklTwP6nX0Rlww9VX3CDL68LbnDUqCGAIDQPnftoNEbQZPB26tbY0nVTIT8nfgBRqC6OlVQ==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.0.0.tgz",
-			"integrity": "sha512-oPB6Dv94FtxVT0Bs69V/TmR+f/hTgv4gKwJZbskRKYn1cYDNWqS4eNZFo2sjnKdmxbbm374etPnQQ1hpK+WGNA==",
+			"version": "npm:@fluidframework/web-code-loader@1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.0.1.tgz",
+			"integrity": "sha512-RgMpoOyvfnM7L6aWklTwP6nX0Rlww9VX3CDL68LbnDUqCGAIDQPnftoNEbQZPB26tbY0nVTIT8nfgBRqC6OlVQ==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/core-interfaces": "^1.0.0",
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.0.1",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
@@ -15939,7 +15939,7 @@
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
 			"dev": true
 		},
 		"address": {
@@ -16323,7 +16323,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true
 		},
 		"array-includes": {
@@ -17215,12 +17215,12 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -17262,7 +17262,7 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
 		},
 		"assert-valid-glob-opts": {
 			"version": "1.0.0",
@@ -17370,7 +17370,7 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"at-least-node": {
 			"version": "1.0.0",
@@ -17511,7 +17511,7 @@
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
 		},
 		"aws4": {
 			"version": "1.9.1",
@@ -18414,7 +18414,7 @@
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -18930,13 +18930,13 @@
 		"builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+			"integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
 			"dev": true
 		},
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+			"integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
 			"dev": true
 		},
 		"byte-size": {
@@ -19340,7 +19340,7 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
 		},
 		"catharsis": {
 			"version": "0.9.0",
@@ -19993,7 +19993,7 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
 		},
 		"clone-deep": {
 			"version": "4.0.1",
@@ -20073,7 +20073,7 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
 		},
 		"codemirror": {
 			"version": "5.65.5",
@@ -20127,7 +20127,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
 		"color-string": {
 			"version": "1.9.1",
@@ -20326,7 +20326,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -20559,7 +20559,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
 		},
 		"constant-case": {
 			"version": "3.0.4",
@@ -22127,7 +22127,7 @@
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -22199,18 +22199,18 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+			"integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
 			"dev": true
 		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
 			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
@@ -22220,7 +22220,7 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
 					"dev": true
 				}
 			}
@@ -22233,7 +22233,7 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
 		},
 		"decompress-response": {
 			"version": "3.3.0",
@@ -22246,7 +22246,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="
 		},
 		"deep-eql": {
 			"version": "3.0.1",
@@ -22563,7 +22563,7 @@
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -22660,12 +22660,12 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
 		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
 		},
 		"denque": {
 			"version": "1.5.1",
@@ -22675,7 +22675,7 @@
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
 		},
 		"dependency-graph": {
 			"version": "0.10.0",
@@ -23132,7 +23132,7 @@
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -23760,7 +23760,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 		},
 		"escodegen": {
 			"version": "2.0.0",
@@ -24934,7 +24934,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
 		},
 		"fake-indexeddb": {
 			"version": "3.1.4",
@@ -25221,7 +25221,7 @@
 		"filter-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+			"integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
 			"dev": true
 		},
 		"finalhandler": {
@@ -25396,14 +25396,15 @@
 			"integrity": "sha512-OapHwT5Ug1c3iiv8JNrwh/3XGjP45l/2iwfl25chePrvCgl0786ZvsJK+hxCCaUZjPm1lHdh5LHZhmKRxunziA=="
 		},
 		"fluid-framework-previous": {
-			"version": "npm:fluid-framework@1.0.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.0.0.tgz",
-			"integrity": "sha512-HLKL0lPrh0I/tKkJcc+FQ1LSjww84d0iNdPngte790wTCdezWpxqgzZW0gc+wbkHkh6Vy1VS6JT2h1bqWWCJHw==",
+			"version": "npm:fluid-framework@1.0.1",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.0.1.tgz",
+			"integrity": "sha512-4gxEgr3cfFpNEEFaRpwoPxC55Fi2z+PLO1Dpp6t6pFJX0v1lmEzPyrSC61n6S8B70ZqW7QYLYxSvJsAbpiuvLw==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.0.0",
-				"@fluidframework/fluid-static": "^1.0.0",
-				"@fluidframework/map": "^1.0.0",
-				"@fluidframework/sequence": "^1.0.0"
+				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-loader": "^1.0.1",
+				"@fluidframework/fluid-static": "^1.0.1",
+				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/sequence": "^1.0.1"
 			}
 		},
 		"flush-write-stream": {
@@ -25522,7 +25523,7 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
 		},
 		"fork-ts-checker-webpack-plugin": {
 			"version": "6.5.2",
@@ -25796,7 +25797,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
 		},
 		"fsevents": {
 			"version": "2.3.2",
@@ -25961,7 +25962,7 @@
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -25976,12 +25977,12 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -25989,7 +25990,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -25999,7 +26000,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -26072,7 +26073,7 @@
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -26158,7 +26159,7 @@
 		"git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
 			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -26168,7 +26169,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 					"dev": true
 				}
 			}
@@ -26213,7 +26214,7 @@
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
@@ -26678,7 +26679,7 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
 		},
 		"har-validator": {
 			"version": "5.1.3",
@@ -26749,7 +26750,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
 		},
 		"has-glob": {
 			"version": "1.0.0",
@@ -26800,7 +26801,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -27435,7 +27436,7 @@
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -27484,7 +27485,7 @@
 		"humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
 			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
@@ -27661,7 +27662,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
 		},
 		"indent-string": {
 			"version": "4.0.0",
@@ -27684,7 +27685,7 @@
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -28083,7 +28084,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"is-bigint": {
 			"version": "1.0.4",
@@ -28211,7 +28212,7 @@
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
 		},
 		"is-finite": {
 			"version": "1.1.0",
@@ -28278,7 +28279,7 @@
 		"is-lambda": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
 			"dev": true
 		},
 		"is-lower-case": {
@@ -28387,7 +28388,7 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -28484,7 +28485,7 @@
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
 			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
@@ -28504,7 +28505,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
 		},
 		"is-unc-path": {
 			"version": "1.0.0",
@@ -28592,12 +28593,12 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
 		},
 		"isomorphic-fetch": {
 			"version": "3.0.0",
@@ -28673,7 +28674,7 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
 		},
 		"istanbul-instrumenter-loader": {
 			"version": "3.0.1",
@@ -30322,7 +30323,7 @@
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
 		},
 		"jmespath": {
 			"version": "0.15.0",
@@ -30384,7 +30385,7 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
 		},
 		"jsdoc": {
 			"version": "3.6.7",
@@ -30601,7 +30602,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
 		},
 		"json-to-pretty-yaml": {
 			"version": "1.2.2",
@@ -30669,7 +30670,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
 			"dev": true
 		},
 		"jsonpointer": {
@@ -32030,7 +32031,7 @@
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
 			"dev": true
 		},
 		"lodash.camelcase": {
@@ -32077,7 +32078,7 @@
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
 		},
 		"lodash.groupby": {
 			"version": "4.6.0",
@@ -32102,7 +32103,7 @@
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
 		},
 		"lodash.isfunction": {
 			"version": "3.0.9",
@@ -32117,7 +32118,7 @@
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
 			"dev": true
 		},
 		"lodash.isnumber": {
@@ -35007,7 +35008,7 @@
 		"noms": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-			"integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+			"integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
@@ -35581,7 +35582,7 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -35821,7 +35822,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -36490,7 +36491,7 @@
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"requires": {
 				"wrappy": "1"
 			}
@@ -36561,7 +36562,7 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ=="
 		},
 		"os-locale": {
 			"version": "1.4.0",
@@ -36584,7 +36585,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -36673,7 +36674,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
 		},
 		"p-is-promise": {
 			"version": "2.1.0",
@@ -37241,7 +37242,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -37317,7 +37318,7 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
 		},
 		"picocolors": {
 			"version": "1.0.0",
@@ -37907,7 +37908,7 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="
 		},
 		"promise-retry": {
 			"version": "2.0.1",
@@ -38190,7 +38191,7 @@
 		"promzard": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+			"integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
 			"dev": true,
 			"requires": {
 				"read": "1"
@@ -38373,7 +38374,7 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
 			"dev": true
 		},
 		"protocols": {
@@ -38566,7 +38567,7 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+			"integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
 		},
 		"qs": {
 			"version": "6.7.0",
@@ -39152,7 +39153,7 @@
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
 			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
@@ -39229,7 +39230,7 @@
 		"read-pkg-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
@@ -39239,7 +39240,7 @@
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -39260,7 +39261,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -39279,7 +39280,7 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -39288,7 +39289,7 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
 					"dev": true
 				},
 				"read-pkg": {
@@ -39362,7 +39363,7 @@
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -40123,7 +40124,7 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
 		},
 		"require-from-string": {
 			"version": "2.0.2",
@@ -40251,7 +40252,7 @@
 		"retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -40858,7 +40859,7 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
@@ -40889,7 +40890,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
 		},
 		"setprototypeof": {
 			"version": "1.2.0",
@@ -41106,7 +41107,7 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
 			"dev": true
 		},
 		"smart-buffer": {
@@ -41504,7 +41505,7 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -41727,7 +41728,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -42109,7 +42110,7 @@
 		"strict-uri-encode": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-			"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+			"integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
 			"dev": true
 		},
 		"string-argv": {
@@ -42710,7 +42711,7 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q=="
 		},
 		"strip-final-newline": {
 			"version": "2.0.0",
@@ -43581,7 +43582,7 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
 			"dev": true
 		},
 		"temp-write": {
@@ -43817,7 +43818,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -43878,7 +43879,7 @@
 		"timsort": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+			"integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
 			"dev": true
 		},
 		"tiny-warning": {
@@ -44570,7 +44571,7 @@
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -44578,7 +44579,7 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -44630,7 +44631,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
 		},
 		"typedarray-to-buffer": {
 			"version": "3.1.5",
@@ -44805,7 +44806,7 @@
 		"uid-number": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+			"integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
 			"dev": true
 		},
 		"uid2": {
@@ -44821,7 +44822,7 @@
 		"umask": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+			"integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
 			"dev": true
 		},
 		"unbox-primitive": {
@@ -44845,7 +44846,7 @@
 		"unc-path-regex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg=="
 		},
 		"underscore": {
 			"version": "1.13.1",
@@ -45036,7 +45037,7 @@
 				"tr46": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
 					"dev": true,
 					"requires": {
 						"punycode": "^2.1.0"
@@ -45473,12 +45474,12 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"util-promisify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
-			"integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
+			"integrity": "sha512-K+5eQPYs14b3+E+hmE2J6gCZ4JmMl9DbYS6BeP2CHq6WMuNxErxf5B/n0fz85L8zUuoO6rIzNNmIQDu/j+1OcA==",
 			"dev": true,
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3"
@@ -45563,7 +45564,7 @@
 		"validate-npm-package-name": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+			"integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
 			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
@@ -45588,7 +45589,7 @@
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -46025,7 +46026,7 @@
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
 			"requires": {
 				"defaults": "^1.0.3"
 			}
@@ -47014,7 +47015,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
 		},
 		"worker-farm": {
 			"version": "1.7.0",
@@ -47101,7 +47102,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"write-file-atomic": {
 			"version": "2.4.3",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -64,6 +64,10 @@
       },
       "ClassDeclaration_SequenceInterval": {
         "forwardCompat": false
+      },
+      "RemovedEnumDeclaration_ConnectionState": {
+        "backCompat": false,
+        "forwardCompat": false
       }
     }
   }

--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
@@ -40,6 +40,18 @@ use_old_EnumDeclaration_AttachState(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedEnumDeclaration_ConnectionState": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedEnumDeclaration_ConnectionState": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ContainerSchema": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ContainerSchema():


### PR DESCRIPTION
We have just released 1.0.1 client with some breaking changes in respect to 2.0. @scottn12 worthwhile looking if this was expected. It seems like a breaking change both ways.

Updated lerna lock.