### PR TITLE
Support cjs extension for lint configs

### DIFF
--- a/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
@@ -41,8 +41,8 @@ export class EsLintTask extends LintBaseTask {
 
     protected get configFileFullPath() {
         if (!this._configFileFullPath) {
-            // TODO: we currently don't support .cjs, .yaml and .yml, or config in package.json
-            const possibleConfig = [".eslintrc.js", ".eslintrc.json", ".eslintrc"];
+            // TODO: we currently don't support .yaml and .yml, or config in package.json
+            const possibleConfig = [".eslintrc.js",  ".eslintrc.cjs", ".eslintrc.json", ".eslintrc"];
             for (const configFile of possibleConfig) {
                 const configFileFullPath = this.getPackageFileFullPath(configFile);
                 if (existsSync(configFileFullPath)) {
@@ -60,7 +60,8 @@ export class EsLintTask extends LintBaseTask {
     protected addDependentTasks(dependentTasks: LeafTask[]) {
         let config: any;
         try {
-            if (path.parse(this.configFileFullPath).ext !== ".js") {
+            const ext = path.parse(this.configFileFullPath).ext;
+            if (ext !== ".js" && ext !== ".cjs") {
                 // TODO: optimize double read for TscDependentTask.getDoneFileContent and there.
                 const configFile = readFileSync(this.configFileFullPath, "utf8");
                 config = JSON5.parse(configFile);


### PR DESCRIPTION
## Description

Setting a package to type "module" in its package.json causes js files in it (including `.eslintrc.js`) to default to being parses as ESM instead of CommonJS. If parsing them as CommonJS is desired, the recommended approach is to rename them to `.cjs`. This PR fixes fluid-build to tolerate this for `.eslintrc.js`.

## Reviewer Guidance

I have tested this my converting a module to ESM, which caused fluid-build to fail. I then made this change and ran `node bin/fluid-build` with these changes and it was fixed. If any more testing is desired let me know.
