### PR TITLE
[bump] package version for azure (patch)

### DIFF
--- a/azure/lerna.json
+++ b/azure/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/**"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/azure-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A tool to enable creation and loading of Fluid containers using the Azure Fluid Relay service",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/azure/packages/azure-client/src/packageVersion.ts
+++ b/azure/packages/azure-client/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/azure-client";
-export const pkgVersion = "1.0.1";
+export const pkgVersion = "1.0.2";

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/azure-service-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Helper service-side utilities for connecting to Azure Fluid Relay service",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/azure/packages/azure-service-utils/src/packageVersion.ts
+++ b/azure/packages/azure-service-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/azure-service-utils";
-export const pkgVersion = "1.0.1";
+export const pkgVersion = "1.0.2";

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-example/app-integration-external-controller",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
   "homepage": "https://fluidframework.com",
@@ -39,7 +39,7 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
-    "@fluidframework/azure-client": "^1.0.1",
+    "@fluidframework/azure-client": "^1.0.2",
     "@fluidframework/common-definitions": "^0.20.1",
     "fluid-framework": "^1.0.1"
   },


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:  0.29.1000 (unchanged)
      @fluidframework/common-definitions:  0.21.1000 (unchanged)
            @fluidframework/common-utils:  0.33.1000 (unchanged)
    @fluidframework/protocol-definitions: 0.1028.3000 (unchanged)
                                   Azure:      1.0.1 -> 1.0.2
                                  Server: 0.1036.5000 (unchanged)
                                  Client:      1.1.0 (unchanged)
                  @fluid-tools/benchmark:     0.41.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)

This will conclude the 1.0.1 patch release of the azure release group.