### PR TITLE
Utility tasks for VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,6 +48,56 @@
                 },
                 "$tslint5"
             ]
+        },
+        {
+            "label": "Build up to current package",
+            "detail": "Runs fluid-build using the package of the current file as target (so all dependencies up to this package are built as necessary).",
+            "type": "process",
+            "command": "node",
+            "args": [
+                "${workspaceRoot}/node_modules/@fluidframework/build-tools/dist/fluidBuild/fluidBuild.js",
+                "--root",
+                "${workspaceRoot}",
+                "--vscode",
+                "${fileDirname}"
+            ],
+            "group": "build",
+            "problemMatcher": [
+                {
+                    "base": "$tsc",
+                    "fileLocation": "absolute"
+                },
+            ]
+        },
+        {
+            "label": "Start tinylicious",
+            "detail": "Starts the tinylicious server from the /server/tinylicious folder. Run the 'Stop tinylicious' task to stop it.",
+            "type": "process",
+            "command": "npm",
+            "args": [
+                "run",
+                "start"
+            ],
+            "group": "none",
+            "options": {
+                "cwd": "${workspaceRoot}/server/tinylicious"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Stop tinylicious",
+            "detail": "Stops the tinylicious server from the /server/tinylicious folder.",
+            "type": "process",
+            "command": "npm",
+            "args": [
+                "run",
+                "stop"
+            ],
+            "group": "none",
+            "options": {
+                "cwd": "${workspaceRoot}/server/tinylicious"
+            },
+            "problemMatcher": []
         }
     ]
 }


### PR DESCRIPTION
## Description

A few utility tasks that can be run from VSCode.

- **Build up to current package**: trigger `fluid-build` targeting the package that contains the file that is in focus, so only dependencies up to this package are built. Functionally it has a lot of overlap with the existing `fluid-build` VSCode task, but I had a scenario where I had WIP changes in some packages and didn't want them to be rebuilt (and failed) every time while I was testing a particular change somewhere else.
- **Start tinylicious**: runs `npm run start` in the tinylicious folder. Purely convenience to be able to run this quickly from VSCode.
- **Stop tinylicious**: runs `npm run stop` in the tinylicious folder. Purely convenience to be able to run this quickly from VSCode.
