### PR TITLE
[r11s] Do not make 413 errors fatal by default

### DIFF
--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -167,6 +167,7 @@ export function createFluidServiceNetworkError(
                 message,
                 false,  /* canRetry */
                 false); /* isFatal */
+        case 413:
         case 422:
             return new NetworkError(
                 statusCode,


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

For specific guidelines for Pull Requests in this repo, visit [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description
We noticed that when the storage service responds to Scribe requests with `413 Payload too large`, our error handling component was setting `isFatal` to `true` by default, causing documents to be marked as corrupted at the Scribe level. However, even though those requests failing with 413 are not retry-able, they are not reason to mark documents as corrupted. This change aims to update our error handling code to allow the default handling of 413 to account for that situation, also allowing the component emitting the 413 to override that through a `NetworkError`-like payload.


