### PR TITLE
Enable eslint for the build-tools project

### DIFF
--- a/tools/build-tools/.eslintrc.js
+++ b/tools/build-tools/.eslintrc.js
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+    "parser": "@typescript-eslint/parser",
+    "plugins": [
+        "@typescript-eslint",
+    ],
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+    ],
+    "parserOptions": {
+        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    },
+    "rules": {
+        "@typescript-eslint/switch-exhaustiveness-check": "error",
+        "@typescript-eslint/no-inferrable-types": "off",
+        "@typescript-eslint/no-var-requires": "off",
+    },
+}

--- a/tools/build-tools/package-lock.json
+++ b/tools/build-tools/package-lock.json
@@ -45,6 +45,40 @@
         "is-negated-glob": "^1.0.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
     "@fluidframework/bundle-size-tools": {
       "version": "0.0.8505",
       "resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.0.8505.tgz",
@@ -62,6 +96,73 @@
           "version": "3.9.10",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
           "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+        }
+      }
+    },
+    "@fluidframework/eslint-config-fluid": {
+      "version": "0.28.2000",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.28.2000.tgz",
+      "integrity": "sha512-/dl2pcSXcNU+5hV9JtbgxOAPDyEPFqy5g2T7B4B3IUBMbgM0lfmlOXUV47tXQW/vtqWtEZZzC9uerpej+pOlpw==",
+      "dev": true,
+      "requires": {
+        "@rushstack/eslint-patch": "~1.1.0",
+        "@rushstack/eslint-plugin": "~0.8.5",
+        "@rushstack/eslint-plugin-security": "~0.2.5",
+        "@typescript-eslint/eslint-plugin": "~5.9.0",
+        "@typescript-eslint/parser": "~5.9.0",
+        "eslint-plugin-editorconfig": "~3.2.0",
+        "eslint-plugin-eslint-comments": "~3.2.0",
+        "eslint-plugin-import": "~2.25.4",
+        "eslint-plugin-promise": "~6.0.0",
+        "eslint-plugin-react": "~7.28.0",
+        "eslint-plugin-tsdoc": "~0.2.14",
+        "eslint-plugin-unicorn": "~40.0.0"
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@microsoft/tsdoc": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
+      "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==",
+      "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
+      "integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.1",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
@@ -241,6 +342,38 @@
         "@octokit/openapi-types": "^11.2.0"
       }
     },
+    "@rushstack/eslint-patch": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
+      "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw==",
+      "dev": true
+    },
+    "@rushstack/eslint-plugin": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-plugin/-/eslint-plugin-0.8.6.tgz",
+      "integrity": "sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==",
+      "dev": true,
+      "requires": {
+        "@rushstack/tree-pattern": "0.2.3",
+        "@typescript-eslint/experimental-utils": "~5.6.0"
+      }
+    },
+    "@rushstack/eslint-plugin-security": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-plugin-security/-/eslint-plugin-security-0.2.6.tgz",
+      "integrity": "sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==",
+      "dev": true,
+      "requires": {
+        "@rushstack/tree-pattern": "0.2.3",
+        "@typescript-eslint/experimental-utils": "~5.6.0"
+      }
+    },
+    "@rushstack/tree-pattern": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/tree-pattern/-/tree-pattern-0.2.3.tgz",
+      "integrity": "sha512-8KWZxzn6XKuy3iKRSAd2CHXSXneRlGCmH9h/qM7jYQDekp+U18oUzub5xqOqHS2PLUC+torOMYZxgAIO/fF86A==",
+      "dev": true
+    },
     "@ts-morph/common": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.5.2.tgz",
@@ -291,6 +424,12 @@
           "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw=="
         }
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.30",
@@ -433,6 +572,258 @@
         }
       }
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
+      "integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/type-utils": "5.9.1",
+        "debug": "^4.3.2",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+          "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.9.1",
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/typescript-estree": "5.9.1",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+          "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+          "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+          "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+          "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.6.0.tgz",
+      "integrity": "sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.6.0",
+        "@typescript-eslint/types": "5.6.0",
+        "@typescript-eslint/typescript-estree": "5.6.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
+      "integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/typescript-estree": "5.9.1",
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+          "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+          "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+          "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+          "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz",
+      "integrity": "sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.6.0",
+        "@typescript-eslint/visitor-keys": "5.6.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
+      "integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "5.9.1",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+          "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.9.1",
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/typescript-estree": "5.9.1",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+          "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+          "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+          "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+          "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.6.0.tgz",
+      "integrity": "sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz",
+      "integrity": "sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.6.0",
+        "@typescript-eslint/visitor-keys": "5.6.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz",
+      "integrity": "sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.6.0",
+        "eslint-visitor-keys": "^3.0.0"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -446,6 +837,18 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true
     },
     "agent-base": {
       "version": "4.3.0",
@@ -511,10 +914,432 @@
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
       "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
     },
+    "array-includes": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.7"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+          "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "regexp.prototype.flags": "^1.4.3",
+            "string.prototype.trimend": "^1.0.5",
+            "string.prototype.trimstart": "^1.0.5",
+            "unbox-primitive": "^1.0.2"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        },
+        "is-negative-zero": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+          "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+          "dev": true
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-weakref": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+          "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        }
+      }
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+    },
+    "array.prototype.flat": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+          "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "regexp.prototype.flags": "^1.4.3",
+            "string.prototype.trimend": "^1.0.5",
+            "string.prototype.trimstart": "^1.0.5",
+            "unbox-primitive": "^1.0.2"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        },
+        "is-negative-zero": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+          "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+          "dev": true
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-weakref": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+          "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        }
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+          "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "regexp.prototype.flags": "^1.4.3",
+            "string.prototype.trimend": "^1.0.5",
+            "string.prototype.trimstart": "^1.0.5",
+            "unbox-primitive": "^1.0.2"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        },
+        "is-negative-zero": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+          "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+          "dev": true
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-weakref": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+          "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        }
+      }
     },
     "arrify": {
       "version": "2.0.1",
@@ -623,6 +1448,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true
+    },
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
@@ -681,6 +1512,21 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
+      }
+    },
+    "ci-info": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
+      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "dev": true
+    },
+    "clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "cliui": {
@@ -860,6 +1706,12 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -902,12 +1754,63 @@
         "path-type": "^4.0.0"
       }
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {
@@ -921,6 +1824,15 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
       }
     },
     "error-ex": {
@@ -956,6 +1868,15 @@
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
         "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "es-to-primitive": {
@@ -995,6 +1916,549 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "eslint": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
+      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "dev": true,
+      "requires": {
+        "@eslint/eslintrc": "^1.0.5",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.3.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-editorconfig": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-editorconfig/-/eslint-plugin-editorconfig-3.2.0.tgz",
+      "integrity": "sha512-XiUg69+qgv6BekkPCjP8+2DMODzPqtLV5i0Q9FO1v40P62pfodG1vjIihVbw/338hS5W26S+8MTtXaAlrg37QQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "editorconfig": "^0.15.0",
+        "eslint": "^8.0.1",
+        "klona": "^2.0.4"
+      }
+    },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.25.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
+      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.2",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.5",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.12.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
+      "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
+      "integrity": "sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.0.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.7.2",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.6"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "is-core-module": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+          "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-tsdoc": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.16.tgz",
+      "integrity": "sha512-F/RWMnyDQuGlg82vQEFHQtGyWi7++XJKdYNn0ulIbyMOFqYIjoJOUdE6olORxgwgLkpJxsCJpJbTHgxJ/ggfXw==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc-config": "0.16.1"
+      }
+    },
+    "eslint-plugin-unicorn": {
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-40.0.0.tgz",
+      "integrity": "sha512-5GRXISfBk8jMmYk1eeNDw8zSRnWTxBjWkzx2Prre6E2/yLu2twozZ3EomLWCBu9nWms/ZE361BItyMQwfnG1qA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "ci-info": "^3.3.0",
+        "clean-regexp": "^1.0.0",
+        "eslint-utils": "^3.0.0",
+        "esquery": "^1.4.0",
+        "indent-string": "^4.0.0",
+        "is-builtin-module": "^3.1.0",
+        "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.24",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.3.5",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "event-lite": {
       "version": "0.1.2",
@@ -1063,12 +2527,27 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
       "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
       }
     },
     "fill-range": {
@@ -1097,6 +2576,33 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "foreach": {
@@ -1146,6 +2652,30 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1234,6 +2764,58 @@
         "is-glob": "^4.0.1"
       }
     },
+    "globals": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
@@ -1261,6 +2843,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -1379,6 +2970,12 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1475,6 +3072,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0"
       }
     },
     "is-callable": {
@@ -1662,6 +3268,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1685,6 +3297,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "json5": {
       "version": "2.2.0",
@@ -1737,6 +3355,16 @@
         }
       }
     },
+    "jsx-ast-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.0.tgz",
+      "integrity": "sha512-XzO9luP6L0xkxwhIJMTJQpZo/eeN60K08jHdexfD569AGxeNug6UketeHXEhROoM8aR7EcUoOQmIhcJQjcuq8Q==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.4",
+        "object.assign": "^4.1.2"
+      }
+    },
     "jszip": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
@@ -1772,6 +3400,12 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
+    "klona": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+      "dev": true
+    },
     "ky": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.12.0.tgz",
@@ -1784,6 +3418,16 @@
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "li": {
@@ -1811,6 +3455,12 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.find": {
       "version": "4.6.0",
@@ -1961,6 +3611,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lru-cache": {
@@ -2252,6 +3911,12 @@
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -2408,6 +4073,12 @@
         "path-key": "^2.0.0"
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
@@ -2438,6 +4109,168 @@
         "object-keys": "^1.1.1"
       }
     },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+          "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "regexp.prototype.flags": "^1.4.3",
+            "string.prototype.trimend": "^1.0.5",
+            "string.prototype.trimstart": "^1.0.5",
+            "unbox-primitive": "^1.0.2"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        },
+        "is-negative-zero": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+          "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+          "dev": true
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-weakref": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+          "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+          "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+          "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.19.5"
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        }
+      }
+    },
+    "object.values": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
     "octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
@@ -2449,6 +4282,20 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "os-name": {
@@ -2591,6 +4438,18 @@
         "irregular-plurals": "^3.2.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
     "prettyjson": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
@@ -2604,6 +4463,29 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -2656,6 +4538,12 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -2769,6 +4657,29 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "regexp-tree": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "dev": true
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
     },
     "replace-in-file": {
       "version": "6.3.2",
@@ -2915,6 +4826,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "requires": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2969,6 +4889,12 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.6",
@@ -3069,6 +4995,30 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        }
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
@@ -3109,6 +5059,12 @@
       "requires": {
         "ansi-regex": "^5.0.1"
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -3157,6 +5113,12 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3185,10 +5147,63 @@
         "code-block-writer": "^10.1.0"
       }
     },
+    "tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/json5": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+          "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
     },
     "type-fest": {
       "version": "2.12.0",
@@ -3305,6 +5320,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -3376,6 +5397,12 @@
       "requires": {
         "execa": "^1.0.0"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "workerpool": {
       "version": "6.2.1",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -26,8 +26,12 @@
     "build": "tsc -b && npm run build:test",
     "build:test": "tsc --project ./src/test/tsconfig.json",
     "debug:layer-check": "node --inspect-brk dist/layerCheck/layerCheck.js --root ../..",
+    "eslint": "eslint --format stylish src",
+    "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "layer-check": "node dist/layerCheck/layerCheck.js --root ../..",
     "layer-check:doc": "node dist/layerCheck/layerCheck.js --root ../.. --md",
+    "lint": "npm run eslint",
+    "lint:fix": "npm run eslint:fix",
     "list-repo-files": "cd ../.. && git ls-files -co --exclude-standard",
     "policy-check": "cd ../.. && node tools/build-tools/dist/repoPolicyCheck/repoPolicyCheck.js",
     "policy-check:debug": "cd ../.. && node --inspect-brk tools/build-tools/dist/repoPolicyCheck/repoPolicyCheck.js ",
@@ -57,6 +61,7 @@
     "ts-morph": "^7.1.2"
   },
   "devDependencies": {
+    "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@types/async": "^3.2.6",
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1",
@@ -70,6 +75,13 @@
     "@types/semver": "^7.1.0",
     "@types/shelljs": "^0.8.8",
     "@types/webpack": "^4.41.22",
+    "@typescript-eslint/eslint-plugin": "~5.9.0",
+    "@typescript-eslint/parser": "~5.9.0",
+    "eslint": "~8.6.0",
+    "eslint-plugin-eslint-comments": "~3.2.0",
+    "eslint-plugin-import": "~2.25.4",
+    "eslint-plugin-unicorn": "~40.0.0",
+    "eslint-plugin-unused-imports": "~2.0.0",
     "mocha": "^10.0.0",
     "typescript": "~4.5.5"
   }

--- a/tools/build-tools/src/buildVersion/buildVersion.ts
+++ b/tools/build-tools/src/buildVersion/buildVersion.ts
@@ -122,7 +122,7 @@ function getVersions(prefix: TagPrefix) {
  */
 export function getVersionsFromStrings(prefix: TagPrefix, tags: string[]) {
     const filtered = filterTags(prefix, tags);
-    let versions = filtered.map((tag) => tag.substring(`${prefix}_v`.length));
+    const versions = filtered.map((tag) => tag.substring(`${prefix}_v`.length));
     sort_semver(versions);
     return versions;
 }

--- a/tools/build-tools/src/bumpVersion/bumpDependencies.ts
+++ b/tools/build-tools/src/bumpVersion/bumpDependencies.ts
@@ -68,7 +68,7 @@ async function bumpDependenciesCore(
             }
         }
 
-        let changedVersionString: string[] = [];
+        const changedVersionString: string[] = [];
         for (const [name, version] of changedVersion) {
             changedVersionString.push(`${name.padStart(40)} -> ${version}`);
         }

--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -35,7 +35,7 @@ export async function bumpVersion(context: Context, bump: string[], version: Ver
 
     let clientNeedBump = false;
     let serverNeedBump = false;
-    let packageNeedBump = new Set<Package>();
+    const packageNeedBump = new Set<Package>();
     for (const name of bump) {
         if (name === MonoRepoKind[MonoRepoKind.Client]) {
             clientNeedBump = true;

--- a/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
@@ -61,7 +61,7 @@ function parseNameVersion(arg: string | undefined) {
 
     const split = name.split("=");
     name = split[0];
-    let v = split[1];
+    const v = split[1];
 
     if (name.toLowerCase() === MonoRepoKind[MonoRepoKind.Client].toLowerCase()) {
         name = MonoRepoKind[MonoRepoKind.Client];

--- a/tools/build-tools/src/bumpVersion/context.ts
+++ b/tools/build-tools/src/bumpVersion/context.ts
@@ -98,6 +98,7 @@ export class Context {
         }
 
         const publishedPackageDependenciesPromises: Promise<void>[] = [];
+        // eslint-disable-next-line no-constant-condition
         while (true) {
             const pkg = pendingDepCheck.pop();
             if (!pkg) {
@@ -123,7 +124,7 @@ export class Context {
                         }
                         continue;
                     }
-                    let depVersion = depBuildPackage.version;
+                    const depVersion = depBuildPackage.version;
                     const reference = `${pkg.name}@local`;
                     // Check if the version in the repo is compatible with the version described in the dependency.
 
@@ -175,4 +176,4 @@ export class Context {
             await this.gitRepo.deleteTag(tag);
         }
     }
-};
+}

--- a/tools/build-tools/src/bumpVersion/releaseVersion.ts
+++ b/tools/build-tools/src/bumpVersion/releaseVersion.ts
@@ -52,7 +52,7 @@ export async function releaseVersion(context: Context, releaseName: string, upda
     const depVersions = await context.collectBumpInfo(releaseName);
 
     let releaseGroup: string | undefined;
-    let packages: Package[] = [];
+    const packages: Package[] = [];
     let monoRepo: MonoRepo | undefined;
     // Assumes that the packages are in dependency order already.
     for (const [name] of depVersions.repoVersions) {

--- a/tools/build-tools/src/bumpVersion/versionBag.ts
+++ b/tools/build-tools/src/bumpVersion/versionBag.ts
@@ -31,7 +31,7 @@ export class VersionBag {
         }
     }
     public get(pkgOrMonoRepoName: Package | string) {
-        let entryName = typeof pkgOrMonoRepoName === "string" ? pkgOrMonoRepoName : VersionBag.getEntryName(pkgOrMonoRepoName);
+        const entryName = typeof pkgOrMonoRepoName === "string" ? pkgOrMonoRepoName : VersionBag.getEntryName(pkgOrMonoRepoName);
         return this.versionData[entryName];
     }
     public [Symbol.iterator]() {

--- a/tools/build-tools/src/common/commonOptions.ts
+++ b/tools/build-tools/src/common/commonOptions.ts
@@ -9,7 +9,7 @@ interface CommonOptions {
     timer: boolean;
     logtime: boolean;
     verbose: boolean;
-};
+}
 
 export const commonOptions : CommonOptions = {
     defaultRoot: process.env["_FLUID_DEFAULT_ROOT_"],

--- a/tools/build-tools/src/common/fileHashCache.ts
+++ b/tools/build-tools/src/common/fileHashCache.ts
@@ -25,4 +25,4 @@ export class FileHashCache {
     public clear() {
         this.fileHashCache.clear();
     }
-};
+}

--- a/tools/build-tools/src/common/fluidRepo.ts
+++ b/tools/build-tools/src/common/fluidRepo.ts
@@ -126,4 +126,4 @@ export class FluidRepo {
         }
         return FluidRepo.ensureInstalled(this.packages.packages);
     }
-};
+}

--- a/tools/build-tools/src/common/fluidUtils.ts
+++ b/tools/build-tools/src/common/fluidUtils.ts
@@ -52,6 +52,7 @@ async function inferRoot() {
             if (await isFluidRoot(curr)) {
                 return true;
             }
+        // eslint-disable-next-line no-empty
         } catch {
         }
         return false;

--- a/tools/build-tools/src/common/monoRepo.ts
+++ b/tools/build-tools/src/common/monoRepo.ts
@@ -11,7 +11,7 @@ export enum MonoRepoKind {
     Client,
     Server,
     Azure,
-};
+}
 
 export class MonoRepo {
     public readonly packages: Package[] = [];
@@ -46,4 +46,4 @@ export class MonoRepo {
     public async uninstall() {
         return rimrafWithErrorAsync(this.getNodeModulePath(), this.repoPath);
     }
-};
+}

--- a/tools/build-tools/src/common/npmPackage.ts
+++ b/tools/build-tools/src/common/npmPackage.ts
@@ -69,7 +69,7 @@ interface IPackage {
             }
         }
     };
-};
+}
 
 export class Package {
     private static packageCount: number = 0;
@@ -223,13 +223,13 @@ export class Package {
         const installScript = "npm i";
         return execWithErrorAsync(installScript, { cwd: this.directory }, this.directory);
     }
-};
+}
 
 interface TaskExec<TItem, TResult> {
     item: TItem;
     resolve: (result: TResult) => void;
     reject: (reason?: any) => void;
-};
+}
 
 async function queueExec<TItem, TResult>(items: Iterable<TItem>, exec: (item: TItem) => Promise<TResult>, messageCallback?: (item: TItem) => string) {
     let numDone = 0;
@@ -286,7 +286,7 @@ export class Packages {
     }
 
     public async forEachAsync<TResult>(exec: (pkg: Package) => Promise<TResult>, parallel: boolean, message?: string) {
-        if (parallel) { return this.queueExecOnAllPackageCore(exec, message) };
+        if (parallel) { return this.queueExecOnAllPackageCore(exec, message) }
 
         const results: TResult[] = [];
         for (const pkg of this.packages) {
@@ -316,7 +316,7 @@ export class Packages {
             if (cleanScript) {
                 cleanP.push(execCleanScript(pkg, cleanScript));
             }
-        };
+        }
         const results = await Promise.all(cleanP);
         return !results.some(result => result.error);
     }

--- a/tools/build-tools/src/common/utils.ts
+++ b/tools/build-tools/src/common/utils.ts
@@ -98,6 +98,7 @@ function printExecError(ret: ExecAsyncResult, command: string, errorPrefix: stri
 
 export function resolveNodeModule(basePath: string, lookupPath: string) {
     let currentBasePath = basePath;
+    // eslint-disable-next-line no-constant-condition
     while (true) {
         const tryPath = path.join(currentBasePath, "node_modules", lookupPath);
         if (existsSync(tryPath)) {
@@ -124,6 +125,7 @@ export function readJsonSync(filename: string) {
 
 export async function lookUpDirAsync(dir: string, callback: (currentDir: string) => Promise<boolean>) {
     let curr = path.resolve(dir);
+    // eslint-disable-next-line no-constant-condition
     while (true) {
         if (await callback(curr)) {
             return curr;
@@ -141,6 +143,7 @@ export async function lookUpDirAsync(dir: string, callback: (currentDir: string)
 
 export function lookUpDirSync(dir: string, callback: (currentDir: string) => boolean) {
     let curr = path.resolve(dir);
+    // eslint-disable-next-line no-constant-condition
     while (true) {
         if (callback(curr)) {
             return curr;

--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -19,7 +19,7 @@ export enum BuildResult {
     Success,
     UpToDate,
     Failed,
-};
+}
 
 export function summarizeBuildResult(results: BuildResult[]) {
     let retResult = BuildResult.UpToDate;
@@ -40,14 +40,14 @@ class TaskStats {
     public leafUpToDateCount = 0;
     public leafBuiltCount = 0;
     public leafExecTimeTotal = 0;
-};
+}
 
 class BuildContext {
     public readonly fileHashCache = new FileHashCache();
     public readonly taskStats = new TaskStats();
     public readonly failedTaskLines: string[] = [];
     constructor(public readonly workerPool?: WorkerPool) { }
-};
+}
 
 export class BuildPackage {
     private buildTask?: Task | null = null;
@@ -127,7 +127,7 @@ export class BuildGraph {
             if (!await buildPackage.pkg.checkInstall()) {
                 succeeded = false;
             }
-        };
+        }
         return succeeded;
     }
 
@@ -233,6 +233,7 @@ export class BuildGraph {
     }
 
     private propagateMarkForBuild(needPropagate: BuildPackage[]) {
+        // eslint-disable-next-line no-constant-condition
         while (true) {
             const node = needPropagate.pop();
             if (!node) {

--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -606,8 +606,7 @@ export class FluidPackageCheck {
     }
     private static async checkOneTestDir(pkg: Package, fix: boolean, subDir: string) {
         const configFile = path.join(this.getTestBaseDir(pkg), subDir, "tsconfig.json");
-        let configJson;
-        configJson = TscUtils.readConfigFile(configFile);
+        const configJson = TscUtils.readConfigFile(configFile);
         if (!configJson) {
             this.logWarn(pkg, `Unable to read ${configFile}`, false);
             return;
@@ -705,6 +704,7 @@ export class FluidPackageCheck {
 
         // Only split test build if there is some ts files in the test directory
         const dirs = [maybeTestDir];
+        // eslint-disable-next-line no-constant-condition
         while (true) {
             const dir = dirs.pop();
             if (!dir) {
@@ -724,4 +724,4 @@ export class FluidPackageCheck {
             dirs.push(...files.filter((dirent) => dirent.isDirectory()).map((dirent) => path.join(dir, dirent.name)));
         }
     }
-};
+}

--- a/tools/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/tools/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -21,7 +21,7 @@ export interface IPackageMatchedOptions {
     server: boolean;
     azure: boolean;
     dirs: string[];
-};
+}
 
 export class FluidRepoBuild extends FluidRepo {
     constructor(resolvedRoot: string, services: boolean) {
@@ -40,7 +40,7 @@ export class FluidRepoBuild extends FluidRepo {
 
         const r = await Promise.all([cleanPackageNodeModules, removePromise]);
         return r[0] && !r[1].some(ret => ret?.error);
-    };
+    }
 
     public setMatched(options: IPackageMatchedOptions) {
         const hasMatchArgs = options.match.length || options.dirs.length;
@@ -143,5 +143,5 @@ export class FluidRepoBuild extends FluidRepo {
         });
         return matched;
     }
-};
+}
 

--- a/tools/build-tools/src/fluidBuild/npmDepChecker.ts
+++ b/tools/build-tools/src/fluidBuild/npmDepChecker.ts
@@ -14,7 +14,7 @@ interface DepCheckRecord {
     peerImport?: RegExp,
     peerDeclare?: RegExp,
     found: boolean,
-};
+}
 
 export class NpmDepChecker {
     private readonly foundTypes: string[] = ["@types/node", "@types/expect-puppeteer", "@types/jest-environment-puppeteer"];
@@ -127,7 +127,7 @@ export class NpmDepChecker {
 
     private dupCheck() {
         if (!this.pkg.packageJson.devDependencies || !this.pkg.packageJson.dependencies) {
-            return false;;
+            return false;
         }
         let changed = false;
         for (const name of Object.keys(this.pkg.packageJson.dependencies)) {
@@ -139,4 +139,4 @@ export class NpmDepChecker {
         }
         return changed;
     }
-};
+}

--- a/tools/build-tools/src/fluidBuild/symlinkUtils.ts
+++ b/tools/build-tools/src/fluidBuild/symlinkUtils.ts
@@ -95,7 +95,7 @@ async function fixSymlink(stat: fs.Stats | undefined, symlinkPath: string, pkg: 
     await symlinkAsync(depBuildPackage.directory, symlinkPath, "junction");
 
     if (depBuildPackage.packageJson.bin) {
-        for (var name of Object.keys(depBuildPackage.packageJson.bin)) {
+        for (const name of Object.keys(depBuildPackage.packageJson.bin)) {
             await writeBin(pkg.directory, name, depBuildPackage.name, depBuildPackage.packageJson.bin[name]);
         }
     }
@@ -113,7 +113,7 @@ async function revertSymlink(symlinkPath: string, pkg: Package, depBuildPackage:
     }
 
     if (depBuildPackage.packageJson.bin) {
-        for (var name of Object.keys(depBuildPackage.packageJson.bin)) {
+        for (const name of Object.keys(depBuildPackage.packageJson.bin)) {
             await revertBin(pkg.directory, name);
         }
     }
@@ -122,7 +122,7 @@ async function revertSymlink(symlinkPath: string, pkg: Package, depBuildPackage:
 export interface ISymlinkOptions {
     symlink: boolean;
     fullSymlink: boolean | undefined;
-};
+}
 
 export async function symlinkPackage(repo: FluidRepoBuild, pkg: Package, buildPackages: Map<string, Package>, options: ISymlinkOptions) {
     let count = 0;

--- a/tools/build-tools/src/fluidBuild/tasks/concurrentNpmTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/concurrentNpmTask.ts
@@ -11,7 +11,7 @@ import { BuildResult, BuildPackage } from "../buildGraph";
 export class ConcurrentNPMTask extends NPMTask {
     constructor(node: BuildPackage, command: string, tasks: Task[]) {
         super(node, command, tasks);
-    };
+    }
 
     protected async runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult> {
         this.logVerboseTask(`Begin Concurrent Child Tasks`);

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/apiExtractorTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/apiExtractorTask.ts
@@ -13,4 +13,4 @@ export class ApiExtractorTask extends TscDependentTask {
     protected get configFileFullPath() {
         return this.getPackageFileFullPath("api-extractor.json");
     }
-};
+}

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -279,6 +279,7 @@ export abstract class LeafTask extends Task {
     protected get recheckLeafIsUpToDate(): boolean { return false; }
 
     // For called when the task has successfully executed
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     protected async markExecDone(): Promise<void> { }
 
     protected getVsCodeErrorMessages(errorMessages: string) { return errorMessages; }
@@ -309,7 +310,7 @@ export abstract class LeafTask extends Task {
 
         // TODO: we should add all the prefix tasks in the task tree of the current package as well.
     }
-};
+}
 
 export abstract class LeafWithDoneFileTask extends LeafTask {
     protected get doneFileFullPath() {
@@ -337,7 +338,7 @@ export abstract class LeafWithDoneFileTask extends LeafTask {
     protected async markExecDone() {
         const doneFileFullPath = this.doneFileFullPath;
         try {
-            let content = await this.getDoneFileContent();
+            const content = await this.getDoneFileContent();
             if (content !== undefined) {
                 await writeFileAsync(doneFileFullPath, content);
             } else {

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
@@ -19,7 +19,7 @@ abstract class LintBaseTask extends TscDependentTask {
         }
         super.addDependentTasks(dependentTasks);
     }
-};
+}
 
 export class TsLintTask extends LintBaseTask {
     protected get doneFile() {

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
+* Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+* Licensed under the MIT License.
+*/
 
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
 import { toPosixPath, globFn, unquote, statAsync, readFileAsync } from "../../../common/utils";
@@ -9,6 +9,8 @@ import { logVerbose } from "../../../common/logging";
 import { ScriptDependencies } from "../../../common/npmPackage";
 import * as path from "path";
 import { BuildPackage } from "../../buildGraph";
+
+/* eslint-disable @typescript-eslint/no-empty-function */
 
 export class EchoTask extends LeafTask {
     protected addDependentTasks(dependentTasks: LeafTask[]) { }
@@ -39,7 +41,7 @@ export class LesscTask extends LeafTask {
             this.logVerboseTrigger("failed to get file stats");
             return false;
         }
-    };
+    }
 }
 
 export class CopyfilesTask extends LeafTask {
@@ -144,13 +146,14 @@ export class GenVerTask extends LeafTask {
         try {
             const file = path.join(this.node.pkg.directory, "src/packageVersion.ts");
             const content = await readFileAsync(file, "utf8");
-            const match = content.match(/.*\nexport const pkgName = \"(.*)\";[\n\r]*export const pkgVersion = \"([0-9.]+)\";.*/m);
+            const match = content.match(/.*\nexport const pkgName = "(.*)";[\n\r]*export const pkgVersion = "([0-9.]+)";.*/m);
             return (match !== null && this.node.pkg.name === match[1] && this.node.pkg.version === match[2]);
+        // eslint-disable-next-line no-empty
         } catch {
         }
         return false;
     }
-};
+}
 
 export abstract class PackageJsonChangedTask extends LeafWithDoneFileTask {
     protected get doneFile(): string {

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -148,10 +148,9 @@ export class GenVerTask extends LeafTask {
             const content = await readFileAsync(file, "utf8");
             const match = content.match(/.*\nexport const pkgName = "(.*)";[\n\r]*export const pkgVersion = "([0-9.]+)";.*/m);
             return (match !== null && this.node.pkg.name === match[1] && this.node.pkg.version === match[2]);
-        // eslint-disable-next-line no-empty
         } catch {
+            return false;
         }
-        return false;
     }
 }
 

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -1,7 +1,7 @@
 /*!
-* Copyright (c) Microsoft Corporation and contributors. All rights reserved.
-* Licensed under the MIT License.
-*/
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
 
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
 import { toPosixPath, globFn, unquote, statAsync, readFileAsync } from "../../../common/utils";

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -24,7 +24,7 @@ interface ITsBuildInfo {
 
 interface TscTaskMatchOptions {
     tsConfig?: string;
-};
+}
 
 export class TscTask extends LeafTask {
     private _tsBuildInfoFullPath: string | undefined;
@@ -161,7 +161,7 @@ export class TscTask extends LeafTask {
         }
 
         const configFileFullPath = this.configFileFullPath;
-        if (!configFileFullPath) { assert.fail(); };
+        if (!configFileFullPath) { assert.fail(); }
 
         // Patch relative path based on the file directory where the config comes from
         const configOptions = TscUtils.filterIncrementalOptions(
@@ -336,7 +336,7 @@ export class TscTask extends LeafTask {
             && (parsed.fileNames.length === 0 || parsed.options.project === undefined)
             && !parsed.watchOptions;
     }
-};
+}
 
 // Base class for tasks that are dependent on a tsc compile
 export abstract class TscDependentTask extends LeafWithDoneFileTask {
@@ -391,4 +391,4 @@ export abstract class TscDependentTask extends LeafWithDoneFileTask {
     }
 
     protected abstract get configFileFullPath(): string;
-};
+}

--- a/tools/build-tools/src/fluidBuild/tasks/npmTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/npmTask.ts
@@ -11,7 +11,7 @@ import { BuildResult, BuildPackage } from "../buildGraph";
 export class NPMTask extends Task {
     constructor(node: BuildPackage, command: string, protected readonly subTasks: Task[]) {
         super(node, command);
-    };
+    }
 
     public initializeDependentTask() {
         for (const task of this.subTasks) {
@@ -69,4 +69,4 @@ export class NPMTask extends Task {
     protected logVerboseTask(msg: string) {
         logVerbose(`Task: ${this.node.pkg.nameColored} ${this.command}: ${msg}`);
     }
-};
+}

--- a/tools/build-tools/src/fluidBuild/tasks/task.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/task.ts
@@ -14,7 +14,7 @@ import { options } from "../options";
 export interface TaskExec {
     task: LeafTask;
     resolve: (value: BuildResult) => void;
-};
+}
 
 export abstract class Task {
     public static createTaskQueue(): AsyncPriorityQueue<TaskExec> {
@@ -67,4 +67,4 @@ export abstract class Task {
     public get forced() {
         return options.force && (options.matchedOnly !== true || this.package.matched);
     }
-};
+}

--- a/tools/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -90,4 +90,4 @@ export class TaskFactory {
         const tasks = scripts.map(value => TaskFactory.Create(node, `npm run ${value}`, {}));
         return tasks.length == 1 ? tasks[0] : new NPMTask(node, `npm run ${scripts.map(name => `npm run ${name}`).join(" && ")}`, tasks);
     }
-};
+}

--- a/tools/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -21,8 +21,8 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
         const messages: string[] = [];
         diagnostics.forEach(diagnostic => {
             if (diagnostic.file) {
-                let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
-                let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+                const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
+                const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
                 messages.push(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
             } else {
                 messages.push(ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
@@ -32,7 +32,7 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
     }
 
     let commandLine = TscUtils.parseCommandLine(command);
-    let diagnostics: Diagnostic[] = [];
+    const diagnostics: Diagnostic[] = [];
 
     if (commandLine) {
         const configFileName = TscUtils.findConfigFile(cwd, commandLine);

--- a/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
@@ -11,7 +11,7 @@ export interface WorkerMessage {
     workerName: string,
     command: string,
     cwd: string,
-};
+}
 
 export interface WorkerExecResult {
     code: number,

--- a/tools/build-tools/src/fluidBuild/tscUtils.ts
+++ b/tools/build-tools/src/fluidBuild/tscUtils.ts
@@ -153,4 +153,4 @@ export function getTscUtil(tsLib: typeof ts) {
         },
         convertToOptionsWithAbsolutePath,
     }
-};
+}

--- a/tools/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
+++ b/tools/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
@@ -229,7 +229,7 @@ async function main() {
     } else if (kind === MonoRepoKind.Azure && repo.azureMonoRepo) {
         await generateMonoRepoInstallPackageJson(repo.azureMonoRepo);
     }
-};
+}
 
 main().catch(error => {
     console.error("ERROR: Unexpected error");

--- a/tools/build-tools/src/layerCheck/layerGraph.ts
+++ b/tools/build-tools/src/layerCheck/layerGraph.ts
@@ -16,7 +16,7 @@ interface ILayerInfo {
     dev?: true;
     dot?: false;
     dotSameRank?: true;
-};
+}
 
 interface ILayerGroupInfo {
     dot?: false;
@@ -27,7 +27,7 @@ interface ILayerGroupInfo {
 
 interface ILayerInfoFile {
     [key: string]: ILayerGroupInfo
-};
+}
 
 class BaseNode {
     constructor(public readonly name: string) { }
@@ -35,7 +35,7 @@ class BaseNode {
     public get dotName() {
         return this.name.replace(/-/g, "_").toLowerCase();
     }
-};
+}
 
 class LayerNode extends BaseNode {
     public packages = new Set<PackageNode>();
@@ -121,7 +121,7 @@ class LayerNode extends BaseNode {
         }
         return false;
     }
-};
+}
 
 /** Used for traversing the layer dependency graph */
 type LayerDependencyNode = { node: LayerNode, orderedChildren: LayerNode[] };
@@ -166,7 +166,7 @@ class GroupNode extends BaseNode {
     ${subGraphs}
   }`;
     }
-};
+}
 
 class PackageNode extends BaseNode {
     private _pkg: Package | undefined;
@@ -245,7 +245,7 @@ class PackageNode extends BaseNode {
         }
         return this._level;
     }
-};
+}
 
 export class LayerGraph {
     private groupNodes: GroupNode[] = [];
@@ -525,4 +525,4 @@ ${lines.join(newline)}
         const layerInfoFile = require(info ?? path.join(__dirname, "..", "..", "data", "layerInfo.json"));
         return new LayerGraph(root, layerInfoFile, packages);
     }
-};
+}

--- a/tools/build-tools/src/repoPolicyCheck/common.ts
+++ b/tools/build-tools/src/repoPolicyCheck/common.ts
@@ -16,7 +16,7 @@ export interface Handler {
   handler: (file: string, root: string) => string | undefined,
   resolver?: (file: string, root: string) => { resolved: boolean, message?: string };
   final?: (root: string, resolve: boolean) => { error?: string } | undefined;
-};
+}
 
 export function readFile(file: string) {
   return fs.readFileSync(file, { encoding: "utf8" });

--- a/tools/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
@@ -13,14 +13,14 @@ import {
 } from "ts-morph";
 import fs from "fs";
 import path from "path";
-import {Handler} from "../common";
+import { Handler } from "../common";
 
 const shortCodes = new Map<number, Node>();
 const newAssetFiles = new Set<SourceFile>();
 const codeToMsgMap = new Map<string, string>();
 let maxShortCode = -1;
 
-function getCallsiteString(msg: Node){
+function getCallsiteString(msg: Node) {
     return `${msg.getSourceFile().getFilePath()}@${msg.getStartLineNumber()}`
 }
 
@@ -30,15 +30,15 @@ function getCallsiteString(msg: Node){
  * @param sourceFile - The file to get the assert message parameters for.
  * @returns - an array of all the assert message parameters
  */
-function getAssertMessageParams(sourceFile: SourceFile): (StringLiteralLike | NumericLiteral)[]{
+function getAssertMessageParams(sourceFile: SourceFile): (StringLiteralLike | NumericLiteral)[] {
     const calls = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
-    const messageArgs:(StringLiteralLike | NumericLiteral)[] = []
-    for(const call of calls){
-        if(call.getExpression().getText() === "assert"){
+    const messageArgs: (StringLiteralLike | NumericLiteral)[] = []
+    for (const call of calls) {
+        if (call.getExpression().getText() === "assert") {
             const args = call.getArguments();
-            if(args.length >=1 && args[1] !== undefined){
+            if (args.length >= 1 && args[1] !== undefined) {
                 const kind = args[1].getKind();
-                switch(kind){
+                switch (kind) {
                     case SyntaxKind.StringLiteral:
                     case SyntaxKind.NumericLiteral:
                     case SyntaxKind.NoSubstitutionTemplateLiteral:
@@ -46,7 +46,7 @@ function getAssertMessageParams(sourceFile: SourceFile): (StringLiteralLike | Nu
                         break;
                     case SyntaxKind.TemplateExpression:
                         throw new Error(`Template expressions are not supported in assertions (they'll be replaced by a short code anyway). ` +
-                                        `Use a string literal instead.\n${getCallsiteString(args[1])}`);
+                            `Use a string literal instead.\n${getCallsiteString(args[1])}`);
                     case SyntaxKind.BinaryExpression:
                     case SyntaxKind.CallExpression:
                         break;
@@ -63,7 +63,7 @@ export const handler: Handler = {
     name: "assert-short-codes",
     match: /^(packages|(common\/lib\/common-utils)|(server\/routerlicious\/packages\/protocol-base)).*\/tsconfig\.json/i,
     handler: (tsconfigPath) => {
-        if(tsconfigPath.includes("test")){
+        if (tsconfigPath.includes("test")) {
             return;
         }
         // load the project based on the tsconfig
@@ -72,19 +72,19 @@ export const handler: Handler = {
             tsConfigFilePath: tsconfigPath,
         });
         // walk all the files in the project
-        for(const sourceFile of project.getSourceFiles()){
+        for (const sourceFile of project.getSourceFiles()) {
             // walk the assert message params in the file
-            for(const msg of getAssertMessageParams(sourceFile)){
+            for (const msg of getAssertMessageParams(sourceFile)) {
                 const nodeKind = msg.getKind();
-                switch(nodeKind) {
+                switch (nodeKind) {
                     // If it's a number, validate it's a shortcode
-                    case SyntaxKind.NumericLiteral:
+                    case SyntaxKind.NumericLiteral: {
                         const numLit = msg as NumericLiteral;
-                        if(!numLit.getText().startsWith("0x")){
+                        if (!numLit.getText().startsWith("0x")) {
                             return `Shortcodes must be provided by automation and be in hex format: ${numLit.getText()}\n\t${getCallsiteString(numLit)}`;
                         }
                         const numLitValue = numLit.getLiteralValue();
-                        if(shortCodes.has(numLitValue)){
+                        if (shortCodes.has(numLitValue)) {
                             // if we find two usages of the same short code then fail
                             return `Duplicate shortcode 0x${numLitValue.toString(16)} detected\n\t${getCallsiteString(shortCodes.get(numLitValue)!)}\n\t${getCallsiteString(numLit)}`;
                         }
@@ -95,13 +95,14 @@ export const handler: Handler = {
                         // If comment already exists, extract it for the mapping file
                         const comments = msg.getTrailingCommentRanges();
                         if (comments.length > 0) {
-                            let originalErrorText = comments[0].getText().replace(/\/\*/g,'').replace(/\*\//g,'').trim();
+                            let originalErrorText = comments[0].getText().replace(/\/\*/g, '').replace(/\*\//g, '').trim();
                             if (originalErrorText.startsWith("\"") || originalErrorText.startsWith("`")) {
                                 originalErrorText = originalErrorText.substring(1, originalErrorText.length - 1)
                             }
                             codeToMsgMap.set(numLit.getText(), originalErrorText);
                         }
                         break;
+                    }
                     // If it's a simple string literal, track the file for replacements later
                     case SyntaxKind.StringLiteral:
                     case SyntaxKind.NoSubstitutionTemplateLiteral:
@@ -112,34 +113,34 @@ export const handler: Handler = {
                         return `Unexpected node kind '${nodeKind}'. Assert messages to be processed can only be numbers (auto-generated by the policy-check tool) or string literals.\n\t${getCallsiteString(msg)}`;
                 }
             }
-        };
+        }
     },
     final: (root, resolve) => {
-        const errors: string[]=[];
+        const errors: string[] = [];
 
-        function isNumericLiteral(msg: StringLiteralLike | NumericLiteral) : msg is NumericLiteral {
+        function isNumericLiteral(msg: StringLiteralLike | NumericLiteral): msg is NumericLiteral {
             return msg.getKind() === SyntaxKind.NumericLiteral;
         }
 
         // go through all the newly collected asserts and add short codes
-        for(const s of newAssetFiles){
+        for (const s of newAssetFiles) {
             // another policy may have changed the file, so reload it
             s.refreshFromFileSystemSync();
-            for(const msg of getAssertMessageParams(s)){
+            for (const msg of getAssertMessageParams(s)) {
                 // here we only want to looks at those messages that are not numbers,
                 // as we validated existing short codes above
-                if(!isNumericLiteral(msg)){
+                if (!isNumericLiteral(msg)) {
                     // resolve === fix
-                    if(resolve){
+                    if (resolve) {
                         //for now we don't care about filling gaps, but possible
                         const shortCode = ++maxShortCode;
                         shortCodes.set(shortCode, msg);
                         const text = msg.getLiteralText();
-                        const shortCodeStr = `0x${shortCode.toString(16).padStart(3,"0")}`;
+                        const shortCodeStr = `0x${shortCode.toString(16).padStart(3, "0")}`;
                         // replace the message with shortcode, and put the message in a comment
                         msg.replaceWithText(`${shortCodeStr} /* ${text} */`);
                         codeToMsgMap.set(shortCodeStr, text);
-                    }else{
+                    } else {
                         // TODO: if we are not in resolve mode we
                         // allow  messages that are not short code. this seems like the right
                         // behavior for main. we may want to enforce shortcodes in release branches in the future
@@ -148,11 +149,11 @@ export const handler: Handler = {
                     }
                 }
             }
-            if(resolve){
+            if (resolve) {
                 s.saveSync();
             }
         }
-        const result = errors.length > 0 ? {error: errors.join("\n")} : undefined;
+        const result = errors.length > 0 ? { error: errors.join("\n") } : undefined;
         if (resolve) {
             writeShortCodeMappingFile();
         }
@@ -169,7 +170,7 @@ function writeShortCodeMappingFile() {
     }
 
     const fileContents =
-`/*!
+        `/*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  *

--- a/tools/build-tools/src/repoPolicyCheck/handlers/copyrightFileHeader.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/copyrightFileHeader.ts
@@ -63,7 +63,7 @@ function makeHandler(config: IFileConfig) {
 export const handlers: Handler[] = [
     {
         name: "html-copyright-file-header",
-        match: /(^|\/)[^\/]+\.html$/i,
+        match: /(^|\/)[^/]+\.html$/i,
         handler: makeHandler({
             type: "Html",
             lineStart: /<!-- /,    // Lines begin with '<!-- '
@@ -100,7 +100,7 @@ export const handlers: Handler[] = [
     },
     {
         name: "js-ts-copyright-file-header",
-        match: /(^|\/)[^\/]+\.[jt]sx?$/i,
+        match: /(^|\/)[^/]+\.[jt]sx?$/i,
         handler: makeHandler({
             type: "JavaScript/TypeScript",
             headerStart: /(#![^\n]*\r?\n)?\/\*!\r?\n/,  // Begins with optional hashbang followed by '/*!'

--- a/tools/build-tools/src/repoPolicyCheck/handlers/dockerfilePackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/dockerfilePackages.ts
@@ -53,7 +53,7 @@ export const handler: Handler = {
             const endOfCopyLinesRegex = /(COPY\s+server\/routerlicious\/packages\/.*\/package\*\.json\s+server\/routerlicious\/packages\/.*\/\s*\n){3,}[^\S\r]*(?<newline>\r?\n)+/gi;
             const regexMatch = endOfCopyLinesRegex.exec(dockerfileContents)!;
             const localNewline = regexMatch.groups!.newline;
-            let insertIndex = regexMatch.index + regexMatch[0].length - localNewline.length;
+            const insertIndex = regexMatch.index + regexMatch[0].length - localNewline.length;
 
             dockerfileContents = dockerfileContents.substring(0, insertIndex)
                 + dockerfileCopyText + localNewline

--- a/tools/build-tools/src/repoPolicyCheck/handlers/fluidCase.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/fluidCase.ts
@@ -11,7 +11,7 @@ import {
 
 export const handler: Handler = {
     name: "fluid-case",
-    match: /(^|\/)[^\/]+\.([tj]s?|html|md|json)$/i,
+    match: /(^|\/)[^/]+\.([tj]s?|html|md|json)$/i,
     handler: file => {
         const content = readFile(file);
         // search for Fluid Framework

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -201,7 +201,7 @@ export const handlers: Handler[] = [
                 return { resolved: false, message: 'Error parsing JSON file: ' + file };
             }
 
-            let resolved = true;
+            const resolved = true;
 
             if (json.author === undefined || json.author !== author) {
                 json.author = author;
@@ -483,7 +483,7 @@ export const handlers: Handler[] = [
                 return { resolved: false, message: 'Error parsing JSON file: ' + file };
             }
 
-            let resolved = true;
+            const resolved = true;
 
             const { valid, validationResults } = runNpmJsonLint(json, file);
 
@@ -545,7 +545,7 @@ const defaultNpmPackageJsonLintConfig = {
 function getLintConfig(file: string) {
     const configFilePath = path.join(path.dirname(file), ".npmpackagejsonlintrc.json");
     const defaultConfig = defaultNpmPackageJsonLintConfig;
-    let finalConfig = {};
+    const finalConfig = {};
     if (pathExistsSync(configFilePath)) {
         let configJson;
         try {

--- a/tools/build-tools/src/test/typeValidator/classValidator.spec.ts
+++ b/tools/build-tools/src/test/typeValidator/classValidator.spec.ts
@@ -13,7 +13,7 @@ import { BreakingIncrement, enableLogging } from "./../../typeValidator/validato
 describe("Class", () => {
     enableLogging(true);
     let project: Project;
-    let pkgDir: string = os.tmpdir();
+    const pkgDir: string = os.tmpdir();
     before(() => {
         project = new Project({
             skipFileDependencyResolution: true,
@@ -65,7 +65,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -83,7 +83,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.minor);
         });
 
@@ -101,7 +101,7 @@ describe("Class", () => {
             export class TestClass {}
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -121,7 +121,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.none);
         });
 
@@ -140,7 +140,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -159,7 +159,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -181,7 +181,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -205,7 +205,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -225,7 +225,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -246,7 +246,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.minor);
         });
 
@@ -267,7 +267,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -289,7 +289,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
     });
@@ -318,7 +318,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -345,7 +345,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -374,7 +374,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.none);
         });
     });
@@ -398,7 +398,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.none);
         });
     });
@@ -418,7 +418,7 @@ describe("Class", () => {
             export class TestClass extends BaseClass<number> {}
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -438,7 +438,7 @@ describe("Class", () => {
             export class TestClass extends BaseClass2<string> {}
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -458,7 +458,7 @@ describe("Class", () => {
             export class TestClass implements TestInterface2 {}
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -478,7 +478,7 @@ describe("Class", () => {
             export class TestClass implements TestInterface2, TestInterface1 {}
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.none);
         });
     });
@@ -500,7 +500,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -520,7 +520,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -540,7 +540,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -560,7 +560,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.minor);
         });
 
@@ -582,7 +582,7 @@ describe("Class", () => {
             }
             `;
 
-            let increment = checkIncrement(classOld, classNew);
+            const increment = checkIncrement(classOld, classNew);
             assert.strictEqual(increment, BreakingIncrement.none);
         });
     });

--- a/tools/build-tools/src/test/typeValidator/enumValidator.spec.ts
+++ b/tools/build-tools/src/test/typeValidator/enumValidator.spec.ts
@@ -13,7 +13,7 @@ import { BreakingIncrement, enableLogging } from "./../../typeValidator/validato
 describe("Enum validator", () => {
     enableLogging(true);
     let project: Project;
-    let pkgDir: string = os.tmpdir();
+    const pkgDir: string = os.tmpdir();
     before(() => {
         project = new Project({
             skipFileDependencyResolution: true,
@@ -66,7 +66,7 @@ describe("Enum validator", () => {
         }
         `;
 
-        let increment = checkIncrement(sourceOld, sourceNew);
+        const increment = checkIncrement(sourceOld, sourceNew);
         assert(increment === BreakingIncrement.minor);
 
     }).timeout(10000);
@@ -88,7 +88,7 @@ describe("Enum validator", () => {
         }
         `;
 
-        let increment = checkIncrement(sourceOld, sourceNew);
+        const increment = checkIncrement(sourceOld, sourceNew);
         assert(increment === BreakingIncrement.major);
 
     }).timeout(10000);
@@ -113,7 +113,7 @@ describe("Enum validator", () => {
         }
         `;
 
-        let increment = checkIncrement(sourceOld, sourceNew);
+        const increment = checkIncrement(sourceOld, sourceNew);
         assert(increment === BreakingIncrement.major);
 
     }).timeout(10000);
@@ -136,7 +136,7 @@ describe("Enum validator", () => {
         }
         `;
 
-        let increment = checkIncrement(sourceOld, sourceNew);
+        const increment = checkIncrement(sourceOld, sourceNew);
         assert(increment === BreakingIncrement.none);
 
     }).timeout(10000);
@@ -158,7 +158,7 @@ describe("Enum validator", () => {
         }
         `;
 
-        let increment = checkIncrement(sourceOld, sourceNew);
+        const increment = checkIncrement(sourceOld, sourceNew);
         assert(increment === BreakingIncrement.major);
 
     }).timeout(10000);

--- a/tools/build-tools/src/test/typeValidator/interfaceValidator.spec.ts
+++ b/tools/build-tools/src/test/typeValidator/interfaceValidator.spec.ts
@@ -13,7 +13,7 @@ import { BreakingIncrement, enableLogging } from "./../../typeValidator/validato
 describe("Interface", () => {
     enableLogging(true);
     let project: Project;
-    let pkgDir: string = os.tmpdir();
+    const pkgDir: string = os.tmpdir();
     before(() => {
         project = new Project({
             skipFileDependencyResolution: true,
@@ -65,7 +65,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -83,7 +83,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.minor);
         });
 
@@ -101,7 +101,7 @@ describe("Interface", () => {
             export interface ITestInterface {}
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -121,7 +121,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -140,7 +140,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.minor);
         });
 
@@ -161,7 +161,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -182,7 +182,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -202,7 +202,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
     });
@@ -225,7 +225,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -245,7 +245,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.minor);
         });
     });
@@ -265,7 +265,7 @@ describe("Interface", () => {
             export interface ITestInterface extends IBaseInterface<number> {}
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -285,7 +285,7 @@ describe("Interface", () => {
             export interface ITestInterface extends IBaseInterface2<string> {}
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -305,7 +305,7 @@ describe("Interface", () => {
             export class TestClass implements ITestInterface2, ITestInterface1 {}
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.none);
         });
 
@@ -314,6 +314,7 @@ describe("Interface", () => {
         // implementing the interface (e.g. addition of a private method that then
         // requires implementers of the interface to also inherit from the extended
         // class).  We don't handle this on the assumption it's incredibly rare
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         it.skip("reflects changes to extended class in implementers", () => {
         });
     });
@@ -336,7 +337,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -358,7 +359,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.none);
         });
     });
@@ -382,7 +383,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
 
@@ -403,7 +404,7 @@ describe("Interface", () => {
             }
             `;
 
-            let increment = checkIncrement(sourceOld, sourceNew);
+            const increment = checkIncrement(sourceOld, sourceNew);
             assert.strictEqual(increment, BreakingIncrement.major);
         });
     });

--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -52,10 +52,6 @@ function safeParse(json: string, error: string){
     }
 }
 
-export async function readPackageJson(packageDir: string) {
-
-}
-
 export async function getPackageDetails(packageDir: string):  Promise<PackageDetails> {
     const packagePath = `${packageDir}/package.json`;
     if(!await util.promisify(fs.exists)(packagePath)){

--- a/tools/build-tools/src/typeValidator/repoValidator.ts
+++ b/tools/build-tools/src/typeValidator/repoValidator.ts
@@ -108,7 +108,7 @@ function setPackageGroupIncrement(
     groups: PackageGroup[] | undefined,
     groupBreaks: Map<string, BreakingIncrement>,
 ): string | undefined {
-    let pkgGroupName = groups ? groupForPackage(groups, pkgDir) : undefined;
+    const pkgGroupName = groups ? groupForPackage(groups, pkgDir) : undefined;
     if (pkgGroupName !== undefined) {
         groupBreaks.set(
             pkgGroupName,
@@ -155,7 +155,7 @@ export async function validateRepo(options?: IValidationOptions): Promise<RepoVa
                 if (packageData.oldVersions.length > 0) {
                     log(`${pkgName}, ${buildPkg.level}`);
 
-                    let { increment, brokenTypes} = await validatePackage(packageData, buildPkg.pkg.directory, allBrokenTypes);
+                    const { increment, brokenTypes } = await validatePackage(packageData, buildPkg.pkg.directory, allBrokenTypes);
 
                     brokenTypes.forEach((v, k) => allBrokenTypes.set(k, v));
 

--- a/tools/build-tools/src/typeValidator/typeData.ts
+++ b/tools/build-tools/src/typeValidator/typeData.ts
@@ -166,7 +166,7 @@ function getIndexSourceFile(basePath: string){
 
 export async function generateTypeDataForProject(packageDir: string, dependencyName: string | undefined): Promise<PackageAndTypeData> {
 
-    let basePath = dependencyName === undefined
+    const basePath = dependencyName === undefined
         ? packageDir
         : tryFindDependencyPath(packageDir, dependencyName);
 

--- a/tools/build-tools/src/typeValidator/validatorUtils.ts
+++ b/tools/build-tools/src/typeValidator/validatorUtils.ts
@@ -25,7 +25,7 @@ export enum BreakingIncrement {
     none = 0,
     minor = 1,
     major = minor << 1 | minor,
-};
+}
 
 export interface IValidator {
     /**


### PR DESCRIPTION
Our build-tools are not using any lint config currently, so this change adds a baseline config using eslint/recommended and @typescript-eslint/recommended. I was motivated to do this because I want to use <https://typescript-eslint.io/rules/switch-exhaustiveness-check>

Code wise, this PR removes unneeded semicolons, uses const instead of let/var where possible, and removes unneeded escaping from regexes.

I didn't inherit from our shared config because doing so would require too many code changes to do in a single PR.