### PR TITLE
Bump external controller to correct version (1.1.0)

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -82,7 +82,6 @@
   },
   "typeValidation": {
     "version": "1.1.0",
-    "broken": {
-    }
+    "broken": {}
   }
 }

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-example/app-integration-external-controller",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
   "homepage": "https://fluidframework.com",


### PR DESCRIPTION
This package must have been missed when we did a manual bump of the azure release group a few weeks ago. The build tools should help prevent this in the future once #10826 is merged.