### PR TITLE
Fix duplicate entries in FluidDataStoreRegistry ctor

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreRegistry.ts
+++ b/packages/runtime/container-runtime/src/dataStoreRegistry.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { UsageError } from "@fluidframework/container-utils";
 import {
     FluidDataStoreRegistryEntry,
     IFluidDataStoreRegistry,
@@ -14,13 +15,12 @@ export class FluidDataStoreRegistry implements IFluidDataStoreRegistry {
     public get IFluidDataStoreRegistry() { return this; }
 
     constructor(namedEntries: NamedFluidDataStoreRegistryEntries) {
-        this.map = new Map(namedEntries);
-        let countOfUniqueNames = 0;
-        for (const _ of namedEntries) {
-            countOfUniqueNames++;
-        }
-        if (this.map.size !== countOfUniqueNames) {
-            throw new Error("Duplicate entry names exist");
+        this.map = new Map();
+        for (const entry of namedEntries) {
+            if (this.map.has(entry[0])) {
+                throw new UsageError("Duplicate entry names exist");
+            }
+            this.map.set(entry[0], entry[1]);
         }
     }
 

--- a/packages/runtime/container-runtime/src/dataStoreRegistry.ts
+++ b/packages/runtime/container-runtime/src/dataStoreRegistry.ts
@@ -15,6 +15,13 @@ export class FluidDataStoreRegistry implements IFluidDataStoreRegistry {
 
     constructor(namedEntries: NamedFluidDataStoreRegistryEntries) {
         this.map = new Map(namedEntries);
+        let countOfUniqueNames = 0;
+        for (const _ of namedEntries) {
+            countOfUniqueNames++;
+        }
+        if (this.map.size !== countOfUniqueNames) {
+            throw new Error("Duplicate entry names exist");
+        }
     }
 
     public async get(name: string): Promise<FluidDataStoreRegistryEntry | undefined> {

--- a/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import {
+    NamedFluidDataStoreRegistryEntries,
+} from "@fluidframework/runtime-definitions";
+import { FluidDataStoreRegistry } from "../dataStoreRegistry";
+
+describe("Data Store Registry Creation Tests", () => {
+    // Define two entries with the same name
+    const defaultName = "default";
+    const entries = [[defaultName, []], [defaultName, []]];
+
+    it("Validate duplicate name entries", () => {
+        try {
+            const fluidDataStoreRegistry = new FluidDataStoreRegistry(entries as NamedFluidDataStoreRegistryEntries);
+        } catch (error: any) {
+            // success = false;
+            assert.strictEqual(error.message, "Duplicate entry names exist");
+        }
+    });
+});

--- a/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
@@ -15,9 +15,9 @@ describe("Data Store Registry Creation Tests", () => {
 
     it("Validate duplicate name entries", () => {
         try {
-            const fluidDataStoreRegistry = new FluidDataStoreRegistry(entries as NamedFluidDataStoreRegistryEntries);
+            new FluidDataStoreRegistry(entries as NamedFluidDataStoreRegistryEntries);
+            assert.fail();
         } catch (error: any) {
-            // success = false;
             assert.strictEqual(error.message, "Duplicate entry names exist");
         }
     });

--- a/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreRegistry.spec.ts
@@ -6,6 +6,7 @@ import { strict as assert } from "assert";
 import {
     NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
+import { UsageError } from "@fluidframework/container-utils";
 import { FluidDataStoreRegistry } from "../dataStoreRegistry";
 
 describe("Data Store Registry Creation Tests", () => {
@@ -18,6 +19,7 @@ describe("Data Store Registry Creation Tests", () => {
             new FluidDataStoreRegistry(entries as NamedFluidDataStoreRegistryEntries);
             assert.fail();
         } catch (error: any) {
+            assert.strictEqual(error instanceof UsageError, true);
             assert.strictEqual(error.message, "Duplicate entry names exist");
         }
     });


### PR DESCRIPTION
## Description

Ticket link: https://dev.azure.com/fluidframework/internal/_workitems/edit/729
To handle the duplicate name entries issue of **FluidDataStoreRegistry**, and add related unit test. 


> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](

The purpose of this PR is to fix this issue: https://github.com/microsoft/FluidFramework/issues/3434




