### PR TITLE
Fix webpacking of @fluid-example/prosemirror

### DIFF
--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -64,7 +64,7 @@
     "prosemirror-example-setup": "^1.0.1",
     "prosemirror-history": "^1.1.3",
     "prosemirror-keymap": "^1.1.3",
-    "prosemirror-menu": "^1.1.2",
+    "prosemirror-menu": "^1.2.1",
     "prosemirror-model": "^1.7.2",
     "prosemirror-schema-list": "^1.0.3",
     "prosemirror-state": "^1.2.4",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -38607,9 +38607,9 @@
 			}
 		},
 		"prosemirror-menu": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.0.tgz",
-			"integrity": "sha512-MignsYhlvuY3suwvJjG05JKyVPPKXDZLMMLd6vSqkRTo6gnK+t012z1yC42bZacom3iX/5C/FaLtvTzWBzQNBQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.1.tgz",
+			"integrity": "sha512-sBirXxVfHalZO4f1ZS63WzewINK4182+7dOmoMeBkqYO8wqMBvBS7wQuwVOHnkMWPEh0+N0LJ856KYUN+vFkmQ==",
 			"requires": {
 				"crelt": "^1.0.0",
 				"prosemirror-commands": "^1.0.0",


### PR DESCRIPTION
## Description

Updates prosemirror-menu so @fluid-example/prosemirror can webpack without error.

This does NOT get @fluid-example/prosemirror working (errors at runtime), nor does it get `npm run webpack` to pass since other examples still fail (`@fluid-example/iframe-host` is the next one the build fails on).

 @fluid-example/prosemirror's build and runtime are still uncovered by CI build and testing.