### PR TITLE
Use correct segment on regeneration of an insert op

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -808,10 +808,6 @@ export class Client {
                         segmentPosition,
                         resetOp.seg,
                     );
-                    // newOp = createInsertSegmentOp(
-                    //     segmentPosition,
-                    //     segment
-                    // )
                     break;
 
                 case MergeTreeDeltaType.REMOVE:

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -32,6 +32,7 @@ import {
     createAnnotateMarkerOp,
     createAnnotateRangeOp,
     createGroupOp,
+    createInsertOp,
     createInsertSegmentOp,
     createRemoveRangeOp,
 } from "./opBuilder";
@@ -803,9 +804,14 @@ export class Client {
                 case MergeTreeDeltaType.INSERT:
                     assert(segment.seq === UnassignedSequenceNumber,
                         0x037 /* "Segment already has assigned sequence number" */);
-                    newOp = createInsertSegmentOp(
+                    newOp = createInsertOp(
                         segmentPosition,
-                        segment);
+                        resetOp.seg,
+                    );
+                    // newOp = createInsertSegmentOp(
+                    //     segmentPosition,
+                    //     segment
+                    // )
                     break;
 
                 case MergeTreeDeltaType.REMOVE:

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -32,7 +32,6 @@ import {
     createAnnotateMarkerOp,
     createAnnotateRangeOp,
     createGroupOp,
-    createInsertOp,
     createInsertSegmentOp,
     createRemoveRangeOp,
 } from "./opBuilder";
@@ -804,9 +803,14 @@ export class Client {
                 case MergeTreeDeltaType.INSERT:
                     assert(segment.seq === UnassignedSequenceNumber,
                         0x037 /* "Segment already has assigned sequence number" */);
-                    newOp = createInsertOp(
+                    let segInsertOp = segment;
+                    if (typeof resetOp.seg === "object" && resetOp.seg.props !== undefined) {
+                        segInsertOp = segment.clone();
+                        segInsertOp.properties = resetOp.seg.props;
+                    }
+                    newOp = createInsertSegmentOp(
                         segmentPosition,
-                        resetOp.seg,
+                        segInsertOp,
                     );
                     break;
 

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -5,122 +5,174 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
-import { IMergeTreeOp } from "../ops";
+import { Marker, reservedMarkerIdKey } from "../mergeTree";
+import { IMergeTreeOp, ReferenceType } from "../ops";
+import { clone } from "../properties";
+import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
 
 describe("resetPendingSegmentsToOp", () => {
     let client: TestClient;
-    let opList: IMergeTreeOp[];
-    let opCount: number = 0;
-    const insertCount = 5;
-    const expectedSegmentCount = insertCount * 2 - 1;
-
-    function applyOpList(cli: TestClient) {
-        while (opList.length > 0) {
-            const op = opList.shift();
-            if (op) {
-                const seqOp = cli.makeOpMessage(op, ++opCount);
-                cli.applyMsg(seqOp);
-            }
-        }
-    }
 
     beforeEach(() => {
         client = new TestClient();
         client.startOrUpdateCollaboration("local user");
         assert(client.mergeTree.pendingSegments?.empty());
-        opList = [];
+    });
 
-        for (let i = 0; i < insertCount; i++) {
-            const op = client.insertTextLocal(i, "hello")!;
-            opList.push(op);
-            assert.equal(client.mergeTree.pendingSegments?.count(), i + 1);
+    describe("with a number of nested inserts", () => {
+        const insertCount = 5;
+        const expectedSegmentCount = insertCount * 2 - 1;
+        let opList: IMergeTreeOp[];
+        let opCount: number = 0;
+
+        function applyOpList(cli: TestClient) {
+            while (opList.length > 0) {
+                const op = opList.shift();
+                if (op) {
+                    const seqOp = cli.makeOpMessage(op, ++opCount);
+                    cli.applyMsg(seqOp);
+                }
+            }
         }
+
+        beforeEach(() => {
+            opList = [];
+            opCount = 0;
+
+            for (let i = 0; i < insertCount; i++) {
+                const op = client.insertTextLocal(i, "hello")!;
+                opList.push(op);
+                assert.equal(client.mergeTree.pendingSegments?.count(), i + 1);
+            }
+        });
+
+        it("acked insertSegment", async () => {
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
+
+        it("nacked insertSegment", async () => {
+            const oldops = opList;
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
+            // we expect a nack op per segment since our original ops split segments
+            // we should expect mores nack ops then original ops.
+            // only the first op didn't split a segment, all the others did
+            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
+
+        it("acked removeRange", async () => {
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+
+            opList.push(client.removeRangeLocal(0, client.getLength())!);
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
+
+        it("nacked removeRange", async () => {
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+
+            opList.push(client.removeRangeLocal(0, client.getLength())!);
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
+            // we expect a nack op per segment since our original ops split segments
+            // we should expect mores nack ops then original ops.
+            // only the first op didn't split a segment, all the others did
+            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
+
+        it("nacked insertSegment and removeRange", async () => {
+            opList.push(client.removeRangeLocal(0, client.getLength())!);
+            const oldops = opList;
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
+
+            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
+
+            applyOpList(client);
+
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
+
+        it("acked annotateRange", async () => {
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+
+            opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
+
+        it("nacked annotateRange", async () => {
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+
+            opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
+            // we expect a nack op per segment since our original ops split segments
+            // we should expect mores nack ops then original ops.
+            // only the first op didn't split a segment, all the others did
+            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
+
+        it("nacked insertSegment and annotateRange", async () => {
+            opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
+            const oldops = opList;
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
+            // we expect a nack op per segment since our original ops split segments
+            // we should expect mores nack ops then original ops.
+            // only the first op didn't split a segment, all the others did
+            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
+            applyOpList(client);
+            assert(client.mergeTree.pendingSegments?.empty());
+        });
     });
 
-    it("acked insertSegment", async () => {
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-    });
+    describe("uses original properties on insert", () => {
+        // Regression tests for an issue where regenerated insert ops would use the properties of a segment
+        // at the time of regeneration rather than its properties at insertion time.
+        it("for markers", () => {
+            const insertOp = client.insertMarkerLocal(
+                0,
+                ReferenceType.Simple,
+                { [reservedMarkerIdKey]: "id", prop1: "foo" },
+            );
+            assert(insertOp);
+            const { segment } = client.getContainingSegment(0);
+            assert(segment !== undefined && Marker.is(segment));
+            client.annotateMarker(segment, { prop2: "bar" });
 
-    it("nacked insertSegment", async () => {
-        const oldops = opList;
-        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
-        // we expect a nack op per segment since our original ops split segments
-        // we should expect mores nack ops then original ops.
-        // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-    });
+            const otherClient = new TestClient();
+            otherClient.startOrUpdateCollaboration("other user");
+            const regeneratedInsert = client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first()!);
+            otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-    it("acked removeRange", async () => {
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
+            const { segment: otherSegment } = otherClient.getContainingSegment(0);
+            assert(otherSegment !== undefined && Marker.is(otherSegment));
+            // `clone` here is because properties use a Object.create(null); to compare strict equal the prototype chain
+            // should therefore not include Object.
+            assert.deepStrictEqual(otherSegment.properties, clone({ [reservedMarkerIdKey]: "id", prop1: "foo" }));
+        });
 
-        opList.push(client.removeRangeLocal(0, client.getLength())!);
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-    });
+        it("for text segments", () => {
+            const insertOp = client.insertTextLocal(0, "abc", { prop1: "foo" });
+            assert(insertOp);
+            client.annotateRangeLocal(0, 3, { prop2: "bar" }, undefined);
 
-    it("nacked removeRange", async () => {
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
+            const otherClient = new TestClient();
+            otherClient.startOrUpdateCollaboration("other user");
+            const regeneratedInsert = client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first()!);
+            otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-        opList.push(client.removeRangeLocal(0, client.getLength())!);
-        opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
-        // we expect a nack op per segment since our original ops split segments
-        // we should expect mores nack ops then original ops.
-        // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-    });
-
-    it("nacked insertSegment and removeRange", async () => {
-        opList.push(client.removeRangeLocal(0, client.getLength())!);
-        const oldops = opList;
-        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
-
-        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
-
-        applyOpList(client);
-
-        assert(client.mergeTree.pendingSegments?.empty());
-    });
-
-    it("acked annotateRange", async () => {
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-
-        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-    });
-
-    it("nacked annotateRange", async () => {
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-
-        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
-        opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
-        // we expect a nack op per segment since our original ops split segments
-        // we should expect mores nack ops then original ops.
-        // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
-    });
-
-    it("nacked insertSegment and annotateRange", async () => {
-        opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
-        const oldops = opList;
-        opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
-        // we expect a nack op per segment since our original ops split segments
-        // we should expect mores nack ops then original ops.
-        // only the first op didn't split a segment, all the others did
-        assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
-        applyOpList(client);
-        assert(client.mergeTree.pendingSegments?.empty());
+            const { segment: otherSegment } = otherClient.getContainingSegment(0);
+            assert(otherSegment !== undefined && TextSegment.is(otherSegment));
+            assert.deepStrictEqual(otherSegment.properties, clone({ prop1: "foo" }));
+        });
     });
 });


### PR DESCRIPTION
When regenerating an insert op, the properties on the original segment should be used: attempting to regenerate with the current state of the segment can yield incorrect properties.

This fix does not affect eventual consistency, but it can put documents in invalid states if subsequent ops fail to ack.