### PR TITLE
Make inspecting dependency graph easier

### DIFF
--- a/packages/dds/tree/src/dependency-tracking/dependencies.ts
+++ b/packages/dds/tree/src/dependency-tracking/dependencies.ts
@@ -22,6 +22,20 @@ export interface NamedComputation {
 	 * Use when measuring / debugging / logging computation costs, invalidation etc.
 	 */
 	readonly computationName: string;
+
+    /**
+     * Lists the currently subscribed set of Dependees.
+     * This is exposed to allow tooling to inspect the dependency graph,
+     * and should not be needed for regular functionality.
+     */
+    listDependees?(): Iterable<Dependee>;
+
+    /**
+     * Lists the currently subscribed set of Dependent.
+     * This is exposed to allow tooling to inspect the dependency graph,
+     * and should not be needed for regular functionality.
+     */
+    listDependents?(): Iterable<Dependent>;
 }
 
 /**
@@ -46,13 +60,6 @@ export interface Dependent extends NamedComputation {
      * there will be a token specific invalidation protocol that must be obeyed.
 	 */
 	markInvalid(token?: InvalidationToken): void;
-
-    /**
-	 * Lists the currently subscribed set of Dependees.
-	 * This is exposed to allow tooling to inspect the dependency graph,
-     * and should not be needed for regular functionality.
-	 */
-	listDependees?(): Iterable<Dependee>;
 }
 
 /**

--- a/packages/dds/tree/src/dependency-tracking/simpleDependee.ts
+++ b/packages/dds/tree/src/dependency-tracking/simpleDependee.ts
@@ -35,4 +35,8 @@ export class SimpleDependee implements Dependee {
 			dependent.markInvalid();
 		}
 	}
+
+	public listDependents() {
+		return this.dependents;
+	}
 }


### PR DESCRIPTION
## Description

This allows walking the dependency graph from a NamedComputation. This means debug tooling in this area will not need to down cast, and thus can be more type safe and have less dependencies.