### PR TITLE
Moved GarbageCollector create params into an interface

### DIFF
--- a/api-report/garbage-collector.api.md
+++ b/api-report/garbage-collector.api.md
@@ -7,7 +7,6 @@
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IGarbageCollectionDetailsBase } from '@fluidframework/runtime-definitions';
 import { IGarbageCollectionState } from '@fluidframework/runtime-definitions';
-import { ITelemetryLogger } from '@fluidframework/common-definitions';
 
 // @public
 export function cloneGCData(gcData: IGarbageCollectionData): IGarbageCollectionData;
@@ -52,7 +51,7 @@ export function removeRouteFromAllNodes(gcNodes: {
 // @public
 export function runGarbageCollection(referenceGraph: {
     [id: string]: string[];
-}, rootIds: string[], logger: ITelemetryLogger): IGCResult;
+}, rootIds: string[]): IGCResult;
 
 // @public
 export function trimLeadingAndTrailingSlashes(str: string): string;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1215,18 +1215,18 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const pendingRuntimeState = context.pendingLocalState as IPendingRuntimeState | undefined;
         const baseSnapshot: ISnapshotTree | undefined = pendingRuntimeState?.baseSnapshot ?? context.baseSnapshot;
 
-        this.garbageCollector = GarbageCollector.create(
-            this,
-            this.runtimeOptions.gcOptions,
-            (nodePath: string) => this.getGCNodePackagePath(nodePath),
-            () => this.messageAtLastSummary?.timestamp,
+        this.garbageCollector = GarbageCollector.create({
+            runtime: this,
+            gcOptions: this.runtimeOptions.gcOptions,
             baseSnapshot,
-            async <T>(id: string) => readAndParse<T>(this.storage, id),
-            this.mc.logger,
+            baseLogger: this.mc.logger,
             existing,
             metadata,
-            this.context.clientDetails.type === summarizerClientType,
-        );
+            isSummarizerClient: this.context.clientDetails.type === summarizerClientType,
+            getNodePackagePath: (nodePath: string) => this.getGCNodePackagePath(nodePath),
+            getLastSummaryTimestampMs: () => this.messageAtLastSummary?.timestamp,
+            readAndParseBlob: async <T>(id: string) => readAndParse<T>(this.storage, id),
+        });
 
         const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;
         this.summarizerNode = createRootSummarizerNodeWithGC(

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -613,11 +613,7 @@ export class GarbageCollector implements IGarbageCollector {
             // Run GC on the nodes in the base summary to get the routes used in each node in the container.
             // This is an optimization for space (vs performance) wherein we don't need to store the used routes of
             // each node in the summary.
-            const usedRoutes = runGarbageCollection(
-                gcNodes,
-                ["/"],
-                this.mc.logger,
-            ).referencedNodeIds;
+            const usedRoutes = runGarbageCollection(gcNodes, ["/"]).referencedNodeIds;
 
             const baseGCDetailsMap = unpackChildNodesGCDetails({ gcData: { gcNodes }, usedRoutes });
             // Currently, the nodes may write the GC data. So, we need to update it's base GC details with the
@@ -698,11 +694,7 @@ export class GarbageCollector implements IGarbageCollector {
 
             // Get the runtime's GC data and run GC on the reference graph in it.
             const gcData = await this.runtime.getGCData(fullGC);
-            const gcResult = runGarbageCollection(
-                gcData.gcNodes,
-                ["/"],
-                logger,
-            );
+            const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
             const gcStats = this.generateStatsAndLogEvents(gcResult, logger);
 
             // Update the state since the last GC run. There can be nodes that were referenced between the last and
@@ -1036,7 +1028,7 @@ export class GarbageCollector implements IGarbageCollector {
          * unreferenced, stop tracking them and remove from unreferenced list.
          * Some of these nodes may be unreferenced now and if so, the current run will add unreferenced state for them.
          */
-        const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, ["/"], logger);
+        const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, ["/"]);
         for (const nodeId of gcResult.referencedNodeIds) {
             const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
             if (nodeStateTracker !== undefined) {

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -79,18 +79,18 @@ describe("Garbage Collection Tests", () => {
         getNodeGCDetails: (id: string) => IGarbageCollectionDetailsBase = () => emptyGCDetails,
         metadata: IContainerRuntimeMetadata | undefined = undefined,
     ) => {
-        return GarbageCollector.create(
-            gcRuntime,
-            { gcAllowed: true, inactiveTimeoutMs },
-            (nodeId: string) => testPkgPath,
-            () => Date.now(),
+        return GarbageCollector.create({
+            runtime: gcRuntime,
+            gcOptions: { gcAllowed: true, inactiveTimeoutMs },
             baseSnapshot,
-            async <T>(id: string) => getNodeGCDetails(id) as T,
-            mockLogger,
-            metadata !== undefined /* existing */,
+            baseLogger: mockLogger,
+            existing: metadata !== undefined /* existing */,
             metadata,
-            true /* summarizerClient */,
-        );
+            isSummarizerClient: true /* summarizerClient */,
+            readAndParseBlob: async <T>(id: string) => getNodeGCDetails(id) as T,
+            getNodePackagePath: (nodeId: string) => testPkgPath,
+            getLastSummaryTimestampMs: () => Date.now(),
+        });
     };
 
     const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;

--- a/packages/runtime/garbage-collector/src/garbageCollector.ts
+++ b/packages/runtime/garbage-collector/src/garbageCollector.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { IGCResult } from "./interfaces";
 
 /**
@@ -11,14 +10,9 @@ import { IGCResult } from "./interfaces";
  * @param referenceGraph - The reference graph to run GC on. It's a list of nodes where each node has an id and set of
  * routes to other nodes in the graph.
  * @param rootIds - The ids of root nodes that are considered referenced.
- * @param logger - Used to log telemetry.
  * @returns the ids of referenced nodes and the ids of deleted nodes in the referenced graph.
  */
-export function runGarbageCollection(
-    referenceGraph: { [id: string]: string[]; },
-    rootIds: string[],
-    logger: ITelemetryLogger,
-): IGCResult {
+export function runGarbageCollection(referenceGraph: { [id: string]: string[]; }, rootIds: string[]): IGCResult {
     // This set keeps track of nodes that we have visited. It is used to detect cycles in the graph.
     const visited: Set<string> = new Set();
 
@@ -37,19 +31,6 @@ export function runGarbageCollection(
         const routes = referenceGraph[id];
         if (routes !== undefined) {
             referencedIds.push(...routes);
-        } else {
-            // Log a telemetry event if there is a node missing for a referenced id. This should not happen but for now
-            // we don't assert. We can monitor telemetry for a while to figure out next steps.
-
-            /*
-             * This telemetry is currently too noisy. Start sending it GC is enabled end-to-end. See here for details -
-             * https://github.com/microsoft/FluidFramework/issues/4939
-             *
-             * logger.sendTelemetryEvent({
-             *    eventName: "MissingGCNode",
-             *    missingNodeId: id,
-             * });
-            */
         }
     }
 

--- a/packages/runtime/garbage-collector/src/test/garbageCollector.spec.ts
+++ b/packages/runtime/garbage-collector/src/test/garbageCollector.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { ITelemetryGenericEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { runGarbageCollection } from "../garbageCollector";
 import { IGCResult } from "../interfaces";
 
@@ -14,19 +13,6 @@ interface IGCNode {
 }
 
 describe("Garbage Collector", () => {
-    let logger: ITelemetryLogger;
-    let telemetryEvents: ITelemetryGenericEvent[];
-
-    beforeEach(() => {
-        logger = {
-            sendTelemetryEvent: (event: ITelemetryGenericEvent) => telemetryEvents.push(event),
-        } as unknown as ITelemetryLogger;
-    });
-
-    afterEach(() => {
-        telemetryEvents = [];
-    });
-
     function runGCAndValidateResults(gcNodes: IGCNode[], startingIds: string[], deletedNodes: IGCNode[]) {
         const referenceGraph: { [ id: string ]: string[]; } = {};
         for (const node of gcNodes) {
@@ -38,7 +24,7 @@ describe("Garbage Collector", () => {
         const referencedNodeIds = Array.from(referencedNodes, (node: IGCNode) => node.id);
         const deletedNodeIds = Array.from(deletedNodes, (node: IGCNode) => node.id);
 
-        const gcResult: IGCResult = runGarbageCollection(referenceGraph, startingIds, logger);
+        const gcResult: IGCResult = runGarbageCollection(referenceGraph, startingIds);
         assert.deepStrictEqual(
             gcResult.referencedNodeIds.sort(),
             referencedNodeIds.sort(),


### PR DESCRIPTION
## Description
This PR does couple of things:
1. Moves the parameters required to create `GarbageCollector` into an interface. The parameter size has grown and warrants an object to be passed. This makes it easier to add / modify params and makes the params clearer at the call site as it has clear property names.
2. Fixes [AB#372](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/372). The telemetry in `runGarbageCollection` is not needed or correct. There can be nodes missing in the GC data. For example, handles to objects that do not participate in GC and we do not want to log these.