### PR TITLE
Bump common-utils dependency

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -1308,12 +1308,6 @@
             "lru-cache": "^6.0.0"
           }
         },
-        "typescript": {
-          "version": "4.5.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-          "dev": true
-        },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3042,6 +3036,12 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
     "async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
@@ -3527,7 +3527,6 @@
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3544,13 +3543,6 @@
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
           }
-        },
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -5005,14 +4997,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.5",
         "ignore": "^5.0.5"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-import": {
@@ -5678,7 +5662,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -5688,7 +5671,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -5697,7 +5679,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -5706,7 +5687,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -5714,23 +5694,12 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.0.0"
-          }
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         }
       }
     },
@@ -5954,13 +5923,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -6525,7 +6487,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -6535,7 +6496,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -6544,7 +6504,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -6553,7 +6512,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -6561,23 +6519,12 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.0.0"
-          }
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         }
       }
     },
@@ -8076,7 +8023,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -11217,6 +11163,12 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true
+    },
     "platform": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
@@ -11981,12 +11933,6 @@
         "eslint": "^6.8.0"
       },
       "dependencies": {
-        "astral-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-          "dev": true
-        },
         "doctrine": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -11999,8 +11945,7 @@
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "eslint": {
           "version": "6.8.0",
@@ -12108,8 +12053,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "regexpp": {
           "version": "2.0.1",
@@ -12126,38 +12070,14 @@
             "glob": "^7.1.3"
           }
         },
-        "slice-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
-          }
-        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
-          }
-        },
-        "table": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-          "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.10.2",
-            "lodash": "^4.17.14",
-            "slice-ansi": "^2.1.0",
-            "string-width": "^3.0.0"
           }
         }
       }
@@ -12552,6 +12472,16 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -13021,7 +12951,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
       },
@@ -13029,8 +12958,7 @@
         "ansi-regex": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-          "dev": true
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
         }
       }
     },
@@ -13114,6 +13042,17 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0"
+      }
     },
     "terminal-link": {
       "version": "2.1.1",
@@ -13364,12 +13303,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
         }
       }

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-experimental/data-objects": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/tinylicious-client": "^1.1.0",
     "fluid-framework": "^1.1.0"
   },

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",
     "@fluidframework/container-runtime-definitions": "^1.1.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^1.1.0",
     "@fluidframework/aqueduct": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/merge-tree": "^1.1.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/task-manager": "^1.1.0",
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -77,7 +77,7 @@
     "@fluid-example/example-utils": "^1.1.0",
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/data-object-base": "^1.1.0",
     "@fluidframework/map": "^1.1.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -45,7 +45,7 @@
     "@fluid-experimental/property-proxy": "^1.1.0",
     "@fluid-experimental/schemas": "^1.1.0",
     "@fluidframework/aqueduct": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -45,7 +45,7 @@
     "@fluid-experimental/property-proxy": "^1.1.0",
     "@fluid-experimental/schemas": "^1.1.0",
     "@fluidframework/aqueduct": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluid-experimental/property-changeset": "^1.1.0",
     "@fluid-experimental/property-properties": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",

--- a/experimental/PropertyDDS/services/property-query-service/package.json
+++ b/experimental/PropertyDDS/services/property-query-service/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluid-experimental/property-dds": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/local-driver": "^1.1.0",
     "@fluidframework/mocha-test-setup": "^1.1.0",
     "@fluidframework/runtime-utils": "^1.1.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -59,7 +59,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluid-experimental/ot": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/experimental/dds/tree-graphql/package.json
+++ b/experimental/dds/tree-graphql/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluid-experimental/tree": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@graphql-codegen/plugin-helpers": "^1.18.2",
     "@graphql-codegen/visitor-plugin-common": "^1.18.2",
     "graphql": "^15.4.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/protocol-base": "^0.1036.5000-0",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/map": "^1.1.0",
     "@fluidframework/runtime-definitions": "^1.1.0"

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/cell": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/merge-tree": "^1.1.0",
     "@fluidframework/sequence": "^1.1.0",
     "react": "^16.10.2"

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1964,6 +1964,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluid-tools/benchmark": {
@@ -2223,6 +2243,26 @@
 				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/odsp-driver": "^1.0.1",
 				"@fluidframework/odsp-driver-definitions": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
@@ -2260,6 +2300,19 @@
 				"webpack-dev-server": "~4.6.0"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -2361,6 +2414,11 @@
 						"uuid": "^8.3.1"
 					}
 				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2436,6 +2494,26 @@
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/aqueduct": {
@@ -2459,6 +2537,26 @@
 				"@fluidframework/synthesize": "^1.0.1",
 				"@fluidframework/view-interfaces": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
@@ -2482,6 +2580,26 @@
 				"@fluidframework/synthesize": "^1.0.1",
 				"@fluidframework/view-interfaces": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/build-common": {
@@ -2587,6 +2705,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/cell-previous": {
@@ -2601,6 +2739,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -2609,9 +2767,9 @@
 			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.32.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
-			"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+			"version": "0.33.1000-74526",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.33.1000-74526.tgz",
+			"integrity": "sha512-AnyWk9MXm9TPQKMsVnHZxyvwtaPW7qhneSo6G56c5mTVcNL+chJY0GgEVBKnOPahhJbsUf03tQoTnqp0MvqtpA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@types/events": "^3.0.0",
@@ -2671,6 +2829,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -2686,6 +2857,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -2710,6 +2886,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -2725,6 +2914,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -2752,6 +2946,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -2767,6 +2974,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -2822,6 +3034,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -2837,6 +3062,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -2850,6 +3080,26 @@
 				"@fluidframework/container-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/container-utils-previous": {
@@ -2862,6 +3112,26 @@
 				"@fluidframework/container-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/core-interfaces": {
@@ -2886,6 +3156,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/counter-previous": {
@@ -2900,6 +3190,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
@@ -2918,6 +3228,26 @@
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/datastore": {
@@ -2943,6 +3273,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -2958,6 +3301,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -2973,6 +3321,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@types/node": "^14.18.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
@@ -2987,6 +3355,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@types/node": "^14.18.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/datastore-previous": {
@@ -3012,6 +3400,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3027,6 +3428,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -3040,6 +3446,26 @@
 				"@fluidframework/merge-tree": "^1.0.1",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/sequence": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/debugger-previous": {
@@ -3053,6 +3479,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/replay-driver": "^1.0.1",
 				"jsonschema": "^1.2.6"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/driver-base": {
@@ -3066,6 +3512,26 @@
 				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/driver-base-previous": {
@@ -3079,6 +3545,26 @@
 				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/driver-definitions": {
@@ -3118,6 +3604,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3133,6 +3632,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -3153,6 +3657,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3168,6 +3685,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -3212,6 +3734,26 @@
 				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/replay-driver": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/fluid-static": {
@@ -3231,6 +3773,26 @@
 				"@fluidframework/request-handler": "^1.0.1",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/runtime-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
@@ -3250,6 +3812,26 @@
 				"@fluidframework/request-handler": "^1.0.1",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/runtime-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/garbage-collector": {
@@ -3260,6 +3842,26 @@
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/runtime-definitions": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
@@ -3270,6 +3872,26 @@
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
 				"@fluidframework/runtime-definitions": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -3290,6 +3912,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/telemetry-utils": "^1.0.1",
 				"comlink": "^4.3.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/ink": {
@@ -3305,6 +3947,26 @@
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/ink-previous": {
@@ -3320,6 +3982,26 @@
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/local-driver": {
@@ -3343,6 +4025,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3430,6 +4125,11 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -3522,6 +4222,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3610,6 +4323,11 @@
 						"uuid": "^8.3.1"
 					}
 				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3696,6 +4414,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"path-browserify": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/map-previous": {
@@ -3714,6 +4452,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"path-browserify": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/matrix": {
@@ -3736,6 +4494,19 @@
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3751,6 +4522,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -3774,6 +4550,19 @@
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3789,6 +4578,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -3808,6 +4602,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
@@ -3826,6 +4640,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
@@ -3860,6 +4694,26 @@
 				"@fluidframework/odsp-driver-definitions": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1",
 				"node-fetch": "^2.6.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
@@ -3874,6 +4728,26 @@
 				"@fluidframework/odsp-driver-definitions": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1",
 				"node-fetch": "^2.6.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/odsp-driver": {
@@ -3899,6 +4773,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3914,6 +4801,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -3956,6 +4848,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -3971,6 +4876,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -4009,6 +4919,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
@@ -4024,6 +4954,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/protocol-base": {
@@ -4035,6 +4985,26 @@
 				"@fluidframework/gitresources": "0.1036.5000-73432",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"lodash": "^4.17.21"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/protocol-definitions": {
@@ -4059,6 +5029,19 @@
 				"@fluidframework/shared-object-base": "^1.0.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4074,6 +5057,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -4091,6 +5079,19 @@
 				"@fluidframework/shared-object-base": "^1.0.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4106,6 +5107,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -4120,6 +5126,26 @@
 				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
@@ -4133,6 +5159,26 @@
 				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/telemetry-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/request-handler": {
@@ -4145,6 +5191,26 @@
 				"@fluidframework/core-interfaces": "^1.0.1",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/runtime-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/request-handler-previous": {
@@ -4157,6 +5223,26 @@
 				"@fluidframework/core-interfaces": "^1.0.1",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/runtime-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
@@ -4182,6 +5268,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4217,6 +5316,11 @@
 						"sillyname": "^0.1.0",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -4248,6 +5352,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4284,6 +5401,11 @@
 						"uuid": "^8.3.1"
 					}
 				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				},
 				"jwt-decode": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -4300,6 +5422,26 @@
 				"@fluidframework/core-interfaces": "^1.0.1",
 				"@fluidframework/driver-definitions": "^1.0.1",
 				"axios": "^0.26.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
@@ -4312,6 +5454,26 @@
 				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"nconf": "^0.11.4"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/runtime-definitions": {
@@ -4326,6 +5488,26 @@
 				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
@@ -4340,6 +5522,26 @@
 				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/runtime-utils": {
@@ -4360,6 +5562,19 @@
 				"@fluidframework/telemetry-utils": "^1.0.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4375,6 +5590,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -4396,6 +5616,19 @@
 				"@fluidframework/telemetry-utils": "^1.0.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4411,6 +5644,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -4431,6 +5669,26 @@
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/sequence-previous": {
@@ -4450,6 +5708,26 @@
 				"@fluidframework/shared-object-base": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/server-lambdas": {
@@ -4478,6 +5756,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4539,6 +5830,11 @@
 					"version": "3.2.4",
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -4628,6 +5924,19 @@
 				"lodash": "^4.17.21"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -4684,6 +5993,11 @@
 					"version": "3.2.4",
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -4773,6 +6087,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/server-lambdas": {
 					"version": "0.1036.5000-73432",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.5000-73432.tgz",
@@ -4858,6 +6185,11 @@
 					"version": "3.2.4",
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -4959,6 +6291,19 @@
 				"ws": "^7.4.6"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -5010,6 +6355,11 @@
 						"debug": "^4.1.1",
 						"nconf": "^0.12.0"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -5106,6 +6456,24 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				},
 				"jwt-decode": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -5129,6 +6497,19 @@
 				"nconf": "^0.12.0"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/server-services-telemetry": {
 					"version": "0.1036.5000-73432",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.5000-73432.tgz",
@@ -5140,6 +6521,11 @@
 						"serialize-error": "^8.1.0",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -5232,6 +6618,19 @@
 				"winston": "^3.3.3"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1035.1000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1035.1000.tgz",
@@ -5302,6 +6701,11 @@
 						"serialize-error": "^8.1.0",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"ioredis": {
 					"version": "4.28.5",
@@ -5363,6 +6767,26 @@
 				"path-browserify": "^1.0.1",
 				"serialize-error": "^8.1.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/server-services-utils": {
@@ -5400,6 +6824,21 @@
 						"@fluidframework/gitresources": "^0.1035.1000",
 						"@fluidframework/protocol-definitions": "^0.1027.1000",
 						"lodash": "^4.17.21"
+					},
+					"dependencies": {
+						"@fluidframework/common-utils": {
+							"version": "0.32.1",
+							"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+							"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+							"requires": {
+								"@fluidframework/common-definitions": "^0.20.1",
+								"@types/events": "^3.0.0",
+								"base64-js": "^1.5.1",
+								"events": "^3.1.0",
+								"lodash": "^4.17.21",
+								"sha.js": "^2.4.11"
+							}
+						}
 					}
 				},
 				"@fluidframework/protocol-definitions": {
@@ -5427,6 +6866,21 @@
 						"jwt-decode": "^3.0.0",
 						"sillyname": "^0.1.0",
 						"uuid": "^8.3.1"
+					},
+					"dependencies": {
+						"@fluidframework/common-utils": {
+							"version": "0.32.1",
+							"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+							"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+							"requires": {
+								"@fluidframework/common-definitions": "^0.20.1",
+								"@types/events": "^3.0.0",
+								"base64-js": "^1.5.1",
+								"events": "^3.1.0",
+								"lodash": "^4.17.21",
+								"sha.js": "^2.4.11"
+							}
+						}
 					}
 				},
 				"@fluidframework/server-services-core": {
@@ -5443,6 +6897,21 @@
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
 						"nconf": "^0.11.0"
+					},
+					"dependencies": {
+						"@fluidframework/common-utils": {
+							"version": "0.32.1",
+							"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+							"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+							"requires": {
+								"@fluidframework/common-definitions": "^0.20.1",
+								"@types/events": "^3.0.0",
+								"base64-js": "^1.5.1",
+								"events": "^3.1.0",
+								"lodash": "^4.17.21",
+								"sha.js": "^2.4.11"
+							}
+						}
 					}
 				},
 				"@fluidframework/server-services-telemetry": {
@@ -5455,7 +6924,27 @@
 						"path-browserify": "^1.0.1",
 						"serialize-error": "^8.1.0",
 						"uuid": "^8.3.1"
+					},
+					"dependencies": {
+						"@fluidframework/common-utils": {
+							"version": "0.32.1",
+							"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+							"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+							"requires": {
+								"@fluidframework/common-definitions": "^0.20.1",
+								"@types/events": "^3.0.0",
+								"base64-js": "^1.5.1",
+								"events": "^3.1.0",
+								"lodash": "^4.17.21",
+								"sha.js": "^2.4.11"
+							}
+						}
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"ioredis": {
 					"version": "4.28.5",
@@ -5525,6 +7014,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/server-services-telemetry": {
 					"version": "0.1036.5000-73432",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.5000-73432.tgz",
@@ -5536,6 +7038,11 @@
 						"serialize-error": "^8.1.0",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -5557,6 +7064,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
@@ -5577,6 +7104,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/telemetry-utils": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
@@ -5591,6 +7138,26 @@
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/runtime-definitions": "^1.0.1",
 				"@fluidframework/shared-object-base": "^1.0.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/synthesize": {
@@ -5613,6 +7180,26 @@
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
@@ -5625,6 +7212,26 @@
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
@@ -5688,6 +7295,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -5775,6 +7395,11 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -5873,6 +7498,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -5961,6 +7599,11 @@
 						"uuid": "^8.3.1"
 					}
 				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -6041,6 +7684,26 @@
 				"@fluidframework/driver-definitions": "^1.0.1",
 				"@fluidframework/driver-utils": "^1.0.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
@@ -6050,6 +7713,26 @@
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
@@ -6059,6 +7742,26 @@
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
@@ -6081,6 +7784,26 @@
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
@@ -6103,6 +7826,26 @@
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-tools": {
@@ -6140,6 +7883,26 @@
 				"@fluidframework/test-runtime-utils": "^1.0.1",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-utils-previous": {
@@ -6171,6 +7934,26 @@
 				"@fluidframework/test-runtime-utils": "^1.0.1",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
@@ -6205,6 +7988,26 @@
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
@@ -6225,6 +8028,26 @@
 				"@fluidframework/runtime-utils": "^1.0.1",
 				"@fluidframework/tinylicious-driver": "^1.0.1",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
@@ -6242,6 +8065,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -6277,6 +8113,11 @@
 						"sillyname": "^0.1.0",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -6300,6 +8141,19 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -6336,6 +8190,11 @@
 						"uuid": "^8.3.1"
 					}
 				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				},
 				"jwt-decode": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -6358,6 +8217,19 @@
 				"proper-lockfile": "^4.1.2"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -6373,6 +8245,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -6391,6 +8268,19 @@
 				"proper-lockfile": "^4.1.2"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1036.4000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
@@ -6406,6 +8296,11 @@
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -6420,6 +8315,19 @@
 				"@fluidframework/sequence": "^0.59.4001"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/container-definitions": {
 					"version": "0.48.2000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.48.2000.tgz",
@@ -6712,6 +8620,11 @@
 						"events": "^3.1.0",
 						"uuid": "^8.3.1"
 					}
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				}
 			}
 		},
@@ -46008,6 +47921,19 @@
 				"winston": "^3.3.3"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.32.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+					"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.1",
+						"@types/events": "^3.0.0",
+						"base64-js": "^1.5.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.21",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/gitresources": {
 					"version": "0.1035.1000",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1035.1000.tgz",
@@ -46183,6 +48109,11 @@
 					"version": "6.2.3",
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
 					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
+				},
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.8.3"
 			}
@@ -16,14 +15,12 @@
 		"@babel/helper-validator-identifier": {
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
-			"dev": true
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
 		},
 		"@babel/highlight": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
 			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.0",
 				"chalk": "^2.0.0",
@@ -57,9 +54,9 @@
 			}
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.71273",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.71273.tgz",
-			"integrity": "sha512-VUcbawEInAx0llWxBGgkGdZOoyVRgFiW2HRCgwqUD3zvVjQVZDOlY9uu/sKzVPCAKJKefDTwdgEQkMxSW8hR/w==",
+			"version": "0.2.74327",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.74327.tgz",
+			"integrity": "sha512-9dEiMAhuynkoIWZR1m7T5WgGE7NVSm/DEdM53DIMcbT3Dem2Os4weVUYimgTa5ub5HsG/YEiNXDE9twZUozX+A==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -131,10 +128,32 @@
 			"dev": true
 		},
 		"@istanbuljs/schema": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
-			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+			"dev": true
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+			"dev": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+			"integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
 		},
 		"@lerna/add": {
 			"version": "4.0.0",
@@ -152,17 +171,6 @@
 				"p-map": "^4.0.0",
 				"pacote": "^11.2.6",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/bootstrap": {
@@ -193,23 +201,6 @@
 				"p-waterfall": "^2.1.1",
 				"read-package-tree": "^5.3.1",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"get-port": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-					"integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-					"dev": true
-				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/changed": {
@@ -320,12 +311,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"human-signals": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-					"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-					"dev": true
-				},
 				"is-stream": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -339,15 +324,6 @@
 					"dev": true,
 					"requires": {
 						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
 					}
 				},
 				"path-key": {
@@ -405,17 +381,6 @@
 				"p-map": "^4.0.0",
 				"p-map-series": "^2.1.0",
 				"p-waterfall": "^2.1.1"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/cli": {
@@ -430,23 +395,6 @@
 				"yargs": "^16.2.0"
 			},
 			"dependencies": {
-				"cliui": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^7.0.0"
-					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -473,12 +421,6 @@
 						"ansi-regex": "^5.0.0"
 					}
 				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-					"dev": true
-				},
 				"yargs": {
 					"version": "16.2.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -493,12 +435,6 @@
 						"y18n": "^5.0.5",
 						"yargs-parser": "^20.2.2"
 					}
-				},
-				"yargs-parser": {
-					"version": "20.2.9",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-					"dev": true
 				}
 			}
 		},
@@ -575,14 +511,6 @@
 				"minimatch": "^3.0.4",
 				"npmlog": "^4.1.2",
 				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/command": {
@@ -637,12 +565,6 @@
 					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 					"dev": true
 				},
-				"human-signals": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-					"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-					"dev": true
-				},
 				"is-stream": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -656,15 +578,6 @@
 					"dev": true,
 					"requires": {
 						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
 					}
 				},
 				"path-key": {
@@ -758,126 +671,16 @@
 				"yargs-parser": "20.2.4"
 			},
 			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-					"dev": true
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"dev": true,
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-					"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.2",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.4"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"globby": {
-					"version": "11.0.4",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
-					"dev": true,
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.1.1",
-						"ignore": "^5.1.4",
-						"merge2": "^1.3.0",
-						"slash": "^3.0.0"
-					}
-				},
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-					"dev": true
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
-					}
-				},
 				"path-type": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"picomatch": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-					"dev": true
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 				},
 				"pify": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
 					"integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
 					"dev": true
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
 				},
 				"tr46": {
 					"version": "2.1.0",
@@ -959,17 +762,6 @@
 				"@lerna/run-topologically": "4.0.0",
 				"@lerna/validation-error": "4.0.0",
 				"p-map": "^4.0.0"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/filter-options": {
@@ -1055,15 +847,6 @@
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
 				},
-				"ssri": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
-					}
-				},
 				"tar": {
 					"version": "6.1.11",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
@@ -1107,12 +890,6 @@
 					"requires": {
 						"@octokit/types": "^6.17.3"
 					}
-				},
-				"@octokit/plugin-request-log": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-					"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-					"dev": true
 				},
 				"@octokit/plugin-rest-endpoint-methods": {
 					"version": "5.3.7",
@@ -1240,17 +1017,6 @@
 				"fs-extra": "^9.1.0",
 				"p-map": "^4.0.0",
 				"write-json-file": "^4.3.0"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/link": {
@@ -1264,23 +1030,6 @@
 				"@lerna/symlink-dependencies": "4.0.0",
 				"p-map": "^4.0.0",
 				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/list": {
@@ -1408,42 +1157,15 @@
 						"debug": "4"
 					}
 				},
-				"cacache": {
-					"version": "15.2.0",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.2.0.tgz",
-					"integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
-					"dev": true,
-					"requires": {
-						"@npmcli/move-file": "^1.0.1",
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"glob": "^7.1.4",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^6.0.0",
-						"minipass": "^3.1.1",
-						"minipass-collect": "^1.0.2",
-						"minipass-flush": "^1.0.5",
-						"minipass-pipeline": "^1.2.2",
-						"mkdirp": "^1.0.3",
-						"p-map": "^4.0.0",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^3.0.2",
-						"ssri": "^8.0.1",
-						"tar": "^6.0.2",
-						"unique-filename": "^1.1.1"
-					}
-				},
 				"chownr": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-					"dev": true
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
 				},
 				"fs-minipass": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
 					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
 					"requires": {
 						"minipass": "^3.0.0"
 					}
@@ -1496,7 +1218,6 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -1505,7 +1226,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
 					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
 					"requires": {
 						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
@@ -1514,8 +1234,7 @@
 				"mkdirp": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
 				"npm-registry-fetch": {
 					"version": "9.0.0",
@@ -1533,38 +1252,18 @@
 						"npm-package-arg": "^8.0.0"
 					}
 				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
-					}
-				},
-				"ssri": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
 					}
 				},
 				"tar": {
 					"version": "6.1.11",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
 					"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-					"dev": true,
 					"requires": {
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.0.0",
@@ -1577,8 +1276,7 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -1802,14 +1500,6 @@
 				"fs-extra": "^9.1.0",
 				"npmlog": "^4.1.2",
 				"upath": "^2.0.1"
-			},
-			"dependencies": {
-				"upath": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-					"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/project": {
@@ -1832,154 +1522,19 @@
 				"write-json-file": "^4.3.0"
 			},
 			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-					"dev": true
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"cosmiconfig": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-					"dev": true,
-					"requires": {
-						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.2.1",
-						"parse-json": "^5.0.0",
-						"path-type": "^4.0.0",
-						"yaml": "^1.10.0"
-					}
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"dev": true,
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"dot-prop": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-					"integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-					"dev": true,
-					"requires": {
-						"is-obj": "^2.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-					"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.2",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.4"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"globby": {
-					"version": "11.0.4",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
-					"dev": true,
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.1.1",
-						"ignore": "^5.1.4",
-						"merge2": "^1.3.0",
-						"slash": "^3.0.0"
-					}
-				},
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					},
-					"dependencies": {
-						"resolve-from": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-							"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-							"dev": true
-						}
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"is-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-					"dev": true
-				},
 				"micromatch": {
 					"version": "4.0.4",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
 					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-					"dev": true,
 					"requires": {
 						"braces": "^3.0.1",
 						"picomatch": "^2.2.3"
-					}
-				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
 					}
 				},
 				"parse-json": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
@@ -1990,35 +1545,13 @@
 				"path-type": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"picomatch": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-					"dev": true
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
 				}
 			}
 		},
@@ -2077,42 +1610,15 @@
 						"debug": "4"
 					}
 				},
-				"cacache": {
-					"version": "15.2.0",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.2.0.tgz",
-					"integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
-					"dev": true,
-					"requires": {
-						"@npmcli/move-file": "^1.0.1",
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"glob": "^7.1.4",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^6.0.0",
-						"minipass": "^3.1.1",
-						"minipass-collect": "^1.0.2",
-						"minipass-flush": "^1.0.5",
-						"minipass-pipeline": "^1.2.2",
-						"mkdirp": "^1.0.3",
-						"p-map": "^4.0.0",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^3.0.2",
-						"ssri": "^8.0.1",
-						"tar": "^6.0.2",
-						"unique-filename": "^1.1.1"
-					}
-				},
 				"chownr": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-					"dev": true
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
 				},
 				"fs-minipass": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
 					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
 					"requires": {
 						"minipass": "^3.0.0"
 					}
@@ -2165,7 +1671,6 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -2174,7 +1679,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
 					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
 					"requires": {
 						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
@@ -2183,8 +1687,7 @@
 				"mkdirp": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
 				"npm-registry-fetch": {
 					"version": "9.0.0",
@@ -2202,38 +1705,18 @@
 						"npm-package-arg": "^8.0.0"
 					}
 				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
-					}
-				},
-				"ssri": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
 					}
 				},
 				"tar": {
 					"version": "6.1.11",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
 					"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-					"dev": true,
 					"requires": {
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.0.0",
@@ -2246,8 +1729,7 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -2324,17 +1806,6 @@
 				"@lerna/timer": "4.0.0",
 				"@lerna/validation-error": "4.0.0",
 				"p-map": "^4.0.0"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/run-lifecycle": {
@@ -2368,17 +1839,6 @@
 				"@lerna/package": "4.0.0",
 				"fs-extra": "^9.1.0",
 				"p-map": "^4.0.0"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/symlink-dependencies": {
@@ -2393,17 +1853,6 @@
 				"fs-extra": "^9.1.0",
 				"p-map": "^4.0.0",
 				"p-map-series": "^2.1.0"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/timer": {
@@ -2495,21 +1944,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2546,20 +1980,26 @@
 			}
 		},
 		"@microsoft/api-documenter": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.17.9.tgz",
-			"integrity": "sha512-crmuhaqKG0zfeoCjIjvRfUzUe/JZaMGE3HS7FwtH7jROy/AHU8nL2Zpq8RzFRNKV9yHMiF8wVcEgfGmH5oM3hw==",
+			"version": "7.17.19",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.17.19.tgz",
+			"integrity": "sha512-6aUzSTmzU4dIXkAwbrpNGVxBigH1e+h49jStQ2f0uH+Z155GEFRoNmyZTZW0b/Q9sjsgSaa+EdJK0UkNwEM1Qw==",
 			"dev": true,
 			"requires": {
-				"@microsoft/api-extractor-model": "7.17.1",
+				"@microsoft/api-extractor-model": "7.18.2",
 				"@microsoft/tsdoc": "0.14.1",
-				"@rushstack/node-core-library": "3.45.3",
-				"@rushstack/ts-command-line": "4.10.9",
+				"@rushstack/node-core-library": "3.45.7",
+				"@rushstack/ts-command-line": "4.11.1",
 				"colors": "~1.2.1",
 				"js-yaml": "~3.13.1",
 				"resolve": "~1.17.0"
 			},
 			"dependencies": {
+				"colors": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+					"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+					"dev": true
+				},
 				"resolve": {
 					"version": "1.17.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -2572,60 +2012,30 @@
 			}
 		},
 		"@microsoft/api-extractor": {
-			"version": "7.22.2",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.22.2.tgz",
-			"integrity": "sha512-G7vXz6UHz+qoaUGPf2k5Md4bSpHii9nFys3sIe3bmFUbmhAe+HfSB/dCn1PsLhW7tZfEXwMHTj7fbL5vcZkrEw==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.25.2.tgz",
+			"integrity": "sha512-ITuiZqMszZE38dGqavkFFIAW/GQGfkk8ahgBqVj3j1qD4wioPTRlSidhQDCezExAhrMt/bTkuZ3woLeR0uiSsg==",
 			"dev": true,
 			"requires": {
-				"@microsoft/api-extractor-model": "7.17.1",
+				"@microsoft/api-extractor-model": "7.18.2",
 				"@microsoft/tsdoc": "0.14.1",
 				"@microsoft/tsdoc-config": "~0.16.1",
-				"@rushstack/node-core-library": "3.45.3",
-				"@rushstack/rig-package": "0.3.10",
-				"@rushstack/ts-command-line": "4.10.9",
+				"@rushstack/node-core-library": "3.45.7",
+				"@rushstack/rig-package": "0.3.12",
+				"@rushstack/ts-command-line": "4.11.1",
 				"colors": "~1.2.1",
 				"lodash": "~4.17.15",
 				"resolve": "~1.17.0",
 				"semver": "~7.3.0",
 				"source-map": "~0.6.1",
-				"typescript": "~4.5.2"
+				"typescript": "~4.6.3"
 			},
 			"dependencies": {
-				"@microsoft/tsdoc-config": {
-					"version": "0.16.1",
-					"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
-					"integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
-					"dev": true,
-					"requires": {
-						"@microsoft/tsdoc": "0.14.1",
-						"ajv": "~6.12.6",
-						"jju": "~1.4.0",
-						"resolve": "~1.19.0"
-					},
-					"dependencies": {
-						"resolve": {
-							"version": "1.19.0",
-							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-							"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-							"dev": true,
-							"requires": {
-								"is-core-module": "^2.1.0",
-								"path-parse": "^1.0.6"
-							}
-						}
-					}
-				},
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
+				"colors": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+					"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+					"dev": true
 				},
 				"resolve": {
 					"version": "1.17.0",
@@ -2637,48 +2047,42 @@
 					}
 				},
 				"typescript": {
-					"version": "4.5.5",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-					"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+					"version": "4.6.4",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+					"integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
 					"dev": true
 				}
 			}
 		},
 		"@microsoft/api-extractor-model": {
-			"version": "7.17.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.17.1.tgz",
-			"integrity": "sha512-DCDtD8TdEpNk2lW4JvXgwwpxKy70P0JLad55iahwO8A+C63KYsrHIpAzo0FUauh5pwJ0v5QVNIJ+OBgKGteemg==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.18.2.tgz",
+			"integrity": "sha512-m7MCvJrudnWyE4iuRhdmgJTdTkYLw+yN/XUp3y9sxicu5/mNdg8y4pflaM82ZbLakhfGreMlB/XgjvyGbLHwkA==",
 			"dev": true,
 			"requires": {
 				"@microsoft/tsdoc": "0.14.1",
 				"@microsoft/tsdoc-config": "~0.16.1",
-				"@rushstack/node-core-library": "3.45.3"
+				"@rushstack/node-core-library": "3.45.7"
+			}
+		},
+		"@microsoft/tsdoc": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
+			"integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==",
+			"dev": true
+		},
+		"@microsoft/tsdoc-config": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
+			"integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+			"dev": true,
+			"requires": {
+				"@microsoft/tsdoc": "0.14.1",
+				"ajv": "~6.12.6",
+				"jju": "~1.4.0",
+				"resolve": "~1.19.0"
 			},
 			"dependencies": {
-				"@microsoft/tsdoc-config": {
-					"version": "0.16.1",
-					"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
-					"integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
-					"dev": true,
-					"requires": {
-						"@microsoft/tsdoc": "0.14.1",
-						"ajv": "~6.12.6",
-						"jju": "~1.4.0",
-						"resolve": "~1.19.0"
-					}
-				},
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
 				"resolve": {
 					"version": "1.19.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
@@ -2690,12 +2094,6 @@
 					}
 				}
 			}
-		},
-		"@microsoft/tsdoc": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
-			"integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==",
-			"dev": true
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.4",
@@ -2961,18 +2359,18 @@
 			},
 			"dependencies": {
 				"@octokit/openapi-types": {
-					"version": "11.2.0",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-					"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+					"version": "12.4.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.4.0.tgz",
+					"integrity": "sha512-Npcb7Pv30b33U04jvcD7l75yLU0mxhuX2Xqrn51YyZ5WTkF04bpbxLaZ6GcaTqu03WZQHoO/Gbfp95NGRueDUA==",
 					"dev": true
 				},
 				"@octokit/types": {
-					"version": "6.34.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-					"integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+					"version": "6.37.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.37.0.tgz",
+					"integrity": "sha512-BXWQhFKRkjX4dVW5L2oYa0hzWOAqsEsujXsQLSdepPoDZfYdubrD1KDGpyNldGXtR8QM/WezDcxcIN1UKJMGPA==",
 					"dev": true,
 					"requires": {
-						"@octokit/openapi-types": "^11.2.0"
+						"@octokit/openapi-types": "^12.4.0"
 					}
 				}
 			}
@@ -2992,29 +2390,6 @@
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
-				"@octokit/auth-token": {
-					"version": "2.4.5",
-					"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
-					"integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
-					"dev": true,
-					"requires": {
-						"@octokit/types": "^6.0.3"
-					}
-				},
-				"@octokit/request": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
-					"integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
-					"dev": true,
-					"requires": {
-						"@octokit/endpoint": "^6.0.1",
-						"@octokit/request-error": "^2.1.0",
-						"@octokit/types": "^6.16.1",
-						"is-plain-object": "^5.0.0",
-						"node-fetch": "^2.6.1",
-						"universal-user-agent": "^6.0.0"
-					}
-				},
 				"@octokit/request-error": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
@@ -3035,17 +2410,10 @@
 						"@octokit/openapi-types": "^8.1.4"
 					}
 				},
-				"before-after-hook": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-					"integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
-					"dev": true
-				},
 				"is-plain-object": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-					"dev": true
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 				},
 				"universal-user-agent": {
 					"version": "6.0.0",
@@ -3103,25 +2471,10 @@
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
-				"@octokit/request": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
-					"integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
-					"dev": true,
-					"requires": {
-						"@octokit/endpoint": "^6.0.1",
-						"@octokit/request-error": "^2.1.0",
-						"@octokit/types": "^6.16.1",
-						"is-plain-object": "^5.0.0",
-						"node-fetch": "^2.6.1",
-						"universal-user-agent": "^6.0.0"
-					}
-				},
 				"@octokit/request-error": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
 					"integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-					"dev": true,
 					"requires": {
 						"@octokit/types": "^6.0.3",
 						"deprecation": "^2.0.0",
@@ -3132,7 +2485,6 @@
 					"version": "6.17.4",
 					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.17.4.tgz",
 					"integrity": "sha512-Ghk/JC4zC/1al1GwH6p8jVX6pLdypSWmbnx6h79C/yo3DeaDd6MsNsBFlHu22KbkFh+CdcAzFqdP7UdPaPPmmA==",
-					"dev": true,
 					"requires": {
 						"@octokit/openapi-types": "^8.1.4"
 					}
@@ -3140,8 +2492,7 @@
 				"is-plain-object": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-					"dev": true
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 				},
 				"universal-user-agent": {
 					"version": "6.0.0",
@@ -3154,8 +2505,7 @@
 		"@octokit/openapi-types": {
 			"version": "8.1.4",
 			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.1.4.tgz",
-			"integrity": "sha512-NnGr4NNDqO5wjSDJo5nxrGtzZUwoT23YasqK2H4Pav/6vSgeVTxuqCL9Aeh+cWfTxDomj1M4Os5BrXFsvl7qiQ==",
-			"dev": true
+			"integrity": "sha512-NnGr4NNDqO5wjSDJo5nxrGtzZUwoT23YasqK2H4Pav/6vSgeVTxuqCL9Aeh+cWfTxDomj1M4Os5BrXFsvl7qiQ=="
 		},
 		"@octokit/plugin-enterprise-rest": {
 			"version": "6.0.1",
@@ -3203,9 +2553,9 @@
 			},
 			"dependencies": {
 				"@octokit/openapi-types": {
-					"version": "11.2.0",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-					"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+					"version": "12.4.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.4.0.tgz",
+					"integrity": "sha512-Npcb7Pv30b33U04jvcD7l75yLU0mxhuX2Xqrn51YyZ5WTkF04bpbxLaZ6GcaTqu03WZQHoO/Gbfp95NGRueDUA==",
 					"dev": true
 				},
 				"@octokit/request-error": {
@@ -3220,12 +2570,12 @@
 					}
 				},
 				"@octokit/types": {
-					"version": "6.34.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-					"integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+					"version": "6.37.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.37.0.tgz",
+					"integrity": "sha512-BXWQhFKRkjX4dVW5L2oYa0hzWOAqsEsujXsQLSdepPoDZfYdubrD1KDGpyNldGXtR8QM/WezDcxcIN1UKJMGPA==",
 					"dev": true,
 					"requires": {
-						"@octokit/openapi-types": "^11.2.0"
+						"@octokit/openapi-types": "^12.4.0"
 					}
 				},
 				"is-plain-object": {
@@ -3296,9 +2646,9 @@
 			}
 		},
 		"@rushstack/node-core-library": {
-			"version": "3.45.3",
-			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.45.3.tgz",
-			"integrity": "sha512-Rn0mxqC3MPb+YbvaeFcRWfcYHLwyZ99/ffYA8chpq5OpqoY+Mr1ycTbMvzl5AxWf1pYmi/2+Eo3iTOsQdYR8xw==",
+			"version": "3.45.7",
+			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.45.7.tgz",
+			"integrity": "sha512-DHfOvgPrm9X4uILlUfGgiqcobe5QGNDmqqYLM8dJ5M5fqQ9H5GwyUwBnFeRsxBo0b75RE83l41Oze+gdHKvKaA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "12.20.24",
@@ -3316,6 +2666,12 @@
 					"version": "12.20.24",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
 					"integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+					"dev": true
+				},
+				"colors": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+					"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
 					"dev": true
 				},
 				"fs-extra": {
@@ -3341,9 +2697,9 @@
 			}
 		},
 		"@rushstack/rig-package": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.10.tgz",
-			"integrity": "sha512-4Z2HhXM4YBWOi4ZYFQNK6Yxz641v+cvc8NKiaNZh+RIdNb3D4Rfpy3XUkggbCozpfDriBfL1+KaXlJtfJfAIXw==",
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.12.tgz",
+			"integrity": "sha512-ZzxuBWG0wbOtI+9IHYvOsr3QN52GtxTWpcaHMsQ/PC9us2ve/k0xK0XOMu+CtStyHSnBG2nDdnF9vFv9HMYOZg==",
 			"dev": true,
 			"requires": {
 				"resolve": "~1.17.0",
@@ -3358,25 +2714,27 @@
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
-				},
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-					"dev": true
 				}
 			}
 		},
 		"@rushstack/ts-command-line": {
-			"version": "4.10.9",
-			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.10.9.tgz",
-			"integrity": "sha512-TE3eZgHNVHOY3p8lp38FoNEJUr0+swPb24sCcYuwlC+MHgMGXyJNM+p7l3TKSBRiY01XShoL2k601oGwL00KlA==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.11.1.tgz",
+			"integrity": "sha512-Xo8LaQOXlNSfp+qIuIPb1tfX7b4H21ksqiMo/HbeZI5AX1klHMqKjWcEs0AqgE9huvQj6cvnCla8Eq/GDcwMIg==",
 			"dev": true,
 			"requires": {
 				"@types/argparse": "1.0.38",
 				"argparse": "~1.0.9",
 				"colors": "~1.2.1",
 				"string-argv": "~0.3.1"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+					"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+					"dev": true
+				}
 			}
 		},
 		"@tootallnate/once": {
@@ -3442,16 +2800,10 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/is-windows": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-1.0.0.tgz",
-			"integrity": "sha512-tJ1rq04tGKuIJoWIH0Gyuwv4RQ3+tIu7wQrC0MV47raQ44kIzXSSFKfrxFUOWVRvesoF7mrTqigXmqoZJsXwTg==",
-			"dev": true
-		},
 		"@types/istanbul-lib-coverage": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-			"integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -3563,6 +2915,12 @@
 			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
 			"dev": true
 		},
+		"ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true
+		},
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3573,7 +2931,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -3592,38 +2949,6 @@
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"argparse": {
@@ -3693,9 +3018,9 @@
 			"dev": true
 		},
 		"async": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
 			"dev": true
 		},
 		"async-retry": {
@@ -3756,8 +3081,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -3778,7 +3102,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3788,7 +3111,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
@@ -3830,43 +3152,25 @@
 			"dev": true
 		},
 		"c8": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/c8/-/c8-7.7.1.tgz",
-			"integrity": "sha512-OO9KpDGv1iTd/MBNUForJH7vPKt9XnRPWSBKeRJGma4xfTaKBObA0zWAplFpFRuf/qRmATFqGFrzxqDk51LXsw==",
+			"version": "7.11.3",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-7.11.3.tgz",
+			"integrity": "sha512-6YBmsaNmqRm9OS3ZbIiL2EZgi1+Xc4O24jL3vMYGE6idixYuGdy76rIfIdltSKDj9DpLNrcXSonUTR1miBD0wA==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@istanbuljs/schema": "^0.1.2",
+				"@istanbuljs/schema": "^0.1.3",
 				"find-up": "^5.0.0",
 				"foreground-child": "^2.0.0",
-				"furi": "^2.0.0",
-				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-coverage": "^3.2.0",
 				"istanbul-lib-report": "^3.0.0",
-				"istanbul-reports": "^3.0.2",
-				"rimraf": "^3.0.0",
+				"istanbul-reports": "^3.1.4",
+				"rimraf": "^3.0.2",
 				"test-exclude": "^6.0.0",
-				"v8-to-istanbul": "^7.1.0",
+				"v8-to-istanbul": "^9.0.0",
 				"yargs": "^16.2.0",
-				"yargs-parser": "^20.2.7"
+				"yargs-parser": "^20.2.9"
 			},
 			"dependencies": {
-				"cliui": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^7.0.0"
-					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
 				"find-up": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3926,30 +3230,24 @@
 					}
 				},
 				"string-width": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
+						"strip-ansi": "^6.0.1"
 					}
 				},
 				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^5.0.0"
+						"ansi-regex": "^5.0.1"
 					}
-				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-					"dev": true
 				},
 				"yargs": {
 					"version": "16.2.0",
@@ -3965,13 +3263,26 @@
 						"y18n": "^5.0.5",
 						"yargs-parser": "^20.2.2"
 					}
-				},
-				"yargs-parser": {
-					"version": "20.2.7",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-					"integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
-					"dev": true
 				}
+			}
+		},
+		"cacache": {
+			"version": "15.2.0",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.2.0.tgz",
+			"integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
+			"dev": true,
+			"requires": {
+				"@npmcli/move-file": "^1.0.1",
+				"glob": "^7.1.4",
+				"infer-owner": "^1.0.4",
+				"lru-cache": "^6.0.0",
+				"minipass-collect": "^1.0.2",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.2",
+				"p-map": "^4.0.0",
+				"promise-inflight": "^1.0.1",
+				"ssri": "^8.0.1",
+				"unique-filename": "^1.1.1"
 			}
 		},
 		"call-bind": {
@@ -3984,11 +3295,16 @@
 				"get-intrinsic": "^1.0.2"
 			}
 		},
+		"callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true
+		},
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"camelcase-keys": {
 			"version": "6.2.2",
@@ -4011,22 +3327,10 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"chardet": {
@@ -4053,6 +3357,21 @@
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
 			"dev": true
 		},
+		"cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^3.1.0"
+			}
+		},
+		"cli-width": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+			"dev": true
+		},
 		"cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -4064,12 +3383,6 @@
 				"wrap-ansi": "^7.0.0"
 			},
 			"dependencies": {
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4077,23 +3390,23 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
+						"strip-ansi": "^6.0.1"
 					}
 				},
 				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^5.0.0"
+						"ansi-regex": "^5.0.1"
 					}
 				}
 			}
@@ -4140,7 +3453,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -4148,13 +3460,12 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-			"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
 			"dev": true
 		},
 		"columnify": {
@@ -4217,25 +3528,29 @@
 					"requires": {
 						"is-obj": "^2.0.0"
 					}
-				},
-				"is-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-					"dev": true
 				}
 			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"typedarray": "^0.0.6"
+			}
 		},
 		"concurrently": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.3.0.tgz",
-			"integrity": "sha512-k4k1jQGHHKsfbqzkUszVf29qECBrkvBKkcPJEUDTyVR7tZd1G/JOfnst4g1sYbFvJ4UjHZisj1aWQR8yLKpGPw==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.5.1.tgz",
+			"integrity": "sha512-FlSwNpGjWQfRwPLXvJ/OgysbBxPkWpiVjy1042b0U7on7S7qwwMIILRj7WTN1mTgqa582bG6NFuScOoh6Zgdag==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
@@ -4293,12 +3608,6 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4310,15 +3619,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
-				},
-				"rxjs": {
-					"version": "6.6.7",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-					"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.9.0"
-					}
 				},
 				"string-width": {
 					"version": "4.2.3",
@@ -4348,12 +3648,6 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
-				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-					"dev": true
 				},
 				"yargs": {
 					"version": "16.2.0",
@@ -4420,171 +3714,6 @@
 				"through2": "^4.0.0"
 			},
 			"dependencies": {
-				"conventional-changelog-writer": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz",
-					"integrity": "sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==",
-					"dev": true,
-					"requires": {
-						"conventional-commits-filter": "^2.0.7",
-						"dateformat": "^3.0.0",
-						"handlebars": "^4.7.6",
-						"json-stringify-safe": "^5.0.1",
-						"lodash": "^4.17.15",
-						"meow": "^8.0.0",
-						"semver": "^6.0.0",
-						"split": "^1.0.0",
-						"through2": "^4.0.0"
-					}
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"get-pkg-repo": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.1.2.tgz",
-					"integrity": "sha512-/FjamZL9cBYllEbReZkxF2IMh80d8TJoC4e3bmLNif8ibHw95aj0N/tzqK0kZz9eU/3w3dL6lF4fnnX/sDdW3A==",
-					"dev": true,
-					"requires": {
-						"@hutson/parse-repository-url": "^3.0.0",
-						"hosted-git-info": "^4.0.0",
-						"meow": "^7.0.0",
-						"through2": "^2.0.0"
-					},
-					"dependencies": {
-						"meow": {
-							"version": "7.1.1",
-							"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
-							"integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
-							"dev": true,
-							"requires": {
-								"@types/minimist": "^1.2.0",
-								"camelcase-keys": "^6.2.2",
-								"decamelize-keys": "^1.1.0",
-								"hard-rejection": "^2.1.0",
-								"minimist-options": "4.1.0",
-								"normalize-package-data": "^2.5.0",
-								"read-pkg-up": "^7.0.1",
-								"redent": "^3.0.0",
-								"trim-newlines": "^3.0.0",
-								"type-fest": "^0.13.1",
-								"yargs-parser": "^18.1.3"
-							}
-						},
-						"normalize-package-data": {
-							"version": "2.5.0",
-							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-							"dev": true,
-							"requires": {
-								"hosted-git-info": "^2.1.4",
-								"resolve": "^1.10.0",
-								"semver": "2 || 3 || 4 || 5",
-								"validate-npm-package-license": "^3.0.1"
-							},
-							"dependencies": {
-								"hosted-git-info": {
-									"version": "2.8.9",
-									"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-									"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-									"dev": true
-								}
-							}
-						},
-						"read-pkg": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-							"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-							"dev": true,
-							"requires": {
-								"@types/normalize-package-data": "^2.4.0",
-								"normalize-package-data": "^2.5.0",
-								"parse-json": "^5.0.0",
-								"type-fest": "^0.6.0"
-							},
-							"dependencies": {
-								"type-fest": {
-									"version": "0.6.0",
-									"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-									"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-									"dev": true
-								}
-							}
-						},
-						"read-pkg-up": {
-							"version": "7.0.1",
-							"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-							"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-							"dev": true,
-							"requires": {
-								"find-up": "^4.1.0",
-								"read-pkg": "^5.2.0",
-								"type-fest": "^0.8.1"
-							},
-							"dependencies": {
-								"type-fest": {
-									"version": "0.8.1",
-									"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-									"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-									"dev": true
-								}
-							}
-						},
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"safe-buffer": {
-							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-							"dev": true
-						},
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"dev": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						},
-						"through2": {
-							"version": "2.0.5",
-							"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-							"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-							"dev": true,
-							"requires": {
-								"readable-stream": "~2.3.6",
-								"xtend": "~4.0.1"
-							}
-						}
-					}
-				},
 				"hosted-git-info": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
@@ -4593,12 +3722,6 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
 				},
 				"load-json-file": {
 					"version": "4.0.0",
@@ -4624,15 +3747,6 @@
 						}
 					}
 				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
 				"normalize-package-data": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
@@ -4656,20 +3770,10 @@
 						}
 					}
 				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
 				"parse-json": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
@@ -4680,8 +3784,7 @@
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
@@ -4734,23 +3837,12 @@
 				"safe-buffer": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"through2": {
 					"version": "4.0.2",
@@ -4764,14 +3856,12 @@
 				"type-fest": {
 					"version": "0.13.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-					"dev": true
+					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
 				},
 				"yargs-parser": {
 					"version": "18.1.3",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
 					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -4784,6 +3874,21 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
 			"integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
 			"dev": true
+		},
+		"conventional-changelog-writer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz",
+			"integrity": "sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==",
+			"dev": true,
+			"requires": {
+				"conventional-commits-filter": "^2.0.7",
+				"dateformat": "^3.0.0",
+				"handlebars": "^4.7.6",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"split": "^1.0.0"
+			}
 		},
 		"conventional-commits-filter": {
 			"version": "2.0.7",
@@ -4824,17 +3929,7 @@
 				"safe-buffer": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				},
 				"through2": {
 					"version": "4.0.2",
@@ -4863,23 +3958,10 @@
 				"q": "^1.5.1"
 			},
 			"dependencies": {
-				"concat-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-					"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^3.0.2",
-						"typedarray": "^0.0.6"
-					}
-				},
 				"readable-stream": {
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -4889,129 +3971,79 @@
 				"safe-buffer": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				}
 			}
 		},
 		"convert-source-map": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+			"integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
 		},
 		"copyfiles": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.2.0.tgz",
-			"integrity": "sha512-iJbHJI+8OKqsq+4JF0rqgRkZzo++jqO6Wf4FUU1JM41cJF6JcY5968XyF4tm3Kkm7ZOMrqlljdm8N9oyY5raGw==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+			"integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.0.5",
 				"minimatch": "^3.0.3",
-				"mkdirp": "^0.5.1",
+				"mkdirp": "^1.0.4",
 				"noms": "0.0.0",
 				"through2": "^2.0.1",
-				"yargs": "^13.2.4"
+				"untildify": "^4.0.0",
+				"yargs": "^16.1.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"dev": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
 				},
 				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
 					}
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
+						"ansi-regex": "^5.0.1"
 					}
 				},
 				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
 					"dev": true,
 					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
 					}
 				}
 			}
@@ -5159,9 +4191,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
-			"integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==",
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
 			"dev": true
 		},
 		"dateformat": {
@@ -5188,8 +4220,7 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
@@ -5260,8 +4291,7 @@
 		"deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
 		},
 		"detect-indent": {
 			"version": "5.0.0",
@@ -5302,6 +4332,15 @@
 				}
 			}
 		},
+		"dot-prop": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+			"integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+			"dev": true,
+			"requires": {
+				"is-obj": "^2.0.0"
+			}
+		},
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -5328,9 +4367,9 @@
 			}
 		},
 		"emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
 		"encoding": {
@@ -5386,7 +4425,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -5451,8 +4489,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -5574,11 +4611,19 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"figures": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
@@ -5590,12 +4635,21 @@
 			"dev": true
 		},
 		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"dev": true,
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				}
 			}
 		},
 		"for-each": {
@@ -5618,9 +4672,9 @@
 			},
 			"dependencies": {
 				"cross-spawn": {
-					"version": "7.0.2",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-					"integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 					"dev": true,
 					"requires": {
 						"path-key": "^3.1.0",
@@ -5725,8 +4779,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -5871,16 +4924,6 @@
 			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
 			"dev": true
 		},
-		"furi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/furi/-/furi-2.0.0.tgz",
-			"integrity": "sha512-uKuNsaU0WVaK/vmvj23wW1bicOFfyqSsAIH71bRZx8kA4Xj+YCHin7CJKJJjkIsmxYaPFLk9ljmjEyB7xF7WvQ==",
-			"dev": true,
-			"requires": {
-				"@types/is-windows": "^1.0.0",
-				"is-windows": "^1.0.2"
-			}
-		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -5950,6 +4993,66 @@
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1"
 			}
+		},
+		"get-pkg-repo": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.1.2.tgz",
+			"integrity": "sha512-/FjamZL9cBYllEbReZkxF2IMh80d8TJoC4e3bmLNif8ibHw95aj0N/tzqK0kZz9eU/3w3dL6lF4fnnX/sDdW3A==",
+			"dev": true,
+			"requires": {
+				"@hutson/parse-repository-url": "^3.0.0",
+				"meow": "^7.0.0",
+				"through2": "^2.0.0"
+			},
+			"dependencies": {
+				"meow": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+					"integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "4.1.0",
+						"normalize-package-data": "^2.5.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.8.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+							"dev": true
+						}
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"get-port": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+			"integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "6.0.0",
@@ -6029,17 +5132,7 @@
 				"safe-buffer": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				},
 				"through2": {
 					"version": "4.0.2",
@@ -6148,7 +5241,6 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -6222,20 +5314,6 @@
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				}
 			}
 		},
 		"hard-rejection": {
@@ -6262,8 +5340,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-property-descriptors": {
 			"version": "1.0.0",
@@ -6395,6 +5472,12 @@
 				}
 			}
 		},
+		"human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true
+		},
 		"humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -6468,6 +5551,16 @@
 			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
 			"dev": true
 		},
+		"import-local": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			}
+		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6490,7 +5583,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6499,8 +5591,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.8",
@@ -6589,15 +5680,6 @@
 				"through": "^2.3.6"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-					"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.21.3"
-					}
-				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6617,21 +5699,6 @@
 						"supports-color": "^7.1.0"
 					}
 				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
-					}
-				},
-				"cli-width": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-					"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-					"dev": true
-				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6646,21 +5713,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"figures": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-					"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -6679,34 +5731,6 @@
 					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 					"dev": true
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"rxjs": {
-					"version": "6.6.7",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-					"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.9.0"
-					}
 				},
 				"string-width": {
 					"version": "4.2.2",
@@ -6740,8 +5764,7 @@
 				"type-fest": {
 					"version": "0.21.3",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-					"dev": true
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
 				}
 			}
 		},
@@ -6803,8 +5826,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-bigint": {
 			"version": "1.0.4",
@@ -6922,8 +5944,7 @@
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
 		"is-number-object": {
 			"version": "1.0.7",
@@ -6933,6 +5954,12 @@
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
+		},
+		"is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -7187,9 +6214,9 @@
 			"dev": true
 		},
 		"isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
 		"isexe": {
@@ -7211,9 +6238,9 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-			"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
 			"dev": true
 		},
 		"istanbul-lib-report": {
@@ -7233,25 +6260,10 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -7260,9 +6272,9 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
+			"integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
 			"dev": true,
 			"requires": {
 				"html-escaper": "^2.0.0",
@@ -7272,14 +6284,13 @@
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -7306,8 +6317,7 @@
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -7342,7 +6352,7 @@
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
@@ -7408,38 +6418,6 @@
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"setimmediate": "^1.0.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"jwa": {
@@ -7511,73 +6489,15 @@
 				"npmlog": "^4.1.2"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"import-local": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-					"dev": true,
-					"requires": {
-						"pkg-dir": "^4.2.0",
-						"resolve-cwd": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				},
-				"resolve-cwd": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-					"dev": true,
-					"requires": {
-						"resolve-from": "^5.0.0"
-					}
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 				}
 			}
 		},
@@ -7648,7 +6568,6 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -7665,20 +6584,10 @@
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
-				"ssri": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
-					}
-				},
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -7694,8 +6603,7 @@
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
 		},
 		"load-json-file": {
 			"version": "6.2.0",
@@ -7736,13 +6644,12 @@
 			}
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "^4.1.0"
 			}
 		},
 		"lodash": {
@@ -7766,7 +6673,7 @@
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
 			"dev": true
 		},
 		"lodash.includes": {
@@ -7784,7 +6691,7 @@
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
 			"dev": true
 		},
 		"lodash.isinteger": {
@@ -7974,6 +6881,23 @@
 			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
 			"dev": true
 		},
+		"make-dir": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
+			"requires": {
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
 		"make-fetch-happen": {
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.0.3.tgz",
@@ -8007,42 +6931,15 @@
 						"debug": "4"
 					}
 				},
-				"cacache": {
-					"version": "15.2.0",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.2.0.tgz",
-					"integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
-					"dev": true,
-					"requires": {
-						"@npmcli/move-file": "^1.0.1",
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"glob": "^7.1.4",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^6.0.0",
-						"minipass": "^3.1.1",
-						"minipass-collect": "^1.0.2",
-						"minipass-flush": "^1.0.5",
-						"minipass-pipeline": "^1.2.2",
-						"mkdirp": "^1.0.3",
-						"p-map": "^4.0.0",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^3.0.2",
-						"ssri": "^8.0.1",
-						"tar": "^6.0.2",
-						"unique-filename": "^1.1.1"
-					}
-				},
 				"chownr": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-					"dev": true
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
 				},
 				"fs-minipass": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
 					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"dev": true,
 					"requires": {
 						"minipass": "^3.0.0"
 					}
@@ -8072,7 +6969,6 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -8081,7 +6977,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
 					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
 					"requires": {
 						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
@@ -8090,41 +6985,20 @@
 				"mkdirp": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
-					}
-				},
-				"ssri": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
 					}
 				},
 				"tar": {
 					"version": "6.1.11",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
 					"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-					"dev": true,
 					"requires": {
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.0.0",
@@ -8137,8 +7011,7 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -8176,16 +7049,6 @@
 				"yargs-parser": "^20.2.3"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"hosted-git-info": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
@@ -8193,15 +7056,6 @@
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
 					}
 				},
 				"normalize-package-data": {
@@ -8216,20 +7070,10 @@
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
 				"parse-json": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
@@ -8240,52 +7084,7 @@
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-					"dev": true,
-					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^2.5.0",
-						"parse-json": "^5.0.0",
-						"type-fest": "^0.6.0"
-					},
-					"dependencies": {
-						"hosted-git-info": {
-							"version": "2.8.9",
-							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-							"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-							"dev": true
-						},
-						"normalize-package-data": {
-							"version": "2.5.0",
-							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-							"dev": true,
-							"requires": {
-								"hosted-git-info": "^2.1.4",
-								"resolve": "^1.10.0",
-								"semver": "2 || 3 || 4 || 5",
-								"validate-npm-package-license": "^3.0.1"
-							}
-						},
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						},
-						"type-fest": {
-							"version": "0.6.0",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-							"dev": true
-						}
-					}
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
 				"read-pkg-up": {
 					"version": "7.0.1",
@@ -8310,12 +7109,6 @@
 					"version": "0.18.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
 					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "20.2.9",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 					"dev": true
 				}
 			}
@@ -8373,7 +7166,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -8640,14 +7432,6 @@
 				"ieee754": "^1.1.8",
 				"int64-buffer": "^0.1.9",
 				"isarray": "^1.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-					"dev": true
-				}
 			}
 		},
 		"multimatch": {
@@ -8663,12 +7447,6 @@
 				"minimatch": "^3.0.4"
 			},
 			"dependencies": {
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
 				"arrify": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -8743,11 +7521,37 @@
 		"noms": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-			"integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+			"integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "~1.0.31"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+					"dev": true
+				}
 			}
 		},
 		"nopt": {
@@ -8772,15 +7576,6 @@
 				"validate-npm-package-license": "^3.0.1"
 			},
 			"dependencies": {
-				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -8788,6 +7583,12 @@
 					"dev": true
 				}
 			}
+		},
+		"normalize-url": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"dev": true
 		},
 		"npm-bundled": {
 			"version": "1.1.2",
@@ -8919,16 +7720,6 @@
 						"ms": "2.1.2"
 					}
 				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8958,15 +7749,6 @@
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
 					"integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
 					"dev": true
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
 				},
 				"meow": {
 					"version": "9.0.0",
@@ -9007,21 +7789,6 @@
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
 				},
 				"read-pkg-up": {
 					"version": "7.0.1",
@@ -9220,9 +7987,17 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
 			}
 		},
 		"os-homedir": {
@@ -9279,12 +8054,21 @@
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^2.2.0"
+			}
+		},
+		"p-map": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+			"dev": true,
+			"requires": {
+				"aggregate-error": "^3.0.0"
 			}
 		},
 		"p-map-series": {
@@ -9366,31 +8150,6 @@
 				"tar": "^6.1.0"
 			},
 			"dependencies": {
-				"cacache": {
-					"version": "15.2.0",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.2.0.tgz",
-					"integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
-					"dev": true,
-					"requires": {
-						"@npmcli/move-file": "^1.0.1",
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"glob": "^7.1.4",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^6.0.0",
-						"minipass": "^3.1.1",
-						"minipass-collect": "^1.0.2",
-						"minipass-flush": "^1.0.5",
-						"minipass-pipeline": "^1.2.2",
-						"mkdirp": "^1.0.3",
-						"p-map": "^4.0.0",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^3.0.2",
-						"ssri": "^8.0.1",
-						"tar": "^6.0.2",
-						"unique-filename": "^1.1.1"
-					}
-				},
 				"chownr": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -9431,15 +8190,6 @@
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
 				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -9447,15 +8197,6 @@
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
-					}
-				},
-				"ssri": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
 					}
 				},
 				"tar": {
@@ -9493,14 +8234,6 @@
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-					"dev": true
-				}
 			}
 		},
 		"parse-diff": {
@@ -9561,17 +8294,6 @@
 				"protocols": "^1.4.0",
 				"qs": "^6.9.4",
 				"query-string": "^6.13.8"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "6.10.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-					"integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-					"dev": true,
-					"requires": {
-						"side-channel": "^1.0.4"
-					}
-				}
 			}
 		},
 		"parse-url": {
@@ -9584,14 +8306,6 @@
 				"normalize-url": "4.5.1",
 				"parse-path": "^4.0.0",
 				"protocols": "^1.4.0"
-			},
-			"dependencies": {
-				"normalize-url": {
-					"version": "4.5.1",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-					"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-					"dev": true
-				}
 			}
 		},
 		"path-exists": {
@@ -9603,8 +8317,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -9636,8 +8349,7 @@
 		"picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
 		},
 		"pify": {
 			"version": "3.0.0",
@@ -9650,6 +8362,15 @@
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
 			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
 			"dev": true
+		},
+		"pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^4.0.0"
+			}
 		},
 		"plur": {
 			"version": "4.0.0",
@@ -9668,14 +8389,6 @@
 			"requires": {
 				"colors": "1.4.0",
 				"minimist": "^1.2.0"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-					"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-					"dev": true
-				}
 			}
 		},
 		"process-nextick-args": {
@@ -9750,9 +8463,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.10.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-			"integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+			"version": "6.10.5",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.5.tgz",
+			"integrity": "sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==",
 			"dev": true,
 			"requires": {
 				"side-channel": "^1.0.4"
@@ -9941,15 +8654,18 @@
 			}
 		},
 		"readable-stream": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdir-scoped-modules": {
@@ -9973,7 +8689,7 @@
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
 			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
@@ -10124,12 +8840,6 @@
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
 				}
 			}
 		},
@@ -10155,11 +8865,27 @@
 				"path-parse": "^1.0.6"
 			}
 		},
+		"resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true
+		},
 		"resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
+		},
+		"restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"requires": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			}
 		},
 		"retry": {
 			"version": "0.12.0",
@@ -10203,11 +8929,19 @@
 			"integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
 			"dev": true
 		},
+		"rxjs": {
+			"version": "6.6.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -10224,20 +8958,10 @@
 				"lru-cache": "^6.0.0"
 			},
 			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -10250,7 +8974,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"dev": true
 		},
 		"shallow-clone": {
@@ -10431,7 +9155,7 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
 		"spdx-correct": {
@@ -10500,28 +9224,13 @@
 						"string_decoder": "^1.1.1",
 						"util-deprecate": "^1.0.1"
 					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
 				}
 			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true
 		},
 		"sshpk": {
@@ -10540,6 +9249,12 @@
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
 			}
+		},
+		"ssri": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+			"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+			"dev": true
 		},
 		"strict-uri-encode": {
 			"version": "2.0.0",
@@ -10606,10 +9321,12 @@
 			}
 		},
 		"string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
@@ -10676,7 +9393,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -10747,26 +9463,10 @@
 					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 					"dev": true
 				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -10801,44 +9501,12 @@
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"timsort": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+			"integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
 			"dev": true
 		},
 		"tmp": {
@@ -10854,7 +9522,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
 			}
@@ -10872,7 +9539,7 @@
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true
 		},
 		"tree-kill": {
@@ -10932,9 +9599,9 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
-			"integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.1.tgz",
+			"integrity": "sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==",
 			"dev": true
 		},
 		"typed-rest-client": {
@@ -11011,7 +9678,7 @@
 		"unc-path-regex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
 			"dev": true
 		},
 		"underscore": {
@@ -11051,7 +9718,7 @@
 				"tr46": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
 					"dev": true,
 					"requires": {
 						"punycode": "^2.1.0"
@@ -11091,6 +9758,18 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
+		"untildify": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+			"dev": true
+		},
+		"upath": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+			"dev": true
+		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -11117,8 +9796,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util-promisify": {
 			"version": "2.1.0",
@@ -11129,23 +9807,21 @@
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
+		"uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"dev": true
+		},
 		"v8-to-istanbul": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz",
-			"integrity": "sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+			"integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
 			"dev": true,
 			"requires": {
+				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0",
-				"source-map": "^0.7.3"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
-				}
+				"convert-source-map": "^1.6.0"
 			}
 		},
 		"validate-npm-package-license": {
@@ -11196,13 +9872,13 @@
 		"webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
 			"dev": true
 		},
 		"whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 			"dev": true,
 			"requires": {
 				"tr46": "~0.0.3",
@@ -11230,12 +9906,6 @@
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
 			}
-		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
 		},
 		"which-typed-array": {
 			"version": "1.1.8",
@@ -11429,12 +10099,6 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -11466,8 +10130,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
 			"version": "2.4.3",
@@ -11506,20 +10169,10 @@
 					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 					"dev": true
 				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"sort-keys": {
 					"version": "4.2.0",
@@ -11606,9 +10259,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true
 		},
 		"yallist": {
@@ -11638,12 +10291,6 @@
 				"yargs-parser": "^21.0.0"
 			},
 			"dependencies": {
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -11669,12 +10316,6 @@
 					"requires": {
 						"ansi-regex": "^5.0.1"
 					}
-				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-					"dev": true
 				},
 				"yargs-parser": {
 					"version": "21.0.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -60,7 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -58,7 +58,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -60,7 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-utils": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/merge-tree": "^1.1.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-utils": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -60,7 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/dds/quorum/package.json
+++ b/packages/dds/quorum/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -60,7 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/protocol-base": "^0.1036.5000-0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-utils": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",
     "@fluidframework/container-utils": "^1.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -61,7 +61,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -61,7 +61,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/datastore-definitions": "^1.1.0",
     "@ungap/structured-clone": "^0.3.4"
   },

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -33,7 +33,7 @@
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, extractLogSafeErrorProperties } from "@fluidframework/common-utils";
+import { assert } from "@fluidframework/common-utils";
 import {
     IDocumentDeltaConnection,
     IDocumentDeltaConnectionEvents,
@@ -28,6 +28,7 @@ import {
     loggerToMonitoringContext,
     MonitoringContext,
     EventEmitterWithErrorHandling,
+    extractLogSafeErrorProperties,
 } from "@fluidframework/telemetry-utils";
 import type { Socket } from "socket.io-client";
 // For now, this package is versioned and released in unison with the specific drivers
@@ -568,7 +569,7 @@ export class DocumentDeltaConnection
             // Please see https://github.com/socketio/engine.io-client/blob/7245b80/lib/transport.ts#L44,
             message = `${messagePrefix}${JSON.stringify(error, getCircularReplacer())}`;
         } else {
-            message = extractLogSafeErrorProperties(error).message;
+            message = extractLogSafeErrorProperties(error, false).message;
         }
 
         const errorObj = createGenericNetworkError(

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -37,7 +37,7 @@
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/odsp-driver": "^1.1.0",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-base": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-base": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/driver-base": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -34,7 +34,7 @@
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "axios": "^0.26.0"

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -37,7 +37,7 @@
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore": "^1.1.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -61,7 +61,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/map": "^1.1.0",
     "@fluidframework/merge-tree": "^1.1.0",
     "@fluidframework/runtime-definitions": "^1.1.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime-definitions": "^1.1.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -60,7 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-runtime-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/runtime-definitions": "^1.1.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-utils": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^1.1.0"

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/gitresources": "^0.1036.5000-0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000"

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime-definitions": "^1.1.0",
     "@fluidframework/container-utils": "^1.1.0",

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLogger, ITelemetryPerformanceEvent } from "@fluidframework/common-definitions";
-import { assert, LazyPromise, Timer } from "@fluidframework/common-utils";
+import { assert, LazyPromise, setLongTimeout, Timer } from "@fluidframework/common-utils";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { ClientSessionExpiredError, DataProcessingError, UsageError } from "@fluidframework/container-utils";
 import { IRequestHeader } from "@fluidframework/core-interfaces";
@@ -1279,25 +1279,3 @@ function generateSortedGCState(gcState: IGarbageCollectionState): IGarbageCollec
     return sortedGCState;
 }
 
-/**
- * setLongTimeout is used for timeouts longer than setTimeout's ~24.8 day max
- * @param timeoutMs - the total time the timeout needs to last in ms
- * @param timeoutFn - the function to execute when the timer ends
- * @param setTimerFn - the function used to update your timer variable
- */
-function setLongTimeout(
-    timeoutMs: number,
-    timeoutFn: () => void,
-    setTimerFn: (timer: ReturnType<typeof setTimeout>) => void,
-) {
-    // The setTimeout max is 24.8 days before looping occurs.
-    const maxTimeout = 2147483647;
-    let timer: ReturnType<typeof setTimeout>;
-    if (timeoutMs > maxTimeout) {
-        const newTimeoutMs = timeoutMs - maxTimeout;
-        timer = setTimeout(() => setLongTimeout(newTimeoutMs, timeoutFn, setTimerFn), maxTimeout);
-    } else {
-        timer = setTimeout(() => timeoutFn(), timeoutMs);
-    }
-    setTimerFn(timer);
-}

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -447,10 +447,11 @@ export class GarbageCollector implements IGarbageCollector {
             }
 
             const timeoutMs = this.sessionExpiryTimeoutMs;
-            setLongTimeout(timeoutMs,
+            setLongTimeout(
                 () => {
                     this.runtime.closeFn(new ClientSessionExpiredError(`Client session expired.`, timeoutMs));
                 },
+                timeoutMs,
                 (timer) => {
                     this.sessionExpiryTimer = timer;
                 });
@@ -1278,4 +1279,3 @@ function generateSortedGCState(gcState: IGarbageCollectionState): IGarbageCollec
     }
     return sortedGCState;
 }
-

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-utils": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/runtime-definitions": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-runtime-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/datastore-definitions": "^1.1.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/cell": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluid-internal/replay-tool": "^1.1.0",
     "@fluidframework/cell": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -57,7 +57,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "random-js": "^1.0.8"
   },
   "devDependencies": {

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/core-interfaces": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/cell": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "random-js": "^1.0.8"
   },
   "devDependencies": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -75,7 +75,7 @@
     "@fluid-experimental/task-manager": "^1.1.0",
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/aqueduct": "^1.1.0",
     "@fluidframework/cell": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluid-tools/fluidapp-odsp-urlresolver": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-runtime": "^1.1.0",
     "@fluidframework/datastore": "^1.1.0",
     "@fluidframework/driver-definitions": "^1.1.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/cell": "^1.1.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/container-runtime": "^1.1.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^1.1.0",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/container-definitions": "^1.1.0",
     "@fluidframework/container-loader": "^1.1.0",
     "@fluidframework/core-interfaces": "^1.1.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/driver-definitions": "^1.1.0",
     "@fluidframework/driver-utils": "^1.1.0",
     "@fluidframework/odsp-driver-definitions": "^1.1.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "debug": "^4.1.1",
     "events": "^3.1.0",
     "uuid": "^8.3.1"

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -61,7 +61,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/odsp-doclib-utils": "^1.1.0",
     "@fluidframework/protocol-base": "^0.1036.5000-0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -27,7 +27,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-74526",
     "@fluidframework/gitresources": "^0.1036.4000-68094",
     "@fluidframework/protocol-base": "^0.1036.5000-73262",
     "@fluidframework/protocol-definitions": "^0.1027.1000",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -24,7 +24,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-74526",
     "@fluidframework/gitresources": "^0.1036.4000-68094",
     "@fluidframework/gitrest-base": "^0.1.0",
     "@fluidframework/protocol-base": "^0.1036.5000-73262",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -439,9 +439,9 @@
 			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.32.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
-			"integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+			"version": "0.33.1000-74526",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.33.1000-74526.tgz",
+			"integrity": "sha512-AnyWk9MXm9TPQKMsVnHZxyvwtaPW7qhneSo6G56c5mTVcNL+chJY0GgEVBKnOPahhJbsUf03tQoTnqp0MvqtpA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@types/events": "^3.0.0",
@@ -8801,9 +8801,9 @@
 			"dev": true
 		},
 		"events": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-			"integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
 		},
 		"execa": {
 			"version": "1.0.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/server-services-client": "^0.1036.5000",
     "@fluidframework/server-services-core": "^0.1036.5000",
     "@fluidframework/server-services-telemetry": "^0.1036.5000",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-base": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-lambdas": "^0.1036.5000",
     "@fluidframework/server-memory-orderer": "^0.1036.5000",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/protocol-base": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-lambdas": "^0.1036.5000",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -58,7 +58,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "lodash": "^4.17.21"

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-kafka-orderer": "^0.1036.5000",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -42,7 +42,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-kafka-orderer": "^0.1036.5000",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -57,7 +57,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-base": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.5000",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/server-services-core": "^0.1036.5000",
     "nconf": "^0.12.0",
     "node-rdkafka": "^2.11.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-base": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "json-stringify-safe": "^5.0.1",
     "path-browserify": "^1.0.1",
     "serialize-error": "^8.1.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/server-services-client": "^0.1036.5000",
     "@fluidframework/server-services-core": "^0.1036.5000",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/protocol-base": "^0.1036.5000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -82,9 +82,9 @@
       "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/common-utils": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
-      "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+      "version": "0.33.1000-74526",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.33.1000-74526.tgz",
+      "integrity": "sha512-AnyWk9MXm9TPQKMsVnHZxyvwtaPW7qhneSo6G56c5mTVcNL+chJY0GgEVBKnOPahhJbsUf03tQoTnqp0MvqtpA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@types/events": "^3.0.0",
@@ -451,6 +451,26 @@
         "@fluidframework/gitresources": "0.1036.5000-73432",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/protocol-definitions": {
@@ -485,6 +505,26 @@
         "semver": "^6.3.0",
         "sha.js": "^2.4.11",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/server-lambdas-driver": {
@@ -498,6 +538,26 @@
         "@fluidframework/server-services-telemetry": "0.1036.5000-73432",
         "async": "^3.2.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/server-local-server": {
@@ -516,6 +576,26 @@
         "debug": "^4.1.1",
         "jsrsasign": "^10.2.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/server-memory-orderer": {
@@ -541,6 +621,26 @@
         "sillyname": "^0.1.0",
         "uuid": "^8.3.1",
         "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/server-services-client": {
@@ -561,6 +661,26 @@
         "querystring": "^0.2.0",
         "sillyname": "^0.1.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/server-services-core": {
@@ -579,10 +699,28 @@
         "nconf": "^0.12.0"
       },
       "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
         "@types/nconf": {
           "version": "0.10.2",
           "resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.2.tgz",
           "integrity": "sha512-qy5EPdN8hnlix/q/QYr4ZnICDgaEFh2qivsNYlg4/KlvM7Ye2CqeDo0UXxSoiWplZzyl2PzOxwx4MODaxS+KpA=="
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         }
       }
     },
@@ -611,6 +749,26 @@
         "socket.io-parser": "^4.0.4",
         "uuid": "^8.3.1",
         "winston": "^3.6.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/server-services-telemetry": {
@@ -623,6 +781,26 @@
         "path-browserify": "^1.0.1",
         "serialize-error": "^8.1.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/server-services-utils": {
@@ -664,6 +842,26 @@
         "lodash": "^4.17.21",
         "string-hash": "^1.1.3",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.32.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+          "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        }
       }
     },
     "@fluidframework/test-driver-definitions": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -34,7 +34,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/common-utils": "^0.33.1000-0",
     "@fluidframework/gitresources": "^0.1036.5000-0",
     "@fluidframework/protocol-base": "^0.1036.5000-0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",


### PR DESCRIPTION
[AB#646](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/646)

This bumps the @fluidframework/common-utils dependency version and updates garbageCollection.ts to use the util version of setLongTimeout.
Also  updates import for extractLogSafeErrorProperties from common-utils to telemetry.