### PR TITLE
Improve Test Debuggability By Allowing Specific Client Ids

### DIFF
--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -338,6 +338,9 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 
 // @public
 export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDataStoreRuntime, IFluidDataStoreChannel, IFluidHandleContext {
+    constructor(overrides?: {
+        clientId?: string;
+    });
     // (undocumented)
     get absolutePath(): string;
     // (undocumented)

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -54,7 +54,7 @@ describe("SharedString interval collections", () => {
     let dataStoreRuntime1: MockFluidDataStoreRuntime;
 
     beforeEach(() => {
-        dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+        dataStoreRuntime1 = new MockFluidDataStoreRuntime({ clientId: "1" });
         sharedString = new SharedString(dataStoreRuntime1, "shared-string-1", SharedStringFactory.Attributes);
     });
 
@@ -76,7 +76,7 @@ describe("SharedString interval collections", () => {
             sharedString.connect(services1);
 
             // Create and connect a second SharedString.
-            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime({ clientId: "2" });
             const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
@@ -386,7 +386,7 @@ describe("SharedString interval collections", () => {
 
         it("can slide intervals on create ack", () => {
             // Create and connect a third SharedString.
-            const dataStoreRuntime3 = new MockFluidDataStoreRuntime();
+            const dataStoreRuntime3 = new MockFluidDataStoreRuntime({ clientId: "3" });
             const containerRuntime3 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime3);
             const services3 = {
                 deltaConnection: containerRuntime3.createDeltaConnection(),
@@ -430,7 +430,7 @@ describe("SharedString interval collections", () => {
 
         it("can slide intervals on change ack", () => {
             // Create and connect a third SharedString.
-            const dataStoreRuntime3 = new MockFluidDataStoreRuntime();
+            const dataStoreRuntime3 = new MockFluidDataStoreRuntime({ clientId: "3" });
             const containerRuntime3 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime3);
             const services3 = {
                 deltaConnection: containerRuntime3.createDeltaConnection(),
@@ -1101,7 +1101,7 @@ describe("SharedString interval collections", () => {
             sharedString.connect(services1);
 
             // Create and connect a second SharedString.
-            const runtime2 = new MockFluidDataStoreRuntime();
+            const runtime2 = new MockFluidDataStoreRuntime({ clientId: "2" });
             containerRuntime2 = containerRuntimeFactory.createContainerRuntime(runtime2);
             sharedString2 = new SharedString(runtime2, "shared-string-2", SharedStringFactory.Attributes);
             const services2: IChannelServices = {

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -378,6 +378,11 @@ export class MockQuorumClients implements IQuorumClients, EventEmitter {
  */
 export class MockFluidDataStoreRuntime extends EventEmitter
     implements IFluidDataStoreRuntime, IFluidDataStoreChannel, IFluidHandleContext {
+    constructor(overrides?: { clientId?: string; }) {
+        super();
+        this.clientId = overrides?.clientId ?? uuid();
+    }
+
     public get IFluidHandleContext(): IFluidHandleContext { return this; }
     public get rootRoutingContext(): IFluidHandleContext { return this; }
     public get channelsRoutingContext(): IFluidHandleContext { return this; }
@@ -389,7 +394,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter
     public readonly id: string = uuid();
     public readonly existing: boolean = undefined as any;
     public options: ILoaderOptions = {};
-    public clientId: string | undefined = uuid();
+    public clientId: string | undefined;
     public readonly path = "";
     public readonly connected = true;
     public deltaManager = new MockDeltaManager();


### PR DESCRIPTION
## Description

With this change is it is much easier to differentiate clients and differentiate operations for multi-client tests. Additionally it allows setting conditional breakpoint that are repeatable,