### PR TITLE
Fixed false positives and ensured package path is always available in inactive object errors

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -123,7 +123,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     getAudience(): IAudience;
     getCurrentReferenceTimestampMs(): number | undefined;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    getGCNodePackagePath(nodePath: string): readonly string[] | undefined;
+    getGCNodePackagePath(nodePath: string): Promise<readonly string[] | undefined>;
     // Warning: (ae-forgotten-export) The symbol "GCNodeType" needs to be exported by the entry point index.d.ts
     getNodeType(nodePath: string): GCNodeType;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2349,7 +2349,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const {
             fullTree = false,
             trackState = true,
-            summaryLogger = this.logger,
+            summaryLogger = this.mc.logger,
             runGC = this.garbageCollector.shouldRunGC,
             runSweep,
             fullGC,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1224,7 +1224,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             existing,
             metadata,
             isSummarizerClient: this.context.clientDetails.type === summarizerClientType,
-            getNodePackagePath: (nodePath: string) => this.getGCNodePackagePath(nodePath),
+            getNodePackagePath: async (nodePath: string) => this.getGCNodePackagePath(nodePath),
             getLastSummaryTimestampMs: () => this.messageAtLastSummary?.timestamp,
             readAndParseBlob: async <T>(id: string) => readAndParse<T>(this.storage, id),
         });
@@ -2463,7 +2463,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * Called by GC to retrieve the package path of the node with the given path. The node should belong to a
      * data store or an attachment blob.
      */
-    public getGCNodePackagePath(nodePath: string): readonly string[] | undefined {
+    public async getGCNodePackagePath(nodePath: string): Promise<readonly string[] | undefined> {
         switch (this.getNodeType(nodePath)) {
             case GCNodeType.Blob:
                 return ["_blobs"];

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -704,7 +704,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
     public abstract generateAttachMessage(): IAttachMessage;
 
-    protected abstract getInitialSnapshotDetails(): Promise<ISnapshotDetails>;
+    public abstract getInitialSnapshotDetails(): Promise<ISnapshotDetails>;
 
     /**
      * @deprecated - Sets the datastore as root, for aliasing purposes: #7948
@@ -858,7 +858,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
         };
     });
 
-    protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
+    public async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
         return this.initialSnapshotDetailsP;
     }
 
@@ -947,7 +947,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         return message;
     }
 
-    protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
+    public async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
         let snapshot = this.snapshotTree;
         let attributes: ReadFluidDataStoreAttributes;
         let isRootDataStore = false;
@@ -1050,7 +1050,7 @@ export class LocalDetachedFluidDataStoreContext
         }
     }
 
-    protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
+    public async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
         if (this.detachedRuntimeCreation) {
             throw new Error("Detached Fluid Data Store context can't be realized! Please attach runtime first!");
         }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -647,13 +647,13 @@ export class DataStores implements IDisposable {
     }
 
     /**
-     * Called during GC to retrieve the package path of a data store node with the given path.
+     * Called by GC to retrieve the package path of a data store node with the given path.
      */
-    public getDataStorePackagePath(nodePath: string): readonly string[] | undefined {
-        // If the node belongs to a data store, return its package path if the data store is loaded. For DDSes, we
-        // return the package path of the data store that contains it.
+    public async getDataStorePackagePath(nodePath: string): Promise<readonly string[] | undefined> {
+        // If the node belongs to a data store, return its package path. For DDSes, we return the package path of the
+        // data store that contains it.
         const context = this.contexts.get(nodePath.split("/")[1]);
-        return context?.isLoaded ? context.packagePath : undefined;
+        return (await context?.getInitialSnapshotDetails())?.pkg;
     }
 
     /**

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -115,12 +115,13 @@ export type GCNodeType = typeof GCNodeType[keyof typeof GCNodeType];
 
 /** The event that is logged when unreferenced node is used after a certain time. */
 interface IUnreferencedEvent {
-    eventName: string;
+    usageType: "Changed" | "Loaded" | "Revived";
     id: string;
     type: GCNodeType;
     age: number;
     timeout: number;
     completedGCRuns: number;
+    fromId?: string;
     lastSummaryTime?: number;
     externalRequest?: boolean;
     viaHandle?: boolean;
@@ -191,7 +192,7 @@ export interface IGarbageCollectorCreateParams {
     readonly metadata: IContainerRuntimeMetadata | undefined;
     readonly baseSnapshot: ISnapshotTree | undefined;
     readonly isSummarizerClient: boolean;
-    readonly getNodePackagePath: (nodePath: string) => readonly string[] | undefined;
+    readonly getNodePackagePath: (nodePath: string) => Promise<readonly string[] | undefined>;
     readonly getLastSummaryTimestampMs: () => number | undefined;
     readonly readAndParseBlob: ReadAndParseBlob;
 }
@@ -370,7 +371,7 @@ export class GarbageCollector implements IGarbageCollector {
     // per event per node.
     private readonly loggedUnreferencedEvents: Set<string> = new Set();
     // Queue for unreferenced events that should be logged the next time GC runs.
-    private readonly pendingEventsQueue: IUnreferencedEvent[] = [];
+    private pendingEventsQueue: IUnreferencedEvent[] = [];
 
     // The number of times GC has successfully completed on this instance of GarbageCollector.
     private completedRuns = 0;
@@ -380,7 +381,7 @@ export class GarbageCollector implements IGarbageCollector {
     private readonly isSummarizerClient: boolean;
 
     /** For a given node path, returns the node's package path. */
-    private readonly getNodePackagePath: (nodePath: string) => readonly string[] | undefined;
+    private readonly getNodePackagePath: (nodePath: string) => Promise<readonly string[] | undefined>;
     /** Returns the timestamp of the last summary generated for this container. */
     private readonly getLastSummaryTimestampMs: () => number | undefined;
 
@@ -678,7 +679,6 @@ export class GarbageCollector implements IGarbageCollector {
         },
     ): Promise<IGCStats> {
         const {
-            runSweep = this.shouldRunSweep,
             fullGC = this.gcOptions.runFullGC === true || this.summaryStateNeedsReset,
         } = options;
 
@@ -687,42 +687,52 @@ export class GarbageCollector implements IGarbageCollector {
             : this.mc.logger;
 
         return PerformanceEvent.timedExecAsync(logger, { eventName: "GarbageCollection" }, async (event) => {
-            await this.initializeBaseStateP;
-
-            // Let the runtime update its pending state before GC runs.
-            await this.runtime.updateStateBeforeGC();
+            await this.runPreGCSteps();
 
             // Get the runtime's GC data and run GC on the reference graph in it.
             const gcData = await this.runtime.getGCData(fullGC);
             const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
-            const gcStats = this.generateStatsAndLogEvents(gcResult, logger);
 
-            // Update the state since the last GC run. There can be nodes that were referenced between the last and
-            // the current run. We need to identify than and update their unreferenced state if needed.
-            this.updateStateSinceLastRun(gcData, logger);
-
-            // Update the current state of the system based on the GC run.
-            const currentReferenceTimestampMs = this.runtime.getCurrentReferenceTimestampMs();
-            this.updateCurrentState(gcData, gcResult, currentReferenceTimestampMs);
-
-            this.runtime.updateUsedRoutes(gcResult.referencedNodeIds, currentReferenceTimestampMs);
-
-            if (runSweep) {
-                // Placeholder for running sweep logic.
-            }
-
-            // If we are running in GC test mode, delete objects for unused routes. This enables testing scenarios
-            // involving access to deleted data.
-            if (this.testMode) {
-                this.runtime.deleteUnusedRoutes(gcResult.deletedNodeIds);
-            }
-
+            const gcStats = await this.runPostGCSteps(gcData, gcResult, logger);
             event.end({ ...gcStats });
-
             this.completedRuns++;
-
             return gcStats;
         }, { end: true, cancel: "error" });
+    }
+
+    private async runPreGCSteps() {
+        // Ensure that base state has been initialized.
+        await this.initializeBaseStateP;
+        // Let the runtime update its pending state before GC runs.
+        await this.runtime.updateStateBeforeGC();
+    }
+
+    private async runPostGCSteps(gcData: IGarbageCollectionData, gcResult: IGCResult, logger: ITelemetryLogger) {
+        // Generate statistics from the current run. This is done before updating the current state because it
+        // generates some of its data based on previous state of the system.
+        const gcStats = this.generateStats(gcResult);
+
+        // Update the state since the last GC run. There can be nodes that were referenced between the last and
+        // the current run. We need to identify than and update their unreferenced state if needed.
+        this.updateStateSinceLastRun(gcData, logger);
+
+        // Update the current state and update the runtime of all routes or ids that used as per the GC run.
+        const currentReferenceTimestampMs = this.runtime.getCurrentReferenceTimestampMs();
+        this.updateCurrentState(gcData, gcResult, currentReferenceTimestampMs);
+        this.runtime.updateUsedRoutes(gcResult.referencedNodeIds, currentReferenceTimestampMs);
+
+        // If we are running in GC test mode, delete objects for unused routes. This enables testing scenarios
+        // involving access to deleted data.
+        if (this.testMode) {
+            this.runtime.deleteUnusedRoutes(gcResult.deletedNodeIds);
+        }
+
+        // Log pending unreferenced events such as a node being used after inactive. This is done after GC runs and
+        // updates its state so that we don't send false positives based on intermediate state. For example, we may get
+        // reference to an unreferenced node from another unreferenced node which means the node wasn't revived.
+        await this.logPendingEvents(logger);
+
+        return gcStats;
     }
 
     /**
@@ -863,13 +873,18 @@ export class GarbageCollector implements IGarbageCollector {
             return;
         }
 
-        this.logIfInactive(
-            reason,
-            nodePath,
-            timestampMs,
-            packagePath,
-            requestHeaders,
-        );
+        const unreferencedState = this.unreferencedNodesState.get(nodePath);
+        if (unreferencedState?.inactive) {
+            this.inactiveNodeUsed(
+                reason,
+                nodePath,
+                unreferencedState,
+                undefined /* fromNodeId */,
+                packagePath,
+                timestampMs,
+                requestHeaders,
+            );
+        }
     }
 
     /**
@@ -888,11 +903,10 @@ export class GarbageCollector implements IGarbageCollector {
         outboundRoutes.push(toNodePath);
         this.newReferencesSinceLastRun.set(fromNodePath, outboundRoutes);
 
-        // If the node that got referenced is inactive, log an event as that may indicate use-after-delete.
-        this.logIfInactive(
-            "Revived",
-            toNodePath,
-        );
+        const unreferencedState = this.unreferencedNodesState.get(toNodePath);
+        if (unreferencedState?.inactive) {
+            this.inactiveNodeUsed("Revived", toNodePath, unreferencedState, fromNodePath);
+        }
     }
 
     public dispose(): void {
@@ -1093,25 +1107,11 @@ export class GarbageCollector implements IGarbageCollector {
     }
 
     /**
-     * Generates the stats of a garbage collection run from the given results of the run. Also, logs any pending events
-     * in the pendingEventsQueue. This should be called before updating the current state because it generates stats
-     * based on previous state of the system.
+     * Generates the stats of a garbage collection run from the given results of the run.
      * @param gcResult - The result of a GC run.
      * @returns the GC stats of the GC run.
      */
-    private generateStatsAndLogEvents(gcResult: IGCResult, logger: ITelemetryLogger): IGCStats {
-        // Log pending events for unreferenced nodes after GC has run. We should have the package data available for
-        // them now since the GC run should have loaded these nodes.
-        let event = this.pendingEventsQueue.shift();
-        while (event !== undefined) {
-            const pkg = this.getNodePackagePath(event.id);
-            logger.sendErrorEvent({
-                ...event,
-                pkg: pkg ? { value: `/${pkg.join("/")}`, tag: TelemetryDataTag.PackageData } : undefined,
-            });
-            event = this.pendingEventsQueue.shift();
-        }
-
+    private generateStats(gcResult: IGCResult): IGCStats {
         const gcStats: IGCStats = {
             nodeCount: 0,
             dataStoreCount: 0,
@@ -1169,18 +1169,26 @@ export class GarbageCollector implements IGarbageCollector {
     }
 
     /**
-     * Logs an event if a node is inactive and is used.
+     * Called when a node is used. If the node is inactive, queue up an event that will be logged next time GC runs.
      */
-    private logIfInactive(
-        eventType: "Changed" | "Loaded" | "Revived",
+    private inactiveNodeUsed(
+        usageType: "Changed" | "Loaded" | "Revived",
         nodeId: string,
-        currentReferenceTimestampMs = this.runtime.getCurrentReferenceTimestampMs(),
+        unreferencedState: UnreferencedStateTracker,
+        fromNodeId?: string,
         packagePath?: readonly string[],
+        currentReferenceTimestampMs = this.runtime.getCurrentReferenceTimestampMs(),
         requestHeaders?: IRequestHeader,
     ) {
         // If there is no reference timestamp to work with, no ops have been processed after creation. If so, skip
         // logging as nothing interesting would have happened worth logging.
         if (currentReferenceTimestampMs === undefined) {
+            return;
+        }
+
+        // For non-summarizer clients, only log "Loaded" type events since these objects may not be loaded in the
+        // summarizer clients if they are based off of user actions (such as scrolling to content for these objects).
+        if (!this.isSummarizerClient && usageType !== "Loaded") {
             return;
         }
 
@@ -1191,43 +1199,68 @@ export class GarbageCollector implements IGarbageCollector {
             return;
         }
 
-        // For non-summarizer clients, only log "Loaded" type events since these objects may not be loaded in the
-        // summarizer clients if they are based off of user actions (such as scrolling to content for these objects).
-        if (!this.isSummarizerClient && eventType !== "Loaded") {
+        // A particular event is logged for a given node only once so that it is not too noisy.
+        const uniqueEventId = `${nodeId}-${usageType}`;
+        if (this.loggedUnreferencedEvents.has(uniqueEventId)) {
             return;
         }
+        this.loggedUnreferencedEvents.add(uniqueEventId);
 
-        const eventName = `inactiveObject_${eventType}`;
-        // We log a particular event for a given node only once so that it is not too noisy.
-        const uniqueEventId = `${nodeId}-${eventName}`;
-        const nodeState = this.unreferencedNodesState.get(nodeId);
-        if (nodeState?.inactive && !this.loggedUnreferencedEvents.has(uniqueEventId)) {
-            this.loggedUnreferencedEvents.add(uniqueEventId);
-            // Save all the properties at this point in time so that if we log this later, these values are preserved.
-            const event: IUnreferencedEvent = {
-                eventName,
-                id: nodeId,
-                type: nodeType,
-                age: currentReferenceTimestampMs - nodeState.unreferencedTimestampMs,
-                timeout: this.inactiveTimeoutMs,
-                completedGCRuns: this.completedRuns,
-                lastSummaryTime: this.getLastSummaryTimestampMs(),
-                externalRequest: requestHeaders?.[RuntimeHeaders.externalRequest],
-                viaHandle: requestHeaders?.[RuntimeHeaders.viaHandle],
-            };
+        const event: IUnreferencedEvent = {
+            usageType,
+            id: nodeId,
+            type: nodeType,
+            age: currentReferenceTimestampMs - unreferencedState.unreferencedTimestampMs,
+            timeout: this.inactiveTimeoutMs,
+            completedGCRuns: this.completedRuns,
+            lastSummaryTime: this.getLastSummaryTimestampMs(),
+            externalRequest: requestHeaders?.[RuntimeHeaders.externalRequest],
+            viaHandle: requestHeaders?.[RuntimeHeaders.viaHandle],
+            fromId: fromNodeId,
+        };
 
-            // If the package data for the node exists, log immediately. Otherwise, queue it and it will be logged the
-            // next time GC runs as the package data should be available then.
-            const pkg = packagePath ?? this.getNodePackagePath(nodeId);
-            if (pkg !== undefined) {
-                this.mc.logger.sendErrorEvent({
-                    ...event,
-                    pkg: { value: pkg.join("/"), tag: TelemetryDataTag.PackageData },
-                });
-            } else {
-                this.pendingEventsQueue.push(event);
-            }
+        // For summarizer client, queue the event so it is logged the next time GC runs if the event is still valid.
+        // For non-summarizer client, log the event now since GC won't run on it. This may result in false positives
+        // but it's a good signal nonetheless and we can consume it with a grain of salt.
+        if (this.isSummarizerClient) {
+            this.pendingEventsQueue.push(event);
+        } else {
+            this.mc.logger.sendErrorEvent({
+                ...event,
+                eventName: `inactiveObject-${usageType}`,
+                pkg: packagePath ? { value: packagePath.join("/"), tag: TelemetryDataTag.PackageData } : undefined,
+            });
         }
+    }
+
+    /**
+     * Logs pending unreferenced events if they are still valid.
+     */
+    private async logPendingEvents(logger: ITelemetryLogger) {
+        for (const event of this.pendingEventsQueue) {
+            const unreferencedState = this.unreferencedNodesState.get(event.id);
+            // Only log revived event if the node is not inactive anymore. If the node is still inactive, the
+            // reference was from another unreferenced node and we don't care about logging this scenario.
+            if (event.usageType === "Revived" && unreferencedState?.inactive) {
+                continue;
+            }
+
+            // Only log loaded and changed event if the node is still inactive. If the node is not inactive, it was
+            // revived and a revived event will be logged for it.
+            if (event.usageType !== "Revived" && !unreferencedState?.inactive) {
+                continue;
+            }
+
+            const pkg = await this.getNodePackagePath(event.id);
+            const fromPkg = event.fromId ? await this.getNodePackagePath(event.fromId) : undefined;
+            logger.sendErrorEvent({
+                ...event,
+                eventName: `inactiveObject_${event.usageType}`,
+                pkg: pkg ? { value: pkg.join("/"), tag: TelemetryDataTag.PackageData } : undefined,
+                fromPkg: fromPkg ? { value: fromPkg.join("/"), tag: TelemetryDataTag.PackageData } : undefined,
+            });
+        }
+        this.pendingEventsQueue = [];
     }
 }
 

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -307,7 +307,7 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg, fromId: nodes[1] },
                 ]),
                 "revived event not logged as expected",
             );
@@ -340,7 +340,7 @@ describe("Garbage Collection Tests", () => {
             }
             assert(
                 mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg, fromId: nodes[1] },
                 ]),
                 "revived event not logged as expected",
             );
@@ -425,7 +425,7 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg, fromId: nodes[2] },
                 ]),
                 "revived event not logged as expected",
             );
@@ -481,7 +481,7 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg, fromId: nodes[2] },
                 ]),
                 "revived event not logged as expected",
             );

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -89,7 +89,7 @@ describe("Garbage Collection Tests", () => {
             metadata: createParams.metadata,
             isSummarizerClient: true /* summarizerClient */,
             readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
-            getNodePackagePath: (nodeId: string) => testPkgPath,
+            getNodePackagePath: async (nodeId: string) => testPkgPath,
             getLastSummaryTimestampMs: () => Date.now(),
         });
     }
@@ -230,11 +230,12 @@ describe("Garbage Collection Tests", () => {
         }
 
         // Simulates node loaded and changed activity for all the nodes in the graph.
-        function updateAllNodes(garbageCollector: IGarbageCollector) {
+        async function updateAllNodesAndRunGC(garbageCollector: IGarbageCollector) {
             nodes.forEach((nodeId) => {
                 garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
                 garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
             });
+            await garbageCollector.collectGarbage({});
         }
 
         // Returns a dummy snapshot tree to be built upon.
@@ -262,19 +263,15 @@ describe("Garbage Collection Tests", () => {
             // Run garbage collection on the default GC data where everything is referenced.
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Update all nodes.
-            updateAllNodes(garbageCollector);
-
-            // Validate that no inactive events are generated yet.
+            // Validate that no inactive events are logged yet.
+            await updateAllNodesAndRunGC(garbageCollector);
             validateNoInactiveEvents();
 
             // Expire the unreferenced timer (if any).
             clock.tick(inactiveTimeoutMs + 1);
 
-            // Change all nodes again.
-            updateAllNodes(garbageCollector);
-
-            // Validate that no inactive events are generated since everything is referenced.
+            // Validate that no inactive events are logged since everything is referenced.
+            await updateAllNodesAndRunGC(garbageCollector);
             validateNoInactiveEvents();
         });
 
@@ -286,18 +283,15 @@ describe("Garbage Collection Tests", () => {
 
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Update all nodes.
-            updateAllNodes(garbageCollector);
-
-            // Validate that no inactive events are generated yet.
+            // Validate that no inactive events are logged yet.
+            await updateAllNodesAndRunGC(garbageCollector);
             validateNoInactiveEvents();
 
             // Expire the unreferenced timer (if any).
             clock.tick(inactiveTimeoutMs + 1);
 
-            // Update all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
-            // are inactive.
-            updateAllNodes(garbageCollector);
+            // Validate that changed and loaded events for node 2 and node 3 are logged since they are inactive.
+            await updateAllNodesAndRunGC(garbageCollector);
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
@@ -305,16 +299,50 @@ describe("Garbage Collection Tests", () => {
                     { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                     { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive events not generated as expected",
+                "inactive events not logged as expected",
             );
 
-            // Add reference from node 1 to node 3 and validate that we get revivedEvent event.
+            // Add reference from node 1 to node 3 and validate that revived event is logged.
             garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
+            await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
                     { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive event not generated as expected",
+                "revived event not logged as expected",
+            );
+        });
+
+        it("generates only revived event when an inactive node is changed and revived", async () => {
+            const garbageCollector = createGarbageCollector();
+
+            // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+            defaultGCData.gcNodes[nodes[1]] = [];
+
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Validate that no inactive events are logged yet.
+            await updateAllNodesAndRunGC(garbageCollector);
+            validateNoInactiveEvents();
+
+            // Expire the unreferenced timer (if any).
+            clock.tick(inactiveTimeoutMs + 1);
+
+            // Validate that only revived event is generated for node 2 when it is changed and revived.
+            garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+            garbageCollector.nodeUpdated(nodes[2], "Loaded", Date.now(), testPkgPath);
+            garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
+            await garbageCollector.collectGarbage({});
+
+            for (const event of mockLogger.events) {
+                assert.notStrictEqual(event.eventName, changedEvent, "Unexpected changed event logged");
+                assert.notStrictEqual(event.eventName, loadedEvent, "Unexpected loaded event logged");
+            }
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
+                ]),
+                "revived event not logged as expected",
             );
         });
 
@@ -329,19 +357,18 @@ describe("Garbage Collection Tests", () => {
             // Expire the unreferenced timer (if any).
             clock.tick(inactiveTimeoutMs + 1);
 
-            // Update all nodes. This should result in an inactiveObjectChanged event for node 3 since it's inactive.
-            updateAllNodes(garbageCollector);
+            // Validate that changed and loaded events are logged for node 3 since it's inactive.
+            await updateAllNodesAndRunGC(garbageCollector);
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                     { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive events not generated as expected",
+                "inactive events not logged as expected",
             );
 
-            // Update all nodes. There shouldn't be any more inactive events since for each node the event is only
-            // once.
-            updateAllNodes(garbageCollector);
+            // Validate there are no more inactive events since for each node an event is only logged once.
+            await updateAllNodesAndRunGC(garbageCollector);
             validateNoInactiveEvents();
         });
 
@@ -357,7 +384,7 @@ describe("Garbage Collection Tests", () => {
             const gcSnapshotTree = getDummySnapshotTree();
             const gcBlobId = "root";
             // Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
-            // is generated by server in real scenarios but we use a static id here for testing.
+            // is logged by server in real scenarios but we use a static id here for testing.
             gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
 
             // Create a base snapshot that contains the GC snapshot tree.
@@ -381,24 +408,26 @@ describe("Garbage Collection Tests", () => {
             defaultGCData.gcNodes[nodes[2]] = [];
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Update node 3. This should result in an inactiveObjectChanged/Loaded event since it should be inactive.
+            // Validate that changed and loaded events are logged for node 3 since it is inactive.
             garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
             garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+            await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                     { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive events not generated as expected",
+                "inactive events not logged as expected",
             );
 
-            // Add reference from node 2 to node 3 and validate that we get revivedEvent event.
+            // Add reference from node 2 to node 3 and validate that we get revived event.
             garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+            await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
                     { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive event not generated as expected",
+                "revived event not logged as expected",
             );
         });
 
@@ -435,24 +464,26 @@ describe("Garbage Collection Tests", () => {
             defaultGCData.gcNodes[nodes[2]] = [];
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Change node 3. This should result in an inactiveObjectChanged/Loaded event since it should be inactive.
+            // Validate that changed and loaded events are logged for node 3 since it is inactive.
             garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
             garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+            await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                     { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive event not generated as expected",
+                "inactive events not logged as expected",
             );
 
-            // Add reference from node 2 to node 3 and validate that we get revivedEvent event.
+            // Add reference from node 2 to node 3 and validate that we get revived event.
             garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+            await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
                     { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive event not generated as expected",
+                "revived event not logged as expected",
             );
         });
 
@@ -500,17 +531,18 @@ describe("Garbage Collection Tests", () => {
 
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Update the nodes and validate that inactive events is correctly generated for each.
+            // Validate that changed and loaded events are logged for inactive nodes.
             garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
             garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
             garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+            await garbageCollector.collectGarbage({});
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[1], pkg: eventPkg },
                     { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
                     { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectChanged event not generated as expected",
+                "inactive events not logged as expected",
             );
         });
 
@@ -525,18 +557,15 @@ describe("Garbage Collection Tests", () => {
 
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Update all nodes.
-            updateAllNodes(garbageCollector);
-
-            // Validate that no inactive events are generated yet.
+            // Validate that no inactive events are logged yet.
+            await updateAllNodesAndRunGC(garbageCollector);
             validateNoInactiveEvents();
 
             // Advance the clock so that inactive timeout expires.
             clock.tick(inactiveTimeoutOverrideMs + 1);
 
-            // Update all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
-            // are inactive.
-            updateAllNodes(garbageCollector);
+            // Validate that changed and loaded events for node 2 and node 3 are logged since they are inactive.
+            await updateAllNodesAndRunGC(garbageCollector);
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[2], pkg: eventPkg },
@@ -544,7 +573,7 @@ describe("Garbage Collection Tests", () => {
                     { eventName: changedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[3], pkg: eventPkg },
                     { eventName: loadedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactive events not generated as expected",
+                "inactive events not logged as expected",
             );
         });
     });


### PR DESCRIPTION
[AB#964](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/964) and [AB#965](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/965)

## Description
This PR fixes the following issues we have seen with the inactive object errors:
- Package information is now always available when logging these errors ([AB#965](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/965)). The data store attributes blob is downloaded to get this information if the data store is not realized. Note that this does not load / realize the data store. 
- The events are not logged immediately but are added to a queue. When GC runs the next time, the events are only logged if they are still valid. For "Revived" events, the node should not be inactive anymore ([AB#964](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/964)). For other events, the node should still be inactive. 
- In case of "Revived" events, added the id and package info of the node that added the reference ([AB#964](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/964)).
- Updated existing tests and added couple new ones to handle this change.