### PR TITLE
Expose latest sequence number and export odsp wire format methods/interfaces from odsp-driver

### DIFF
--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -16,7 +16,9 @@ import { IOdspUrlParts } from '@fluidframework/odsp-driver-definitions';
 import { IPersistedCache } from '@fluidframework/odsp-driver-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
+import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotOptions } from '@fluidframework/odsp-driver-definitions';
+import { ISnapshotTree } from '@fluidframework/protocol-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
@@ -38,6 +40,9 @@ export function createOdspCreateContainerRequest(siteUrl: string, driveId: strin
 
 // @public
 export function createOdspUrl(l: OdspFluidDataStoreLocator): string;
+
+// @public (undocumented)
+export const currentReadVersion = "1.0";
 
 // @public
 export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocator): string;
@@ -64,6 +69,18 @@ export interface IClpCompliantAppHeader {
 export interface ISharingLinkHeader {
     // (undocumented)
     [SharingLinkHeader.isSharingLinkToRedeem]: boolean;
+}
+
+// @public (undocumented)
+export interface ISnapshotContents {
+    // (undocumented)
+    blobs: Map<string, ArrayBuffer>;
+    latestSequenceNumber: number | undefined;
+    // (undocumented)
+    ops: ISequencedDocumentMessage[];
+    sequenceNumber: number | undefined;
+    // (undocumented)
+    snapshotTree: ISnapshotTree;
 }
 
 // @public
@@ -138,10 +155,38 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     fileVersion?: string;
 }
 
+// @public
+export function parseCompactSnapshotResponse(buffer: ReadBuffer): ISnapshotContents;
+
 // Warning: (ae-forgotten-export) The symbol "SnapshotFormatSupportType" needs to be exported by the entry point index.d.ts
 //
 // @public @deprecated
 export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, forceAccessTokenViaAuthorizationHeader: boolean, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, fetchBinarySnapshotFormat?: boolean, snapshotFormatFetchType?: SnapshotFormatSupportType): Promise<boolean>;
+
+// @public
+export class ReadBuffer {
+    constructor(data: Uint8Array);
+    // (undocumented)
+    get buffer(): Uint8Array;
+    // (undocumented)
+    protected readonly data: Uint8Array;
+    // (undocumented)
+    get eof(): boolean;
+    // (undocumented)
+    protected index: number;
+    // (undocumented)
+    get length(): number;
+    // (undocumented)
+    get pos(): number;
+    // (undocumented)
+    read(lengthArg?: number): number;
+    // (undocumented)
+    reset(): void;
+    // (undocumented)
+    skip(length: number): void;
+    // (undocumented)
+    slice(start: number, end: number): Uint8Array;
+}
 
 // @public
 export interface ShareLinkFetcherProps {
@@ -154,6 +199,9 @@ export enum SharingLinkHeader {
     // (undocumented)
     isSharingLinkToRedeem = "isSharingLinkToRedeem"
 }
+
+// @public (undocumented)
+export const snapshotMinReadVersion = "1.0";
 
 // @public
 export function storeLocatorInOdspUrl(url: URL, locator: OdspFluidDataStoreLocator): void;

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { ISnapshotContents } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 import { ReadBuffer } from "./ReadBufferUtils";
 import { ISnapshotTreeEx } from "./contracts";
 import {

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -127,19 +127,23 @@ export function parseCompactSnapshotResponse(buffer: ReadBuffer): ISnapshotConte
     const root = builder.getNode(0);
 
     const records = getAndValidateNodeProps(root,
-        ["mrv", "cv", "snapshot", "blobs", "deltas"], false);
+        ["mrv", "cv", "lsn", "snapshot", "blobs", "deltas"], false);
 
     assertBlobCoreInstance(records.mrv, "minReadVersion should be of BlobCore type");
     assertBlobCoreInstance(records.cv, "createVersion should be of BlobCore type");
-    assert(snapshotMinReadVersion >= records.mrv.toString(),
+    assertNumberInstance(records.lsn, "lsn should be a number");
+
+    assert(parseFloat(snapshotMinReadVersion) >= parseFloat(records.mrv.toString()),
         0x20f /* "Driver min read version should >= to server minReadVersion" */);
-    assert(records.cv.toString() >= snapshotMinReadVersion,
+    assert(parseFloat(records.cv.toString()) >= parseFloat(snapshotMinReadVersion),
         0x210 /* "Snapshot should be created with minReadVersion or above" */);
     assert(currentReadVersion === records.cv.toString(),
         0x2c2 /* "Create Version should be equal to currentReadVersion" */);
+
     return {
         ...readSnapshotSection(records.snapshot),
         blobs: readBlobSection(records.blobs),
         ops: records.deltas !== undefined ? readOpsSection(records.deltas) : [],
+        latestSequenceNumber: records.lsn,
     };
 }

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -131,9 +131,8 @@ export function convertToCompactSnapshot(snapshotContents: ISnapshotContents): R
     // Create the root node.
     const rootNode = builder.addNode();
     assert(snapshotContents.sequenceNumber !== undefined, 0x21c /* "Seq number should be provided" */);
-    const ops = snapshotContents.ops;
-    const latestSequenceNumber = ops.length > 0 ? ops[ops.length - 1].sequenceNumber : snapshotContents.sequenceNumber;
-    writeSnapshotProps(rootNode, latestSequenceNumber);
+
+    writeSnapshotProps(rootNode, snapshotContents.latestSequenceNumber);
 
     writeSnapshotSection(
         rootNode,
@@ -145,7 +144,7 @@ export function convertToCompactSnapshot(snapshotContents: ISnapshotContents): R
     writeBlobsSection(rootNode, snapshotContents.blobs);
 
     // Then write the ops node.
-    writeOpsSection(rootNode, ops);
+    writeOpsSection(rootNode, snapshotContents.ops);
 
     return builder.serialize();
 }

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -132,7 +132,11 @@ export function convertToCompactSnapshot(snapshotContents: ISnapshotContents): R
     const rootNode = builder.addNode();
     assert(snapshotContents.sequenceNumber !== undefined, 0x21c /* "Seq number should be provided" */);
 
-    writeSnapshotProps(rootNode, snapshotContents.latestSequenceNumber);
+    const latestSequenceNumber = snapshotContents.latestSequenceNumber ??
+        snapshotContents.ops.length > 0 ?
+        snapshotContents.ops[snapshotContents.ops.length - 1].sequenceNumber : snapshotContents.sequenceNumber;
+
+    writeSnapshotProps(rootNode, latestSequenceNumber);
 
     writeSnapshotSection(
         rootNode,

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -6,7 +6,7 @@
 import { assert, stringToBuffer } from "@fluidframework/common-utils";
 import { IBlob, ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { snapshotMinReadVersion } from "./compactSnapshotParser";
-import { ISnapshotContents } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 import { ReadBuffer } from "./ReadBufferUtils";
 import { TreeBuilderSerializer } from "./WriteBufferUtils";
 import { addBoolProperty, addNumberProperty, addStringProperty, NodeCore } from "./zipItDataRepresentationUtils";

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -5,7 +5,7 @@
 
 import * as api from "@fluidframework/protocol-definitions";
 import { HostStoragePolicy } from "@fluidframework/odsp-driver-definitions";
-import { ISnapshotContents } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 
 /** https://portal.microsofticm.com/imp/v3/incidents/details/308931013/home
  * The commits property was removed from protocol-definitions but in order to support back compat, we will

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -30,9 +30,9 @@ import {
     getWithRetryForTokenRefresh,
     INewFileInfo,
     getOrigin,
-    ISnapshotContents,
     maxUmpPostBodySize,
 } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 import { createOdspUrl } from "./createOdspUrl";
 import { getApiRoot } from "./odspUrlHelper";
 import { EpochTracker } from "./epochTracker";
@@ -91,7 +91,7 @@ export async function createNewFluidFile(
         sharingLinkErrorReason = content.sharingLinkErrorReason;
     }
 
-    const odspUrl = createOdspUrl({ ... newFileInfo, itemId, dataStorePath: "/" });
+    const odspUrl = createOdspUrl({ ...newFileInfo, itemId, dataStorePath: "/" });
     const resolver = new OdspDriverUrlResolver();
     const odspResolvedUrl = await resolver.resolve({
         url: odspUrl,

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -7,7 +7,7 @@ import { v4 as uuid } from "uuid";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { getDocAttributesFromProtocolSummary } from "@fluidframework/driver-utils";
 import { stringToBuffer, unreachableCase } from "@fluidframework/common-utils";
-import { ISnapshotContents } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 import { ISnapshotTreeEx } from "./contracts";
 
 /**
@@ -25,6 +25,7 @@ export function convertCreateNewSummaryTreeToTreeAndBlobs(summary: ISummaryTree,
         blobs,
         ops: [],
         sequenceNumber,
+        latestSequenceNumber: sequenceNumber,
     };
 
     return snapshotTreeValue;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -26,8 +26,8 @@ import {
     getWithRetryForTokenRefresh,
     getWithRetryForTokenRefreshRepeat,
     IOdspResponse,
-    ISnapshotContents,
 } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "./odspSnapshotParser";
 import { currentReadVersion, parseCompactSnapshotResponse } from "./compactSnapshotParser";
 import { ReadBuffer } from "./ReadBufferUtils";
@@ -93,11 +93,11 @@ export async function fetchSnapshotWithRedeem(
     forceAccessTokenViaAuthorizationHeader: boolean,
     logger: ITelemetryLogger,
     snapshotDownloader: (
-            finalOdspResolvedUrl: IOdspResolvedUrl,
-            storageToken: string,
-            snapshotOptions: ISnapshotOptions | undefined,
-            controller?: AbortController,
-        ) => Promise<ISnapshotRequestAndResponseOptions>,
+        finalOdspResolvedUrl: IOdspResolvedUrl,
+        storageToken: string,
+        snapshotOptions: ISnapshotOptions | undefined,
+        controller?: AbortController,
+    ) => Promise<ISnapshotRequestAndResponseOptions>,
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
     removeEntries: () => Promise<void>,
     enableRedeemFallback?: boolean,
@@ -126,12 +126,13 @@ export async function fetchSnapshotWithRedeem(
             await redeemSharingLink(
                 odspResolvedUrl, storageTokenFetcher, logger, forceAccessTokenViaAuthorizationHeader);
             const odspResolvedUrlWithoutShareLink: IOdspResolvedUrl =
-                { ...odspResolvedUrl,
-                    shareLinkInfo: {
-                        ...odspResolvedUrl.shareLinkInfo,
-                        sharingLinkToRedeem: undefined,
-                    },
-                };
+            {
+                ...odspResolvedUrl,
+                shareLinkInfo: {
+                    ...odspResolvedUrl.shareLinkInfo,
+                    sharingLinkToRedeem: undefined,
+                },
+            };
 
             return fetchLatestSnapshotCore(
                 odspResolvedUrlWithoutShareLink,
@@ -168,15 +169,15 @@ async function redeemSharingLink(
             eventName: "RedeemShareLink",
         },
         async () => getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
-                assert(!!odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem,
-                    0x1ed /* "Share link should be present" */);
-                const storageToken = await storageTokenFetcher(tokenFetchOptions, "RedeemShareLink");
-                const encodedShareUrl = getEncodedShareUrl(odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem);
-                const redeemUrl = `${odspResolvedUrl.siteUrl}/_api/v2.0/shares/${encodedShareUrl}`;
-                const { url, headers } = getUrlAndHeadersWithAuth(
-                    redeemUrl, storageToken, forceAccessTokenViaAuthorizationHeader);
-                headers.prefer = "redeemSharingLink";
-                return fetchAndParseAsJSONHelper(url, { headers });
+            assert(!!odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem,
+                0x1ed /* "Share link should be present" */);
+            const storageToken = await storageTokenFetcher(tokenFetchOptions, "RedeemShareLink");
+            const encodedShareUrl = getEncodedShareUrl(odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem);
+            const redeemUrl = `${odspResolvedUrl.siteUrl}/_api/v2.0/shares/${encodedShareUrl}`;
+            const { url, headers } = getUrlAndHeadersWithAuth(
+                redeemUrl, storageToken, forceAccessTokenViaAuthorizationHeader);
+            headers.prefer = "redeemSharingLink";
+            return fetchAndParseAsJSONHelper(url, { headers });
         }),
     );
 }
@@ -187,11 +188,11 @@ async function fetchLatestSnapshotCore(
     snapshotOptions: ISnapshotOptions | undefined,
     logger: ITelemetryLogger,
     snapshotDownloader: (
-            finalOdspResolvedUrl: IOdspResolvedUrl,
-            storageToken: string,
-            snapshotOptions: ISnapshotOptions | undefined,
-            controller?: AbortController,
-        ) => Promise<ISnapshotRequestAndResponseOptions>,
+        finalOdspResolvedUrl: IOdspResolvedUrl,
+        storageToken: string,
+        snapshotOptions: ISnapshotOptions | undefined,
+        controller?: AbortController,
+    ) => Promise<ISnapshotRequestAndResponseOptions>,
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
     enableRedeemFallback?: boolean,
 ): Promise<ISnapshotContents> {
@@ -513,7 +514,7 @@ function isRedeemSharingLinkError(odspResolvedUrl: IOdspResolvedUrl, error: any)
     if (odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem !== undefined
         && (typeof error === "object" && error !== null)
         && (error.errorType === DriverErrorType.authorizationError
-        || error.errorType === DriverErrorType.fileNotFoundOrAccessDeniedError)) {
+            || error.errorType === DriverErrorType.fileNotFoundOrAccessDeniedError)) {
         return true;
     }
     return false;
@@ -526,9 +527,9 @@ function getEncodedShareUrl(url: string): string {
      */
     let encodedUrl = fromUtf8ToBase64(encodeURI(url));
     encodedUrl = encodedUrl
-      .replace(/=+$/g, "")
-      .replace(/\//g, "_")
-      .replace(/\+/g, "-");
+        .replace(/=+$/g, "")
+        .replace(/\//g, "_")
+        .replace(/\+/g, "-");
     encodedUrl = "u!".concat(encodedUrl);
     return encodedUrl;
 }

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -34,5 +34,4 @@ export * from "./odspFluidFileLink";
 
 // Wire format related
 export * from "./compactSnapshotParser";
-export * from "./odspUtils";
 export * from "./ReadBufferUtils";

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -31,3 +31,8 @@ export * from "./odspDriverUrlResolver";
 
 // It's used by URL resolve code, but also has some public functions
 export * from "./odspFluidFileLink";
+
+// Wire format related
+export * from "./compactSnapshotParser";
+export * from "./odspUtils";
+export * from "./ReadBufferUtils";

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -38,8 +38,8 @@ import { IOdspCache } from "./odspCache";
 import {
     createCacheSnapshotKey,
     getWithRetryForTokenRefresh,
-    ISnapshotContents,
 } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 import { defaultCacheExpiryTimeoutMs, EpochTracker } from "./epochTracker";
 import { OdspSummaryUploadManager } from "./odspSummaryUploadManager";
 import { FlushResult } from "./odspDocumentDeltaConnection";
@@ -275,7 +275,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                 method: "POST",
                             },
                             "createBlob",
-                    ));
+                        ));
                     event.end({
                         blobId: res.content.id,
                         ...res.propsToLog,
@@ -437,7 +437,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                 }
 
                                 return snapshotCachedEntry;
-                        });
+                            });
 
                     // Based on the concurrentSnapshotFetch policy:
                     // Either retrieve both the network and cache snapshots concurrently and pick the first to return,
@@ -648,7 +648,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         // Enable flushing only if we have single commit summary and this is not the initial summary for an empty file
         if (".protocol" in summary.tree && context.ackHandle !== undefined) {
             let retry = 0;
-            for (;;) {
+            for (; ;) {
                 const result = await this.flushCallback();
                 const seq = result.lastPersistedSequenceNumber;
                 if (seq !== undefined && seq >= context.referenceSequenceNumber) {

--- a/packages/drivers/odsp-driver/src/odspPublicUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspPublicUtils.ts
@@ -4,8 +4,25 @@
  */
 
 import { hashFile, IsoBuffer } from "@fluidframework/common-utils";
+import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 
 export async function getHashedDocumentId(driveId: string, itemId: string): Promise<string> {
     const buffer = IsoBuffer.from(`${driveId}_${itemId}`);
     return encodeURIComponent(await hashFile(buffer, "SHA-256", "base64"));
+}
+
+export interface ISnapshotContents {
+    snapshotTree: ISnapshotTree;
+    blobs: Map<string, ArrayBuffer>;
+    ops: ISequencedDocumentMessage[];
+
+    /**
+     * Sequence number of the snapshot
+     */
+    sequenceNumber: number | undefined;
+
+    /**
+     * Sequence number for the latest op/snapshot for the file in ODSP
+     */
+    latestSequenceNumber: number | undefined;
 }

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -62,13 +62,16 @@ export function convertOdspSnapshotToSnapshotTreeAndBlobs(
             blobsWithBufferContent.set(blob.id, stringToBuffer(blob.content, blob.encoding ?? "utf8"));
         });
     }
+
+    const sequenceNumber = odspSnapshot?.trees[0].sequenceNumber;
+
     const val: ISnapshotContents = {
         blobs: blobsWithBufferContent,
         ops: odspSnapshot.ops?.map((op) => op.op) ?? [],
-        sequenceNumber: odspSnapshot?.trees[0].sequenceNumber,
+        sequenceNumber,
         snapshotTree: buildHierarchy(odspSnapshot.trees[0]),
-        latestSequenceNumber: odspSnapshot.ops?.[odspSnapshot.ops.length - 1].sequenceNumber ??
-            odspSnapshot?.trees[0].sequenceNumber,
+        latestSequenceNumber: (odspSnapshot.ops && odspSnapshot.ops.length > 0) ?
+            odspSnapshot.ops[odspSnapshot.ops.length - 1].sequenceNumber : sequenceNumber,
     };
     return val;
 }

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -67,7 +67,8 @@ export function convertOdspSnapshotToSnapshotTreeAndBlobs(
         ops: odspSnapshot.ops?.map((op) => op.op) ?? [],
         sequenceNumber: odspSnapshot?.trees[0].sequenceNumber,
         snapshotTree: buildHierarchy(odspSnapshot.trees[0]),
-        latestSequenceNumber: odspSnapshot.ops?.[odspSnapshot.ops.length - 1].sequenceNumber ?? odspSnapshot?.trees[0].sequenceNumber,
+        latestSequenceNumber: odspSnapshot.ops?.[odspSnapshot.ops.length - 1].sequenceNumber ??
+            odspSnapshot?.trees[0].sequenceNumber,
     };
     return val;
 }

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -6,7 +6,7 @@
 import { assert, stringToBuffer } from "@fluidframework/common-utils";
 import * as api from "@fluidframework/protocol-definitions";
 import { IOdspSnapshot, IOdspSnapshotCommit, ISnapshotTreeEx } from "./contracts";
-import { ISnapshotContents } from "./odspUtils";
+import { ISnapshotContents } from "./odspPublicUtils";
 
 /**
  * Build a tree hierarchy base on a flat tree
@@ -67,6 +67,7 @@ export function convertOdspSnapshotToSnapshotTreeAndBlobs(
         ops: odspSnapshot.ops?.map((op) => op.op) ?? [],
         sequenceNumber: odspSnapshot?.trees[0].sequenceNumber,
         snapshotTree: buildHierarchy(odspSnapshot.trees[0]),
+        latestSequenceNumber: odspSnapshot.ops?.[odspSnapshot.ops.length - 1].sequenceNumber ?? odspSnapshot?.trees[0].sequenceNumber,
     };
     return val;
 }

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -43,22 +43,6 @@ export const getWithRetryForTokenRefreshRepeat = "getWithRetryForTokenRefreshRep
 /** Parse the given url and return the origin (host name) */
 export const getOrigin = (url: string) => new URL(url).origin;
 
-export interface ISnapshotContents {
-    snapshotTree: ISnapshotTree;
-    blobs: Map<string, ArrayBuffer>;
-    ops: ISequencedDocumentMessage[];
-
-    /**
-     * Sequence number of the summary
-     */
-    sequenceNumber: number;
-
-    /**
-     * Sequence number for the latest op/summary for the file in ODSP
-     */
-    latestSequenceNumber: number;
-}
-
 export interface IOdspResponse<T> {
     content: T;
     headers: Map<string, string>;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -13,7 +13,6 @@ import {
     NetworkErrorBasic,
 } from "@fluidframework/driver-utils";
 import { assert, performance } from "@fluidframework/common-utils";
-import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { ChildLogger, PerformanceEvent, wrapError } from "@fluidframework/telemetry-utils";
 import {
     fetchIncorrectResponse,

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -47,7 +47,16 @@ export interface ISnapshotContents {
     snapshotTree: ISnapshotTree;
     blobs: Map<string, ArrayBuffer>;
     ops: ISequencedDocumentMessage[];
-    sequenceNumber: number | undefined;
+
+    /**
+     * Sequence number of the summary
+     */
+    sequenceNumber: number;
+
+    /**
+     * Sequence number for the latest op/summary for the file in ODSP
+     */
+    latestSequenceNumber: number;
 }
 
 export interface IOdspResponse<T> {
@@ -243,7 +252,8 @@ export const createOdspLogger = (logger?: ITelemetryBaseLogger) =>
     ChildLogger.create(
         logger,
         "OdspDriver",
-        { all:
+        {
+            all:
             {
                 driverVersion,
             },

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -10,8 +10,8 @@ import { IFileEntry, IOdspResolvedUrl, ShareLinkTypes } from "@fluidframework/od
 import { convertCreateNewSummaryTreeToTreeAndBlobs } from "../createNewUtils";
 import { createNewFluidFile } from "../createFile";
 import { EpochTracker } from "../epochTracker";
-import { getHashedDocumentId } from "../odspPublicUtils";
-import { INewFileInfo, createCacheSnapshotKey, ISnapshotContents } from "../odspUtils";
+import { getHashedDocumentId, ISnapshotContents } from "../odspPublicUtils";
+import { INewFileInfo, createCacheSnapshotKey } from "../odspUtils";
 import { LocalPersistentCache } from "../odspCache";
 import { mockFetchOk } from "./mockFetch";
 
@@ -89,7 +89,7 @@ describe("Create New Utils Tests", () => {
     });
 
     afterEach(async () => {
-        await epochTracker.removeEntries().catch(() => {});
+        await epochTracker.removeEntries().catch(() => { });
     });
 
     const test = (snapshot: ISnapshotContents) => {
@@ -125,22 +125,22 @@ describe("Create New Utils Tests", () => {
 
     it("Should cache converted summary during createNewFluidFile", async () => {
         const odspResolvedUrl = await mockFetchOk(
-                async () => createNewFluidFile(
-                    async (_options) => "token",
-                    newFileParams,
-                    new TelemetryNullLogger(),
-                    createSummary(),
-                    epochTracker,
-                    fileEntry,
-                    true,
-                    false,
-                ),
-                { itemId: "itemId1", id: "Summary handle" },
-                { "x-fluid-epoch": "epoch1" },
-                );
+            async () => createNewFluidFile(
+                async (_options) => "token",
+                newFileParams,
+                new TelemetryNullLogger(),
+                createSummary(),
+                epochTracker,
+                fileEntry,
+                true,
+                false,
+            ),
+            { itemId: "itemId1", id: "Summary handle" },
+            { "x-fluid-epoch": "epoch1" },
+        );
         const snapshot = await epochTracker.get(createCacheSnapshotKey(odspResolvedUrl));
         test(snapshot);
-        await epochTracker.removeEntries().catch(() => {});
+        await epochTracker.removeEntries().catch(() => { });
     });
 
     it("Should save share link information received during createNewFluidFile", async () => {
@@ -150,19 +150,19 @@ describe("Create New Utils Tests", () => {
         // Test that sharing link is set appropriately when it is received in the response from ODSP
         const mockSharingLink = "mockSharingLink";
         let odspResolvedUrl = await mockFetchOk(
-                async () => createNewFluidFile(
-                    async (_options) => "token",
-                    newFileParams,
-                    new TelemetryNullLogger(),
-                    createSummary(),
-                    epochTracker,
-                    fileEntry,
-                    false,
-                    false,
-                ),
-                { itemId: "mockItemId", id: "mockId", sharingLink: mockSharingLink, sharingLinkErrorReason: undefined },
-                { "x-fluid-epoch": "epoch1" },
-                );
+            async () => createNewFluidFile(
+                async (_options) => "token",
+                newFileParams,
+                new TelemetryNullLogger(),
+                createSummary(),
+                epochTracker,
+                fileEntry,
+                false,
+                false,
+            ),
+            { itemId: "mockItemId", id: "mockId", sharingLink: mockSharingLink, sharingLinkErrorReason: undefined },
+            { "x-fluid-epoch": "epoch1" },
+        );
         assert.deepStrictEqual(odspResolvedUrl.shareLinkInfo?.createLink, {
             type: createLinkType,
             link: mockSharingLink,
@@ -184,31 +184,31 @@ describe("Create New Utils Tests", () => {
             ),
             { itemId: "mockItemId", id: "mockId", sharingLink: undefined, sharingLinkErrorReason: mockError },
             { "x-fluid-epoch": "epoch1" },
-            );
+        );
         assert.deepStrictEqual(odspResolvedUrl.shareLinkInfo?.createLink, {
             type: createLinkType,
             link: undefined,
             error: mockError,
         });
-        await epochTracker.removeEntries().catch(() => {});
+        await epochTracker.removeEntries().catch(() => { });
     });
 
     it("Should set the isClpCompliantApp prop on resolved url if already present", async () => {
         const odspResolvedUrl1 = await mockFetchOk(
-                async () => createNewFluidFile(
-                    async (_options) => "token",
-                    newFileParams,
-                    new TelemetryNullLogger(),
-                    createSummary(),
-                    epochTracker,
-                    fileEntry,
-                    true,
-                    false,
-                    true /* isClpCompliantApp */,
-                ),
-                { itemId: "itemId1", id: "Summary handle" },
-                { "x-fluid-epoch": "epoch1" },
-                );
+            async () => createNewFluidFile(
+                async (_options) => "token",
+                newFileParams,
+                new TelemetryNullLogger(),
+                createSummary(),
+                epochTracker,
+                fileEntry,
+                true,
+                false,
+                true /* isClpCompliantApp */,
+            ),
+            { itemId: "itemId1", id: "Summary handle" },
+            { "x-fluid-epoch": "epoch1" },
+        );
         assert(odspResolvedUrl1.isClpCompliantApp, "isClpCompliantApp should be set");
 
         const odspResolvedUrl2 = await mockFetchOk(
@@ -225,8 +225,8 @@ describe("Create New Utils Tests", () => {
             ),
             { itemId: "itemId1", id: "Summary handle" },
             { "x-fluid-epoch": "epoch1" },
-            );
+        );
         assert(!odspResolvedUrl2.isClpCompliantApp, "isClpCompliantApp should be falsy");
-        await epochTracker.removeEntries().catch(() => {});
+        await epochTracker.removeEntries().catch(() => { });
     });
 });

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -11,9 +11,9 @@ import { EpochTracker } from "../epochTracker";
 import { HostStoragePolicyInternal } from "../contracts";
 import * as fetchSnapshotImport from "../fetchSnapshot";
 import { LocalPersistentCache, NonPersistentCache } from "../odspCache";
-import { INewFileInfo, IOdspResponse, ISnapshotContents } from "../odspUtils";
+import { INewFileInfo, IOdspResponse } from "../odspUtils";
 import { createOdspUrl } from "../createOdspUrl";
-import { getHashedDocumentId } from "../odspPublicUtils";
+import { getHashedDocumentId, ISnapshotContents } from "../odspPublicUtils";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 
@@ -48,7 +48,7 @@ describe("Tests for snapshot fetch headers", () => {
     const resolver = new OdspDriverUrlResolver();
     const nonPersistentCache = new NonPersistentCache();
     const logger = new TelemetryNullLogger();
-    const odspUrl = createOdspUrl({ ... newFileParams, itemId, dataStorePath: "/" });
+    const odspUrl = createOdspUrl({ ...newFileParams, itemId, dataStorePath: "/" });
 
     const content: ISnapshotContents = {
         snapshotTree: {
@@ -86,11 +86,11 @@ describe("Tests for snapshot fetch headers", () => {
             hostPolicy,
             epochTracker,
             async () => { return {}; },
-            );
+        );
     });
 
     afterEach(async () => {
-        await epochTracker.removeEntries().catch(() => {});
+        await epochTracker.removeEntries().catch(() => { });
     });
 
     it("Mds limit check in fetch snapshot", async () => {
@@ -122,7 +122,7 @@ describe("Tests for snapshot fetch headers", () => {
                 Promise.resolve(response),
                 async () => service.getVersions(null, 1),
             );
-        } catch (error) {}
+        } catch (error) { }
         assert(success, "mds limit should not be set!!");
     });
 });

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -59,6 +59,7 @@ describe("Tests for snapshot fetch headers", () => {
         blobs: new Map(),
         ops: [],
         sequenceNumber: 0,
+        latestSequenceNumber: 0,
     };
     before(async () => {
         hashedDocumentId = await getHashedDocumentId(driveId, itemId);

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -77,6 +77,7 @@ describe("Tests for snapshot fetch", () => {
         blobs: new Map(),
         ops: [],
         sequenceNumber: 0,
+        latestSequenceNumber: 0,
     };
 
     const value: IVersionedValueWithEpoch = {

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -17,9 +17,9 @@ import {
     persistedCacheValueVersion,
 } from "../contracts";
 import { LocalPersistentCache, NonPersistentCache } from "../odspCache";
-import { INewFileInfo, ISnapshotContents } from "../odspUtils";
+import { INewFileInfo } from "../odspUtils";
 import { createOdspUrl } from "../createOdspUrl";
-import { getHashedDocumentId } from "../odspPublicUtils";
+import { getHashedDocumentId, ISnapshotContents } from "../odspPublicUtils";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { OdspDocumentStorageService, defaultSummarizerCacheExpiryTimeout } from "../odspDocumentStorageManager";
 import { mockFetchSingle, notFound, createResponse } from "./mockFetch";
@@ -57,7 +57,7 @@ describe("Tests for snapshot fetch", () => {
     const resolver = new OdspDriverUrlResolver();
     const nonPersistentCache = new NonPersistentCache();
     const logger = new TelemetryNullLogger();
-    const odspUrl = createOdspUrl({ ... newFileParams, itemId, dataStorePath: "/" });
+    const odspUrl = createOdspUrl({ ...newFileParams, itemId, dataStorePath: "/" });
 
     const odspSnapshot: IOdspSnapshot = {
         id: "id",
@@ -79,16 +79,19 @@ describe("Tests for snapshot fetch", () => {
         sequenceNumber: 0,
     };
 
-    const value: IVersionedValueWithEpoch = { value: { ...content, cacheEntryTime: Date.now() },
+    const value: IVersionedValueWithEpoch = {
+        value: { ...content, cacheEntryTime: Date.now() },
         fluidEpoch: "epoch1",
-        version: persistedCacheValueVersion };
+        version: persistedCacheValueVersion
+    };
 
     // Set the cacheEntryTime to anything greater than the current maxCacheAge
     function valueWithExpiredCache(cacheExpiryTimeoutMs: number): IVersionedValueWithEpoch {
         const versionedValue: IVersionedValueWithEpoch = {
-             value: { ...content, cacheEntryTime: Date.now() - cacheExpiryTimeoutMs - 1000 },
-        fluidEpoch: "epoch1",
-        version: persistedCacheValueVersion };
+            value: { ...content, cacheEntryTime: Date.now() - cacheExpiryTimeoutMs - 1000 },
+            fluidEpoch: "epoch1",
+            version: persistedCacheValueVersion
+        };
         return versionedValue;
     }
     const expectedVersion = [{ id: "id", treeId: undefined! }];
@@ -120,11 +123,11 @@ describe("Tests for snapshot fetch", () => {
                 GetHostStoragePolicyInternal(),
                 epochTracker,
                 async () => { return {}; },
-                );
+            );
         });
 
         afterEach(async () => {
-            await epochTracker.removeEntries().catch(() => {});
+            await epochTracker.removeEntries().catch(() => { });
         });
 
         it("cache fetch throws and network fetch succeeds", async () => {
@@ -149,7 +152,8 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl } };
+                file: { docId: hashedDocumentId, resolvedUrl }
+            };
             await localCache.put(cacheEntry, value);
 
             const version = await mockFetchSingle(
@@ -178,7 +182,8 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl } };
+                file: { docId: hashedDocumentId, resolvedUrl }
+            };
             await localCache.put(cacheEntry, value);
 
             const version = await mockFetchSingle(
@@ -203,7 +208,8 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl } };
+                file: { docId: hashedDocumentId, resolvedUrl }
+            };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
 
             const version = await mockFetchSingle(
@@ -221,7 +227,8 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl } };
+                file: { docId: hashedDocumentId, resolvedUrl }
+            };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
 
             await assert.rejects(async () => {
@@ -256,18 +263,19 @@ describe("Tests for snapshot fetch", () => {
                 GetHostStoragePolicyInternal(true /* isSummarizer */),
                 epochTracker,
                 async () => { return {}; },
-                );
+            );
         });
 
         afterEach(async () => {
-            await epochTracker.removeEntries().catch(() => {});
+            await epochTracker.removeEntries().catch(() => { });
         });
 
         it("cache expires and network fetch succeeds", async () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl } };
+                file: { docId: hashedDocumentId, resolvedUrl }
+            };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultSummarizerCacheExpiryTimeout));
 
             const version = await mockFetchSingle(
@@ -285,7 +293,8 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl } };
+                file: { docId: hashedDocumentId, resolvedUrl }
+            };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultSummarizerCacheExpiryTimeout - 5000));
 
             assert.notEqual(cacheEntry, undefined, "Cache should have been restored");

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -83,7 +83,7 @@ describe("Tests for snapshot fetch", () => {
     const value: IVersionedValueWithEpoch = {
         value: { ...content, cacheEntryTime: Date.now() },
         fluidEpoch: "epoch1",
-        version: persistedCacheValueVersion
+        version: persistedCacheValueVersion,
     };
 
     // Set the cacheEntryTime to anything greater than the current maxCacheAge
@@ -91,7 +91,7 @@ describe("Tests for snapshot fetch", () => {
         const versionedValue: IVersionedValueWithEpoch = {
             value: { ...content, cacheEntryTime: Date.now() - cacheExpiryTimeoutMs - 1000 },
             fluidEpoch: "epoch1",
-            version: persistedCacheValueVersion
+            version: persistedCacheValueVersion,
         };
         return versionedValue;
     }
@@ -153,7 +153,7 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl }
+                file: { docId: hashedDocumentId, resolvedUrl },
             };
             await localCache.put(cacheEntry, value);
 
@@ -183,7 +183,7 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl }
+                file: { docId: hashedDocumentId, resolvedUrl },
             };
             await localCache.put(cacheEntry, value);
 
@@ -209,7 +209,7 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl }
+                file: { docId: hashedDocumentId, resolvedUrl },
             };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
 
@@ -228,7 +228,7 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl }
+                file: { docId: hashedDocumentId, resolvedUrl },
             };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
 
@@ -275,7 +275,7 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl }
+                file: { docId: hashedDocumentId, resolvedUrl },
             };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultSummarizerCacheExpiryTimeout));
 
@@ -294,7 +294,7 @@ describe("Tests for snapshot fetch", () => {
             const cacheEntry: ICacheEntry = {
                 key: "",
                 type: "snapshot",
-                file: { docId: hashedDocumentId, resolvedUrl }
+                file: { docId: hashedDocumentId, resolvedUrl },
             };
             await localCache.put(cacheEntry, valueWithExpiredCache(defaultSummarizerCacheExpiryTimeout - 5000));
 

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -10,7 +10,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { stringToBuffer } from "@fluidframework/common-utils";
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser";
 import { convertToCompactSnapshot } from "../compactSnapshotWriter";
-import { ISnapshotContents } from "../odspUtils";
+import { ISnapshotContents } from "../odspPublicUtils";
 import { ISnapshotTreeEx } from "../contracts";
 
 const snapshotTree: ISnapshotTreeEx = {

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -28,35 +28,35 @@ const snapshotTree: ISnapshotTreeEx = {
             trees: {},
         },
         ".app": {
-                blobs: { ".metadata": "bARD4RKvW4LL1KmaUKp6hUMSp" },
-                commits: {},
-                trees: {
-                    ".channels": {
-                        blobs: {},
-                        commits: {},
-                        trees: {
-                            default: {
-                                    blobs: {
-                                        ".component": "bARC6dCXlcrPxQHw3PeROtmKc",
-                                        "gc": "bARDNMoBed+nKrsf04id52iUA",
-                                    },
+            blobs: { ".metadata": "bARD4RKvW4LL1KmaUKp6hUMSp" },
+            commits: {},
+            trees: {
+                ".channels": {
+                    blobs: {},
+                    commits: {},
+                    trees: {
+                        default: {
+                            blobs: {
+                                ".component": "bARC6dCXlcrPxQHw3PeROtmKc",
+                                "gc": "bARDNMoBed+nKrsf04id52iUA",
+                            },
+                            commits: {},
+                            trees: {
+                                ".channels": {
+                                    blobs: {},
                                     commits: {},
                                     trees: {
-                                        ".channels": {
-                                            blobs: {},
-                                            commits: {},
-                                            trees: {
-                                            root: { blobs: {}, commits: {}, trees: {} },
-                                            },
-                                        },
+                                        root: { blobs: {}, commits: {}, trees: {} },
                                     },
+                                },
                             },
                         },
-                        unreferenced: true,
                     },
-                    ".blobs": { blobs: {}, commits: {}, trees: {} },
+                    unreferenced: true,
                 },
-                unreferenced: true,
+                ".blobs": { blobs: {}, commits: {}, trees: {} },
+            },
+            unreferenced: true,
         },
     },
 };
@@ -68,7 +68,7 @@ const blobs = new Map<string, ArrayBuffer>(
         ["bARBkx1nses1pHL1vKnmFUfIC", stringToBuffer(JSON.stringify([]), "utf8")],
         ["bARD4RKvW4LL1KmaUKp6hUMSp", stringToBuffer(JSON.stringify({ summaryFormatVersion: 1, gcFeature: 0 }), "utf8")],
         ["bARC6dCXlcrPxQHw3PeROtmKc",
-        stringToBuffer(JSON.stringify({ pkg: "[\"@fluid-example/smde\"]", summaryFormatVersion: 2, isRootDataStore: true }), "utf8")],
+            stringToBuffer(JSON.stringify({ pkg: "[\"@fluid-example/smde\"]", summaryFormatVersion: 2, isRootDataStore: true }), "utf8")],
         ["bARDNMoBed+nKrsf04id52iUA", stringToBuffer(JSON.stringify(
             { usedRoutes: [""], gcData: { gcNodes: { "/root": ["/default/01b197a2-0432-413b-b2c9-83a992b804c4", "/default"], "/01b197a2-0432-413b-b2c9-83a992b804c4": ["/default"], "/": ["/default/root", "/default/01b197a2-0432-413b-b2c9-83a992b804c4"] } } }), "utf8")],
     ],
@@ -106,6 +106,7 @@ describe("Snapshot Format Conversion Tests", () => {
             blobs,
             ops,
             sequenceNumber: 0,
+            latestSequenceNumber: 0,
         };
         const compactSnapshot = convertToCompactSnapshot(snapshotContents);
         const result = parseCompactSnapshotResponse(compactSnapshot);
@@ -113,6 +114,7 @@ describe("Snapshot Format Conversion Tests", () => {
         assert.deepStrictEqual(result.blobs, blobs, "Blobs content should match");
         assert.deepStrictEqual(result.ops, ops, "Ops should match");
         assert(result.sequenceNumber === 0, "Seq number should match");
+        assert(result.latestSequenceNumber === 0, "Seq number should match");
         assert(result.snapshotTree.id = snapshotContents.snapshotTree.id, "Snapshot id should match");
         // Convert to compact snapshot again and then match to previous one.
         const compactSnapshot2 = convertToCompactSnapshot(result);

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -106,7 +106,7 @@ describe("Snapshot Format Conversion Tests", () => {
             blobs,
             ops,
             sequenceNumber: 0,
-            latestSequenceNumber: 0,
+            latestSequenceNumber: 2,
         };
         const compactSnapshot = convertToCompactSnapshot(snapshotContents);
         const result = parseCompactSnapshotResponse(compactSnapshot);
@@ -114,7 +114,7 @@ describe("Snapshot Format Conversion Tests", () => {
         assert.deepStrictEqual(result.blobs, blobs, "Blobs content should match");
         assert.deepStrictEqual(result.ops, ops, "Ops should match");
         assert(result.sequenceNumber === 0, "Seq number should match");
-        assert(result.latestSequenceNumber === 0, "Seq number should match");
+        assert(result.latestSequenceNumber === 2, "Latest sequence number should match");
         assert(result.snapshotTree.id = snapshotContents.snapshotTree.id, "Snapshot id should match");
         // Convert to compact snapshot again and then match to previous one.
         const compactSnapshot2 = convertToCompactSnapshot(result);


### PR DESCRIPTION
- Expose latest sequence number (lsn) in ISnapshotContents
- Fix version comparison checks - It was comparing strings, which can fail for cases like `"100.0" >= "20.0"` (that returns false)
- Export wire format related methods/interfaces so they can be used externally (ODSP server)
- Misc whitespace/formatting changes