### PR TITLE
The peerDependency on fluid-framework should be ~, not ^

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -78,7 +78,7 @@
     "typescript": "~4.5.5"
   },
   "peerDependencies": {
-    "fluid-framework": "^1.0.1"
+    "fluid-framework": "~1.0.1"
   },
   "typeValidation": {
     "version": "1.1.0",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@fluidframework/azure-client": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "fluid-framework": "^1.0.1"
+    "fluid-framework": "~1.0.1"
   },
   "devDependencies": {
     "@fluid-experimental/get-container": "^1.0.1",


### PR DESCRIPTION
This will mean patches of fluid-framework will be picked up but minor versions will need to be explicitly updated.