### PR TITLE
refactor: fire event before parsing

### DIFF
--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -64,7 +64,7 @@ export interface IDeltaSender {
 /** Events emitted by the Delta Manager */
 export interface IDeltaManagerEvents extends IEvent {
     (event: "prepareSend", listener: (messageBuffer: any[]) => void);
-    (event: "submitOp", listener: (message: IDocumentMessage) => void);
+    (event: "submitOp" | "beforeParsing", listener: (message: IDocumentMessage) => void);
     (event: "op", listener: (message: ISequencedDocumentMessage, processingTime: number) => void);
     (event: "allSentOpsAckd", listener: () => void);
     (event: "pong" | "processTime", listener: (latency: number) => void);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -757,6 +757,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
             0x0ed /* "non-system message have to have clientId" */,
         );
 
+        // fire event before parsing
+        this.emit("beforeParsing", message);
+
         // TODO Remove after SPO picks up the latest build.
         if (
             typeof message.contents === "string"


### PR DESCRIPTION

Closes #9774

## Description

Added new `beforeParsing` event that will fire before the message is parsed (in `processInboundMessage`)


