### PR TITLE
Adjust forest Curor API

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -47,9 +47,13 @@ export interface ITreeCursor {
     keys: Iterable<FieldKey>;
     // (undocumented)
     length(key: FieldKey): number;
+    seek(offset: number): {
+        result: TreeNavigationResult;
+        moved: number;
+    };
     readonly type: TreeType;
     up(): TreeNavigationResult;
-    readonly value: undefined | Serializable;
+    readonly value: Value;
 }
 
 // @public
@@ -68,6 +72,9 @@ export const enum TreeNavigationResult {
 
 // @public (undocumented)
 export type TreeType = Brand<number | string, "TreeType">;
+
+// @public
+export type Value = undefined | Serializable;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/dds/tree/src/forest/cursor.ts
+++ b/packages/dds/tree/src/forest/cursor.ts
@@ -18,6 +18,16 @@ export const enum TreeNavigationResult {
 }
 
 /**
+ * Value stored on a node.
+ *
+ * TODO: `Serializable` is not really the right type to use here,
+ * since may types (including functions) are "Serializable" (according to the type) despite not being serializable.
+ *
+ * Use this type instead of directly using Serializable for both clarity and so the above TODO can be addressed.
+ */
+export type Value = undefined | Serializable;
+
+/**
  * A stateful low-level interface for reading tree data.
  *
  * TODO: Needs rules around invalidation/mutation of the underlying tree.
@@ -25,10 +35,22 @@ export const enum TreeNavigationResult {
  * (and likely via returning a sub-interface with documentation on the subject).
  *
  * TODO: Needs a way to efficiently clone Cursor so patterns like lazy tree reification can be implemented efficiently.
+ *
+ * TODO: add optional fast path APIs for more efficient handling when supported by underlying format and reader.
+ * Leverage "chunks" and "shape" for this, and skip to next chunk with seek (chunk length).
+ * Default chunks of size 1, and "node" shape?
  */
 export interface ITreeCursor {
     /** Select the child located at the given key and index. */
     down(key: FieldKey, index: number): TreeNavigationResult;
+
+    /**
+     * Moves `offset` entries in the field.
+     * May move less if Pending or NotFound.
+     * In this case the distance moved is returned, and may be less than `offset`.
+     * Iff `ok` then `moved` will equal `offset`.
+     */
+    seek(offset: number): { result: TreeNavigationResult; moved: number; };
 
     /** Select the parent of the currently selected node. */
     up(): TreeNavigationResult;
@@ -36,12 +58,16 @@ export interface ITreeCursor {
     /** The type of the currently selected node. */
     readonly type: TreeType;
 
-    /** @returns the keys of the currently selected node. */
+    /**
+     * @returns the keys of the currently selected node.
+     * TODO: ordering invariants: Consistent over time? Consistent across nodes? Sorted?
+     * TODO: empty fields: are they always omitted here? Sometimes omitted? Depends on field kind and schema?
+     * */
     keys: Iterable<FieldKey>;
 
     /** @returns the number of immediate children for the given key of the currently selected node. */
     length(key: FieldKey): number;
 
     /** value associated with the currently selected node. */
-    readonly value: undefined | Serializable;
+    readonly value: Value;
 }

--- a/packages/dds/tree/src/forest/index.ts
+++ b/packages/dds/tree/src/forest/index.ts
@@ -6,4 +6,5 @@
 export {
     ITreeCursor,
     TreeNavigationResult,
+    Value,
 } from "./cursor";

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -5,7 +5,7 @@
 
 export { FieldKey, TreeType } from "./tree";
 
-export { ITreeCursor, TreeNavigationResult } from "./forest";
+export { ITreeCursor, TreeNavigationResult, Value } from "./forest";
 
 export {
     Brand,


### PR DESCRIPTION
## Description

Add some more clarity to open issue with Cursor API, and add `seek` so its possible to enumerate a sequence without having to call up and down for each entry.