### PR TITLE
Removal of ((message: any) => void) from ISignaler offSignal() API definition 

### DIFF
--- a/experimental/framework/data-objects/src/signalManager/signalManager.ts
+++ b/experimental/framework/data-objects/src/signalManager/signalManager.ts
@@ -37,7 +37,7 @@ export interface ISignaler {
      * @param listener - The callback signal handler to remove
      * @returns This ISignaler
      */
-    offSignal(signalName: string, listener: SignalListener | ((message: any) => void)): ISignaler;
+    offSignal(signalName: string, listener: SignalListener): ISignaler;
     /**
      * Send a signal with payload to its connected listeners.
      * @param signalName - The name of the signal


### PR DESCRIPTION
## Description
Removal done to reflect implementation of offSignal() in the Signaler class and to fix the assymetry between onSignal() and offSignal().

## Other information or known dependencies
ADO link: [Task 974](https://dev.azure.com/fluidframework/internal/_workitems/edit/974) 
