### PR TITLE
Post 1.1.0 release clean up.

### DIFF
--- a/azure/lerna-package-lock.json
+++ b/azure/lerna-package-lock.json
@@ -5063,7 +5063,7 @@
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -6079,7 +6079,7 @@
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
     },
     "address": {
@@ -6260,7 +6260,7 @@
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
     "array-includes": {
@@ -6315,13 +6315,13 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.6",
@@ -6346,7 +6346,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -6380,7 +6380,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -6408,7 +6408,7 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.11.0",
@@ -6651,7 +6651,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -6842,13 +6842,13 @@
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true
     },
     "byte-size": {
@@ -7125,7 +7125,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -7262,7 +7262,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-deep": {
@@ -7313,7 +7313,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -7350,7 +7350,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.9.1",
@@ -7486,7 +7486,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -7624,7 +7624,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "content-disposition": {
@@ -7675,7 +7675,7 @@
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -7690,7 +7690,7 @@
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -7702,7 +7702,7 @@
         "locate-path": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -7721,7 +7721,7 @@
         "p-locate": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -7730,13 +7730,13 @@
         "p-try": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -7746,7 +7746,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-type": {
@@ -7761,13 +7761,13 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
@@ -7792,7 +7792,7 @@
         "read-pkg-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
             "find-up": "^2.0.0",
@@ -8321,7 +8321,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -8384,18 +8384,18 @@
     "debuglog": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -8405,7 +8405,7 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
       }
@@ -8418,7 +8418,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -8431,7 +8431,7 @@
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-equal": {
@@ -8540,7 +8540,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -8657,12 +8657,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "denque": {
@@ -8673,7 +8673,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -8883,7 +8883,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -9164,7 +9164,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "2.0.0",
@@ -10054,7 +10054,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -10159,7 +10159,7 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
       "dev": true
     },
     "finalhandler": {
@@ -10406,7 +10406,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.5.1",
@@ -10498,7 +10498,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -10536,7 +10536,7 @@
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
         "aproba": "^1.0.3",
@@ -10552,13 +10552,13 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -10567,7 +10567,7 @@
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -10578,7 +10578,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -10677,7 +10677,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -10762,7 +10762,7 @@
     "git-remote-origin-url": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
         "gitconfiglocal": "^1.0.0",
@@ -10772,7 +10772,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -10842,7 +10842,7 @@
     "gitconfiglocal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
         "ini": "^1.3.2"
@@ -10983,7 +10983,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
@@ -11016,7 +11016,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -11042,7 +11042,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -11285,7 +11285,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -11319,7 +11319,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
@@ -11399,7 +11399,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -11415,7 +11415,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -11582,7 +11582,7 @@
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha512-rBtCAQAJm8A110nbwn6YdveUnuZH3WrC36IwkRXxDnq53JvXA2NVQvB7IHyKomxK1MJ4VDNw3UtFDdXQ+AvLYA=="
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -11635,7 +11635,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -11759,7 +11759,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -11791,7 +11791,7 @@
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
     },
     "is-nan": {
@@ -11930,7 +11930,7 @@
     "is-text-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
@@ -11985,7 +11985,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -12025,17 +12025,17 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-git": {
       "version": "1.17.1",
@@ -12070,7 +12070,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -13623,7 +13623,7 @@
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
     },
     "joi": {
       "version": "17.6.0",
@@ -13653,7 +13653,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "16.7.0",
@@ -13805,7 +13805,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.1",
@@ -13831,7 +13831,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
@@ -14265,7 +14265,7 @@
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash.defaults": {
@@ -14287,7 +14287,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.includes": {
@@ -14308,7 +14308,7 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.isinteger": {
@@ -14319,7 +14319,7 @@
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
     },
     "lodash.isnumber": {
@@ -14850,7 +14850,7 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         }
       }
@@ -15566,7 +15566,7 @@
     "noms": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -15576,13 +15576,13 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -15594,7 +15594,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
@@ -15854,7 +15854,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nwsapi": {
@@ -15870,7 +15870,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -16023,7 +16023,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
       }
@@ -16070,7 +16070,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ=="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-name": {
       "version": "3.1.0",
@@ -16085,7 +16085,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
@@ -16112,7 +16112,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -16436,7 +16436,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -16479,7 +16479,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -16669,7 +16669,7 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "promise-retry": {
@@ -16694,7 +16694,7 @@
     "promzard": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-      "integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "requires": {
         "read": "1"
@@ -16713,7 +16713,7 @@
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
     "protocols": {
@@ -16857,7 +16857,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
@@ -16943,7 +16943,7 @@
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
         "mute-stream": "~0.0.4"
@@ -17112,7 +17112,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
@@ -17362,7 +17362,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -17451,7 +17451,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "reusify": {
@@ -17869,7 +17869,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -17895,7 +17895,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "setprototypeof": {
@@ -17923,7 +17923,7 @@
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -17931,7 +17931,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shelljs": {
       "version": "0.8.5",
@@ -18018,7 +18018,7 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "smart-buffer": {
@@ -18229,7 +18229,7 @@
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
@@ -18238,7 +18238,7 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         }
       }
@@ -18321,7 +18321,7 @@
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
     "spawnd": {
@@ -18474,7 +18474,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.17.0",
@@ -18682,7 +18682,7 @@
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true
     },
     "string-argv": {
@@ -18776,12 +18776,12 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q=="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -18888,7 +18888,7 @@
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
       "dev": true
     },
     "temp-write": {
@@ -19094,7 +19094,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
@@ -19114,7 +19114,7 @@
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
     "tinylicious": {
@@ -19317,7 +19317,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -19462,7 +19462,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -19470,7 +19470,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",
@@ -19514,7 +19514,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -19567,7 +19567,7 @@
     "uid-number": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "dev": true
     },
     "uid2": {
@@ -19578,7 +19578,7 @@
     "umask": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-      "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
+      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
       "dev": true
     },
     "unbox-primitive": {
@@ -19595,7 +19595,7 @@
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "underscore": {
@@ -19646,7 +19646,7 @@
         "tr46": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -19799,12 +19799,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-promisify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
-      "integrity": "sha512-K+5eQPYs14b3+E+hmE2J6gCZ4JmMl9DbYS6BeP2CHq6WMuNxErxf5B/n0fz85L8zUuoO6rIzNNmIQDu/j+1OcA==",
+      "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3"
@@ -19853,7 +19853,7 @@
     "validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
@@ -19873,7 +19873,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -19883,7 +19883,7 @@
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         }
       }
     },
@@ -19983,7 +19983,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
@@ -19992,7 +19992,7 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "webpack": {
       "version": "5.72.1",
@@ -20376,7 +20376,7 @@
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -20541,7 +20541,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "workerpool": {
@@ -20585,7 +20585,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.3",
@@ -20670,7 +20670,7 @@
         "detect-indent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "type-fest": {

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -2467,7 +2467,7 @@
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -2648,7 +2648,7 @@
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
     },
     "agent-base": {
@@ -2756,7 +2756,7 @@
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
     "array-union": {
@@ -2768,13 +2768,13 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -2801,7 +2801,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "async": {
@@ -2822,7 +2822,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "at-least-node": {
@@ -2846,7 +2846,7 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
@@ -2874,7 +2874,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -2926,13 +2926,13 @@
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true
     },
     "byte-size": {
@@ -3145,7 +3145,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
@@ -3206,7 +3206,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-deep": {
@@ -3249,7 +3249,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "color-convert": {
@@ -3264,7 +3264,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -3322,7 +3322,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
@@ -3456,7 +3456,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -3494,7 +3494,7 @@
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -3509,7 +3509,7 @@
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -3521,7 +3521,7 @@
         "locate-path": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -3540,7 +3540,7 @@
         "p-locate": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -3549,13 +3549,13 @@
         "p-try": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -3565,7 +3565,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-type": {
@@ -3580,13 +3580,13 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
@@ -3611,7 +3611,7 @@
         "read-pkg-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
             "find-up": "^2.0.0",
@@ -3992,7 +3992,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4022,19 +4022,19 @@
     "debuglog": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -4044,7 +4044,7 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
       }
@@ -4052,19 +4052,19 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -4083,19 +4083,19 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "deprecation": {
@@ -4153,7 +4153,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -4290,7 +4290,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "esprima": {
@@ -4381,7 +4381,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
@@ -4445,7 +4445,7 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
       "dev": true
     },
     "find-up": {
@@ -4523,7 +4523,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
@@ -4567,7 +4567,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
@@ -4597,7 +4597,7 @@
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
         "aproba": "^1.0.3",
@@ -4613,13 +4613,13 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -4628,7 +4628,7 @@
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4639,7 +4639,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4727,7 +4727,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4813,7 +4813,7 @@
     "git-remote-origin-url": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
         "gitconfiglocal": "^1.0.0",
@@ -4823,7 +4823,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -4893,7 +4893,7 @@
     "gitconfiglocal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
         "ini": "^1.3.2"
@@ -4973,7 +4973,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
@@ -5010,7 +5010,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-property-descriptors": {
@@ -5040,7 +5040,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "hasurl": {
@@ -5109,7 +5109,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -5147,7 +5147,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
@@ -5231,7 +5231,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
@@ -5249,7 +5249,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -5395,7 +5395,7 @@
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha512-rBtCAQAJm8A110nbwn6YdveUnuZH3WrC36IwkRXxDnq53JvXA2NVQvB7IHyKomxK1MJ4VDNw3UtFDdXQ+AvLYA==",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "irregular-plurals": {
@@ -5427,7 +5427,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bigint": {
@@ -5499,7 +5499,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -5529,7 +5529,7 @@
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
     },
     "is-nan": {
@@ -5651,7 +5651,7 @@
     "is-text-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
@@ -5706,7 +5706,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-unc-path": {
@@ -5742,25 +5742,25 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -5825,7 +5825,7 @@
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
     },
     "js-tokens": {
@@ -5837,7 +5837,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -5867,7 +5867,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
@@ -5895,7 +5895,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
@@ -6130,7 +6130,7 @@
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash.find": {
@@ -6142,7 +6142,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.includes": {
@@ -6160,7 +6160,7 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.isinteger": {
@@ -6172,7 +6172,7 @@
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
     },
     "lodash.isnumber": {
@@ -6546,7 +6546,7 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         }
       }
@@ -6860,7 +6860,7 @@
     "noms": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -6870,13 +6870,13 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6888,7 +6888,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
       }
@@ -7131,7 +7131,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
@@ -7143,7 +7143,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-inspect": {
@@ -7200,7 +7200,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -7218,7 +7218,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-name": {
@@ -7234,7 +7234,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
@@ -7256,7 +7256,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
@@ -7522,7 +7522,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
@@ -7546,7 +7546,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
@@ -7604,7 +7604,7 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "promise-retry": {
@@ -7620,7 +7620,7 @@
     "promzard": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-      "integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "requires": {
         "read": "1"
@@ -7629,7 +7629,7 @@
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
     "protocols": {
@@ -7663,7 +7663,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
@@ -7702,7 +7702,7 @@
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
         "mute-stream": "~0.0.4"
@@ -7880,7 +7880,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
@@ -8025,7 +8025,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-from-string": {
@@ -8081,7 +8081,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "reusify": {
@@ -8153,13 +8153,13 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "shallow-clone": {
@@ -8174,7 +8174,7 @@
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
@@ -8183,7 +8183,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shelljs": {
@@ -8223,7 +8223,7 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "smart-buffer": {
@@ -8267,7 +8267,7 @@
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
@@ -8276,7 +8276,7 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         }
       }
@@ -8334,7 +8334,7 @@
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
     "spdx-correct": {
@@ -8409,7 +8409,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
@@ -8452,7 +8452,7 @@
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true
     },
     "string-argv": {
@@ -8523,13 +8523,13 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-final-newline": {
@@ -8632,7 +8632,7 @@
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
       "dev": true
     },
     "temp-write": {
@@ -8691,7 +8691,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
@@ -8707,7 +8707,7 @@
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
     "tmp": {
@@ -8741,7 +8741,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
     },
     "tree-kill": {
@@ -8782,7 +8782,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -8791,7 +8791,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-fest": {
@@ -8814,7 +8814,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typedarray-to-buffer": {
@@ -8842,13 +8842,13 @@
     "uid-number": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "dev": true
     },
     "umask": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-      "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
+      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
       "dev": true
     },
     "unbox-primitive": {
@@ -8866,7 +8866,7 @@
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "underscore": {
@@ -8906,7 +8906,7 @@
         "tr46": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -8984,13 +8984,13 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "util-promisify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
-      "integrity": "sha512-K+5eQPYs14b3+E+hmE2J6gCZ4JmMl9DbYS6BeP2CHq6WMuNxErxf5B/n0fz85L8zUuoO6rIzNNmIQDu/j+1OcA==",
+      "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3"
@@ -9026,7 +9026,7 @@
     "validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
@@ -9041,7 +9041,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -9052,7 +9052,7 @@
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         }
       }
@@ -9060,7 +9060,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
@@ -9069,13 +9069,13 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
         "tr46": "~0.0.3",
@@ -9172,7 +9172,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
@@ -9215,7 +9215,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write-file-atomic": {
@@ -9301,7 +9301,7 @@
         "detect-indent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "type-fest": {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1950,20 +1950,20 @@
 			}
 		},
 		"@fluid-experimental/task-manager-previous": {
-			"version": "npm:@fluid-experimental/task-manager@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-1.0.1.tgz",
-			"integrity": "sha512-f3TdetE+E+txRITOTe+9LbtOJCCnMLGWWQmB2cjnNz437a2WDEQ6bqv5V7p5KvwzT5q5r3SpLh7FpkU+bQnrRw==",
+			"version": "npm:@fluid-experimental/task-manager@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/task-manager/-/task-manager-1.1.0.tgz",
+			"integrity": "sha512-TgJP40Z/Kcy/mOGy3rRrjrhC7q1ZS2+TopiewViYjRLnM/cm1/MIp/cD6kkhqRGPKRZbPSK1DYalb0aQiVxdYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			}
 		},
 		"@fluid-tools/benchmark": {
@@ -2214,44 +2214,44 @@
 			}
 		},
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-1.0.1.tgz",
-			"integrity": "sha512-Lw45k5XCzG8hPT3Tlf6a0eZnuqFUQwDW/dWY0RGlwLlCNHaePFwz54f4trp1vH57nFrA0DCmcXncUm9qO7uvJg==",
+			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-1.1.0.tgz",
+			"integrity": "sha512-db9VMSvkzakzNHLi3cojWTDZEC9NJcGyfOXNsF30m4wbuKGkynnV9r1//KZhjqtecvc1wATKV+eQWoZwcCjmzQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/odsp-driver": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1"
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/odsp-driver": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0"
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.0.1.tgz",
-			"integrity": "sha512-xzbeHss7tPDonC9SOYxndR2E475IvTfsLx9JU8hPtPwIReqbP3JKqPGnn0nso4HUgO8CmpcxBGONsQeIlLsYpQ==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.1.0.tgz",
+			"integrity": "sha512-x+gP8uA2iKOKF0QjC6wYe8hrzf8uekqfmOMyELzv9XZo8OfKIsU4ddCFeJG0oEEvHrXDYJD9IJCmdWnknSYlxQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.1",
+				"@fluidframework/aqueduct": "^1.1.0",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/local-driver": "^1.0.1",
-				"@fluidframework/odsp-doclib-utils": "^1.0.1",
-				"@fluidframework/odsp-driver": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/local-driver": "^1.1.0",
+				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/odsp-driver": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/server-local-server": "^0.1036.4000",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/test-runtime-utils": "^1.0.1",
-				"@fluidframework/tool-utils": "^1.0.1",
-				"@fluidframework/view-adapters": "^1.0.1",
-				"@fluidframework/view-interfaces": "^1.0.1",
-				"@fluidframework/web-code-loader": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/server-local-server": "^0.1036.5000",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/test-runtime-utils": "^1.1.0",
+				"@fluidframework/tool-utils": "^1.1.0",
+				"@fluidframework/view-adapters": "^1.1.0",
+				"@fluidframework/view-interfaces": "^1.1.0",
+				"@fluidframework/web-code-loader": "^1.1.0",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
 				"nconf": "^0.11.4",
@@ -2261,47 +2261,47 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.4000.tgz",
-					"integrity": "sha512-r//V5DxkzTmKhyKXj9e7PjoQcQJa/hK4yxtryu7MMwpj+bRHla9fNOHf2oFosXJg/QpXRmG9k9mx1/OYqgXxcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.5000.tgz",
+					"integrity": "sha512-ogPVoWEp8U0v6FBiwq/x30pEMLiz+KB37M7FMGJvLnS6n281v5LA8Sw/NB2e8AI33WfQrQ9rYXGEwh4BvZ60Ig==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-lambdas": "^0.1036.4000",
-						"@fluidframework/server-memory-orderer": "^0.1036.4000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
-						"@fluidframework/server-test-utils": "^0.1036.4000",
+						"@fluidframework/server-lambdas": "^0.1036.5000",
+						"@fluidframework/server-memory-orderer": "^0.1036.5000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
+						"@fluidframework/server-test-utils": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -2315,15 +2315,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -2344,17 +2344,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.4000.tgz",
-					"integrity": "sha512-AZyjRMPaosbTpd8xXPkDzHhT+mt7aRMQ5u65WOgD/EmWq+k3vRXQXFhO8o466NL3R63zA9ZIlhxYs7RclNudcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.5000.tgz",
+					"integrity": "sha512-uTgeuHWjKzicNL8TVdYdK9r5nTSCPnsxMhhq4SFTy8saIbvyQQ8bhkl252gVjpUI8xTk0BlqjAikWrs+1oDaxQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -2421,66 +2421,66 @@
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.0.1.tgz",
-			"integrity": "sha512-iYEGq/C8fLFNSitpBhqg+yFxeGl0jjoXmYKKvqJ93mc2ip7CppMM67AOHHbny+cfyJQRq6alK2RBq40IK5Y1Ag==",
+			"version": "npm:@fluidframework/agent-scheduler@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.1.0.tgz",
+			"integrity": "sha512-FoYKlsnHMS+yHA+yfIAqedkG+RpEhuaUQD0vmJkQbLqExjnQhEF2F+es+1AQIc/eCoHZ2VtcAryG72O9xb8cPg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
-				"@fluidframework/register-collection": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
+				"@fluidframework/register-collection": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.0.1.tgz",
-			"integrity": "sha512-mr5uuioC8qN6PrQLpSj0dFQnbjEnb0xVPGW9erocD8KuT+8MJ3WJ4PE/O1RUqWglUf0rWhul6fhmt6hqHNQdvA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.1.0.tgz",
+			"integrity": "sha512-RWxNNM7B6AF3JbCgrzH8L+W7HjiUYqDj2lYtgLFFeFFU9hkDUmp1fbZnjxiCrvtXZCwC3FqhRgNN9LaN1d5j1Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
-				"@fluidframework/request-handler": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/synthesize": "^1.0.1",
-				"@fluidframework/view-interfaces": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
+				"@fluidframework/request-handler": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/synthesize": "^1.1.0",
+				"@fluidframework/view-interfaces": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.0.1.tgz",
-			"integrity": "sha512-mr5uuioC8qN6PrQLpSj0dFQnbjEnb0xVPGW9erocD8KuT+8MJ3WJ4PE/O1RUqWglUf0rWhul6fhmt6hqHNQdvA==",
+			"version": "npm:@fluidframework/aqueduct@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.1.0.tgz",
+			"integrity": "sha512-RWxNNM7B6AF3JbCgrzH8L+W7HjiUYqDj2lYtgLFFeFFU9hkDUmp1fbZnjxiCrvtXZCwC3FqhRgNN9LaN1d5j1Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
-				"@fluidframework/request-handler": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/synthesize": "^1.0.1",
-				"@fluidframework/view-interfaces": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
+				"@fluidframework/request-handler": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/synthesize": "^1.1.0",
+				"@fluidframework/view-interfaces": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -2576,31 +2576,31 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.0.1.tgz",
-			"integrity": "sha512-yv4kPoSje3EIkKxeadjzNoh4Gm9sVvVoz78wCxoQgUGzW9IbhSfC4B6FxTl7SP+mti3+Rmit5pwBLVPswEyg7g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.1.0.tgz",
+			"integrity": "sha512-MBReNvBGNAHGHVu9kbtFxxYhtLDeG98jm21ubfGMO1aM+8i/k9Z62AymKKGp9uI7mwyKQnsrS6Wkhr87/M5wxg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.0.1.tgz",
-			"integrity": "sha512-yv4kPoSje3EIkKxeadjzNoh4Gm9sVvVoz78wCxoQgUGzW9IbhSfC4B6FxTl7SP+mti3+Rmit5pwBLVPswEyg7g==",
+			"version": "npm:@fluidframework/cell@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.1.0.tgz",
+			"integrity": "sha512-MBReNvBGNAHGHVu9kbtFxxYhtLDeG98jm21ubfGMO1aM+8i/k9Z62AymKKGp9uI7mwyKQnsrS6Wkhr87/M5wxg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -2629,42 +2629,42 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.0.1.tgz",
-			"integrity": "sha512-C8r6rNzA3nmsKelK3nFVr7AF5NCDM6a0zgUxWLO2/uTH5XPWir+s1b8qbnvWXIWrbgriEJFLUh22SWz1EXv9ow==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.1.0.tgz",
+			"integrity": "sha512-SINUvqZdEkUY1RnpYEJ1uWRb0DCJfNWVny2pkmPaVYY8dg8I85+iX90+bTPEF3RXXSaa4Cdhj09h9cBHwp/fxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/container-definitions-previous": {
-			"version": "npm:@fluidframework/container-definitions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.0.1.tgz",
-			"integrity": "sha512-C8r6rNzA3nmsKelK3nFVr7AF5NCDM6a0zgUxWLO2/uTH5XPWir+s1b8qbnvWXIWrbgriEJFLUh22SWz1EXv9ow==",
+			"version": "npm:@fluidframework/container-definitions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.1.0.tgz",
+			"integrity": "sha512-SINUvqZdEkUY1RnpYEJ1uWRb0DCJfNWVny2pkmPaVYY8dg8I85+iX90+bTPEF3RXXSaa4Cdhj09h9cBHwp/fxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.0.1.tgz",
-			"integrity": "sha512-0FzdCNLKcldyD8xheiMJemnKy+5HXTMMMnWcaIaLUgqi+TnIpNFZ/jMYFh9LG83LPPXsOA0hMY6KvY87SCZvTQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.1.0.tgz",
+			"integrity": "sha512-NVPyrf0ncEURTvxOCdYE2PRzhwA3J+OYXrjr4MK6jnbdf+sp64u2oAm8ous1lvn7VmTFUt5udF0F/RLyvj/WKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2672,17 +2672,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -2690,20 +2690,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.0.1.tgz",
-			"integrity": "sha512-0FzdCNLKcldyD8xheiMJemnKy+5HXTMMMnWcaIaLUgqi+TnIpNFZ/jMYFh9LG83LPPXsOA0hMY6KvY87SCZvTQ==",
+			"version": "npm:@fluidframework/container-loader@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.1.0.tgz",
+			"integrity": "sha512-NVPyrf0ncEURTvxOCdYE2PRzhwA3J+OYXrjr4MK6jnbdf+sp64u2oAm8ous1lvn7VmTFUt5udF0F/RLyvj/WKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2711,17 +2711,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -2729,41 +2729,41 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.0.1.tgz",
-			"integrity": "sha512-OCkTXpgOW0XhqrXu9je6V0qhAut3+SmKI5p/wV4uK7rzyxrbk18ItiZ9s43zOTvD7/X8s38JO2rtGSEkCFgqMw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.1.0.tgz",
+			"integrity": "sha512-rAxOnFNfeYXUsNebMHNu1F1OGYHZb4gy/rUr9svZA7lkviaZSW5o+PVV49G4RKXRdocidL+IkoRUvEgX7PT7Ng==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/garbage-collector": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -2771,69 +2771,69 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.0.1.tgz",
-			"integrity": "sha512-scJoGh/aLCiA+VSH0Oc+MRPx3KkpX1B3GrKDLOwY2VHrW4UtyLaMLQTq+nlUZiw9EQRo42A7B1NQqQwdUQpfAw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.1.0.tgz",
+			"integrity": "sha512-flCKCjLWnJ7xijNTWdt8mlW60nTVo0MwaxByyhTSVijkO9uXbwOzPdwcKZHzAsrCmCC1EuNDB0kyvyKFP2cV9Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.0.1.tgz",
-			"integrity": "sha512-scJoGh/aLCiA+VSH0Oc+MRPx3KkpX1B3GrKDLOwY2VHrW4UtyLaMLQTq+nlUZiw9EQRo42A7B1NQqQwdUQpfAw==",
+			"version": "npm:@fluidframework/container-runtime-definitions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.1.0.tgz",
+			"integrity": "sha512-flCKCjLWnJ7xijNTWdt8mlW60nTVo0MwaxByyhTSVijkO9uXbwOzPdwcKZHzAsrCmCC1EuNDB0kyvyKFP2cV9Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.0.1.tgz",
-			"integrity": "sha512-OCkTXpgOW0XhqrXu9je6V0qhAut3+SmKI5p/wV4uK7rzyxrbk18ItiZ9s43zOTvD7/X8s38JO2rtGSEkCFgqMw==",
+			"version": "npm:@fluidframework/container-runtime@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.1.0.tgz",
+			"integrity": "sha512-rAxOnFNfeYXUsNebMHNu1F1OGYHZb4gy/rUr9svZA7lkviaZSW5o+PVV49G4RKXRdocidL+IkoRUvEgX7PT7Ng==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/garbage-collector": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -2841,120 +2841,120 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.0.1.tgz",
-			"integrity": "sha512-LmNsG79MjD9AFi2oZTxHjfp1M1VF4XKX02bNqe2mCplShO4Cldd0Zo0w68St5Nrro4eWFIE3STapwE8/kdzC3A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.1.0.tgz",
+			"integrity": "sha512-Z3fDlytTQL4Y5eeWTQhYHZG+wOPd7QCdbwi9zM6nc7OvSBkdCwY5HGsck/sgYvRwcBIdLIVoZ+DctVplKVboBw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.0.1.tgz",
-			"integrity": "sha512-LmNsG79MjD9AFi2oZTxHjfp1M1VF4XKX02bNqe2mCplShO4Cldd0Zo0w68St5Nrro4eWFIE3STapwE8/kdzC3A==",
+			"version": "npm:@fluidframework/container-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.1.0.tgz",
+			"integrity": "sha512-Z3fDlytTQL4Y5eeWTQhYHZG+wOPd7QCdbwi9zM6nc7OvSBkdCwY5HGsck/sgYvRwcBIdLIVoZ+DctVplKVboBw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.0.1.tgz",
-			"integrity": "sha512-Bt6ONbZJgKSK0WQcV6od9xqa6t4VcAKX6tRIwougvm/YJSc7YLz3itKR6g+ILaO0yH8+GnMHt6l11Bjsl44NBw=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.1.0.tgz",
+			"integrity": "sha512-lwZTJwF67dQJjw7VHVeqJyLukarD/apxYOBcVDHMFFFA5yvkHMOTfN6rAOrjQ6TmJ3uwzamZxRm3+3wUU2rBVA=="
 		},
 		"@fluidframework/core-interfaces-previous": {
-			"version": "npm:@fluidframework/core-interfaces@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.0.1.tgz",
-			"integrity": "sha512-Bt6ONbZJgKSK0WQcV6od9xqa6t4VcAKX6tRIwougvm/YJSc7YLz3itKR6g+ILaO0yH8+GnMHt6l11Bjsl44NBw=="
+			"version": "npm:@fluidframework/core-interfaces@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.1.0.tgz",
+			"integrity": "sha512-lwZTJwF67dQJjw7VHVeqJyLukarD/apxYOBcVDHMFFFA5yvkHMOTfN6rAOrjQ6TmJ3uwzamZxRm3+3wUU2rBVA=="
 		},
 		"@fluidframework/counter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.0.1.tgz",
-			"integrity": "sha512-kYM5tbxEH9tMobsu+9DCBicgDbFSj/UGLxBH+8Lumw3SdqY1afW0kgDXoJ39yiLQmIRsEJVe2/kZqqyVbJR6Mw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.1.0.tgz",
+			"integrity": "sha512-zv9Yd4wXjdMjHV1CZL29iOSJvkJAMf5B5xXVX9Ayvql3yvdXodtIpGSrLzvV9v0Nb8crolbTeiF6JvdYjqc5xQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.0.1.tgz",
-			"integrity": "sha512-kYM5tbxEH9tMobsu+9DCBicgDbFSj/UGLxBH+8Lumw3SdqY1afW0kgDXoJ39yiLQmIRsEJVe2/kZqqyVbJR6Mw==",
+			"version": "npm:@fluidframework/counter@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.1.0.tgz",
+			"integrity": "sha512-zv9Yd4wXjdMjHV1CZL29iOSJvkJAMf5B5xXVX9Ayvql3yvdXodtIpGSrLzvV9v0Nb8crolbTeiF6JvdYjqc5xQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.0.1.tgz",
-			"integrity": "sha512-gXpP7hZ95zUuBdQFypnWEl2BvYGQnX4hfd+fdXXdEPk/Y4Dtoy9V6j379Mb3XUeRQCWUkkk6WvLNnUbHcU45vQ==",
+			"version": "npm:@fluidframework/data-object-base@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.1.0.tgz",
+			"integrity": "sha512-BPzBS5xBNpG90P+eIyrZ3+pmOoBFuJAqbl37Y2vTPqmS2HqQ5NncLRx0fwOBH4pqBuJKdAPFMIf+xA3jiqEqwQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/request-handler": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/request-handler": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.0.1.tgz",
-			"integrity": "sha512-bo4qqiZUXGd4SzmMeQgCIbcMiPo6uTWJe4/jFHwrj24gWmY8VFjcHNIdX1VFe1SS9hTIbJS9L93zcz2vr0yhfA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.1.0.tgz",
+			"integrity": "sha512-9c/b7neSKrmLo8Hzf9yDR6AtiI6zY+sn6pJyur6+uiG4X9cG5K4KONoP2oW9nMEwI1ZuFlPaKQf22y8ABhTX5w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/garbage-collector": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -2962,68 +2962,68 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.0.1.tgz",
-			"integrity": "sha512-3knrsvPUzcdf6VwEBzLFdDbKBH7cz9YZn1QtCkamr4skrHWTP9bknzpQCT9PrKPdk5D9gJxUQsJXYYs+SITYVA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.1.0.tgz",
+			"integrity": "sha512-QtDJP1B2/krmvtDfds3hEV5fpIHJgtP5bqxW/OdhP342jmsiLe7bottSoGTBRaz2sFrhtVO49cfI3Wnv1c9Mfw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.0.1.tgz",
-			"integrity": "sha512-3knrsvPUzcdf6VwEBzLFdDbKBH7cz9YZn1QtCkamr4skrHWTP9bknzpQCT9PrKPdk5D9gJxUQsJXYYs+SITYVA==",
+			"version": "npm:@fluidframework/datastore-definitions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.1.0.tgz",
+			"integrity": "sha512-QtDJP1B2/krmvtDfds3hEV5fpIHJgtP5bqxW/OdhP342jmsiLe7bottSoGTBRaz2sFrhtVO49cfI3Wnv1c9Mfw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.0.1.tgz",
-			"integrity": "sha512-bo4qqiZUXGd4SzmMeQgCIbcMiPo6uTWJe4/jFHwrj24gWmY8VFjcHNIdX1VFe1SS9hTIbJS9L93zcz2vr0yhfA==",
+			"version": "npm:@fluidframework/datastore@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.1.0.tgz",
+			"integrity": "sha512-9c/b7neSKrmLo8Hzf9yDR6AtiI6zY+sn6pJyur6+uiG4X9cG5K4KONoP2oW9nMEwI1ZuFlPaKQf22y8ABhTX5w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/garbage-collector": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -3031,105 +3031,105 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.0.1.tgz",
-			"integrity": "sha512-V+XN4+aOVqrEv9M0+HxC9Qq9lwrgLj40LpNK7s2SWGCtERcVIPzNEeCKYnpjGbL5TJ6cfHCDuybr/STBreBKlA==",
+			"version": "npm:@fluidframework/dds-interceptions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.1.0.tgz",
+			"integrity": "sha512-Ch/3zg01QWXTe6k51eA5iFZ6lV9PSJ/cPTtZOCAugT3fToj+V6oMLRFoT5NKQ4/8xMsCGUf7r4nx7JkG5N+aSA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^1.0.1",
-				"@fluidframework/merge-tree": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/sequence": "^1.0.1"
+				"@fluidframework/map": "^1.1.0",
+				"@fluidframework/merge-tree": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/sequence": "^1.1.0"
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.0.1.tgz",
-			"integrity": "sha512-IAmLd1myBpLRZvvuE9iQ8NF4i4BPMvJy7lDpWBUkqoOHc3gxlyG2WCJHEf+86kO+TAVxYi07vr4mXBQpPccZ5w==",
+			"version": "npm:@fluidframework/debugger@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.1.0.tgz",
+			"integrity": "sha512-4lnYRVm4f0fUCTuiiX73EdvXEsrd+sy6/caIVYgEH3Y9mxwDoP2cd5/tF2KLPzi4ZEy04XQG4mdTY9jHIVnjpg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.0.1",
+				"@fluidframework/replay-driver": "^1.1.0",
 				"jsonschema": "^1.2.6"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.0.1.tgz",
-			"integrity": "sha512-QVWhz0eqeJar//hNTfdLJ+mnuTv9hV2DhxjnnTU+ZsxJ6w3fvW+5nj4yKxyWM+k6CF9XKNBVn1Kh3tOA3e08IQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.1.0.tgz",
+			"integrity": "sha512-K93DVQg+ILGrvY3UwdGGiTm0oqL4mjHhYTpl8nnf7ELSqAM2lLPHs3CwvFVphoUJjY62n3UgDVKn6SENxvCJKA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.0.1.tgz",
-			"integrity": "sha512-QVWhz0eqeJar//hNTfdLJ+mnuTv9hV2DhxjnnTU+ZsxJ6w3fvW+5nj4yKxyWM+k6CF9XKNBVn1Kh3tOA3e08IQ==",
+			"version": "npm:@fluidframework/driver-base@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.1.0.tgz",
+			"integrity": "sha512-K93DVQg+ILGrvY3UwdGGiTm0oqL4mjHhYTpl8nnf7ELSqAM2lLPHs3CwvFVphoUJjY62n3UgDVKn6SENxvCJKA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.0.1.tgz",
-			"integrity": "sha512-WlcfXUsslcm5egApzpKmTOMawIsneYiTIG9LwVaY0yNvE5I/xVg54Z5SIqKc7Ov4kA/jxRPp/PLjsARGvHuWnQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.1.0.tgz",
+			"integrity": "sha512-NzvFeDy8Rzi2fXED6NWTdm+RIfUF0mkoEmj1oZkHhWyoNrAhXviS4k03J8Pib+A3LZqVufVclrFQhcrSVQiobA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/driver-definitions-previous": {
-			"version": "npm:@fluidframework/driver-definitions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.0.1.tgz",
-			"integrity": "sha512-WlcfXUsslcm5egApzpKmTOMawIsneYiTIG9LwVaY0yNvE5I/xVg54Z5SIqKc7Ov4kA/jxRPp/PLjsARGvHuWnQ==",
+			"version": "npm:@fluidframework/driver-definitions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.1.0.tgz",
+			"integrity": "sha512-NzvFeDy8Rzi2fXED6NWTdm+RIfUF0mkoEmj1oZkHhWyoNrAhXviS4k03J8Pib+A3LZqVufVclrFQhcrSVQiobA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.0.1.tgz",
-			"integrity": "sha512-k53mRghyr0+tzLca/353AZAAHTzphgwTmhRucwtXP3RXWMucpCEJN+9BL5TP0YGlvW7aceFkwgrY2pOTQ4Bm4A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.1.0.tgz",
+			"integrity": "sha512-M3T1sfopSc0+lBSMGmlJlW3KS0DalT/LSmHd3/lChKS0KVBJSHXWmwPw6zqJiorH6A26bZIoBG2/SbpPRdte2w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/gitresources": "^0.1036.5000",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -3137,34 +3137,34 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.0.1.tgz",
-			"integrity": "sha512-k53mRghyr0+tzLca/353AZAAHTzphgwTmhRucwtXP3RXWMucpCEJN+9BL5TP0YGlvW7aceFkwgrY2pOTQ4Bm4A==",
+			"version": "npm:@fluidframework/driver-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.1.0.tgz",
+			"integrity": "sha512-M3T1sfopSc0+lBSMGmlJlW3KS0DalT/LSmHd3/lChKS0KVBJSHXWmwPw6zqJiorH6A26bZIoBG2/SbpPRdte2w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/gitresources": "^0.1036.5000",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -3172,13 +3172,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.0.1.tgz",
-			"integrity": "sha512-tTdthVkg2qgk60I0arPwQhmaL8lKuZXLDxzdesXly7H6pfp9iVp9mPs19EzC1V2iXJ5oVmLdEMNRHFGmVWj5Pg==",
+			"version": "npm:@fluidframework/driver-web-cache@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.1.0.tgz",
+			"integrity": "sha512-0e5+mcWUtaKUakolo9i8ltVyovk5boTYw43X9WFXG9geGsm8DHa1RYmGfs43lTGKpiQUzkxuRsC6OdG3ssDhUA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3202,74 +3202,74 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.0.1.tgz",
-			"integrity": "sha512-8aBLyiD1npigMEz4GkgsY09UwQsEXDjAeRRhFfWS0vQBjSEDP9R6zLrqnMQHJmn4zSXfc9ul+RaNXdjT3jBRDA==",
+			"version": "npm:@fluidframework/file-driver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.1.0.tgz",
+			"integrity": "sha512-Gcl99NCWO7WKNG65d0eRQ6/mfD13IxaGMK5iKO31Tf/07mHyF5G0zoflEDZW7gIra0TH4yHsPKC3Gs8th8AxFA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.0.1"
+				"@fluidframework/replay-driver": "^1.1.0"
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.0.1.tgz",
-			"integrity": "sha512-7YD22HbWmtNBZSwVYrBMU9W6A/6TGpI7TrV2aqTHm8NTbQ/BfFzPKqvBKstGOQhmkd5HXHXuq8XgsMQg56BiHQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.1.0.tgz",
+			"integrity": "sha512-QAKkDGPy7wQv2wo6jHO8RSd4EGoiQt6UwpC0CBjH1G8sC9DELiTAqP1D0aATyh9OEr3tv2224FseCg0jwYqkow==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.1",
+				"@fluidframework/aqueduct": "^1.1.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1"
+				"@fluidframework/request-handler": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.0.1.tgz",
-			"integrity": "sha512-7YD22HbWmtNBZSwVYrBMU9W6A/6TGpI7TrV2aqTHm8NTbQ/BfFzPKqvBKstGOQhmkd5HXHXuq8XgsMQg56BiHQ==",
+			"version": "npm:@fluidframework/fluid-static@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.1.0.tgz",
+			"integrity": "sha512-QAKkDGPy7wQv2wo6jHO8RSd4EGoiQt6UwpC0CBjH1G8sC9DELiTAqP1D0aATyh9OEr3tv2224FseCg0jwYqkow==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.1",
+				"@fluidframework/aqueduct": "^1.1.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1"
+				"@fluidframework/request-handler": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.0.1.tgz",
-			"integrity": "sha512-1QyuKdcAcyaFiVCtn7NU/sMAoo2cHKxWwA0oi8LEbXCf5k9aSo+bPWvDItsqx2Am0xGJ+DAZArD5LtD0wm1KsQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.1.0.tgz",
+			"integrity": "sha512-NXyzumWwpANyPeOZUaEF+U31RjYINXjgCUUpVZJOZ6GV+15dTaqXrjg9Cc3j39u0lP3xnCk1wZYGVOxssaKqxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.0.1.tgz",
-			"integrity": "sha512-1QyuKdcAcyaFiVCtn7NU/sMAoo2cHKxWwA0oi8LEbXCf5k9aSo+bPWvDItsqx2Am0xGJ+DAZArD5LtD0wm1KsQ==",
+			"version": "npm:@fluidframework/garbage-collector@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.1.0.tgz",
+			"integrity": "sha512-NXyzumWwpANyPeOZUaEF+U31RjYINXjgCUUpVZJOZ6GV+15dTaqXrjg9Cc3j39u0lP3xnCk1wZYGVOxssaKqxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -3278,113 +3278,113 @@
 			"integrity": "sha512-DnK7PqHJWJndck0uVLaFB8J1QgpkpTPgN5tZvLl1wbadKr0Zh9i8Fm9u+Ssj+iAxc6BuCahyQk6vs5OfUAygGg=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.0.1.tgz",
-			"integrity": "sha512-3XqLQKOgvq4R8LOyLvb4FLFnTfhIpkgZYQ00eWjUj4ZWgtFymkCaU1mg9DiNJi1p2AAFMrFiFEC3BUoOp6M/XA==",
+			"version": "npm:@fluidframework/iframe-driver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.1.0.tgz",
+			"integrity": "sha512-RJo0jI7gEHetOyUgxFNVGeYz9VMUyGlHQN76wOl/eE5sEDSjSYbPXcg2u1EpCN7hjYO/t02N3lJICUwzAngrLQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"comlink": "^4.3.0"
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.0.1.tgz",
-			"integrity": "sha512-bphRTjyDnValhS/SXUPpg9cbYzBh256S3zOgG0hP0GO7e9dMR63lrZDO4ysAEZ+rc+JrMJJ4BiASThMRwhrSIw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.1.0.tgz",
+			"integrity": "sha512-n60rnzmZUs+DG6U3FQYzdT7hE6vtvq/Z6qZiZu7vmisvT9qaDXKTCQhkiFRTdPNXJIU/Zh9OYJQqlGyvfz7Yrg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.0.1.tgz",
-			"integrity": "sha512-bphRTjyDnValhS/SXUPpg9cbYzBh256S3zOgG0hP0GO7e9dMR63lrZDO4ysAEZ+rc+JrMJJ4BiASThMRwhrSIw==",
+			"version": "npm:@fluidframework/ink@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.1.0.tgz",
+			"integrity": "sha512-n60rnzmZUs+DG6U3FQYzdT7hE6vtvq/Z6qZiZu7vmisvT9qaDXKTCQhkiFRTdPNXJIU/Zh9OYJQqlGyvfz7Yrg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.0.1.tgz",
-			"integrity": "sha512-wOR5tNksImVAnikpU5DU5+VcmisYT+2Aaq1BB1PJpr8ly0nPccggTb3qs+iL1JsHrvHmyG3WQqZi/KzcObg7mw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.1.0.tgz",
+			"integrity": "sha512-08rEMv254BqJD75f5XLZ5zYVyZ8E5t7n9DOOzoWgBg3lfvoRc303Fng3H19g/fODHz5s//ZUlfq9LxrUKYVzJQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-base": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-base": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/server-local-server": "^0.1036.4000",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/server-services-core": "^0.1036.4000",
-				"@fluidframework/server-test-utils": "^0.1036.4000",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/server-local-server": "^0.1036.5000",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/server-services-core": "^0.1036.5000",
+				"@fluidframework/server-test-utils": "^0.1036.5000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.4000.tgz",
-					"integrity": "sha512-r//V5DxkzTmKhyKXj9e7PjoQcQJa/hK4yxtryu7MMwpj+bRHla9fNOHf2oFosXJg/QpXRmG9k9mx1/OYqgXxcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.5000.tgz",
+					"integrity": "sha512-ogPVoWEp8U0v6FBiwq/x30pEMLiz+KB37M7FMGJvLnS6n281v5LA8Sw/NB2e8AI33WfQrQ9rYXGEwh4BvZ60Ig==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-lambdas": "^0.1036.4000",
-						"@fluidframework/server-memory-orderer": "^0.1036.4000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
-						"@fluidframework/server-test-utils": "^0.1036.4000",
+						"@fluidframework/server-lambdas": "^0.1036.5000",
+						"@fluidframework/server-memory-orderer": "^0.1036.5000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
+						"@fluidframework/server-test-utils": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -3398,15 +3398,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -3414,17 +3414,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.4000.tgz",
-					"integrity": "sha512-AZyjRMPaosbTpd8xXPkDzHhT+mt7aRMQ5u65WOgD/EmWq+k3vRXQXFhO8o466NL3R63zA9ZIlhxYs7RclNudcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.5000.tgz",
+					"integrity": "sha512-uTgeuHWjKzicNL8TVdYdK9r5nTSCPnsxMhhq4SFTy8saIbvyQQ8bhkl252gVjpUI8xTk0BlqjAikWrs+1oDaxQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -3502,68 +3502,68 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.0.1.tgz",
-			"integrity": "sha512-wOR5tNksImVAnikpU5DU5+VcmisYT+2Aaq1BB1PJpr8ly0nPccggTb3qs+iL1JsHrvHmyG3WQqZi/KzcObg7mw==",
+			"version": "npm:@fluidframework/local-driver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.1.0.tgz",
+			"integrity": "sha512-08rEMv254BqJD75f5XLZ5zYVyZ8E5t7n9DOOzoWgBg3lfvoRc303Fng3H19g/fODHz5s//ZUlfq9LxrUKYVzJQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-base": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-base": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/server-local-server": "^0.1036.4000",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/server-services-core": "^0.1036.4000",
-				"@fluidframework/server-test-utils": "^0.1036.4000",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/server-local-server": "^0.1036.5000",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/server-services-core": "^0.1036.5000",
+				"@fluidframework/server-test-utils": "^0.1036.5000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.4000.tgz",
-					"integrity": "sha512-r//V5DxkzTmKhyKXj9e7PjoQcQJa/hK4yxtryu7MMwpj+bRHla9fNOHf2oFosXJg/QpXRmG9k9mx1/OYqgXxcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.5000.tgz",
+					"integrity": "sha512-ogPVoWEp8U0v6FBiwq/x30pEMLiz+KB37M7FMGJvLnS6n281v5LA8Sw/NB2e8AI33WfQrQ9rYXGEwh4BvZ60Ig==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-lambdas": "^0.1036.4000",
-						"@fluidframework/server-memory-orderer": "^0.1036.4000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
-						"@fluidframework/server-test-utils": "^0.1036.4000",
+						"@fluidframework/server-lambdas": "^0.1036.5000",
+						"@fluidframework/server-memory-orderer": "^0.1036.5000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
+						"@fluidframework/server-test-utils": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -3577,15 +3577,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -3593,17 +3593,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.4000.tgz",
-					"integrity": "sha512-AZyjRMPaosbTpd8xXPkDzHhT+mt7aRMQ5u65WOgD/EmWq+k3vRXQXFhO8o466NL3R63zA9ZIlhxYs7RclNudcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.5000.tgz",
+					"integrity": "sha512-uTgeuHWjKzicNL8TVdYdK9r5nTSCPnsxMhhq4SFTy8saIbvyQQ8bhkl252gVjpUI8xTk0BlqjAikWrs+1oDaxQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -3681,73 +3681,73 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.0.1.tgz",
-			"integrity": "sha512-GunY9b1lNqacwTWN4LGkeyUFb5liZLGN21X29KRmt4AO1LysACIfylBd/zUejerci1F20773+Ao491DeMHaF3g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.1.0.tgz",
+			"integrity": "sha512-Uwi/nYcgNlA2oTR5J9Q/LXwi7fSphxWIPgvUUgO99iRl6/1PNfqFmDMSMSxtCzBTDmXIMkTyikWkaM1xWGc3/A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.0.1.tgz",
-			"integrity": "sha512-GunY9b1lNqacwTWN4LGkeyUFb5liZLGN21X29KRmt4AO1LysACIfylBd/zUejerci1F20773+Ao491DeMHaF3g==",
+			"version": "npm:@fluidframework/map@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.1.0.tgz",
+			"integrity": "sha512-Uwi/nYcgNlA2oTR5J9Q/LXwi7fSphxWIPgvUUgO99iRl6/1PNfqFmDMSMSxtCzBTDmXIMkTyikWkaM1xWGc3/A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.0.1.tgz",
-			"integrity": "sha512-yyL2DQZnlt/Hg/O+Trszy8yNKFvaUDcHI7HpsD1czaWln9qTUIIsKa6Nas+JNte6VbylWze9ySr8r+JidoFftQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.1.0.tgz",
+			"integrity": "sha512-J7wOhr3Ph1djvR0XRQmUwM2/29uf1sCerBvnhgmhSu3Yy1+QsaURjFvuOthyI1KKZElgfcQ0bwc/6wgUHTfihA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/merge-tree": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/merge-tree": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -3755,37 +3755,37 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.0.1.tgz",
-			"integrity": "sha512-yyL2DQZnlt/Hg/O+Trszy8yNKFvaUDcHI7HpsD1czaWln9qTUIIsKa6Nas+JNte6VbylWze9ySr8r+JidoFftQ==",
+			"version": "npm:@fluidframework/matrix@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.1.0.tgz",
+			"integrity": "sha512-J7wOhr3Ph1djvR0XRQmUwM2/29uf1sCerBvnhgmhSu3Yy1+QsaURjFvuOthyI1KKZElgfcQ0bwc/6wgUHTfihA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/merge-tree": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/merge-tree": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -3793,106 +3793,106 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.0.1.tgz",
-			"integrity": "sha512-QgDvz75hkBV3dZ+5zHLvKZLk40h3qTdarztrXxRl0b0dQd4q7gA5Vpg+0f1AEZKECMCGPPBdkpZ3Cn1BNBH7yw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.1.0.tgz",
+			"integrity": "sha512-HRnDdlQmqPSFWgGRaZ/IA3R49Hp0lC8ZeIn+fprb1MD2uJ7/WbE484mYd0ZV/VnpPHHy/reKdC4wFTNorqjnOg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.0.1.tgz",
-			"integrity": "sha512-QgDvz75hkBV3dZ+5zHLvKZLk40h3qTdarztrXxRl0b0dQd4q7gA5Vpg+0f1AEZKECMCGPPBdkpZ3Cn1BNBH7yw==",
+			"version": "npm:@fluidframework/merge-tree@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.1.0.tgz",
+			"integrity": "sha512-HRnDdlQmqPSFWgGRaZ/IA3R49Hp0lC8ZeIn+fprb1MD2uJ7/WbE484mYd0ZV/VnpPHHy/reKdC4wFTNorqjnOg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.0.1.tgz",
-			"integrity": "sha512-vCOEXQ3uokayRaYfO69+VVESGcL0z7iIKxOjRHPNGtiJRvV/kIze6bsp8nBGba4K/45CJPqIKo3kX1+PWa8SjQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.1.0.tgz",
+			"integrity": "sha512-6WIj7FNZE2WniFdAUvPE469KQcFYUJdbjP1h3Ma4Zong63TeQBbzN/HUM7N8p/3tJijdXLvRoFxRGzBFzDgMZA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.0.1",
+				"@fluidframework/test-driver-definitions": "^1.1.0",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.0.1.tgz",
-			"integrity": "sha512-vCOEXQ3uokayRaYfO69+VVESGcL0z7iIKxOjRHPNGtiJRvV/kIze6bsp8nBGba4K/45CJPqIKo3kX1+PWa8SjQ==",
+			"version": "npm:@fluidframework/mocha-test-setup@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.1.0.tgz",
+			"integrity": "sha512-6WIj7FNZE2WniFdAUvPE469KQcFYUJdbjP1h3Ma4Zong63TeQBbzN/HUM7N8p/3tJijdXLvRoFxRGzBFzDgMZA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.0.1",
+				"@fluidframework/test-driver-definitions": "^1.1.0",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.0.1.tgz",
-			"integrity": "sha512-MF3v2f1jTphvic2GoHmXg+oFG8ttAsGzNdCJB7LEfLG5P5EVJyFB2BUOxsGnh3EIbB0o7un8bJ09qLSxRMzaKA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.1.0.tgz",
+			"integrity": "sha512-oM5ukWlkf95zfnXPfEAz2wHMVWg2r5qC0lQuaNECG4jOJ3CBPwiVXLQ7xHI83gDY5Uxkwuqoq261L3ANX9WoGQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.0.1.tgz",
-			"integrity": "sha512-MF3v2f1jTphvic2GoHmXg+oFG8ttAsGzNdCJB7LEfLG5P5EVJyFB2BUOxsGnh3EIbB0o7un8bJ09qLSxRMzaKA==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.1.0.tgz",
+			"integrity": "sha512-oM5ukWlkf95zfnXPfEAz2wHMVWg2r5qC0lQuaNECG4jOJ3CBPwiVXLQ7xHI83gDY5Uxkwuqoq261L3ANX9WoGQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.0.1.tgz",
-			"integrity": "sha512-zXGD4UH6+ddi/ekcYrJ68HpAYj6QI2L/19+b3jM6NcTYSXoyusdBLRUhC1vBNL6sBEV75ATzGYP/kmJI2YroNw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.1.0.tgz",
+			"integrity": "sha512-A6BkhAOZSu8judvhrNLCI/3iLzV46jbjAuBnVQSRIPuoOkEjMFgsFPdU59bVIhnm6yO/hTf6TV36xdZHdR7fNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-base": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/odsp-doclib-utils": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-base": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/gitresources": "^0.1036.5000",
+				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -3900,17 +3900,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -3918,38 +3918,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.0.1.tgz",
-			"integrity": "sha512-bFJTbZtdWSO1CMhVwmcTsx65VFMq1qA3DFPhI2OGsDV1dWH3rCSuxceTSIIlrDILgI0EzCdK8rYdM6mDWXEDMg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.1.0.tgz",
+			"integrity": "sha512-CVUXIPN1OGMUz6rLTxPubVSCGCi4pbRXWWkHCSWIbK1NrHIhOOkbVjuOUkbdMGZtp18qrZ4GB1IKcxF1elcApg==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.0.1"
+				"@fluidframework/driver-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.0.1.tgz",
-			"integrity": "sha512-bFJTbZtdWSO1CMhVwmcTsx65VFMq1qA3DFPhI2OGsDV1dWH3rCSuxceTSIIlrDILgI0EzCdK8rYdM6mDWXEDMg==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.1.0.tgz",
+			"integrity": "sha512-CVUXIPN1OGMUz6rLTxPubVSCGCi4pbRXWWkHCSWIbK1NrHIhOOkbVjuOUkbdMGZtp18qrZ4GB1IKcxF1elcApg==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.0.1"
+				"@fluidframework/driver-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.0.1.tgz",
-			"integrity": "sha512-zXGD4UH6+ddi/ekcYrJ68HpAYj6QI2L/19+b3jM6NcTYSXoyusdBLRUhC1vBNL6sBEV75ATzGYP/kmJI2YroNw==",
+			"version": "npm:@fluidframework/odsp-driver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.1.0.tgz",
+			"integrity": "sha512-A6BkhAOZSu8judvhrNLCI/3iLzV46jbjAuBnVQSRIPuoOkEjMFgsFPdU59bVIhnm6yO/hTf6TV36xdZHdR7fNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-base": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/odsp-doclib-utils": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-base": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/gitresources": "^0.1036.5000",
+				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -3957,17 +3957,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -3975,54 +3975,54 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.0.1.tgz",
-			"integrity": "sha512-Zhe3HJaXMGnSRieMwPmTOhrHbWdu6QD9MqFxd2bmOK/l5M02YGJwMHG9nRsiJsLA7QZJ5RCviBLAyraAA6BnUA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.1.0.tgz",
+			"integrity": "sha512-GjfgNGxJOySAY6wRTbM49KDcKDPb7QvNjtoCFB+1DXTfh3AmPhvtPsQIfVAca9dP2WFjFClN6soPsU/ZRYX40w==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/odsp-driver": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1"
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/odsp-driver": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.0.1.tgz",
-			"integrity": "sha512-Zhe3HJaXMGnSRieMwPmTOhrHbWdu6QD9MqFxd2bmOK/l5M02YGJwMHG9nRsiJsLA7QZJ5RCviBLAyraAA6BnUA==",
+			"version": "npm:@fluidframework/odsp-urlresolver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.1.0.tgz",
+			"integrity": "sha512-GjfgNGxJOySAY6wRTbM49KDcKDPb7QvNjtoCFB+1DXTfh3AmPhvtPsQIfVAca9dP2WFjFClN6soPsU/ZRYX40w==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/odsp-driver": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1"
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/odsp-driver": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.0.1.tgz",
-			"integrity": "sha512-6jlLzi3+ktpbSnbYpdAD+/uOhEcF9kXfozR5I9aPhgavgKA1pHNo8qkpx62ZbmXUoM09RhArmXqgxbf9bLFKlA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.1.0.tgz",
+			"integrity": "sha512-4t9BgJhcvbZiKah+Y2jZQNHqLxLo7ZZI31CpGozHahk9qnN7ixwZGufCOcOg9c/X2B/HB/I81vml3jo+ITS9yQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.0.1.tgz",
-			"integrity": "sha512-6jlLzi3+ktpbSnbYpdAD+/uOhEcF9kXfozR5I9aPhgavgKA1pHNo8qkpx62ZbmXUoM09RhArmXqgxbf9bLFKlA==",
+			"version": "npm:@fluidframework/ordered-collection@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.1.0.tgz",
+			"integrity": "sha512-4t9BgJhcvbZiKah+Y2jZQNHqLxLo7ZZI31CpGozHahk9qnN7ixwZGufCOcOg9c/X2B/HB/I81vml3jo+ITS9yQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4046,31 +4046,31 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.0.1.tgz",
-			"integrity": "sha512-I2LytiwJBtuYqisJBUg0VQPyLWNTdHw9Le6b4XmgG+oRUPFI/Dfv/RR3rph3t9/vFpAIwu3qnSSMZH/BEk5ptA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.1.0.tgz",
+			"integrity": "sha512-SvP9Ouk/Dt46LI8ySh1FbL4i1k4IUJlJxoN1re2+DVbMko2UJRuaSsVv2dRVWHwPl5ynLlFUQd1cir5UDXElcw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -4078,31 +4078,31 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.0.1.tgz",
-			"integrity": "sha512-I2LytiwJBtuYqisJBUg0VQPyLWNTdHw9Le6b4XmgG+oRUPFI/Dfv/RR3rph3t9/vFpAIwu3qnSSMZH/BEk5ptA==",
+			"version": "npm:@fluidframework/register-collection@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.1.0.tgz",
+			"integrity": "sha512-SvP9Ouk/Dt46LI8ySh1FbL4i1k4IUJlJxoN1re2+DVbMko2UJRuaSsVv2dRVWHwPl5ynLlFUQd1cir5UDXElcw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -4110,70 +4110,70 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.0.1.tgz",
-			"integrity": "sha512-6dWFUw2K+ZZxxU4cYy0jQ82uToXp2RARMB/5evH1e2coRMd8/Mz/HZp6XDgkKI/VujsF2Y36yDtLVB4ZhiOCQw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.1.0.tgz",
+			"integrity": "sha512-+PvOw5TWKdyWmIyvhjbl94JkAskIJqRuLu5hH/tnsJYxmM2B6HL7fyS0qH9b6yd+shEnIx3hzmY2+bI3/eA5mg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.0.1.tgz",
-			"integrity": "sha512-6dWFUw2K+ZZxxU4cYy0jQ82uToXp2RARMB/5evH1e2coRMd8/Mz/HZp6XDgkKI/VujsF2Y36yDtLVB4ZhiOCQw==",
+			"version": "npm:@fluidframework/replay-driver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.1.0.tgz",
+			"integrity": "sha512-+PvOw5TWKdyWmIyvhjbl94JkAskIJqRuLu5hH/tnsJYxmM2B6HL7fyS0qH9b6yd+shEnIx3hzmY2+bI3/eA5mg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.0.1.tgz",
-			"integrity": "sha512-j3b/p8qqdqOZ5Xm5UuXMAKJ0e0KIaedzTePNr/DOku9+DZuWfWRankYB2cArdZwfYmOmarEg3GTu/4pNK9iDrg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.1.0.tgz",
+			"integrity": "sha512-u6bP8w2GDXkIZnSe8ZBnkSh1pkT98HXyeuRrodkah9/Wu1HogS0asxfcDrbcrrPZS8luvooXusfjReYCBHFhNQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1"
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.0.1.tgz",
-			"integrity": "sha512-j3b/p8qqdqOZ5Xm5UuXMAKJ0e0KIaedzTePNr/DOku9+DZuWfWRankYB2cArdZwfYmOmarEg3GTu/4pNK9iDrg==",
+			"version": "npm:@fluidframework/request-handler@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.1.0.tgz",
+			"integrity": "sha512-u6bP8w2GDXkIZnSe8ZBnkSh1pkT98HXyeuRrodkah9/Wu1HogS0asxfcDrbcrrPZS8luvooXusfjReYCBHFhNQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1"
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.0.1.tgz",
-			"integrity": "sha512-wgxyOzV+NfsjmvPAGmGMdro8jgbQhsB8PrVkgNvZjkofY9JbVNNDdISgUeQ+Kw8jE9FMqlwUPPPpWTuGgCI2CA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.1.0.tgz",
+			"integrity": "sha512-dF9fSfNk+q+vqNGN7L7jdqG0GjBVGQBTxX2/IOqWfwsd6lEZr7daWte/hytrNHcNSxCYEP2OuYtthICbPfM4AA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/driver-base": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/gitresources": "^0.1036.5000",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4183,29 +4183,29 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -4226,20 +4226,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.0.1.tgz",
-			"integrity": "sha512-wgxyOzV+NfsjmvPAGmGMdro8jgbQhsB8PrVkgNvZjkofY9JbVNNDdISgUeQ+Kw8jE9FMqlwUPPPpWTuGgCI2CA==",
+			"version": "npm:@fluidframework/routerlicious-driver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.1.0.tgz",
+			"integrity": "sha512-dF9fSfNk+q+vqNGN7L7jdqG0GjBVGQBTxX2/IOqWfwsd6lEZr7daWte/hytrNHcNSxCYEP2OuYtthICbPfM4AA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/driver-base": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/gitresources": "^0.1036.5000",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4249,29 +4249,29 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -4292,86 +4292,86 @@
 			}
 		},
 		"@fluidframework/routerlicious-host-previous": {
-			"version": "npm:@fluidframework/routerlicious-host@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-1.0.1.tgz",
-			"integrity": "sha512-PB2mDwl7tOv87JCjw5/KeLeRNKBQ7u/2U0ugFGqntYtUuPCaSoBUS+tLjW1SAhNTsXAb6fAY9lURmfUJFSOsmQ==",
+			"version": "npm:@fluidframework/routerlicious-host@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-host/-/routerlicious-host-1.1.0.tgz",
+			"integrity": "sha512-E9vmoeNNdNnf3VBVGsa9VT8eOW1d7sVpDQbr2XRH4XromFwbtytsM07VxfnKF9ml3tVxbaVQrlkv3BWeN3Hejg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"axios": "^0.26.0"
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.0.1.tgz",
-			"integrity": "sha512-6xPToCcCaEqTV7fmJ82X08WjXwf4atB55BMZZZgvZTSszm7caZ+rqKH33OGtu3KvcOtIqYj+P5xDYPuXPVBi+w==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.1.0.tgz",
+			"integrity": "sha512-Gk0pIO2Prd9+iZJuwOF6fH8pcstqrDFadAYZ5JrbUkgR7oPN8ay883GqscsGMAPucW4rmSP2sr4Z0jUJWG/0ww==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"nconf": "^0.11.4"
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.0.1.tgz",
-			"integrity": "sha512-G1zLa/qMYOioeDx7v7R/c32A9qZMOdF697OK9pGVo1goXgIyNkPa0Tz9s3kuZvzDmubyYNZvDP8SynI7wnS9eA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.1.0.tgz",
+			"integrity": "sha512-Wn/mOCN7Jt4PWbh5IikKpUCuoBdy3N4CAOi9jB3J1KjqAqRisa1kjl6c2ExYmY/H1Q8GrzvuHP8boVkgbsNLvw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.0.1.tgz",
-			"integrity": "sha512-G1zLa/qMYOioeDx7v7R/c32A9qZMOdF697OK9pGVo1goXgIyNkPa0Tz9s3kuZvzDmubyYNZvDP8SynI7wnS9eA==",
+			"version": "npm:@fluidframework/runtime-definitions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.1.0.tgz",
+			"integrity": "sha512-Wn/mOCN7Jt4PWbh5IikKpUCuoBdy3N4CAOi9jB3J1KjqAqRisa1kjl6c2ExYmY/H1Q8GrzvuHP8boVkgbsNLvw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.0.1.tgz",
-			"integrity": "sha512-2Y8WgH5RldOigzegU+xMqhmXY6HhJEseb5TGPD1tu3qy0UJSkE7CJLbVGP70lySdG2wYrq9ckp3rkvWMzcIHnA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.1.0.tgz",
+			"integrity": "sha512-bpUcWTl7HirLr1h6KVpI5cTWDc7cX4p1R4//J+3SaCw2znGBCC1K6kwUYraYy5+1N15NWfr4nu2hx2D3sIVPgQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/garbage-collector": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -4379,35 +4379,35 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.0.1.tgz",
-			"integrity": "sha512-2Y8WgH5RldOigzegU+xMqhmXY6HhJEseb5TGPD1tu3qy0UJSkE7CJLbVGP70lySdG2wYrq9ckp3rkvWMzcIHnA==",
+			"version": "npm:@fluidframework/runtime-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.1.0.tgz",
+			"integrity": "sha512-bpUcWTl7HirLr1h6KVpI5cTWDc7cX4p1R4//J+3SaCw2znGBCC1K6kwUYraYy5+1N15NWfr4nu2hx2D3sIVPgQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/garbage-collector": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -4415,57 +4415,57 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.0.1.tgz",
-			"integrity": "sha512-46VC/p4HoSh/Je5ivYaoa+u0znD/Wv+IFfxmmopqwnvU2YnjHkto1cT37BRjaHtFFY0mbs+TQb9tOTktaBuXuQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.1.0.tgz",
+			"integrity": "sha512-qRkySflYdL3IBaEKT7Dq5css/o9D4gcSIjc+6HLyArnupgvqbCDg1KYkQwa6nbOSZ0GesdfO8Nd8tdLPHoSang==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/merge-tree": "^1.0.1",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/merge-tree": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.0.1.tgz",
-			"integrity": "sha512-46VC/p4HoSh/Je5ivYaoa+u0znD/Wv+IFfxmmopqwnvU2YnjHkto1cT37BRjaHtFFY0mbs+TQb9tOTktaBuXuQ==",
+			"version": "npm:@fluidframework/sequence@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.1.0.tgz",
+			"integrity": "sha512-qRkySflYdL3IBaEKT7Dq5css/o9D4gcSIjc+6HLyArnupgvqbCDg1KYkQwa6nbOSZ0GesdfO8Nd8tdLPHoSang==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/merge-tree": "^1.0.1",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/merge-tree": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/server-lambdas": {
-			"version": "0.1036.4000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.4000.tgz",
-			"integrity": "sha512-SPEjwsrIY8It8+5wd5eM4cchKol1cy+2y5oJaPkbdUmNcuRQqoR38pLa6mcUEpawnggk89Lx2FUQCmSNaE+Fdg==",
+			"version": "0.1036.5000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1036.5000.tgz",
+			"integrity": "sha512-gwfcoJV5Yl9D87MlSgJTryplacmF/jWbf7+iwH4tsP+kVKMrFu1Prsen24fS2f/bcuV5egf8rnmtSnKu2vpohg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "^0.1036.4000",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/gitresources": "^0.1036.5000",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/server-lambdas-driver": "^0.1036.4000",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/server-services-core": "^0.1036.4000",
-				"@fluidframework/server-services-telemetry": "^0.1036.4000",
+				"@fluidframework/server-lambdas-driver": "^0.1036.5000",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/server-services-core": "^0.1036.5000",
+				"@fluidframework/server-services-telemetry": "^0.1036.5000",
 				"@types/semver": "^6.0.1",
 				"async": "^3.2.2",
 				"axios": "^0.26.0",
@@ -4479,29 +4479,29 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -4515,15 +4515,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -4616,42 +4616,42 @@
 			}
 		},
 		"@fluidframework/server-lambdas-driver": {
-			"version": "0.1036.4000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.4000.tgz",
-			"integrity": "sha512-U8KcQbPQTDfLtmzj+QrEYumjBL1RUOSQ9VPJLGRd/T9hy8mjVI3psrxCp9pfEU8qvj1c90G0QzxUmI27h3FTOQ==",
+			"version": "0.1036.5000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1036.5000.tgz",
+			"integrity": "sha512-eroTFaJe4809RAfJom1HRmd/IPek9TpX2jXCzaV7qdGurJ4wDa4i1y92Cy0GpVR4JZu6RX//GWPocM5kBG0drg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/server-services-core": "^0.1036.4000",
-				"@fluidframework/server-services-telemetry": "^0.1036.4000",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/server-services-core": "^0.1036.5000",
+				"@fluidframework/server-services-telemetry": "^0.1036.5000",
 				"async": "^3.2.2",
 				"lodash": "^4.17.21"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -4665,15 +4665,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -4935,17 +4935,17 @@
 			}
 		},
 		"@fluidframework/server-memory-orderer": {
-			"version": "0.1036.4000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.4000.tgz",
-			"integrity": "sha512-Kuepsway1D3jkqCyrwC+M2YuOFslnlFfZ8YfvVpKgIRULKRZWwo6eI5FKyEYa4G0G0BAGQ1knVy89IxeCitAmQ==",
+			"version": "0.1036.5000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1036.5000.tgz",
+			"integrity": "sha512-oe7Qk1tnvIvJDjBur/KhMrakEPyvWX8zb912y3uuqoypAud5nyQj/lQVvWgljedHVGE1PHJ98JDXnHYFdErumw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/server-lambdas": "^0.1036.4000",
-				"@fluidframework/server-services-client": "^0.1036.4000",
-				"@fluidframework/server-services-core": "^0.1036.4000",
-				"@fluidframework/server-services-telemetry": "^0.1036.4000",
+				"@fluidframework/server-lambdas": "^0.1036.5000",
+				"@fluidframework/server-services-client": "^0.1036.5000",
+				"@fluidframework/server-services-core": "^0.1036.5000",
+				"@fluidframework/server-services-telemetry": "^0.1036.5000",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
@@ -4960,29 +4960,29 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -4996,15 +4996,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -5354,9 +5354,9 @@
 			}
 		},
 		"@fluidframework/server-services-telemetry": {
-			"version": "0.1036.4000",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.4000.tgz",
-			"integrity": "sha512-e3XUXqk0TE4lIowCgYStAQ4nUR8kxibM3JBzIzoB6Xn94uIgr2ntARXEprZmJokuqv2WKfO0cRxNQ66ntopNvA==",
+			"version": "0.1036.5000",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1036.5000.tgz",
+			"integrity": "sha512-l8rG4fBBW+gF13XZFBUFXQd23eoKTXnvxGxuqyx+4fKbJlwngXjc5X2KpLKLc/OJi8Il9UiVvfMtuR9wSlTS5g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"json-stringify-safe": "^5.0.1",
@@ -5540,73 +5540,73 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.0.1.tgz",
-			"integrity": "sha512-MLJFK3zfTLYJlu2zVXiENHMCcRnh90BLnpzMl41hC+NM1dJ4uU4MbiYe8IP/7zt1T7TVoH6+GuFGsJa3PX8mQA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.1.0.tgz",
+			"integrity": "sha512-DkiTKIK0HH/lGKQQgjJo/NFD47s41MbWkO+OTt7gKLORimawjpHtaVy9mRf8VdV4QPYs3z+DzZxuFXc7OpcwLw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.0.1.tgz",
-			"integrity": "sha512-MLJFK3zfTLYJlu2zVXiENHMCcRnh90BLnpzMl41hC+NM1dJ4uU4MbiYe8IP/7zt1T7TVoH6+GuFGsJa3PX8mQA==",
+			"version": "npm:@fluidframework/shared-object-base@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.1.0.tgz",
+			"integrity": "sha512-DkiTKIK0HH/lGKQQgjJo/NFD47s41MbWkO+OTt7gKLORimawjpHtaVy9mRf8VdV4QPYs3z+DzZxuFXc7OpcwLw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/container-utils": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/container-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.0.1.tgz",
-			"integrity": "sha512-eTktyzjE1NcDNBwmcvF6zX8598i38KQe/wReJveLVqpEI0AJXEHOa8WVJ/Np2ipK8eS48EGVTJ8bxJgqDvlW2g==",
+			"version": "npm:@fluidframework/shared-summary-block@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.1.0.tgz",
+			"integrity": "sha512-Pz1vVEihvXzQ5XcBewXF32Pmbc53f98IJqh3u5LguM7ObmkSQs4rgugyYle4d2GY0thaUA20p+T2c7MC6odfiQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/shared-object-base": "^1.0.1"
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/shared-object-base": "^1.1.0"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.0.1.tgz",
-			"integrity": "sha512-wi7vJCT7eMAzgmoWxMPM8+7XQMqLJ//lNvhyvZtSajhBVmnVXi/yfVuqTMUXoC6KkcWFjAp6EAgw+CWt2YtoUw=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.1.0.tgz",
+			"integrity": "sha512-G052+fcd3cs/SMbgUbAqzwWIIP3y0ZNqQ5PmMk4ed3RMTNmJpCNeF8ZHDvZpcekp4ZWn9XhUd9OmPkLbH8l5Hw=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.0.1.tgz",
-			"integrity": "sha512-wi7vJCT7eMAzgmoWxMPM8+7XQMqLJ//lNvhyvZtSajhBVmnVXi/yfVuqTMUXoC6KkcWFjAp6EAgw+CWt2YtoUw=="
+			"version": "npm:@fluidframework/synthesize@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.1.0.tgz",
+			"integrity": "sha512-G052+fcd3cs/SMbgUbAqzwWIIP3y0ZNqQ5PmMk4ed3RMTNmJpCNeF8ZHDvZpcekp4ZWn9XhUd9OmPkLbH8l5Hw=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.0.1.tgz",
-			"integrity": "sha512-IaroFRAAhPx39cy/66hy33WcnXGz/6S/PGUaG1ut4aMaskRumMmt1aJmLaN1wUGjl2i+GNqn2optrl4myk37wA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.1.0.tgz",
+			"integrity": "sha512-YMCsD/RwhFF1pRuUkf5BHiKzebQWZMMSBlaIbsXV9sTBIdukDLx29isWkU0uvIS8/46RSyc6hoBSGH0eUv8YIA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -5616,9 +5616,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.0.1.tgz",
-			"integrity": "sha512-IaroFRAAhPx39cy/66hy33WcnXGz/6S/PGUaG1ut4aMaskRumMmt1aJmLaN1wUGjl2i+GNqn2optrl4myk37wA==",
+			"version": "npm:@fluidframework/telemetry-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.1.0.tgz",
+			"integrity": "sha512-YMCsD/RwhFF1pRuUkf5BHiKzebQWZMMSBlaIbsXV9sTBIdukDLx29isWkU0uvIS8/46RSyc6hoBSGH0eUv8YIA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -5628,108 +5628,108 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.0.1.tgz",
-			"integrity": "sha512-GvxmERKcGiFW4mND6dkB7O/nLKkiQwAMsP2Y1n5MtpdttW8mtwUE4j9It0o9skOGcRljcSVtalxhqPuV6pFCIA==",
+			"version": "npm:@fluidframework/test-client-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.1.0.tgz",
+			"integrity": "sha512-kvaRKG4fWXhO4ivUlZ0R63xwMFZ6omt8bO2icJ3nJETYdaZfbjmR7S18YHWmhfGa+xPx+eCbRybcxfndS7pAlg==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/test-runtime-utils": "^1.0.1",
+				"@fluidframework/test-runtime-utils": "^1.1.0",
 				"sillyname": "^0.1.0"
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.0.1.tgz",
-			"integrity": "sha512-k/4lc61H9mXk3wNFWPr665OUafbWPw9v84mvMU4honx7oPCGlhrjoZZFNQF2k7k2MUoR7xsmwZGlH9Lc4J/x+g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.1.0.tgz",
+			"integrity": "sha512-m1R1Q1wSUBlGImQZ4jxnYNifaIruv0QArR5Dnp0aRXFCbz/bSVibR8NBpqT3GG+kn3GiUzhYk29RgUi8llTzSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "npm:@fluidframework/test-driver-definitions@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.0.1.tgz",
-			"integrity": "sha512-k/4lc61H9mXk3wNFWPr665OUafbWPw9v84mvMU4honx7oPCGlhrjoZZFNQF2k7k2MUoR7xsmwZGlH9Lc4J/x+g==",
+			"version": "npm:@fluidframework/test-driver-definitions@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.1.0.tgz",
+			"integrity": "sha512-m1R1Q1wSUBlGImQZ4jxnYNifaIruv0QArR5Dnp0aRXFCbz/bSVibR8NBpqT3GG+kn3GiUzhYk29RgUi8llTzSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.0.1.tgz",
-			"integrity": "sha512-GXpFJls0cv9CKgG2U1znuvLATySA2B+/7ffFIj6jU19AQATJyAXRa7eZgklb79RfzNnftldoBVIr15JY1/Jl4Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.1.0.tgz",
+			"integrity": "sha512-J+UuqFS2O/jhwcGhF2xO/28yREJmWJf/laFDiQTAoKVXJi7i5t+HDZGxVbrHFsmoJCi+MXU60FC9zJ9aTWMRQA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/local-driver": "^1.0.1",
-				"@fluidframework/odsp-doclib-utils": "^1.0.1",
-				"@fluidframework/odsp-driver": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
-				"@fluidframework/odsp-urlresolver": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/local-driver": "^1.1.0",
+				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/odsp-driver": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/odsp-urlresolver": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/server-local-server": "^0.1036.4000",
-				"@fluidframework/test-driver-definitions": "^1.0.1",
-				"@fluidframework/test-pairwise-generator": "^1.0.1",
-				"@fluidframework/test-runtime-utils": "^1.0.1",
-				"@fluidframework/tinylicious-driver": "^1.0.1",
-				"@fluidframework/tool-utils": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/server-local-server": "^0.1036.5000",
+				"@fluidframework/test-driver-definitions": "^1.1.0",
+				"@fluidframework/test-pairwise-generator": "^1.1.0",
+				"@fluidframework/test-runtime-utils": "^1.1.0",
+				"@fluidframework/tinylicious-driver": "^1.1.0",
+				"@fluidframework/tool-utils": "^1.1.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.4000.tgz",
-					"integrity": "sha512-r//V5DxkzTmKhyKXj9e7PjoQcQJa/hK4yxtryu7MMwpj+bRHla9fNOHf2oFosXJg/QpXRmG9k9mx1/OYqgXxcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.5000.tgz",
+					"integrity": "sha512-ogPVoWEp8U0v6FBiwq/x30pEMLiz+KB37M7FMGJvLnS6n281v5LA8Sw/NB2e8AI33WfQrQ9rYXGEwh4BvZ60Ig==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-lambdas": "^0.1036.4000",
-						"@fluidframework/server-memory-orderer": "^0.1036.4000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
-						"@fluidframework/server-test-utils": "^0.1036.4000",
+						"@fluidframework/server-lambdas": "^0.1036.5000",
+						"@fluidframework/server-memory-orderer": "^0.1036.5000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
+						"@fluidframework/server-test-utils": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -5743,15 +5743,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -5759,17 +5759,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.4000.tgz",
-					"integrity": "sha512-AZyjRMPaosbTpd8xXPkDzHhT+mt7aRMQ5u65WOgD/EmWq+k3vRXQXFhO8o466NL3R63zA9ZIlhxYs7RclNudcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.5000.tgz",
+					"integrity": "sha512-uTgeuHWjKzicNL8TVdYdK9r5nTSCPnsxMhhq4SFTy8saIbvyQQ8bhkl252gVjpUI8xTk0BlqjAikWrs+1oDaxQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -5847,74 +5847,74 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.0.1.tgz",
-			"integrity": "sha512-GXpFJls0cv9CKgG2U1znuvLATySA2B+/7ffFIj6jU19AQATJyAXRa7eZgklb79RfzNnftldoBVIr15JY1/Jl4Q==",
+			"version": "npm:@fluidframework/test-drivers@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.1.0.tgz",
+			"integrity": "sha512-J+UuqFS2O/jhwcGhF2xO/28yREJmWJf/laFDiQTAoKVXJi7i5t+HDZGxVbrHFsmoJCi+MXU60FC9zJ9aTWMRQA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/local-driver": "^1.0.1",
-				"@fluidframework/odsp-doclib-utils": "^1.0.1",
-				"@fluidframework/odsp-driver": "^1.0.1",
-				"@fluidframework/odsp-driver-definitions": "^1.0.1",
-				"@fluidframework/odsp-urlresolver": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/local-driver": "^1.1.0",
+				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/odsp-driver": "^1.1.0",
+				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/odsp-urlresolver": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/server-local-server": "^0.1036.4000",
-				"@fluidframework/test-driver-definitions": "^1.0.1",
-				"@fluidframework/test-pairwise-generator": "^1.0.1",
-				"@fluidframework/test-runtime-utils": "^1.0.1",
-				"@fluidframework/tinylicious-driver": "^1.0.1",
-				"@fluidframework/tool-utils": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/server-local-server": "^0.1036.5000",
+				"@fluidframework/test-driver-definitions": "^1.1.0",
+				"@fluidframework/test-pairwise-generator": "^1.1.0",
+				"@fluidframework/test-runtime-utils": "^1.1.0",
+				"@fluidframework/tinylicious-driver": "^1.1.0",
+				"@fluidframework/tool-utils": "^1.1.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.4000.tgz",
-					"integrity": "sha512-r//V5DxkzTmKhyKXj9e7PjoQcQJa/hK4yxtryu7MMwpj+bRHla9fNOHf2oFosXJg/QpXRmG9k9mx1/OYqgXxcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1036.5000.tgz",
+					"integrity": "sha512-ogPVoWEp8U0v6FBiwq/x30pEMLiz+KB37M7FMGJvLnS6n281v5LA8Sw/NB2e8AI33WfQrQ9rYXGEwh4BvZ60Ig==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-lambdas": "^0.1036.4000",
-						"@fluidframework/server-memory-orderer": "^0.1036.4000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
-						"@fluidframework/server-test-utils": "^0.1036.4000",
+						"@fluidframework/server-lambdas": "^0.1036.5000",
+						"@fluidframework/server-memory-orderer": "^0.1036.5000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
+						"@fluidframework/server-test-utils": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.2.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -5928,15 +5928,15 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.4000.tgz",
-					"integrity": "sha512-/GT2MNwZ/tNTYnZ6pdWO8lcwDlp5WN80Hm95qdqwJsPtZtI3lKaUbDkOU8rv1XZ8xy3iGgicu7ETUyplBfj7Tw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1036.5000.tgz",
+					"integrity": "sha512-n0/E5EqkvhRZGTmQRZwKm55tNLghq2dnfszqRHZTewjyM6Ai9hrtKQ4lbbegmtCFC6Lxe/kNrOgV3b50N4KFjw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"@types/nconf": "^0.10.2",
 						"@types/node": "^14.18.0",
 						"debug": "^4.1.1",
@@ -5944,17 +5944,17 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.4000.tgz",
-					"integrity": "sha512-AZyjRMPaosbTpd8xXPkDzHhT+mt7aRMQ5u65WOgD/EmWq+k3vRXQXFhO8o466NL3R63zA9ZIlhxYs7RclNudcw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1036.5000.tgz",
+					"integrity": "sha512-uTgeuHWjKzicNL8TVdYdK9r5nTSCPnsxMhhq4SFTy8saIbvyQQ8bhkl252gVjpUI8xTk0BlqjAikWrs+1oDaxQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/server-services-client": "^0.1036.4000",
-						"@fluidframework/server-services-core": "^0.1036.4000",
-						"@fluidframework/server-services-telemetry": "^0.1036.4000",
+						"@fluidframework/server-services-client": "^0.1036.5000",
+						"@fluidframework/server-services-core": "^0.1036.5000",
+						"@fluidframework/server-services-telemetry": "^0.1036.5000",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.21",
 						"string-hash": "^1.1.3",
@@ -6032,74 +6032,74 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.0.1.tgz",
-			"integrity": "sha512-4Ro+NjVYuAcsLdHrJ4Y9zjaK+c8BY0BC4meXehrof9JrXl2vxzSzBfHewNG8sV2W5qXKMGhMEuWCPiibvj0nAg==",
+			"version": "npm:@fluidframework/test-loader-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.1.0.tgz",
+			"integrity": "sha512-oP9lJbi9RuvScOgQmmJ/qX9bLGT+D8flyR+p5HLg1OEjipS2YoncW3ZqS3hvEb+cSnt7LIBlDLPmy4VcZg5yhQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.0.1.tgz",
-			"integrity": "sha512-or+wTZ/NEYxoaouflIvth9CxPr6e+W7doHrAGYDyEoUayOMNo3DzkSLNm/ct8dtL1RkPt5aWyfN96KrmQpBGww==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.1.0.tgz",
+			"integrity": "sha512-GnkRw43klkKLyso+xQCgNIp3t1FrMDw6T2mUy+rIGkt3WtxZr6iBOjROU6DbCPkxYfuGk6o0+z9IFR7eYhHRIg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.0.1.tgz",
-			"integrity": "sha512-or+wTZ/NEYxoaouflIvth9CxPr6e+W7doHrAGYDyEoUayOMNo3DzkSLNm/ct8dtL1RkPt5aWyfN96KrmQpBGww==",
+			"version": "npm:@fluidframework/test-pairwise-generator@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.1.0.tgz",
+			"integrity": "sha512-GnkRw43klkKLyso+xQCgNIp3t1FrMDw6T2mUy+rIGkt3WtxZr6iBOjROU6DbCPkxYfuGk6o0+z9IFR7eYhHRIg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.0.1.tgz",
-			"integrity": "sha512-ODs6IhU/Ah4sr7OBENff59rSdecBFJjS3ZRVDoaQRcK5xLwS9az82Hzvfe5zXSHSEbfmdXoBIPSbQRKgSr9cSw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.1.0.tgz",
+			"integrity": "sha512-iIDOrASdZ/sCKNIq/8yfC56otRS9X4w5WVyz4pGu6+EDiAW3XmOn6FLW3wsRXM6GABSa8+FSDkZSNDG+SjZHsA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.0.1.tgz",
-			"integrity": "sha512-ODs6IhU/Ah4sr7OBENff59rSdecBFJjS3ZRVDoaQRcK5xLwS9az82Hzvfe5zXSHSEbfmdXoBIPSbQRKgSr9cSw==",
+			"version": "npm:@fluidframework/test-runtime-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.1.0.tgz",
+			"integrity": "sha512-iIDOrASdZ/sCKNIq/8yfC56otRS9X4w5WVyz4pGu6+EDiAW3XmOn6FLW3wsRXM6GABSa8+FSDkZSNDG+SjZHsA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
@@ -6112,160 +6112,160 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.0.1.tgz",
-			"integrity": "sha512-LHlBNMkzc9RoEVden1pnjyGpWdVVgaMhJ19CSJ41PPIt0OxseUo2u523Uen3FBJKR/V6/aBJ37Kvm3sU8WNUnQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.1.0.tgz",
+			"integrity": "sha512-UGs2dUPrHySWHdJ9CCt2nV3Yrg2cMpgBf5I9rPCGDsDL1YB+VAREKCyTy3oCVOVJKLkJuTWS8eeG+T38FgvvcA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.1",
+				"@fluidframework/aqueduct": "^1.1.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/local-driver": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/local-driver": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.1",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
-				"@fluidframework/test-driver-definitions": "^1.0.1",
-				"@fluidframework/test-runtime-utils": "^1.0.1",
+				"@fluidframework/request-handler": "^1.1.0",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/test-driver-definitions": "^1.1.0",
+				"@fluidframework/test-runtime-utils": "^1.1.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.0.1.tgz",
-			"integrity": "sha512-LHlBNMkzc9RoEVden1pnjyGpWdVVgaMhJ19CSJ41PPIt0OxseUo2u523Uen3FBJKR/V6/aBJ37Kvm3sU8WNUnQ==",
+			"version": "npm:@fluidframework/test-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.1.0.tgz",
+			"integrity": "sha512-UGs2dUPrHySWHdJ9CCt2nV3Yrg2cMpgBf5I9rPCGDsDL1YB+VAREKCyTy3oCVOVJKLkJuTWS8eeG+T38FgvvcA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.1",
+				"@fluidframework/aqueduct": "^1.1.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/container-runtime-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/datastore": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/local-driver": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/container-runtime-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/datastore": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/local-driver": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.0.1",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/telemetry-utils": "^1.0.1",
-				"@fluidframework/test-driver-definitions": "^1.0.1",
-				"@fluidframework/test-runtime-utils": "^1.0.1",
+				"@fluidframework/request-handler": "^1.1.0",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/test-driver-definitions": "^1.1.0",
+				"@fluidframework/test-runtime-utils": "^1.1.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.0.1.tgz",
-			"integrity": "sha512-xH351nBi9LCKu1U9wGE+a02CjPCofnBjTwpZExfoGXpvlh2tVc8oA5decYzXFV1YJrWkx4rfbg5hlBfditBpYg==",
+			"version": "npm:@fluidframework/test-version-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.1.0.tgz",
+			"integrity": "sha512-RjefwQsVETBEDrTxt/ihYTDhTI8uMa8ga67+4GqgrTrRELxXJc4IKpdeWZPoEyxY7hSaFV+GhVDE0JFSSS9vOQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.0.1",
-				"@fluidframework/cell": "^1.0.1",
+				"@fluidframework/aqueduct": "^1.1.0",
+				"@fluidframework/cell": "^1.1.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/container-runtime": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/counter": "^1.0.1",
-				"@fluidframework/datastore-definitions": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/ink": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
-				"@fluidframework/matrix": "^1.0.1",
-				"@fluidframework/mocha-test-setup": "^1.0.1",
-				"@fluidframework/ordered-collection": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/container-runtime": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/counter": "^1.1.0",
+				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/ink": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
+				"@fluidframework/matrix": "^1.1.0",
+				"@fluidframework/mocha-test-setup": "^1.1.0",
+				"@fluidframework/ordered-collection": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/register-collection": "^1.0.1",
-				"@fluidframework/runtime-definitions": "^1.0.1",
-				"@fluidframework/sequence": "^1.0.1",
-				"@fluidframework/test-driver-definitions": "^1.0.1",
-				"@fluidframework/test-drivers": "^1.0.1",
-				"@fluidframework/test-utils": "^1.0.1",
+				"@fluidframework/register-collection": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/sequence": "^1.1.0",
+				"@fluidframework/test-driver-definitions": "^1.1.0",
+				"@fluidframework/test-drivers": "^1.1.0",
+				"@fluidframework/test-utils": "^1.1.0",
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.0.1.tgz",
-			"integrity": "sha512-o+RwCFMR6xpJLE9BAjD1hedJ9nKoeGvHPjeLIwzhxXHO5OARdbRJuMZWJGqyIe/WM7h/gYLSOMrnChc+eZvDHA==",
+			"version": "npm:@fluidframework/tinylicious-client@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.1.0.tgz",
+			"integrity": "sha512-txxmzhXT/c1/z3fIvIWTrShBZ5byX3uFsGwHs5pnRrVIxzjauDK7sCVRxycFU9tK2QMBR3azIsvw6rIW0lEBxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
-				"@fluidframework/fluid-static": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/fluid-static": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/runtime-utils": "^1.0.1",
-				"@fluidframework/tinylicious-driver": "^1.0.1",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/runtime-utils": "^1.1.0",
+				"@fluidframework/tinylicious-driver": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.0.1.tgz",
-			"integrity": "sha512-PzrHYukjzMMJNWa5AbX6szYCY0LNowi8W2XxEWvkJgbFaz2gfAbbbLCBnvCrZQ4DLxOpmjcIID6GSZTVfJQ5tA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.1.0.tgz",
+			"integrity": "sha512-9nF1F9oBbXRin8d2IQme5K4JL/5SrZ3XxncoQVR1ExemUMyVu6GpUI/fhF6y1oY3rcQOVAI9rY1WObZqXOifzA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^0.1036.4000",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -6286,44 +6286,44 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.0.1.tgz",
-			"integrity": "sha512-PzrHYukjzMMJNWa5AbX6szYCY0LNowi8W2XxEWvkJgbFaz2gfAbbbLCBnvCrZQ4DLxOpmjcIID6GSZTVfJQ5tA==",
+			"version": "npm:@fluidframework/tinylicious-driver@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.1.0.tgz",
+			"integrity": "sha512-9nF1F9oBbXRin8d2IQme5K4JL/5SrZ3XxncoQVR1ExemUMyVu6GpUI/fhF6y1oY3rcQOVAI9rY1WObZqXOifzA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/driver-definitions": "^1.0.1",
-				"@fluidframework/driver-utils": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/driver-utils": "^1.1.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.0.1",
-				"@fluidframework/server-services-client": "^0.1036.4000",
+				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.4000.tgz",
-					"integrity": "sha512-O0oVX0rJtCxLw+qhC1XIoe2Qfv+PRXn0M1oHnnZuMGHzJj8cl8D9JVyx71wgnXVgKoNLK7LwGv7ZmfAvR0VgOw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
+					"integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
-						"@fluidframework/protocol-base": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
+						"@fluidframework/protocol-base": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"axios": "^0.26.0",
 						"crc-32": "1.2.0",
@@ -6344,13 +6344,13 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.0.1.tgz",
-			"integrity": "sha512-e2FFqI1JJk6ZQUTtKEWyxANIGEOrACdiARs1ub0maD//wK+DVSbsrNxwyKjRno13Z7PKJA5KD7leFoB3+3XHYQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.1.0.tgz",
+			"integrity": "sha512-NWewWIDJ3yKfdX1L7HrtkiSfUkMAdzoy6ZJVbUc3o5SIiF8jagFZVdd33gwsRTLpnzoemPBLo1/stPtnwsOhjg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
 				"debug": "^4.1.1",
@@ -6359,17 +6359,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -6377,13 +6377,13 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.0.1.tgz",
-			"integrity": "sha512-e2FFqI1JJk6ZQUTtKEWyxANIGEOrACdiARs1ub0maD//wK+DVSbsrNxwyKjRno13Z7PKJA5KD7leFoB3+3XHYQ==",
+			"version": "npm:@fluidframework/tool-utils@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.1.0.tgz",
+			"integrity": "sha512-NWewWIDJ3yKfdX1L7HrtkiSfUkMAdzoy6ZJVbUc3o5SIiF8jagFZVdd33gwsRTLpnzoemPBLo1/stPtnwsOhjg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.0.1",
-				"@fluidframework/protocol-base": "^0.1036.4000",
+				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
 				"debug": "^4.1.1",
@@ -6392,17 +6392,17 @@
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -6561,9 +6561,9 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.4000.tgz",
-					"integrity": "sha512-dUi5nF4E2eahgqL/wxIy3asWHO4AniDsoYR1V2eMazN8Acpc7+KSQ2drwmc7vGutSFzSQ81yeGwBTCzgh97wzQ=="
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
+					"integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
 				},
 				"@fluidframework/map": {
 					"version": "0.59.4001",
@@ -6621,12 +6621,12 @@
 					}
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1036.4000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.4000.tgz",
-					"integrity": "sha512-LJSY9bJ3P84GVfO7NsGeuwxo8crohrUtCBHW2EaKW2jr2bP0DCc6FVoSNcRZqw5illTiE7VL2UhY0L2vqd/Vmw==",
+					"version": "0.1036.5000",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
+					"integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1036.4000",
+						"@fluidframework/gitresources": "^0.1036.5000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
 						"lodash": "^4.17.21"
 					}
@@ -6716,60 +6716,60 @@
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.0.1.tgz",
-			"integrity": "sha512-KFSXgTds64ZlUtrPvA9LWGldLGsFiLIAhkkE/pg4bXtUq9F3gMzJWfrsHazXrQPc+xO4f8ypEFz793Xs+oAumQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.1.0.tgz",
+			"integrity": "sha512-OQuW/cAgZvrPKAbQEoU1A3hkpFDTSmsTUnO9SKx95fJctd/ZhomBaH/SMzyTzQqpx4NUtz6kjo6i/k/+Dc/c+g==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/view-interfaces": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/view-interfaces": "^1.1.0",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.0.1.tgz",
-			"integrity": "sha512-KFSXgTds64ZlUtrPvA9LWGldLGsFiLIAhkkE/pg4bXtUq9F3gMzJWfrsHazXrQPc+xO4f8ypEFz793Xs+oAumQ==",
+			"version": "npm:@fluidframework/view-adapters@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.1.0.tgz",
+			"integrity": "sha512-OQuW/cAgZvrPKAbQEoU1A3hkpFDTSmsTUnO9SKx95fJctd/ZhomBaH/SMzyTzQqpx4NUtz6kjo6i/k/+Dc/c+g==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1",
-				"@fluidframework/view-interfaces": "^1.0.1",
+				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/view-interfaces": "^1.1.0",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.0.1.tgz",
-			"integrity": "sha512-OLup6/jkBkHfHwQBi5YrhZhTIJKrrrFZpZkP820wBxq9+qzaneRZo7IhsCEYnqBCLKX9zuHHO9l8wxeNKafTlQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.1.0.tgz",
+			"integrity": "sha512-K3AoXG0EuRoUnmXMtoAm1hgo91/kkl/p1LbveUQr9iNuWMrk87zDuJjate0dtL2REZ+GWuWSgN2dcKZOtHXyZw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1"
+				"@fluidframework/core-interfaces": "^1.1.0"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.0.1.tgz",
-			"integrity": "sha512-OLup6/jkBkHfHwQBi5YrhZhTIJKrrrFZpZkP820wBxq9+qzaneRZo7IhsCEYnqBCLKX9zuHHO9l8wxeNKafTlQ==",
+			"version": "npm:@fluidframework/view-interfaces@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.1.0.tgz",
+			"integrity": "sha512-K3AoXG0EuRoUnmXMtoAm1hgo91/kkl/p1LbveUQr9iNuWMrk87zDuJjate0dtL2REZ+GWuWSgN2dcKZOtHXyZw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.0.1"
+				"@fluidframework/core-interfaces": "^1.1.0"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.0.1.tgz",
-			"integrity": "sha512-RgMpoOyvfnM7L6aWklTwP6nX0Rlww9VX3CDL68LbnDUqCGAIDQPnftoNEbQZPB26tbY0nVTIT8nfgBRqC6OlVQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.1.0.tgz",
+			"integrity": "sha512-KAjD/zEcvq/vmWvohUmeQwHJjGVshC5RemjFtjgWqTcTAUHdau1Go6JC20aoBfL3njfACmdLPSBEJOMMgzCb2Q==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.0.1.tgz",
-			"integrity": "sha512-RgMpoOyvfnM7L6aWklTwP6nX0Rlww9VX3CDL68LbnDUqCGAIDQPnftoNEbQZPB26tbY0nVTIT8nfgBRqC6OlVQ==",
+			"version": "npm:@fluidframework/web-code-loader@1.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.1.0.tgz",
+			"integrity": "sha512-KAjD/zEcvq/vmWvohUmeQwHJjGVshC5RemjFtjgWqTcTAUHdau1Go6JC20aoBfL3njfACmdLPSBEJOMMgzCb2Q==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/core-interfaces": "^1.0.1",
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.1.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
@@ -27474,15 +27474,15 @@
 			"integrity": "sha512-OapHwT5Ug1c3iiv8JNrwh/3XGjP45l/2iwfl25chePrvCgl0786ZvsJK+hxCCaUZjPm1lHdh5LHZhmKRxunziA=="
 		},
 		"fluid-framework-previous": {
-			"version": "npm:fluid-framework@1.0.1",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.0.1.tgz",
-			"integrity": "sha512-4gxEgr3cfFpNEEFaRpwoPxC55Fi2z+PLO1Dpp6t6pFJX0v1lmEzPyrSC61n6S8B70ZqW7QYLYxSvJsAbpiuvLw==",
+			"version": "npm:fluid-framework@1.1.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.1.0.tgz",
+			"integrity": "sha512-M6kyInipXUbWx34bKnGSagtCZPWWhnFqFqeJ0MEy8NF78/YQ5p+FCF6vzZXN3ddBcRWW8XUWbCzaZv62o0km7A==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.0.1",
-				"@fluidframework/container-loader": "^1.0.1",
-				"@fluidframework/fluid-static": "^1.0.1",
-				"@fluidframework/map": "^1.0.1",
-				"@fluidframework/sequence": "^1.0.1"
+				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-loader": "^1.1.0",
+				"@fluidframework/fluid-static": "^1.1.0",
+				"@fluidframework/map": "^1.1.0",
+				"@fluidframework/sequence": "^1.1.0"
 			}
 		},
 		"flush-write-stream": {

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@^1.0.0",
+    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -60,7 +60,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@^1.0.0",
+    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -53,7 +53,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@^1.0.0",
+    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -72,7 +72,7 @@
     "@fluid-internal/test-dds-utils": "^1.2.0",
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/cell-previous": "npm:@fluidframework/cell@^1.0.0",
+    "@fluidframework/cell-previous": "npm:@fluidframework/cell@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/counter-previous": "npm:@fluidframework/counter@^1.0.0",
+    "@fluidframework/counter-previous": "npm:@fluidframework/counter@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
@@ -87,7 +87,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/ink-previous": "npm:@fluidframework/ink@^1.0.0",
+    "@fluidframework/ink-previous": "npm:@fluidframework/ink@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -90,7 +90,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/map-previous": "npm:@fluidframework/map@^1.0.0",
+    "@fluidframework/map-previous": "npm:@fluidframework/map@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -95,7 +95,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@^1.0.0",
+    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -101,7 +101,7 @@
     "uuid": "^8.3.1"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@^1.0.0",
+    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -98,11 +98,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "ClassDeclaration_Client": {
-        "forwardCompat": false
-      }
-    }
+    "version": "1.2.0",
+    "broken": {}
   }
 }

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.ts
@@ -143,7 +143,6 @@ declare function get_old_ClassDeclaration_Client():
 declare function use_current_ClassDeclaration_Client(
     use: TypeOnly<current.Client>);
 use_current_ClassDeclaration_Client(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_Client());
 
 /*
@@ -1933,6 +1932,30 @@ declare function use_old_TypeAliasDeclaration_LocalReferenceMapper(
     use: TypeOnly<old.LocalReferenceMapper>);
 use_old_TypeAliasDeclaration_LocalReferenceMapper(
     get_current_TypeAliasDeclaration_LocalReferenceMapper());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_LocalReferencePosition": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_LocalReferencePosition():
+    TypeOnly<old.LocalReferencePosition>;
+declare function use_current_InterfaceDeclaration_LocalReferencePosition(
+    use: TypeOnly<current.LocalReferencePosition>);
+use_current_InterfaceDeclaration_LocalReferencePosition(
+    get_old_InterfaceDeclaration_LocalReferencePosition());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_LocalReferencePosition": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_LocalReferencePosition():
+    TypeOnly<current.LocalReferencePosition>;
+declare function use_old_InterfaceDeclaration_LocalReferencePosition(
+    use: TypeOnly<old.LocalReferencePosition>);
+use_old_InterfaceDeclaration_LocalReferencePosition(
+    get_current_InterfaceDeclaration_LocalReferencePosition());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@^1.0.0",
+    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -92,7 +92,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@^1.0.0",
+    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/gitresources": "^0.1036.5000-0",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@^1.0.0",
+    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@1.1.0",
     "@fluidframework/server-services-client": "^0.1036.5000-0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -105,14 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "ClassDeclaration_IntervalCollection": {
-        "forwardCompat": false
-      },
-      "ClassDeclaration_SequenceInterval": {
-        "forwardCompat": false
-      }
-    }
+    "version": "1.2.0",
+    "broken": {}
   }
 }

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.ts
@@ -16,6 +16,30 @@ type TypeOnly<T> = {
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_CompressedSerializedInterval": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_CompressedSerializedInterval():
+    TypeOnly<old.CompressedSerializedInterval>;
+declare function use_current_TypeAliasDeclaration_CompressedSerializedInterval(
+    use: TypeOnly<current.CompressedSerializedInterval>);
+use_current_TypeAliasDeclaration_CompressedSerializedInterval(
+    get_old_TypeAliasDeclaration_CompressedSerializedInterval());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_CompressedSerializedInterval": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_CompressedSerializedInterval():
+    TypeOnly<current.CompressedSerializedInterval>;
+declare function use_old_TypeAliasDeclaration_CompressedSerializedInterval(
+    use: TypeOnly<old.CompressedSerializedInterval>);
+use_old_TypeAliasDeclaration_CompressedSerializedInterval(
+    get_current_TypeAliasDeclaration_CompressedSerializedInterval());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_DeserializeCallback": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_DeserializeCallback():
@@ -112,6 +136,30 @@ use_old_InterfaceDeclaration_IJSONRunSegment(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMapMessageLocalMetadata": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IMapMessageLocalMetadata():
+    TypeOnly<old.IMapMessageLocalMetadata>;
+declare function use_current_InterfaceDeclaration_IMapMessageLocalMetadata(
+    use: TypeOnly<current.IMapMessageLocalMetadata>);
+use_current_InterfaceDeclaration_IMapMessageLocalMetadata(
+    get_old_InterfaceDeclaration_IMapMessageLocalMetadata());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMapMessageLocalMetadata": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IMapMessageLocalMetadata():
+    TypeOnly<current.IMapMessageLocalMetadata>;
+declare function use_old_InterfaceDeclaration_IMapMessageLocalMetadata(
+    use: TypeOnly<old.IMapMessageLocalMetadata>);
+use_old_InterfaceDeclaration_IMapMessageLocalMetadata(
+    get_current_InterfaceDeclaration_IMapMessageLocalMetadata());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_Interval": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_Interval():
@@ -143,7 +191,6 @@ declare function get_old_ClassDeclaration_IntervalCollection():
 declare function use_current_ClassDeclaration_IntervalCollection(
     use: TypeOnly<current.IntervalCollection<any>>);
 use_current_ClassDeclaration_IntervalCollection(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_IntervalCollection());
 
 /*
@@ -277,6 +324,30 @@ declare function use_old_InterfaceDeclaration_ISerializedInterval(
     use: TypeOnly<old.ISerializedInterval>);
 use_old_InterfaceDeclaration_ISerializedInterval(
     get_current_InterfaceDeclaration_ISerializedInterval());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISerializedIntervalCollectionV2": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISerializedIntervalCollectionV2():
+    TypeOnly<old.ISerializedIntervalCollectionV2>;
+declare function use_current_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    use: TypeOnly<current.ISerializedIntervalCollectionV2>);
+use_current_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    get_old_InterfaceDeclaration_ISerializedIntervalCollectionV2());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISerializedIntervalCollectionV2": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISerializedIntervalCollectionV2():
+    TypeOnly<current.ISerializedIntervalCollectionV2>;
+declare function use_old_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    use: TypeOnly<old.ISerializedIntervalCollectionV2>);
+use_old_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    get_current_InterfaceDeclaration_ISerializedIntervalCollectionV2());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -672,7 +743,6 @@ declare function get_old_ClassDeclaration_SequenceInterval():
 declare function use_current_ClassDeclaration_SequenceInterval(
     use: TypeOnly<current.SequenceInterval>);
 use_current_ClassDeclaration_SequenceInterval(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SequenceInterval());
 
 /*

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@^1.0.0",
+    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -100,7 +100,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@^1.0.0",
+    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/shared-object-base": "^1.2.0"
   },
   "devDependencies": {
-    "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@^1.0.0",
+    "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@1.1.0",
     "@fluid-internal/test-dds-utils": "^1.2.0",
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
@@ -95,7 +95,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@^1.0.0",
+    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,7 +58,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
-    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@^1.0.0",
+    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@^1.0.0",
+    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -61,7 +61,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@^1.0.0",
+    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/odsp-driver-definitions": "^1.2.0"
   },
   "devDependencies": {
-    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@^1.0.0",
+    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@1.1.0",
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
@@ -60,7 +60,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@^1.0.0",
+    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -61,7 +61,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@^1.0.0",
+    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@^1.0.0",
+    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -55,7 +55,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@^1.0.0",
+    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -100,7 +100,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.ts
@@ -112,6 +112,30 @@ use_old_FunctionDeclaration_createOdspUrl(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_currentReadVersion": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_currentReadVersion():
+    TypeOnly<typeof old.currentReadVersion>;
+declare function use_current_VariableDeclaration_currentReadVersion(
+    use: TypeOnly<typeof current.currentReadVersion>);
+use_current_VariableDeclaration_currentReadVersion(
+    get_old_VariableDeclaration_currentReadVersion());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_currentReadVersion": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_currentReadVersion():
+    TypeOnly<typeof current.currentReadVersion>;
+declare function use_old_VariableDeclaration_currentReadVersion(
+    use: TypeOnly<typeof old.currentReadVersion>);
+use_old_VariableDeclaration_currentReadVersion(
+    get_current_VariableDeclaration_currentReadVersion());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_encodeOdspFluidDataStoreLocator": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_encodeOdspFluidDataStoreLocator():
@@ -276,6 +300,30 @@ declare function use_old_InterfaceDeclaration_ISharingLinkHeader(
     use: TypeOnly<old.ISharingLinkHeader>);
 use_old_InterfaceDeclaration_ISharingLinkHeader(
     get_current_InterfaceDeclaration_ISharingLinkHeader());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISnapshotContents": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISnapshotContents():
+    TypeOnly<old.ISnapshotContents>;
+declare function use_current_InterfaceDeclaration_ISnapshotContents(
+    use: TypeOnly<current.ISnapshotContents>);
+use_current_InterfaceDeclaration_ISnapshotContents(
+    get_old_InterfaceDeclaration_ISnapshotContents());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISnapshotContents": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISnapshotContents():
+    TypeOnly<current.ISnapshotContents>;
+declare function use_old_InterfaceDeclaration_ISnapshotContents(
+    use: TypeOnly<old.ISnapshotContents>);
+use_old_InterfaceDeclaration_ISnapshotContents(
+    get_current_InterfaceDeclaration_ISnapshotContents());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -568,6 +616,30 @@ use_old_InterfaceDeclaration_OdspFluidDataStoreLocator(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_parseCompactSnapshotResponse": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_parseCompactSnapshotResponse():
+    TypeOnly<typeof old.parseCompactSnapshotResponse>;
+declare function use_current_FunctionDeclaration_parseCompactSnapshotResponse(
+    use: TypeOnly<typeof current.parseCompactSnapshotResponse>);
+use_current_FunctionDeclaration_parseCompactSnapshotResponse(
+    get_old_FunctionDeclaration_parseCompactSnapshotResponse());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_parseCompactSnapshotResponse": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_parseCompactSnapshotResponse():
+    TypeOnly<typeof current.parseCompactSnapshotResponse>;
+declare function use_old_FunctionDeclaration_parseCompactSnapshotResponse(
+    use: TypeOnly<typeof old.parseCompactSnapshotResponse>);
+use_old_FunctionDeclaration_parseCompactSnapshotResponse(
+    get_current_FunctionDeclaration_parseCompactSnapshotResponse());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_prefetchLatestSnapshot": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_prefetchLatestSnapshot():
@@ -588,6 +660,30 @@ declare function use_old_FunctionDeclaration_prefetchLatestSnapshot(
     use: TypeOnly<typeof old.prefetchLatestSnapshot>);
 use_old_FunctionDeclaration_prefetchLatestSnapshot(
     get_current_FunctionDeclaration_prefetchLatestSnapshot());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_ReadBuffer": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_ReadBuffer():
+    TypeOnly<old.ReadBuffer>;
+declare function use_current_ClassDeclaration_ReadBuffer(
+    use: TypeOnly<current.ReadBuffer>);
+use_current_ClassDeclaration_ReadBuffer(
+    get_old_ClassDeclaration_ReadBuffer());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_ReadBuffer": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_ReadBuffer():
+    TypeOnly<current.ReadBuffer>;
+declare function use_old_ClassDeclaration_ReadBuffer(
+    use: TypeOnly<old.ReadBuffer>);
+use_old_ClassDeclaration_ReadBuffer(
+    get_current_ClassDeclaration_ReadBuffer());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -636,6 +732,30 @@ declare function use_old_EnumDeclaration_SharingLinkHeader(
     use: TypeOnly<old.SharingLinkHeader>);
 use_old_EnumDeclaration_SharingLinkHeader(
     get_current_EnumDeclaration_SharingLinkHeader());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_snapshotMinReadVersion": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_snapshotMinReadVersion():
+    TypeOnly<typeof old.snapshotMinReadVersion>;
+declare function use_current_VariableDeclaration_snapshotMinReadVersion(
+    use: TypeOnly<typeof current.snapshotMinReadVersion>);
+use_current_VariableDeclaration_snapshotMinReadVersion(
+    get_old_VariableDeclaration_snapshotMinReadVersion());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_snapshotMinReadVersion": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_snapshotMinReadVersion():
+    TypeOnly<typeof current.snapshotMinReadVersion>;
+declare function use_old_VariableDeclaration_snapshotMinReadVersion(
+    use: TypeOnly<typeof old.snapshotMinReadVersion>);
+use_old_VariableDeclaration_snapshotMinReadVersion(
+    get_current_VariableDeclaration_snapshotMinReadVersion());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@^1.0.0",
+    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "concurrently": "^6.2.0",
@@ -59,7 +59,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@^1.0.0",
+    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -61,7 +61,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@^1.0.0",
+    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -102,7 +102,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
-    "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@^1.0.0",
+    "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@^1.0.0",
+    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nconf": "^0.10.0",
@@ -63,7 +63,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@^1.0.0",
+    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^9.1.1",
@@ -59,7 +59,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -64,7 +64,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@^1.0.0",
+    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@1.1.0",
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
@@ -89,7 +89,7 @@
     }
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -81,7 +81,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@^1.0.0",
+    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@1.1.0",
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
@@ -102,7 +102,7 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
-    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@^1.0.0",
+    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -91,7 +91,7 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@^1.0.0",
+    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -52,20 +52,13 @@
     "copyfiles": "^2.1.0",
     "cross-env": "^7.0.2",
     "eslint": "~8.6.0",
-    "fluid-framework-previous": "npm:fluid-framework@^1.0.0",
+    "fluid-framework-previous": "npm:fluid-framework@1.1.0",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "ClassDeclaration_IntervalCollection": {
-        "forwardCompat": false
-      },
-      "ClassDeclaration_SequenceInterval": {
-        "forwardCompat": false
-      }
-    }
+    "version": "1.2.0",
+    "broken": {}
   }
 }

--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
@@ -40,6 +40,30 @@ use_old_EnumDeclaration_AttachState(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_CompressedSerializedInterval": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_CompressedSerializedInterval():
+    TypeOnly<old.CompressedSerializedInterval>;
+declare function use_current_TypeAliasDeclaration_CompressedSerializedInterval(
+    use: TypeOnly<current.CompressedSerializedInterval>);
+use_current_TypeAliasDeclaration_CompressedSerializedInterval(
+    get_old_TypeAliasDeclaration_CompressedSerializedInterval());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_CompressedSerializedInterval": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_CompressedSerializedInterval():
+    TypeOnly<current.CompressedSerializedInterval>;
+declare function use_old_TypeAliasDeclaration_CompressedSerializedInterval(
+    use: TypeOnly<old.CompressedSerializedInterval>);
+use_old_TypeAliasDeclaration_CompressedSerializedInterval(
+    get_current_TypeAliasDeclaration_CompressedSerializedInterval());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_ConnectionState": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_ConnectionState():
@@ -496,6 +520,30 @@ use_old_InterfaceDeclaration_IJSONRunSegment(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMapMessageLocalMetadata": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IMapMessageLocalMetadata():
+    TypeOnly<old.IMapMessageLocalMetadata>;
+declare function use_current_InterfaceDeclaration_IMapMessageLocalMetadata(
+    use: TypeOnly<current.IMapMessageLocalMetadata>);
+use_current_InterfaceDeclaration_IMapMessageLocalMetadata(
+    get_old_InterfaceDeclaration_IMapMessageLocalMetadata());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMapMessageLocalMetadata": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IMapMessageLocalMetadata():
+    TypeOnly<current.IMapMessageLocalMetadata>;
+declare function use_old_InterfaceDeclaration_IMapMessageLocalMetadata(
+    use: TypeOnly<old.IMapMessageLocalMetadata>);
+use_old_InterfaceDeclaration_IMapMessageLocalMetadata(
+    get_current_InterfaceDeclaration_IMapMessageLocalMetadata());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IMember": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IMember():
@@ -551,7 +599,6 @@ declare function get_old_ClassDeclaration_IntervalCollection():
 declare function use_current_ClassDeclaration_IntervalCollection(
     use: TypeOnly<current.IntervalCollection<any>>);
 use_current_ClassDeclaration_IntervalCollection(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_IntervalCollection());
 
 /*
@@ -709,6 +756,30 @@ declare function use_old_InterfaceDeclaration_ISerializedInterval(
     use: TypeOnly<old.ISerializedInterval>);
 use_old_InterfaceDeclaration_ISerializedInterval(
     get_current_InterfaceDeclaration_ISerializedInterval());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISerializedIntervalCollectionV2": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISerializedIntervalCollectionV2():
+    TypeOnly<old.ISerializedIntervalCollectionV2>;
+declare function use_current_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    use: TypeOnly<current.ISerializedIntervalCollectionV2>);
+use_current_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    get_old_InterfaceDeclaration_ISerializedIntervalCollectionV2());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISerializedIntervalCollectionV2": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISerializedIntervalCollectionV2():
+    TypeOnly<current.ISerializedIntervalCollectionV2>;
+declare function use_old_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    use: TypeOnly<old.ISerializedIntervalCollectionV2>);
+use_old_InterfaceDeclaration_ISerializedIntervalCollectionV2(
+    get_current_InterfaceDeclaration_ISerializedIntervalCollectionV2());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1488,7 +1559,6 @@ declare function get_old_ClassDeclaration_SequenceInterval():
 declare function use_current_ClassDeclaration_SequenceInterval(
     use: TypeOnly<current.SequenceInterval>);
 use_current_ClassDeclaration_SequenceInterval(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SequenceInterval());
 
 /*

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@^1.0.0",
+    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
@@ -66,7 +66,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@^1.0.0",
+    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/datastore": "^1.2.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@^1.0.0",
+    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -85,7 +85,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@^1.0.0",
+    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/aqueduct": "^1.2.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@^1.0.0",
+    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -74,7 +74,7 @@
     "fluid-framework": "^1.0.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.ts
+++ b/packages/framework/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.ts
@@ -228,3 +228,27 @@ declare function use_old_InterfaceDeclaration_TinyliciousMember(
     use: TypeOnly<old.TinyliciousMember>);
 use_old_InterfaceDeclaration_TinyliciousMember(
     get_current_InterfaceDeclaration_TinyliciousMember());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_TinyliciousUser": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_TinyliciousUser():
+    TypeOnly<old.TinyliciousUser>;
+declare function use_current_InterfaceDeclaration_TinyliciousUser(
+    use: TypeOnly<current.TinyliciousUser>);
+use_current_InterfaceDeclaration_TinyliciousUser(
+    get_old_InterfaceDeclaration_TinyliciousUser());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_TinyliciousUser": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_TinyliciousUser():
+    TypeOnly<current.TinyliciousUser>;
+declare function use_old_InterfaceDeclaration_TinyliciousUser(
+    use: TypeOnly<old.TinyliciousUser>);
+use_old_InterfaceDeclaration_TinyliciousUser(
+    get_current_InterfaceDeclaration_TinyliciousUser());

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@^1.0.0",
+    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
@@ -52,7 +52,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@^1.0.0",
+    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
@@ -49,7 +49,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@^1.0.0",
+    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-loader-utils": "^1.2.0",
@@ -102,7 +102,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@^1.0.0",
+    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
@@ -86,7 +86,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@^1.0.0",
+    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/runtime-utils": "^1.2.0",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@^1.0.0",
+    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",
@@ -47,7 +47,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
-    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@^1.0.0",
+    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/isomorphic-fetch": "^0.0.35",
@@ -54,7 +54,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
-    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@^1.0.0",
+    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -54,7 +54,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@^1.0.0",
+    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
@@ -105,7 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
-    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@^1.0.0",
+    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -54,7 +54,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@^1.0.0",
+    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@fluidframework/test-runtime-utils": "^1.2.0",
@@ -101,7 +101,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@^1.0.0",
+    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -88,7 +88,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@^1.0.0",
+    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -55,11 +55,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "InterfaceDeclaration_ISignalEnvelope": {
-        "forwardCompat": false
-      }
-    }
+    "version": "1.2.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.ts
@@ -767,7 +767,6 @@ declare function get_old_InterfaceDeclaration_ISignalEnvelope():
 declare function use_current_InterfaceDeclaration_ISignalEnvelope(
     use: TypeOnly<current.ISignalEnvelope>);
 use_current_InterfaceDeclaration_ISignalEnvelope(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISignalEnvelope());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@^1.0.0",
+    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -95,7 +95,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@^1.0.0",
+    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -96,14 +96,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "ClassDeclaration_MockContainerRuntimeFactory": {
-        "forwardCompat": false
-      },
-      "ClassDeclaration_MockContainerRuntimeFactoryForReconnection": {
-        "forwardCompat": false
-      }
-    }
+    "version": "1.2.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.ts
@@ -95,7 +95,6 @@ declare function get_old_ClassDeclaration_MockContainerRuntimeFactory():
 declare function use_current_ClassDeclaration_MockContainerRuntimeFactory(
     use: TypeOnly<current.MockContainerRuntimeFactory>);
 use_current_ClassDeclaration_MockContainerRuntimeFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockContainerRuntimeFactory());
 
 /*
@@ -120,7 +119,6 @@ declare function get_old_ClassDeclaration_MockContainerRuntimeFactoryForReconnec
 declare function use_current_ClassDeclaration_MockContainerRuntimeFactoryForReconnection(
     use: TypeOnly<current.MockContainerRuntimeFactoryForReconnection>);
 use_current_ClassDeclaration_MockContainerRuntimeFactoryForReconnection(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockContainerRuntimeFactoryForReconnection());
 
 /*

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@^1.0.0",
+    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -75,7 +75,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@^1.0.0",
+    "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -78,7 +78,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -81,7 +81,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@^1.0.0",
+    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -96,7 +96,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@^1.0.0",
+    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",
@@ -70,7 +70,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@^1.0.0",
+    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -103,11 +103,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "ClassDeclaration_TestObjectProvider": {
-        "forwardCompat": false
-      }
-    }
+    "version": "1.2.0",
+    "broken": {}
   }
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.ts
@@ -551,7 +551,6 @@ declare function get_old_ClassDeclaration_TestObjectProvider():
 declare function use_current_ClassDeclaration_TestObjectProvider(
     use: TypeOnly<current.TestObjectProvider>);
 use_current_ClassDeclaration_TestObjectProvider(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestObjectProvider());
 
 /*

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@^1.0.0",
+    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nock": "^9.3.0",
@@ -104,7 +104,7 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.ts
+++ b/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.ts
@@ -376,6 +376,30 @@ use_old_InterfaceDeclaration_ITestDataObject(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITestObjectProviderOptions": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITestObjectProviderOptions():
+    TypeOnly<old.ITestObjectProviderOptions>;
+declare function use_current_InterfaceDeclaration_ITestObjectProviderOptions(
+    use: TypeOnly<current.ITestObjectProviderOptions>);
+use_current_InterfaceDeclaration_ITestObjectProviderOptions(
+    get_old_InterfaceDeclaration_ITestObjectProviderOptions());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITestObjectProviderOptions": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITestObjectProviderOptions():
+    TypeOnly<current.ITestObjectProviderOptions>;
+declare function use_old_InterfaceDeclaration_ITestObjectProviderOptions(
+    use: TypeOnly<old.ITestObjectProviderOptions>);
+use_old_InterfaceDeclaration_ITestObjectProviderOptions(
+    get_current_InterfaceDeclaration_ITestObjectProviderOptions());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_itExpects": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_itExpects():

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -92,7 +92,7 @@
     "webpack-dev-server": "~4.6.0"
   },
   "devDependencies": {
-    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@^1.0.0",
+    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@1.1.0",
     "@fluidframework/build-common": "^0.24.0-0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
@@ -117,7 +117,7 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@^1.0.0",
+    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node-fetch": "^2.5.10",
@@ -86,7 +86,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@^1.0.0",
+    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -93,12 +93,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "RemovedFunctionDeclaration_originatedAsExternalError": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
-    }
+    "version": "1.2.0",
+    "broken": {}
   }
 }

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
@@ -760,18 +760,6 @@ use_old_FunctionDeclaration_normalizeError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_originatedAsExternalError": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_originatedAsExternalError": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_PerformanceEvent": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_PerformanceEvent():

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.2.0",
-    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@^1.0.0",
+    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }


### PR DESCRIPTION
package lock and typetests updated.

@tylerbutler it's worth noting that typevalidation tools are specing out "^1.x.x"  on main for "previous" version, instead of being specific: `1.x.x`. What happened here is on clean reinstall, my local main was breaking. It was picking up "1.1.0" (newly released version) as "previous" even though we did not yet run postrelease typevalidation cleanup. Usually you can rely on lock files to pin the "previous" version until the lock file is explicitly updated, but given devs can clean install at any time, it may be worthwhile sorting this one out.

Interestingly, https://dev.azure.com/fluidframework/public/_build/results?buildId=76468&view=results failed as if it did not obey existing lock file. @ms-avocado.