### PR TITLE
Refine PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,30 @@
-# [Work Item ID or Title](./link-to-the-work-item)
+For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).
 
-For more information about how to contribute to this repo, visit this [page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md)
+For specific guidelines for Pull Requests in this repo, visit [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
+
+The sections included below are suggestions for what you may want to include.
+Feel free to remove or alter parts of this template that do not offer value for your specific change.
 
 ## Description
 
-> Should include a concise description of the changes (bug or feature), it's impact, along with a summary of the solution
+> A concise description of the changes (bug or feature) and their impact/motivation.
+> If this description is short enough to be used as the title, delete this section and just use the title.
 
-## Steps to Reproduce Bug and Validate Solution
+> For bug fixes, also include specifics of how to reproduce it / confirm it is fixed.
 
-> Only applicable if the work is to address a bug. Please remove this section if the work is for a feature or story
-> Provide details on the environment the bug is found, and detailed steps to recreate the bug.
-> This should be detailed enough for a team member to confirm that the bug no longer occurs
+> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.
 
-## PR Checklist
+## Reviewer Guidance
 
-> Use the check-list below to ensure your branch is ready for PR. If the item is not applicable, leave it blank.
-
--   [ ] I have updated the documentation accordingly.
--   [ ] I have added tests to cover my changes.
--   [ ] All new and existing tests passed.
--   [ ] My code follows the code style of this project.
--   [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
--   [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.
+> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
+> Things you might want to include:
+>
+> -   Questions about how to properly make automated tests for your changes.
+> -   Questions about design choices you made.
+> -   Descriptions of how to manually test the changes (and how much of that you have done).
+> -   etc.
+>
+> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
 
 ## Does this introduce a breaking change?
 
@@ -29,10 +32,7 @@ For more information about how to contribute to this repo, visit this [page](htt
 -   [ ] No
 
 > If this introduces a breaking change, please describe the impact and migration path for existing applications below.
-
-## Testing
-
-> -   Instructions for testing and validation of your code so the reviewer can follow those steps and validate code works as expected
+> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
 
 ## Any relevant logs or outputs
 
@@ -41,4 +41,5 @@ For more information about how to contribute to this repo, visit this [page](htt
 ## Other information or known dependencies
 
 > -   Any other information or known dependencies that is important to this PR.
+> -   Links to internal bug/work tracker items.
 > -   TODO that are to be done after this PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,11 +28,9 @@ Feel free to remove or alter parts of this template that do not offer value for 
 
 ## Does this introduce a breaking change?
 
--   [ ] Yes
--   [ ] No
-
 > If this introduces a breaking change, please describe the impact and migration path for existing applications below.
 > See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
+> If there are no breaking changes, delete this section.
 
 ## Any relevant logs or outputs
 


### PR DESCRIPTION
## Description

This change aims to adjust the PR template to be a better fir for this specific repo.
The checklist is removed as it is redundant with the newly linked guidelines and CI tasks (ex: linting and testing).
Work items have been deemphasized as not all PRs have them, and they are often internal and thus not useful to everyone.
More specific links have been added where extra information/context is useful, and the template now clearly states that following it is a suggestion and not required.

## Reviewer Guidance

This in intentionally a rather opinionated and subjective change in an attempt to try and make the PR process feel qualitatively better rather than make any specific policy change. I welcome comments and discussions on these changes, even if they are just that you like or dislike some aspect of it: after all, the goal of this change is to make the PR process such that you like it more.