### PR TITLE
Revert "Replace GetSharingInfo api with /LinkingUrl api (#10151)"

### DIFF
--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -94,7 +94,7 @@ async function getFileLinkCore(
     // ODSP link requires extra call to return link that is resistant to file being renamed or moved to different folder
     return PerformanceEvent.timedExecAsync(
         logger,
-        { eventName: "odspFileLink", requestName: "getSharingLink" },
+        { eventName: "odspFileLink", requestName: "getSharingInformation" },
         async (event) => {
             let attempts = 0;
             let additionalProps;
@@ -111,8 +111,8 @@ async function getFileLinkCore(
                     0x2bb /* "Instrumented token fetcher with throwOnNullToken = true should never return null" */);
 
                 const { url, headers } = getUrlAndHeadersWithAuth(
-                    `${odspUrlParts.siteUrl}/_api/web/GetFileByServerRelativeUrl(@a1)/Linkingurl?@a1=${
-                        encodeURIComponent(`'${new URL(fileItem.webDavUrl).pathname}'`)
+                    `${odspUrlParts.siteUrl}/_api/web/GetFileByUrl(@a1)/ListItemAllFields/GetSharingInformation?@a1=${
+                        encodeURIComponent(`'${fileItem.webDavUrl}'`)
                     }`,
                     storageToken,
                     false,
@@ -129,15 +129,15 @@ async function getFileLinkCore(
                 additionalProps = response.propsToLog;
 
                 const sharingInfo = await response.content.json();
-                const linkingUrl = sharingInfo?.d?.LinkingUrl;
-                if (typeof linkingUrl !== "string") {
+                const directUrl = sharingInfo?.d?.directUrl;
+                if (typeof directUrl !== "string") {
                     // This will retry once in getWithRetryForTokenRefresh
                     throw new NonRetryableError(
-                        "Malformed GetSharingLink response",
+                        "Malformed GetSharingInformation response",
                         DriverErrorType.incorrectServerResponse,
                         { driverVersion });
                 }
-                return linkingUrl;
+                return directUrl;
             });
             event.end({ ...additionalProps, attempts });
             return fileLink;

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -14,8 +14,8 @@ describe("getFileLink", () => {
     const logger = new TelemetryUTLogger();
     const storageTokenFetcher = async () => "StorageToken";
     const fileItemResponse = {
-        webDavUrl: `${siteUrl}/fetchDavUrl`,
-        webUrl: `${siteUrl}/fetchWebUrl`,
+        webDavUrl: "fetchDavUrl",
+        webUrl: "fetchWebUrl",
     };
 
     it("should return web url for Consumer user", async () => {
@@ -50,7 +50,7 @@ describe("getFileLink", () => {
             async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId4" }, "Enterprise", logger),
             [
                 async () => okResponse({}, fileItemResponse),
-                async () => okResponse({}, { d: { LinkingUrl: "sharelink" } }),
+                async () => okResponse({}, { d: { directUrl: "sharelink" } }),
             ],
         );
         assert.strictEqual(


### PR DESCRIPTION
## Description
Revert to using /getSharingInfo instead of /linkingUrl as /linkingUrl does not handle files with .loop extension.
