### PR TITLE
Added runtimeVersion as property

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -681,6 +681,7 @@ class ScheduleManagerCore {
                 throw new DataCorruptionError(
                     "OpBatchIncomplete",
                     {
+                        runtimeVersion: pkgVersion,
                         batchClientId: this.currentBatchClientId,
                         ...extractSafePropertiesFromMessage(message),
                     });
@@ -905,7 +906,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 const error = new DataCorruptionError(
                     // pre-0.58 error message: SummaryMetadataMismatch
                     "Summary metadata mismatch",
-                    { runtimeSequenceNumber, protocolSequenceNumber },
+                    { runtimeVersion: pkgVersion, runtimeSequenceNumber, protocolSequenceNumber },
                 );
 
                 if (loadSequenceNumberVerification === "log") {


### PR DESCRIPTION
[Bug 441](https://dev.azure.com/fluidframework/internal/_workitems/edit/441/)

Added runtimeVersion as a property whenever a DataCorruption error is thrown causing the container to close.