### PR TITLE
Remove comma that breaks parsing of json file

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -59,7 +59,7 @@ data:
         },
         "storage": {
             "enableWholeSummaryUpload": {{ .Values.storage.enableWholeSummaryUpload }},
-            "storageUrl": "{{ .Values.storage.storageUrl }}",
+            "storageUrl": "{{ .Values.storage.storageUrl }}"
         },
         "alfred": {
             "kafkaClientId": "{{ template "alfred.fullname" . }}",


### PR DESCRIPTION
## Description

Fix json syntax in k8s `configMap`. Currently the pods in the routerlicious deployment in AKS fail to start, complaining that they can't parse this file:

![image](https://user-images.githubusercontent.com/716334/175358237-7278ce82-be2a-413c-861b-c1c25c777c54.png)

