### PR TITLE
MergeTree: Fire Remove Event before Sliding

### DIFF
--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -194,6 +194,33 @@ export class LocalReferenceCollection {
         return iterator;
     }
 
+        /**
+     *
+     * @internal - this method should only be called by mergeTree
+     */
+    public clear() {
+        this.refCount = 0;
+        this.hierRefCount = 0;
+        const detachSegments = (refs: List<LocalReference> | undefined) => {
+            if (refs) {
+                for (const r of refs) {
+                    if (r.getSegment() === this.segment) {
+                        r.link(undefined, r.getOffset(), undefined);
+                    }
+                }
+            }
+        };
+        for (let i = 0; i < this.refsByOffset.length; i++) {
+            const refsAtOffset = this.refsByOffset[i];
+            if (refsAtOffset) {
+                detachSegments(refsAtOffset.before);
+                detachSegments(refsAtOffset.at);
+                detachSegments(refsAtOffset.before);
+                this.refsByOffset[i] = undefined;
+            }
+        }
+    }
+
     /**
      *
      * @internal - this method should only be called by mergeTree

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -194,33 +194,6 @@ export class LocalReferenceCollection {
         return iterator;
     }
 
-        /**
-     *
-     * @internal - this method should only be called by mergeTree
-     */
-    public clear() {
-        this.refCount = 0;
-        this.hierRefCount = 0;
-        const detachSegments = (refs: List<LocalReference> | undefined) => {
-            if (refs) {
-                for (const r of refs) {
-                    if (r.getSegment() === this.segment) {
-                        r.link(undefined, r.getOffset(), undefined);
-                    }
-                }
-            }
-        };
-        for (let i = 0; i < this.refsByOffset.length; i++) {
-            const refsAtOffset = this.refsByOffset[i];
-            if (refsAtOffset) {
-                detachSegments(refsAtOffset.before);
-                detachSegments(refsAtOffset.at);
-                detachSegments(refsAtOffset.before);
-                this.refsByOffset[i] = undefined;
-            }
-        }
-    }
-
     /**
      *
      * @internal - this method should only be called by mergeTree

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2478,7 +2478,7 @@ export class MergeTree {
         }
         const pending = this.collabWindow.collaborating && clientId === this.collabWindow.clientId;
         // these events are newly removed
-        // so we slide after eventing incase the consumer wants to make references
+        // so we slide after eventing in case the consumer wants to make reference
         // changes at remove time, like add a ref to track undo redo.
         removedSegments.forEach(
             (rSeg) => this.updateSegmentRefsAfterMarkRemoved(rSeg.segment, pending));

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1460,27 +1460,21 @@ export class MergeTree {
             return;
         }
         const refsToSlide: ReferencePosition[] = [];
-        const refsToStay: ReferencePosition[] = [];
         for (const lref of segment.localRefs) {
             if (refTypeIncludesFlag(lref, ReferenceType.StayOnRemove)) {
-                refsToStay.push(lref);
-            } else if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
-                if (pending) {
-                    refsToStay.push(lref);
-                } else {
+                continue;
+            } if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
+                if (!pending) {
                     refsToSlide.push(lref);
                 }
+            } else {
+                segment.localRefs.removeLocalRef(lref);
             }
         }
         // Rethink implementation of keeping and sliding refs once other reference
         // changes are complete. This works but is fragile and possibly slow.
         if (!pending) {
             this.slideReferences(segment, refsToSlide);
-        }
-        segment.localRefs.clear();
-        for (const lref of refsToStay) {
-            assertLocalReferences(lref);
-            segment.localRefs.addLocalRef(lref, lref.getOffset());
         }
     }
 

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1459,22 +1459,15 @@ export class MergeTree {
         if (!segment.localRefs || segment.localRefs.empty) {
             return;
         }
-        const refsToSlide: ReferencePosition[] = [];
         for (const lref of segment.localRefs) {
-            if (refTypeIncludesFlag(lref, ReferenceType.StayOnRemove)) {
-                continue;
-            } if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
-                if (!pending) {
-                    refsToSlide.push(lref);
-                }
-            } else {
+            if (!refTypeIncludesFlag(lref, ReferenceType.StayOnRemove | ReferenceType.SlideOnRemove)) {
                 segment.localRefs.removeLocalRef(lref);
             }
         }
         // Rethink implementation of keeping and sliding refs once other reference
         // changes are complete. This works but is fragile and possibly slow.
-        if (!pending) {
-            this.slideReferences(segment, refsToSlide);
+        if (!pending && segment.localRefs.empty === false) {
+            this.slideReferences(segment, segment.localRefs);
         }
     }
 

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1427,7 +1427,7 @@ export class MergeTree {
      * Otherwise eventual consistency is not guaranteed.
      * See `packages\dds\merge-tree\REFERENCEPOSITIONS.md`
      */
-    private slideReferences(segment: ISegment, refsToSlide: LocalReferencePosition[]) {
+    private slideReferences(segment: ISegment, refsToSlide: Iterable<LocalReferencePosition>) {
         assert(
             isRemovedAndAcked(segment),
             0x2f1 /* slideReferences from a segment which has not been removed and acked */);
@@ -2414,7 +2414,7 @@ export class MergeTree {
         this.ensureIntervalBoundary(end, refSeq, clientId);
         let segmentGroup: SegmentGroup;
         const removedSegments: IMergeTreeSegmentDelta[] = [];
-        const segmentsWithRefs: ISegment[] = [];
+        const localOverlapWithRefs: ISegment[] = [];
         const localSeq = seq === UnassignedSequenceNumber ? ++this.collabWindow.localSeq : undefined;
         const markRemoved = (segment: ISegment, pos: number, _start: number, _end: number) => {
             const existingRemovalInfo = toRemovalInfo(segment);
@@ -2428,6 +2428,9 @@ export class MergeTree {
                     existingRemovalInfo.removedClientIds.unshift(clientId);
                     existingRemovalInfo.removedSeq = seq;
                     segment.localRemovedSeq = undefined;
+                    if (segment.localRefs?.empty === false) {
+                        localOverlapWithRefs.push(segment);
+                    }
                 } else {
                     // Do not replace earlier sequence number for remove
                     existingRemovalInfo.removedClientIds.push(clientId);
@@ -2438,9 +2441,6 @@ export class MergeTree {
                 segment.localRemovedSeq = localSeq;
 
                 removedSegments.push({ segment });
-            }
-            if (segment.localRefs && !segment.localRefs.empty) {
-                segmentsWithRefs.push(segment);
             }
 
             // Save segment so can assign removed sequence number when acked by server
@@ -2464,11 +2464,9 @@ export class MergeTree {
             return true;
         };
         this.mapRange({ leaf: markRemoved, post: afterMarkRemoved }, refSeq, clientId, undefined, start, end);
-        const pending = this.collabWindow.collaborating && clientId === this.collabWindow.clientId;
-        for (const segment of segmentsWithRefs) {
-            this.updateSegmentRefsAfterMarkRemoved(segment, pending);
-        }
-
+        // these segments are already viewed as being removed locally and are not event-ed
+        // so can slide immediately
+        localOverlapWithRefs.forEach((s) => this.slideReferences(s, s.localRefs!));
         // opArgs == undefined => test code
         if (this.mergeTreeDeltaCallback && removedSegments.length > 0) {
             this.mergeTreeDeltaCallback(
@@ -2478,6 +2476,13 @@ export class MergeTree {
                     deltaSegments: removedSegments,
                 });
         }
+        const pending = this.collabWindow.collaborating && clientId === this.collabWindow.clientId;
+        // these segments are newly removed
+        // so we slide after eventing incase the consumer wants to make references
+        // changes at remove time, like add a ref to track undo redo.
+        removedSegments.forEach(
+            (rSeg) => this.updateSegmentRefsAfterMarkRemoved(rSeg.segment, pending));
+
         if (this.collabWindow.collaborating && (seq !== UnassignedSequenceNumber)) {
             if (MergeTree.options.zamboniSegments) {
                 this.zamboniSegments();

--- a/packages/dds/merge-tree/src/test/client.localReference.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReference.spec.ts
@@ -10,6 +10,7 @@ import { Client } from "../client";
 import { toRemovalInfo } from "../mergeTree";
 import { MergeTreeDeltaType, ReferenceType } from "../ops";
 import { TextSegment } from "../textSegment";
+import { DetachedReferencePosition } from "../referencePositions";
 import { createClientsAtInitialState } from "./testClientLogger";
 import { TestClient } from "./";
 
@@ -52,7 +53,7 @@ describe("MergeTree.Client", () => {
         client2.applyMsg(remove);
 
         // this only works because zamboni hasn't run yet
-        assert.equal(client1.localReferencePositionToPosition(c1LocalRef), -1, "after remove");
+        assert.equal(client1.localReferencePositionToPosition(c1LocalRef), DetachedReferencePosition, "after remove");
 
         // this will force Zamboni to run
         for (let i = 0; i < 5; i++) {
@@ -64,8 +65,7 @@ describe("MergeTree.Client", () => {
             client1.applyMsg(insert);
             client2.applyMsg(insert);
         }
-        assert.equal(c1LocalRef.getSegment(), undefined);
-        assert.equal(client1.localReferencePositionToPosition(c1LocalRef), -1, "after zamboni");
+        assert.equal(client1.localReferencePositionToPosition(c1LocalRef), DetachedReferencePosition, "after zamboni");
     });
 
     it("Remove segment of sliding local reference", () => {
@@ -281,7 +281,7 @@ describe("MergeTree.Client", () => {
         client1.applyMsg(remove);
         client2.applyMsg(remove);
 
-        assert.equal(client1.localReferencePositionToPosition(c1LocalRef), -1);
+        assert.equal(client1.localReferencePositionToPosition(c1LocalRef), DetachedReferencePosition);
     });
 
     it("References can have offsets on removed segment", () => {


### PR DESCRIPTION
## Description

This change moves local reference sliding to after the remove event (mergeTreeDeltaCallback) is fired. This will allow consumers to add a reference at removal time that can be used to more efficiently track removed segments. Additionally, I've removed some redundant iteration and array allocations that should improve perf around the reference sliding code.

## Additional Testing
Ran the currently disabled fuzz tests, they all passed.

## Other information or known dependencies

[AB#150](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/150)
