### PR TITLE
9694 Fix ITelemetryContext implementation

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -104,7 +104,8 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     ) {
         super(
             logger,
-            async (fullTree: boolean) => summarizeFn(fullTree, true /* trackState */),
+            async (fullTree: boolean, _trackState: boolean, telemetryContext?: ITelemetryContext) =>
+                summarizeFn(fullTree, true /* trackState */, telemetryContext),
             config,
             changeSequenceNumber,
             latestSummary,

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -366,6 +366,10 @@ export class TelemetryContext implements ITelemetryContext {
      * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.serialize}
      */
     serialize(): string {
-        return JSON.stringify(this.telemetry);
+        const jsonObject = {};
+        this.telemetry.forEach((value, key) => {
+            jsonObject[key] = value;
+        });
+        return JSON.stringify(jsonObject);
     }
 }

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -23,6 +23,7 @@ import {
     convertSnapshotTreeToSummaryTree,
     convertSummaryTreeToITree,
     convertToSummaryTree,
+    TelemetryContext,
     utf8ByteLength,
 } from "../summaryUtils";
 
@@ -272,6 +273,24 @@ describe("Summary Utils", () => {
                 "������",
             ];
             a.map((s) => assert.strictEqual(utf8ByteLength(s), stringToBuffer(s, "utf8").byteLength, s));
+        });
+    });
+
+    describe("TelemetryContext", () => {
+        it("Should serialize properly", () => {
+            const telemetryContext = new TelemetryContext();
+
+            telemetryContext.set("pre1_", "prop1", 10);
+            telemetryContext.set("pre2_", "prop1", "10");
+            telemetryContext.set("pre2_", "prop2", true);
+            telemetryContext.set("pre1_", "prop2", undefined);
+
+            const obj = JSON.parse(telemetryContext.serialize());
+
+            assert.strictEqual(obj.pre1_prop1, 10);
+            assert.strictEqual(obj.pre1_prop2, undefined);
+            assert.strictEqual(obj.pre2_prop1, "10");
+            assert.strictEqual(obj.pre2_prop2, true);
         });
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { assert, bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
+import { strict as assert } from "assert";
+import { bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import {
     ContainerRuntime,
@@ -14,9 +15,16 @@ import {
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
 import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { describeFullCompat, ITestDataObject, TestDataObjectType } from "@fluidframework/test-version-utils";
+import {
+    describeFullCompat,
+    describeNoCompat,
+    ITestDataObject,
+    TestDataObjectType,
+} from "@fluidframework/test-version-utils";
 import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
 import { ConnectionState } from "@fluidframework/container-loader";
+import { MockLogger } from "@fluidframework/telemetry-utils";
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 
 const defaultDataStoreId = "default";
 const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));
@@ -35,6 +43,7 @@ const testContainerConfig: ITestContainerConfig = {
 async function createContainer(
     provider: ITestObjectProvider,
     summaryOpt: ISummaryRuntimeOptions,
+    logger?: ITelemetryBaseLogger,
 ): Promise<IContainer> {
     // Force generateSummaries to false.
     const summaryOptions: ISummaryRuntimeOptions = {
@@ -44,7 +53,7 @@ async function createContainer(
             state: "disabled",
         } };
 
-    return provider.makeTestContainer({ runtimeOptions: { summaryOptions } });
+    return provider.makeTestContainer({ runtimeOptions: { summaryOptions }, loaderProps: { logger } });
 }
 
 async function createSummarizer(provider: ITestObjectProvider): Promise<ISummarizer> {
@@ -278,5 +287,40 @@ describeFullCompat("Summaries", (getTestObjectProvider) => {
         defaultDataStore._root.set("key", "value");
         await provider.ensureSynchronized();
         await summaryCollection.waitSummaryAck(container.deltaManager.lastSequenceNumber);
+    });
+});
+
+describeNoCompat("Summaries", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+    beforeEach(() => {
+        provider = getTestObjectProvider();
+    });
+
+    it("TelemetryContext is populated with data", async () => {
+        const mockLogger = new MockLogger();
+        const container = await createContainer(provider, { disableIsolatedChannels: true }, mockLogger);
+        const defaultDataStore = await requestFluidObject<ITestDataObject>(container, defaultDataStoreId);
+        const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
+        await provider.ensureSynchronized();
+
+        const directory1 = defaultDataStore._root;
+        directory1.set("key", "value");
+        assert.strictEqual(await directory1.get("key"), "value", "value1 is not set");
+
+        await containerRuntime.summarize({
+            runGC: false,
+            fullTree: false,
+            trackState: false,
+            summaryLogger: new TelemetryNullLogger(),
+        });
+
+        const summarizeTelemetryEvents =
+            mockLogger.events.filter((event) => event.eventName === "fluid:telemetry:SummarizeTelemetry");
+        assert.strictEqual(summarizeTelemetryEvents.length, 1, "There should only be one event");
+
+        const parsed = JSON.parse(summarizeTelemetryEvents[0].details as string);
+        assert(parsed && typeof parsed === "object", "Should be proper JSON");
+
+        assert.notStrictEqual(summarizeTelemetryEvents[0].details, "{}", "Should not be empty JSON object");
     });
 });


### PR DESCRIPTION
## Description

The implementation for `ITelemetryContext` was not properly serializing the object and was always returning an empty JSON object.
There was also a missing layer where the `ITelemetryContext` object gets passed through.
See https://github.com/microsoft/FluidFramework/pull/10294
