### PR TITLE
Api docs cleanup

### DIFF
--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -98,8 +98,12 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
 }
 
 /**
- * Events emitted in response to changes to the directory data.  These events only emit on the ISharedDirectory itself,
+ * Events emitted in response to changes to the directory data. These events only emit on the ISharedDirectory itself,
  * and not on subdirectories.
+ *
+ * @remarks
+ *
+ * The following is the list of events emitted.
  *
  * ### "valueChanged"
  *
@@ -151,7 +155,7 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
  *
  * - `target` - The ISharedDirectory itself.
  *
- * * ### "subDirectoryDeleted"
+ * ###"subDirectoryDeleted"
  *
  * The subDirectoryDeleted event is emitted when a subdirectory is deleted.
  *
@@ -193,6 +197,10 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 /**
  * Events emitted in response to changes to the directory data.
  *
+ * @remarks
+ *
+ * The following is the list of events emitted.
+ *
  * ### "containedValueChanged"
  *
  * The containedValueChanged event is emitted when a key is set or deleted.  As opposed to the SharedDirectory's
@@ -207,8 +215,8 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
  *
  * - `local` - Whether the change originated from the this client.
  *
- *
  * - `target` - The IDirectory itself.
+ *
  * ### "subDirectoryCreated"
  *
  * The subDirectoryCreated event is emitted when a subdirectory is created.
@@ -225,7 +233,7 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
  *
  * - `target` - The ISharedDirectory itself.
  *
- * * ### "subDirectoryDeleted"
+ * ### "subDirectoryDeleted"
  *
  * The subDirectoryDeleted event is emitted when a subdirectory is deleted.
  *
@@ -288,7 +296,7 @@ export interface ISharedDirectory extends
 }
 
 /**
- * Type of "valueChanged" event parameter for SharedDirectory
+ * Type of "valueChanged" event parameter for SharedDirectory.
  */
 export interface IDirectoryValueChanged extends IValueChanged {
     /**
@@ -299,6 +307,10 @@ export interface IDirectoryValueChanged extends IValueChanged {
 
 /**
  * Events emitted in response to changes to the map data.
+ *
+ * @remarks
+ *
+ * The following is the list of events emitted.
  *
  * ### "valueChanged"
  *
@@ -363,19 +375,22 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
 }
 
 /**
- * The _ready-for-serialization_ format of values contained in DDS contents.  This allows us to use
+ * The _ready-for-serialization_ format of values contained in DDS contents. This allows us to use
  * ISerializableValue.type to understand whether they're storing a Plain JS object, a SharedObject, or a value type.
+ *
+ * @remarks
+ *
  * Note that the in-memory equivalent of ISerializableValue is ILocalValue (similarly holding a type, but with
  * the _in-memory representation_ of the value instead).  An ISerializableValue is what gets passed to
- * JSON.stringify and comes out of JSON.parse.  This format is used both for snapshots (loadCore/populate)
+ * JSON.stringify and comes out of JSON.parse. This format is used both for snapshots (loadCore/populate)
  * and ops (set).
  * If type is Plain, it must be a plain JS object that can survive a JSON.stringify/parse.  E.g. a URL object will
- * just get stringified to a URL string and not rehydrate as a URL object on the other side.  It may contain members
+ * just get stringified to a URL string and not rehydrate as a URL object on the other side. It may contain members
  * that are ISerializedHandle (the serialized form of a handle).
  * If type is a value type then it must be amongst the types registered via registerValueType or we won't know how
  * to serialize/deserialize it (we rely on its factory via .load() and .store()).  Its value will be type-dependent.
  * If type is Shared, then the in-memory value will just be a reference to the SharedObject.  Its value will be a
- * channel ID.  This type is legacy and deprecated.
+ * channel ID. This type is legacy and deprecated.
  */
 export interface ISerializableValue {
     /**

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -67,6 +67,10 @@ const contentPath = "content";
 /**
  * Events emitted in response to changes to the sequence data.
  *
+ *  @remarks
+ *
+ * The following is the list of events emitted.
+ *
  * ### "sequenceDelta"
  *
  * The sequenceDelta event is emitted when segments are inserted, annotated, or removed.

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -12,6 +12,10 @@ import { RootDataObject } from "./rootDataObject";
 /**
  * Events emitted from IFluidContainer.
  *
+ *  @remarks
+ *
+ * The following is the list of events emitted.
+ *
  * ### "connected"
  *
  * The connected event is emitted when the `IFluidContainer` completes connecting to the Fluid service.

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -86,6 +86,10 @@ export interface ContainerSchema {
  * Only changes that would be reflected in the returned map of IServiceAudience's getMembers method
  * will emit events.
  *
+ *  @remarks
+ *
+ * The following is the list of events emitted.
+ *
  * ### "membersChanged"
  *
  * The membersChanged event is emitted when a member is either added or removed.


### PR DESCRIPTION
When we summarize types/interfaces we load embedded markdown into description column, which our template does not support. See `IDirectoryEvents` as an example here: https://fluidframework.com/docs/apis/map/. Therefore, splitting some of the content into `remarks` that is more suitable for page detailing particular type/interface.

@Josmithr this is just a format change, it should not conflict with your PRs focused on semantic changes.