### PR TITLE
Bugfix for applyChangeSet. String changes maintain value and oldValue

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
@@ -317,16 +317,14 @@ export class ChangeSet {
                 }
                 baseIsSetChange = true;
             }
-            let appliedChanges = in_appliedPropertyChanges[in_changedKey];
-            if (isObject(appliedChanges) && appliedChanges.hasOwnProperty("value")) {
-                appliedChanges = (appliedChanges as SerializedChangeSet).value;
-            }
+            const appliedChanges = in_appliedPropertyChanges[in_changedKey];
+            const appliedChangesValue = appliedChanges?.value ?? appliedChanges;
 
-            if (splitTypeid.typeid === "String" && isString(appliedChanges)) {
+            if (splitTypeid.typeid === "String" && isString(appliedChangesValue)) {
                 // we've got a 'set' command and just overwrite the changes
                 if (baseIsSetChange && oldValue !== undefined) {
                     in_baseChanges[in_changedKey] = {
-                        value: appliedChanges,
+                        value: appliedChangesValue,
                         oldValue,
                     };
                 } else {


### PR DESCRIPTION
applyChangeSet is incorrectly applying changes to string properties when combining reversible changeSets (i.e. with value and oldValue) causing oldValue for the secondary changeSet to be lost on application.

### Behaviour

```typescript
const cs1 = {
  String: {
    x: {
      oldValue: "a",
      value: "b"
    }
  }
};
const cs2 = {
  String: {
    y: {
      oldValue: "c",
      value: "d"
    }
  }
};
```

#### applyChangeSet (Before fix)
```typescript
{
  String: {
    x: {
      oldValue: "a",
      value: "b"
    }
    y: "d",
  },
}
```

#### applyChangeSet (After fix)
```typescript
{
  String: {
    x: {
      oldValue: "a",
      value: "b"
    }
    y:  {
      oldValue: "c",
      value: "d"
    }
  },
}
```