### PR TITLE
Remove and replace depreciated ConnectionState.Connecting with ConnectionState.CatchingUp

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,8 @@ There are a few steps you can take to write a good change note and avoid needing
 - [LocalReference class and method deprecations removed](#LocalReference-class-and-method-deprecations-removed)
 - [Remove TelemetryDataTag.PackageData](#Remove-TelemetryDataTagPackageData)
 - [Deprecate ISummaryRuntimeOptions.disableIsolatedChannels](#Deprecate-ISummaryRuntimeOptionsdisableIsolatedChannels)
+- [Remove ICodeLoader from @fluidframework/container-definitions](#Remove-ICodeLoader-from-container-definitions)
+- [Remove ConnectionState.Connecting and replace remaining with ConnectionState.CatchingUp](#Remove-ConnectionState.Connecting-and-replace-remaining-with-ConnectionState.CatchingUp)
 
 ### Deprecate ISummaryConfigurationHeuristics.idleTime
 `ISummaryConfigurationHeuristics.idleTime` has been deprecated and will be removed in a future release. See [#10008](https://github.com/microsoft/FluidFramework/issues/10008)
@@ -52,6 +54,8 @@ The following deprecated methods are  now removed from sequence and merge-tree. 
 
  ### IContainerRuntime.createRootDataStore is deprecated
  See [#9660](https://github.com/microsoft/FluidFramework/issues/9660). The API is vulnerable to name conflicts, which lead to invalid documents. As a replacement, create a regular datastore using the `IContainerRuntimeBase.createDataStore` function, then alias the datastore by using the `IDataStore.trySetAlias` function and specify a string value to serve as the alias to which the datastore needs to be bound. If successful, "Success" will be returned, and a call to `getRootDataStore` with the alias as parameter will return the same datastore.
+### Remove ConnectionState.Connecting and replace remaining with ConnectionState.CatchingUp
+`ConnectionState.Connecting` has been removed. Migrate all usage to `ConnectionState.CatchingUp` instead.
 
 # 1.0.0
 

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -56,14 +56,12 @@ export enum BindState {
 export namespace ConnectionState {
     export type CatchingUp = 1;
     export type Connected = 2;
-    // @deprecated (undocumented)
-    export type Connecting = 1;
     export type Disconnected = 0;
     export type EstablishingConnection = 3;
 }
 
 // @public
-export type ConnectionState = ConnectionState.Disconnected | ConnectionState.EstablishingConnection | ConnectionState.CatchingUp | ConnectionState.Connecting | ConnectionState.Connected;
+export type ConnectionState = ConnectionState.Disconnected | ConnectionState.EstablishingConnection | ConnectionState.CatchingUp  | ConnectionState.Connected;
 
 // @public
 export enum ContainerErrorType {

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -44,8 +44,6 @@ import { TelemetryLogger } from '@fluidframework/telemetry-utils';
 export enum ConnectionState {
     CatchingUp = 1,
     Connected = 2,
-    // @deprecated (undocumented)
-    Connecting = 1,
     Disconnected = 0,
     EstablishingConnection = 3
 }

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -60,9 +60,21 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-   "version": "2.0.0",
+    "version": "2.0.0",
     "broken": {
       "InterfaceDeclaration_IConnectionDetails": {
+        "backCompat": false
+      },
+      "RemovedInterfaceDeclaration_ICodeLoader": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "RemovedTypeAliasDeclaration_ConnectionState.Connecting": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "TypeAliasDeclaration_ConnectionState.Connecting": {
+        "forwardCompat": false,
         "backCompat": false
       }
     }

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -150,12 +150,6 @@ export namespace ConnectionState {
     export type CatchingUp = 1;
 
     /**
-     * @see ConnectionState.CatchingUp, which is the new name for this state.
-     * @deprecated - This state itself is not gone, just being renamed. Please use ConnectionState.CatchingUp.
-     */
-    export type Connecting = 1;
-
-    /**
      * The container is fully connected and syncing
      */
      export type Connected = 2;
@@ -168,7 +162,6 @@ export type ConnectionState =
     | ConnectionState.Disconnected
     | ConnectionState.EstablishingConnection
     | ConnectionState.CatchingUp
-    | ConnectionState.Connecting
     | ConnectionState.Connected;
 
 /**

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -136,26 +136,14 @@ use_old_TypeAliasDeclaration_ConnectionState_Connected(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ConnectionState.Connecting": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_ConnectionState.Connecting": {"forwardCompat": false}
 */
-declare function get_old_TypeAliasDeclaration_ConnectionState_Connecting():
-    TypeOnly<old.ConnectionState.Connecting>;
-declare function use_current_TypeAliasDeclaration_ConnectionState_Connecting(
-    use: TypeOnly<current.ConnectionState.Connecting>);
-use_current_TypeAliasDeclaration_ConnectionState_Connecting(
-    get_old_TypeAliasDeclaration_ConnectionState_Connecting());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ConnectionState.Connecting": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_ConnectionState.Connecting": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_ConnectionState_Connecting():
-    TypeOnly<current.ConnectionState.Connecting>;
-declare function use_old_TypeAliasDeclaration_ConnectionState_Connecting(
-    use: TypeOnly<old.ConnectionState.Connecting>);
-use_old_TypeAliasDeclaration_ConnectionState_Connecting(
-    get_current_TypeAliasDeclaration_ConnectionState_Connecting());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -64,22 +64,48 @@
         "backCompat": false
       },
       "ClassDeclaration_SequenceInterval": {
+        "forwardCompat": false,
         "backCompat": false
       },
-      "InterfaceDeclaration_ISharedString": {"backCompat": false},
-      "ClassDeclaration_SequenceEvent": {"backCompat": false},
-      "ClassDeclaration_SequenceDeltaEvent": {"backCompat": false},
-      "ClassDeclaration_SequenceMaintenanceEvent": {"backCompat": false},
-      "ClassDeclaration_SharedString": {"backCompat": false},
-      "ClassDeclaration_SharedNumberSequence": {"backCompat": false},
-      "ClassDeclaration_SharedObjectSequence": {"backCompat": false},
-      "ClassDeclaration_SharedSegmentSequence": {"backCompat": false},
-      "ClassDeclaration_SharedSequence": {"backCompat": false},
-      "TypeAliasDeclaration_SharedStringSegment": {"backCompat": false},
-      "ClassDeclaration_SparseMatrix": {"backCompat": false},
+      "InterfaceDeclaration_ISharedString": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SequenceEvent": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SequenceDeltaEvent": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SequenceMaintenanceEvent": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SharedString": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SharedNumberSequence": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SharedObjectSequence": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SharedSegmentSequence": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SharedSequence": {
+        "backCompat": false
+      },
+      "TypeAliasDeclaration_SharedStringSegment": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SparseMatrix": {
+        "backCompat": false
+      },
       "RemovedEnumDeclaration_ConnectionState": {
         "forwardCompat": false,
         "backCompat": false
+      },
+      "EnumDeclaration_ConnectionState": {
+        "forwardCompat": false
       }
     }
   }

--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
@@ -71,6 +71,7 @@ declare function get_old_EnumDeclaration_ConnectionState():
 declare function use_current_EnumDeclaration_ConnectionState(
     use: TypeOnly<current.ConnectionState>);
 use_current_EnumDeclaration_ConnectionState(
+    // @ts-expect-error compatibility expected to be broken
     get_old_EnumDeclaration_ConnectionState());
 
 /*

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -103,6 +103,13 @@
   },
   "typeValidation": {
     "version": "2.0.0",
-    "broken": {}
+    "broken": {
+      "EnumDeclaration_ConnectionState": {
+        "forwardCompat": false
+      },
+      "ClassDeclaration_Container": {
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/packages/loader/container-loader/src/connectionState.ts
+++ b/packages/loader/container-loader/src/connectionState.ts
@@ -18,12 +18,6 @@ export enum ConnectionState {
     EstablishingConnection = 3,
 
     /**
-     * @see ConnectionState.CatchingUp, which is the new name for this state.
-     * @deprecated - This state itself is not gone, just being renamed. Please use ConnectionState.CatchingUp.
-     */
-    Connecting = 1,
-
-    /**
      * The container has an inbound connection only, and is catching up to the latest known state from the service.
      */
     CatchingUp = 1,

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -81,7 +81,7 @@ describe("ConnectionStateHandler Tests", () => {
             quorumClients: () => protocolHandler.quorum,
             shouldClientJoinWrite: () => shouldClientJoinWrite,
             logConnectionIssue: (eventName: string, details?: ITelemetryProperties) => { throw new Error(`logConnectionIssue: ${eventName} ${JSON.stringify(details)}`); },
-            connectionStateChanged: () => {},
+            connectionStateChanged: () => { },
         };
         connectionStateHandler = new ConnectionStateHandler(
             handlerInputs,
@@ -126,7 +126,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
             "Client should be in disconnected state");
         connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
             "Client should be in connecting state");
 
         // Restore quorumClients fn to return the test quorum object
@@ -186,7 +186,7 @@ describe("ConnectionStateHandler Tests", () => {
         connectionDetails.clientId = "pendingClientId2";
         protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
             "Client 2 should be in connecting state as we are waiting for leave");
 
         // Send leave
@@ -382,209 +382,209 @@ describe("ConnectionStateHandler Tests", () => {
 
     it("Should wait for savedEvent before moving to connected state(Client 3) when client 2 " +
         "got disconnected from connecting state", async () => {
-        client.mode = "write";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(pendingClientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 1 should be in connected state");
+            client.mode = "write";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(pendingClientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 1 should be in connected state");
 
-        shouldClientJoinWrite = true;
-        client.mode = "write";
-        // Disconnect the client
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 1 should be in disconnected state");
+            shouldClientJoinWrite = true;
+            client.mode = "write";
+            // Disconnect the client
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 1 should be in disconnected state");
 
-        // Make new client join but disconnect it from connecting state
-        connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 2 should be in connecting state");
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 2 should be in disconnected state");
+            // Make new client join but disconnect it from connecting state
+            connectionDetails.clientId = "pendingClientId2";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 2 should be in connecting state");
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 2 should be in disconnected state");
 
-        // Make new client 3 join so that it waits for client 1 to leave
-        connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
+            // Make new client 3 join so that it waits for client 1 to leave
+            connectionDetails.clientId = "pendingClientId3";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
 
-        // Send leave for client 2 and check that client 3 should not move to connected state as we were waiting
-        // on client 1 leave.
-        connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state");
+            // Send leave for client 2 and check that client 3 should not move to connected state as we were waiting
+            // on client 1 leave.
+            connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state");
 
-        // Pass some time.
-        await tickClock(expectedTimeout - 1);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state as timeout has not occured");
+            // Pass some time.
+            await tickClock(expectedTimeout - 1);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state as timeout has not occured");
 
-        connectionStateHandler.containerSaved();
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 3 should move to connected state");
-        // Sending client 1 leave now should not cause any error
-        connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 3 should move to connected state");
-    });
+            connectionStateHandler.containerSaved();
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 3 should move to connected state");
+            // Sending client 1 leave now should not cause any error
+            connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 3 should move to connected state");
+        });
 
     it("Should wait for client 1 to leave before moving to connected state(Client 3) when client 2 " +
         "got disconnected from connected state", async () => {
-        client.mode = "write";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(pendingClientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 1 should be in connected state");
+            client.mode = "write";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(pendingClientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 1 should be in connected state");
 
-        shouldClientJoinWrite = true;
-        client.mode = "write";
-        // Disconnect the client
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 1 should be in disconnected state");
+            shouldClientJoinWrite = true;
+            client.mode = "write";
+            // Disconnect the client
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 1 should be in disconnected state");
 
-        // Make new client join but disconnect it from connected state
-        connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent("pendingClientId2");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 2 should still be in connecting state");
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 2 should be in disconnected state");
+            // Make new client join but disconnect it from connected state
+            connectionDetails.clientId = "pendingClientId2";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent("pendingClientId2");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 2 should still be in connecting state");
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 2 should be in disconnected state");
 
-        // Make new client 3 join so that it waits for client 1 to leave
-        connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state");
+            // Make new client 3 join so that it waits for client 1 to leave
+            connectionDetails.clientId = "pendingClientId3";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state");
 
-        // Send leave for client 2 and check that client 3 should not move to connected state as we were waiting
-        // on client 1 leave
-        connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state");
+            // Send leave for client 2 and check that client 3 should not move to connected state as we were waiting
+            // on client 1 leave
+            connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state");
 
-        // Client 1 leaves.
-        connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 3 should move to connected state");
-        // Timeout should not raise any error as timer should be cleared
-        await tickClock(expectedTimeout);
-    });
+            // Client 1 leaves.
+            connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 3 should move to connected state");
+            // Timeout should not raise any error as timer should be cleared
+            await tickClock(expectedTimeout);
+        });
 
     it("Should wait for client 1 timeout before moving to connected state(Client 3) when client 2 " +
         "got disconnected from connected state", async () => {
-        client.mode = "write";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(pendingClientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 1 should be in connected state");
+            client.mode = "write";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(pendingClientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 1 should be in connected state");
 
-        shouldClientJoinWrite = true;
-        client.mode = "write";
-        // Disconnect the client
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 1 should be in disconnected state");
+            shouldClientJoinWrite = true;
+            client.mode = "write";
+            // Disconnect the client
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 1 should be in disconnected state");
 
-        // Make new client join but disconnect it from connecting state
-        connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent("pendingClientId2");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 2 should still be in connecting state");
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 2 should be in disconnected state");
+            // Make new client join but disconnect it from connecting state
+            connectionDetails.clientId = "pendingClientId2";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent("pendingClientId2");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 2 should still be in connecting state");
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 2 should be in disconnected state");
 
-        // Make new client 3 join so that it waits for client 1 to leave
-        connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
+            // Make new client 3 join so that it waits for client 1 to leave
+            connectionDetails.clientId = "pendingClientId3";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
 
-        // Send leave for client 2 and check that client 3 should not move to connected state as we were waiting
-        // on client 1 leave.
-        connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state");
+            // Send leave for client 2 and check that client 3 should not move to connected state as we were waiting
+            // on client 1 leave.
+            connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state");
 
-        // Pass some time.
-        await tickClock(expectedTimeout - 1);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state as timeout has not occured");
+            // Pass some time.
+            await tickClock(expectedTimeout - 1);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state as timeout has not occured");
 
-        await tickClock(1);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 3 should move to connected state");
+            await tickClock(1);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 3 should move to connected state");
 
-        // Sending client 1 leave now should not cause any error
-        connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 3 should move to connected state");
-    });
+            // Sending client 1 leave now should not cause any error
+            connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 3 should move to connected state");
+        });
 
     it("Client 3 should wait for client 2(which got disconnected without sending any ops) to leave " +
         "when client 2 already waited on client 1", async () => {
-        client.mode = "write";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(pendingClientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 1 should be in connected state");
+            client.mode = "write";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(pendingClientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 1 should be in connected state");
 
-        shouldClientJoinWrite = true;
-        client.mode = "write";
-        // Disconnect the client
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 1 should be in disconnected state");
+            shouldClientJoinWrite = true;
+            client.mode = "write";
+            // Disconnect the client
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 1 should be in disconnected state");
 
-        // Make new client join but disconnect it from connected state
-        connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent("pendingClientId2");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 2 should still be in connecting state");
-        // Client 1 leaves.
-        connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
+            // Make new client join but disconnect it from connected state
+            connectionDetails.clientId = "pendingClientId2";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent("pendingClientId2");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 2 should still be in connecting state");
+            // Client 1 leaves.
+            connectionStateHandler_receivedRemoveMemberEvent(pendingClientId);
 
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 2 should move to connected state");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 2 should move to connected state");
 
-        // Client 2 leaves without sending any ops.
-        connectionStateHandler.receivedDisconnectEvent("Test");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
-            "Client 2 should be in disconnected state");
+            // Client 2 leaves without sending any ops.
+            connectionStateHandler.receivedDisconnectEvent("Test");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+                "Client 2 should be in disconnected state");
 
-        // Make new client 3 join. Now it should not wait for previous client as client 2 already waited.
-        connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state");
-        protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
-        connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
-            "Client 3 should still be in connecting state");
+            // Make new client 3 join. Now it should not wait for previous client as client 2 already waited.
+            connectionDetails.clientId = "pendingClientId3";
+            connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state");
+            protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
+            connectionStateHandler_receivedAddMemberEvent(connectionDetails.clientId);
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
+                "Client 3 should still be in connecting state");
 
-        // Client 2 leaves.
-        connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
-        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
-            "Client 3 should move to connected state");
-        // Timeout should not raise any error as timer should be cleared
-        await tickClock(expectedTimeout);
-    });
+            // Client 2 leaves.
+            connectionStateHandler_receivedRemoveMemberEvent("pendingClientId2");
+            assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+                "Client 3 should move to connected state");
+            // Timeout should not raise any error as timer should be cleared
+            await tickClock(expectedTimeout);
+        });
 
     afterEach(() => {
         clock.reset();

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.ts
@@ -23,6 +23,7 @@ declare function get_old_EnumDeclaration_ConnectionState():
 declare function use_current_EnumDeclaration_ConnectionState(
     use: TypeOnly<current.ConnectionState>);
 use_current_EnumDeclaration_ConnectionState(
+    // @ts-expect-error compatibility expected to be broken
     get_old_EnumDeclaration_ConnectionState());
 
 /*
@@ -47,6 +48,7 @@ declare function get_old_ClassDeclaration_Container():
 declare function use_current_ClassDeclaration_Container(
     use: TypeOnly<current.Container>);
 use_current_ClassDeclaration_Container(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_Container());
 
 /*


### PR DESCRIPTION
# Work Item
Replace remaining usages of `ConnectionState.Connecting` with `ConnectionState.CatchingUp`.

## Approach
`ConnectionState.Connecting` has been removed. Migrate all usage to `ConnectionState.CatchingUp` instead.

## Steps
The alternative for `ConnectionState.Connecting` enum value is the `ConnectionState.Connecting` enum value.

## Does this introduce a breaking change?

-   [X] Yes
-   [ ] No

## Other information or known dependencies

[AB#813](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/813)
