### PR TITLE
Disabling discovery on local connections

### DIFF
--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -69,10 +69,10 @@ export class AzureClient {
         this.urlResolver = new AzureUrlResolver();
         // The local service implementation differs from the Azure Fluid Relay in blob
         // storage format. Azure Fluid Relay supports whole summary upload. Local currently does not.
-        const enableWholeSummaryUpload = isAzureRemoteConnectionConfig(this.props.connection);
+        const isRemoteConnection = isAzureRemoteConnectionConfig(this.props.connection);
         this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
             this.props.connection.tokenProvider,
-            { enableWholeSummaryUpload, enableDiscovery: true },
+            { enableWholeSummaryUpload: isRemoteConnection, enableDiscovery: isRemoteConnection },
         );
     }
 


### PR DESCRIPTION
At this point local connections (ex. Tinylicious) do not support service discovery endpoint, therefore disabling it.