### PR TITLE
Update k8s resource apiVersion

### DIFF
--- a/server/charts/fluid-metrics/templates/metrics-deployment.yaml
+++ b/server/charts/fluid-metrics/templates/metrics-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    app: {{ template "metrics.fullname" . }}
+    component: "{{ .Values.name }}"
+    release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/server/charts/fluid-metrics/templates/metrics-deployment.yaml
+++ b/server/charts/fluid-metrics/templates/metrics-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "metrics.fullname" . }}

--- a/server/charts/historian/templates/historian-ingress.yaml
+++ b/server/charts/historian/templates/historian-ingress.yaml
@@ -23,6 +23,9 @@ spec:
    http:
      paths:
      - path: /
+       pathType: ImplementationSpecific
        backend:
-         serviceName: {{ template "historian.fullname" . }}
-         servicePort: 80
+         service:
+           name: {{ template "historian.fullname" . }}
+           port:
+             number: 80

--- a/server/charts/historian/templates/historian-ingress.yaml
+++ b/server/charts/historian/templates/historian-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "historian.fullname" . }}

--- a/server/routerlicious/kubernetes/README.md
+++ b/server/routerlicious/kubernetes/README.md
@@ -1,11 +1,14 @@
 # Kubernetes deployment
 
 ## Cluster preparation
+
 Azure Container Service is the simplest way to get a cluster up and running. Optionally instructions on how to manually
 prepare a Kubernetes cluster on Azure can be found [here](azure.md).
 
 You can also make use of minikube to run a local cluster for testing. The [minikube](minikube.md) page provides setup
 instructions.
+
+**NOTE**: we currently support Kubernetes v1.23.
 
 ## Routerlicious deployment
 
@@ -20,14 +23,14 @@ chart. Or in the future simpling installing a chart we have published to a chart
 Prior to deploying the Routerlicious chart first a few base components need to be configured
 
 To actually deploy our services you'll need to provide the cluster with credentials to our private container as
-documented at https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/. This boils
+documented [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). This boils
 down to the below command to create a secret in Kubernetes
 
-```
+```bash
 kubectl create secret docker-registry regsecret --docker-server=prague.azurecr.io --docker-username=prague --docker-password=/vM3i=D+K4+vj+pgha=cg=55OQLDWj3w --docker-email=kurtb@microsoft.com
 ```
 
-```
+```bash
 kubectl apply -f system/azure-unmanaged-premium.yaml
 ```
 
@@ -49,7 +52,7 @@ these files. But with the ability to provide runtime parameters.
 
 Once they are built we build dependencies (the helm version of npm install) followed by packaging the chart.
 
-```
+```bash
 node tools/generateChart.js ./routerlicious/ $(Build.BuildId) $(Build.BuildId)
 cd routerlicious
 helm dependency build
@@ -60,7 +63,7 @@ helm package .
 
 Simply take the tarball from the package step and deploy it to the cluster
 
-```
+```bash
 helm upgrade -i pesky-platypus chart.tgz
 ```
 
@@ -75,17 +78,20 @@ care of by Azure Container Service.
 
 ### Current Environments
 
-Shared
-Kafka - left-numbat
+#### Shared
 
-PPE
-Mongo - quoting-armadillo
-Redis - lumpy-condor
-Historian - terrific-otter
-Rabbitmq - modest-poodle
+- Kafka - left-numbat
 
-Prod
-Mongo - quieting-guppy
-Redis - winsome-wombat
-Historian - smelly-wolf
-Rabbitmq - lumpy-worm
+#### PPE
+
+- Mongo - quoting-armadillo
+- Redis - lumpy-condor
+- Historian - terrific-otter
+- Rabbitmq - modest-poodle
+
+#### Prod
+
+- Mongo - quieting-guppy
+- Redis - winsome-wombat
+- Historian - smelly-wolf
+- Rabbitmq - lumpy-worm

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.jarvis.replicas }}
+  selector:
+    app: {{ template "routerlicious.name" . }}
+    component: "{{ .Values.jarvis.name }}"
+    release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jarvis.fullname" . }}

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-ingress.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-ingress.yaml
@@ -26,6 +26,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: {{ template "jarvis.fullname" . }}
-          servicePort: 80
+          service:
+            name: {{ template "jarvis.fullname" . }}
+            port:
+              number: 80

--- a/server/routerlicious/kubernetes/jarvis/templates/alfred-ingress.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/alfred-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "jarvis.fullname" . }}

--- a/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/deli-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "deli.fullname" . }}
@@ -10,6 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.deli.replicas }}
+  selector:
+    app: {{ template "routerlicious.name" . }}
+    component: "{{ .Values.deli.name }}"
+    release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/scriptorium-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scriptorium.fullname" . }}
@@ -10,6 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.scriptorium.replicas }}
+  selector:
+    app: {{ template "routerlicious.name" . }}
+    component: "{{ .Values.scriptorium.name }}"
+    release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/server/routerlicious/kubernetes/logging/elastalert/elastalert-stateful-set.yaml
+++ b/server/routerlicious/kubernetes/logging/elastalert/elastalert-stateful-set.yaml
@@ -1,10 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elastalert
 spec:
   serviceName: elastalert
   replicas: 1
+  selector:
+    app: elastalert
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/logging/elasticsearch/es-stateful-set.yml
+++ b/server/routerlicious/kubernetes/logging/elasticsearch/es-stateful-set.yml
@@ -1,10 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch
 spec:
   serviceName: elasticsearch
   replicas: 1
+  selector:
+    app: elasticsearch
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/logging/fluentd/fluentd-daemonset.yaml
+++ b/server/routerlicious/kubernetes/logging/fluentd/fluentd-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd

--- a/server/routerlicious/kubernetes/logging/fluentd/fluentd-daemonset.yaml
+++ b/server/routerlicious/kubernetes/logging/fluentd/fluentd-daemonset.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    app: fluentd
+    version: v1
+    kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/logging/kibana/kibana-deployment.yml
+++ b/server/routerlicious/kubernetes/logging/kibana/kibana-deployment.yml
@@ -1,9 +1,11 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana
 spec:
   replicas: 1
+  selector:
+    app: kibana
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/metric/grafana/grafana-deployment.yaml
+++ b/server/routerlicious/kubernetes/metric/grafana/grafana-deployment.yaml
@@ -1,10 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
   namespace: metric
 spec:
   replicas: 1
+  selector:
+    task: monitoring
+    k8s-app: grafana
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/metric/grafana/grafana-ingress.yml
+++ b/server/routerlicious/kubernetes/metric/grafana/grafana-ingress.yml
@@ -16,6 +16,9 @@ spec:
    http:
      paths:
      - path: /
+       pathType: ImplementationSpecific
        backend:
-         serviceName: grafana
-         servicePort: 80
+         service:
+           name: grafana
+           port:
+             number: 80

--- a/server/routerlicious/kubernetes/metric/grafana/grafana-ingress.yml
+++ b/server/routerlicious/kubernetes/metric/grafana/grafana-ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  name: grafana

--- a/server/routerlicious/kubernetes/metric/influxdb/templates/deployment.yaml
+++ b/server/routerlicious/kubernetes/metric/influxdb/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/server/routerlicious/kubernetes/metric/influxdb/templates/deployment.yaml
+++ b/server/routerlicious/kubernetes/metric/influxdb/templates/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    app: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/metric/telegraf/telegraf-daemonset/templates/daemonset.yaml
+++ b/server/routerlicious/kubernetes/metric/telegraf/telegraf-daemonset/templates/daemonset.yaml
@@ -8,6 +8,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
+  selector:
+    app: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/metric/telegraf/telegraf-daemonset/templates/daemonset.yaml
+++ b/server/routerlicious/kubernetes/metric/telegraf/telegraf-daemonset/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if not (empty .Values.config.outputs.influxdb.url) }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fullname" . }}

--- a/server/routerlicious/kubernetes/metric/telegraf/telegraf-service/templates/deployment.yaml
+++ b/server/routerlicious/kubernetes/metric/telegraf/telegraf-service/templates/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     release: "{{ .Release.Name }}"
 spec:
   replicas: 1
+  selector:
+    app: {{ template "fullname" . }}
   template:
     metadata:
       labels:

--- a/server/routerlicious/kubernetes/metric/telegraf/telegraf-service/templates/deployment.yaml
+++ b/server/routerlicious/kubernetes/metric/telegraf/telegraf-service/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if gt (len .Values.config.outputs.influxdb.urls) 0 }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/server/routerlicious/kubernetes/routerlicious/templates/alfred-ingress.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/alfred-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "alfred.fullname" . }}

--- a/server/routerlicious/kubernetes/routerlicious/templates/alfred-ingress.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/alfred-ingress.yaml
@@ -26,6 +26,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: {{ template "alfred.fullname" . }}
-          servicePort: 80
+          service:
+            name: {{ template "alfred.fullname" . }}
+            port:
+              number: 80


### PR DESCRIPTION
## Description

Update `apiVersion` for Kubernetes resources to latest versions, as part of the move to k8s 1.23.5 in the CI AKS cluster.

- `apiVersion: extensions/v1beta1` for `DaemonSet` and `Deployment` resources [stopped working in k8s 1.16](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-16) and should now be `apps/v1`. 
- `apiVersion: extensions/v1beta1` for `Ingress` resources [stopped working in 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) and should now be `networking.k8s.io/v1`.

~Not entirely sure how this was all working on the 1.19 cluster we had... some components might not have been necessary and/or running?~ I realized the only charts deployed to the CI AKS cluster are routerlicious (`/server/routerlicious/kubernetes/routerlicious`) and historian (`/server/charts/historian`) and those only use the `Ingress` resource whose `apiVersion` was removed in 1.22.

## Reviewer Guidance

The two manifests that are blocking the CI AKS cluster upgrade are the ones in `/server/routerlicious/kubernetes/routerlicious` and historian `/server/charts/historian`. Not sure if the rest need/should be upgraded right now, as I don't have visibility into where or how they are used. It feels like a good idea to update them all together, though.

## Other information or known dependencies

After we merge this I'll kick off the pipelines to rebuild the routerlicious and historian charts so we can deploy those (with the newer `apiVersion` values) to the 1.23 AKS cluster.