### PR TITLE
skip flaky stashed ops test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -805,6 +805,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(map3.get(testKey2), testValue);
     });
 
+    // TODO: https://github.com/microsoft/FluidFramework/issues/10729
     it.skip("works with summary while offline", async function() {
         map1.set("test op 1", "test op 1");
         await waitForSummary();
@@ -824,5 +825,20 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
         assert.strictEqual(map1.get(testKey), testValue);
         assert.strictEqual(map2.get(testKey), testValue);
+    });
+
+    // TODO: https://github.com/microsoft/FluidFramework/issues/10729
+    it.skip("can stash between summary op and ack", async function() {
+        map1.set("test op 1", "test op 1");
+        const container = await provider.loadTestContainer(testContainerConfig);
+        const pendingOps = await new Promise<string>((res) => container.on("op", (op) => {
+            if (op.type === "summarize") {
+                res(container.closeAndGetPendingLocalState());
+            }
+        }));
+
+        const container2 = await loader.resolve({ url }, pendingOps);
+        await ensureContainerConnected(container2);
+        await provider.ensureSynchronized();
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -805,7 +805,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(map3.get(testKey2), testValue);
     });
 
-    it("works with summary while offline", async function() {
+    it.skip("works with summary while offline", async function() {
         map1.set("test op 1", "test op 1");
         await waitForSummary();
 


### PR DESCRIPTION
This is intermittently hitting a check in summarizer that sends an error event when it sees a summaryAck op without seeing the summary. This condition is expected when loading with stashed ops, so this check should be skipped in that scenario at which point this test can be re-enabled.