### PR TITLE
fix: Await promise

### DIFF
--- a/docs/rollup-api-json.js
+++ b/docs/rollup-api-json.js
@@ -139,7 +139,7 @@ const main = async () => {
     await cpy(stagedPackageFiles, stagingPath, { cwd: originalPath });
 
     // Combine members.
-    combineMembers(stagingPath, stagingPath, data.memberCombineInstructions);
+    await combineMembers(stagingPath, stagingPath, data.memberCombineInstructions);
 
     // Rewrite any remaining references in the output files using replace-in-files
     const from = [];


### PR DESCRIPTION
#10706 refactored functions to be async. One call-site was not correctly updated to await the returned promise. This fixes that issue. 