### PR TITLE
Refactor SequenceInterval to avoid EventEmitter

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -58,8 +58,9 @@ export type DeserializeCallback = (properties: PropertySet) => void;
 
 // @public (undocumented)
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
+    (event: "changeInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): any;
     // (undocumented)
-    (event: "addInterval" | "changeInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage) => void): any;
+    (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage) => void): any;
     // (undocumented)
     (event: "propertyChanged", listener: (interval: TInterval, propertyArgs: PropertySet) => void): any;
 }
@@ -213,12 +214,6 @@ export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationT
     // (undocumented)
     propertyDeltas: PropertySet;
     segment: ISegment;
-}
-
-// @public
-export interface ISequenceIntervalEvents extends IEvent {
-    // (undocumented)
-    (event: "beforePositionChange" | "afterPositionChange", listener: () => void): any;
 }
 
 // @public (undocumented)
@@ -387,8 +382,10 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
 }
 
 // @public (undocumented)
-export class SequenceInterval extends TypedEventEmitter<ISequenceIntervalEvents> implements ISerializableInterval {
+export class SequenceInterval implements ISerializableInterval {
     constructor(start: LocalReference, end: LocalReference, intervalType: IntervalType, props?: PropertySet);
+    // @internal
+    addPositionChangeListeners(beforePositionChange: () => void, afterPositionChange: () => void): void;
     // (undocumented)
     addProperties(newProps: PropertySet, collab?: boolean, seq?: number, op?: ICombiningOp): PropertySet | undefined;
     // (undocumented)
@@ -415,6 +412,8 @@ export class SequenceInterval extends TypedEventEmitter<ISequenceIntervalEvents>
     properties: PropertySet;
     // (undocumented)
     propertyManager: PropertiesManager;
+    // @internal
+    removePositionChangeListeners(): void;
     // (undocumented)
     serialize(client: Client): ISerializedInterval;
     // (undocumented)

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -14,7 +14,6 @@ export {
     ISerializableInterval,
     ISerializedInterval,
     SequenceInterval,
-    ISequenceIntervalEvents,
 } from "./intervalCollection";
 export {
     IMapMessageLocalMetadata,

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -13,6 +13,7 @@ import {
     MockContainerRuntimeForReconnection,
     MockStorage,
 } from "@fluidframework/test-runtime-utils";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
 import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
@@ -920,6 +921,98 @@ describe("SharedString interval collections", () => {
                 { label: "test3", local: true },
                 { label: "test1", local: false },
             ]);
+        });
+
+        describe("emits changeInterval events", () => {
+            let collection: IntervalCollection<SequenceInterval>;
+            const eventLog: {
+                interval: { start: number; end: number; };
+                local: boolean;
+                op: ISequencedDocumentMessage;
+            }[] = [];
+            let intervalId: string;
+            beforeEach(() => {
+                sharedString.insertText(0, "hello world");
+                collection = sharedString.getIntervalCollection("test");
+                collection.on("changeInterval",
+                    ({ start, end }, local, op) => eventLog.push({
+                        interval: {
+                            start: sharedString.localReferencePositionToPosition(start),
+                            end: sharedString.localReferencePositionToPosition(end),
+                        },
+                        local,
+                        op,
+                    }),
+                );
+                intervalId = collection.add(0, 1, IntervalType.SlideOnRemove).getIntervalId();
+                containerRuntimeFactory.processAllMessages();
+                eventLog.length = 0;
+            });
+
+            it("on local change", () => {
+                collection.change(intervalId, 2, 3);
+                assert.equal(eventLog.length, 1);
+                {
+                    const [{ interval, local, op }] = eventLog;
+                    assert.deepEqual(interval, { start: 2, end: 3 });
+                    assert.equal(local, true);
+                    assert.equal(op, undefined);
+                }
+                containerRuntimeFactory.processAllMessages();
+                assert.equal(eventLog.length, 2);
+                {
+                    const { interval, local, op } = eventLog[1];
+                    assert.deepEqual(interval, { start: 2, end: 3 });
+                    assert.equal(local, true);
+                    assert.equal(op.contents.type, "act");
+                }
+            });
+
+            it("on a remote change", () => {
+                const collection2 = sharedString2.getIntervalCollection("test");
+                collection2.change(intervalId, 2, 3);
+                assert.equal(eventLog.length, 0);
+                containerRuntimeFactory.processAllMessages();
+                assert.equal(eventLog.length, 1);
+                {
+                    const [{ interval, local, op }] = eventLog;
+                    assert.deepEqual(interval, { start: 2, end: 3 });
+                    assert.equal(local, false);
+                    assert.equal(op.contents.type, "act");
+                }
+            });
+
+            it("on a property change", () => {
+                collection.changeProperties(intervalId, { foo: "bar" });
+                assert.equal(eventLog.length, 1);
+                {
+                    const [{ interval, local, op }] = eventLog;
+                    assert.deepEqual(interval, { start: 0, end: 1 });
+                    assert.equal(local, true);
+                    assert.equal(op, undefined);
+                }
+                containerRuntimeFactory.processAllMessages();
+                assert.equal(eventLog.length, 2);
+                {
+                    const { interval, local, op } = eventLog[1];
+                    assert.deepEqual(interval, { start: 0, end: 1 });
+                    assert.equal(local, true);
+                    assert.equal(op.contents.type, "act");
+                }
+            });
+
+            it("on a change due to an endpoint sliding", () => {
+                sharedString.removeRange(1, 3);
+                assert.equal(eventLog.length, 0);
+                containerRuntimeFactory.processAllMessages();
+                assert.equal(eventLog.length, 1);
+                {
+                    const [{ interval, local, op }] = eventLog;
+                    assert.deepEqual(interval, { start: 0, end: 1 });
+                    assert.equal(local, true);
+                    assert.equal(op, undefined);
+                }
+            });
         });
 
         it("can be concurrently created", () => {


### PR DESCRIPTION
Refactors `SequenceInterval` to support a single subscriber, which is a perf win for memory (TypedEventEmitter has a lot of bound fields and so extending it bloats the otherwise relatively small class).

Since consumers may care about intervals sliding--for example to update UI--this additionally surfaces such changes via the existing `changeInterval` event on `IntervalCollection`. While refactoring that aspect and adding coverage/documentation for the event's semantics I noticed and fixed a bug where we'd emit an event with the old interval on local change.

[AB#735](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/735)