### PR TITLE
minor fix to update custom data to make it include disabled tenants

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -222,8 +222,14 @@ export class TenantManager {
             customData.externalStorageData.accessInfo = this.encryptAccessInfo(accessInfo);
         }
         await collection.update({ _id: tenantId }, { customData }, null);
-
-        return (await this.getTenantDocument(tenantId)).customData;
+        const tenantDocument = await this.getTenantDocument(tenantId, true);
+        if (tenantDocument.disabled) {
+            Lumberjack.info(
+                "Updated custom data of a disabled tenant",
+                { [BaseTelemetryProperties.tenantId]: tenantId },
+            );
+        }
+        return tenantDocument.customData;
     }
 
     /**


### PR DESCRIPTION
## Description

Riddler updateCustomData will use getTenantDocument to return updated custom data. It should include disabled tenant since it already updated the data and we need to update custom data of disabled tenant for some scenarios: like CMK. Without including the disabled tenant, it will return errors on disabled tenant, even if the update itself succeeds.

## Does this introduce a breaking change?

No breaking changes
