### PR TITLE
Minor fixes around type validation package details.

### DIFF
--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -102,7 +102,7 @@ export async function getAndUpdatePackageDetails(packageDir: string, updateOptio
     * previous major. In the case of minor we target specific previous minor version.
     * Similarly for patch we do not use semver, we compare directly to the previous patch version.
     *
-    * We do this to align with our release process. We are strictest between patches, and looser between minor and major
+    * We do this to align with our release process. We are strictest between patches and minor, and looser between major
     * We may need to adjust this as we adjust our release processes.
     */
     let normalizeParts = normalizedVersion.split(".").map((p)=>Number.parseInt(p));

--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -98,22 +98,22 @@ export async function getAndUpdatePackageDetails(packageDir: string, updateOptio
 
     /*
     * this is where we build the previous version we use to compare against the current version.
-    * For both major and minor we use semver such that the current major is compared against the latest
-    * previous major, and the same for minor.
-    * For patch we do not use semver, we compare directly to the previous patch version.
+    * For major we use semver such that the current major is compared against the latest
+    * previous major. In the case of minor we target specific previous minor version.
+    * Similarly for patch we do not use semver, we compare directly to the previous patch version.
     *
     * We do this to align with our release process. We are strictest between patches, and looser between minor and major
     * We may need to adjust this as we adjust our release processes.
     */
     let normalizeParts = normalizedVersion.split(".").map((p)=>Number.parseInt(p));
     const validationVersionParts = packageDetails.pkg.typeValidation?.version?.split(".").map((p)=>Number.parseInt(p)) ?? [0,0,0];
-    let semVer="^"
+    let semVer = "";
     if(normalizeParts[0] !== validationVersionParts[0]){
+        semVer = "^"
         normalizeParts= [normalizeParts[0] -1, 0, 0];
     }else if(normalizeParts[1] !== validationVersionParts[1]){
         normalizeParts= [normalizeParts[0], normalizeParts[1] -1, 0];
     }else{
-        semVer="";
         normalizeParts[2] = validationVersionParts[2];
     }
     const previousVersion = normalizeParts.join(".");


### PR DESCRIPTION
Once we are preparing minor version type validations, we are now targeting specific previous version (instead of ^).
a. It's more explicit what "previous" version we are targeting against.
b. We are avoiding transient state between (minor) version release and the follow up type validation prep, where clean install/build would fail.

