### PR TITLE
Require at least node >=14.13.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript": "~4.5.5"
   },
   "engines": {
-    "node": ">=15.13.0"
+    "node": ">=14.13.0"
   },
   "fluidBuild": {
     "repoPackages": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/microsoft/FluidFramework.git",
     "directory": ""
   },
+  "engines": {
+    "node": ">=14.13.0"
+  },
   "license": "MIT",
   "author": "Microsoft and contributors",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "url": "https://github.com/microsoft/FluidFramework.git",
     "directory": ""
   },
-  "engines": {
-    "node": ">=14.13.0"
-  },
   "license": "MIT",
   "author": "Microsoft and contributors",
   "scripts": {
@@ -124,6 +121,9 @@
     "rimraf": "^2.6.2",
     "run-script-os": "^1.1.6",
     "typescript": "~4.5.5"
+  },
+  "engines": {
+    "node": ">=15.13.0"
   },
   "fluidBuild": {
     "repoPackages": {


### PR DESCRIPTION
## Description

Enforce that the version of node used is at least 14.13.0 (released on 2020-09-29), which according to https://www.the-guild.dev/blog/support-nodejs-esm means it should support ESM. This uses the mechanism documented in https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines.

This produces an error when running `npm i` in the root if using an older version of node.

Note that the 14 branch of node is the oldest supported branch (see https://nodejs.org/en/about/releases/), no one should be one node older than 14, so updating to at least 14.13.0 should be a non-breaking change.

Additionally, our `.nvmrc` file specifies node 14, and our readme says to use that version.

 Since this is in the root package.json, not one we ship to users, it should have no impact on consumers of our packages.

## Reviewer Guidance

I'm not aware of us placing any restrictions on node versions within the 14 range in the past.
This change is intended to introduce a new approach for being explicit about how old of Node we support for development.

I'd like opinions on if this is a good approach to take, and if this is a good version to start with.
I'm not aware of any other specific features that were added to 14 after release that we might care about: if you have a reason to pick some other version let me know.

## Example Error

If I force requiring version 15 instead (so my system errors) the error looks like:

```
$ npm i
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for root@0.14.0: wanted: {"node":">=15.13.0"} (current: {"node":"14.19.3","npm":"6.14.17"})
npm ERR! notsup Not compatible with your version of node/npm: root@0.14.0
npm ERR! notsup Not compatible with your version of node/npm: root@0.14.0
npm ERR! notsup Required: {"node":">=15.13.0"}
npm ERR! notsup Actual:   {"npm":"6.14.17","node":"14.19.3"}
```

I have confirmed `npm ci` also produces this error.