### PR TITLE
docs: Remove usages of `@see` tag, which is not TSDoc compliant

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -56,7 +56,7 @@ export enum BindState {
 export namespace ConnectionState {
     export type CatchingUp = 1;
     export type Connected = 2;
-    // @deprecated (undocumented)
+    // @deprecated
     export type Connecting = 1;
     export type Disconnected = 0;
     export type EstablishingConnection = 3;

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -44,7 +44,7 @@ import { TelemetryLogger } from '@fluidframework/telemetry-utils';
 export enum ConnectionState {
     CatchingUp = 1,
     Connected = 2,
-    // @deprecated (undocumented)
+    // @deprecated
     Connecting = 1,
     Disconnected = 0,
     EstablishingConnection = 3

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -262,7 +262,7 @@ export class AzureClient {
         );
         return new (class extends FluidContainer {
             /**
-             * @see {@link FluidContainer.attach}
+             * See {@link FluidContainer.attach}
              *
              * @remarks This is required since the FluidContainer doesn't have knowledge of how the attach will happen
              * or the id that will be returned.

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -262,7 +262,7 @@ export class AzureClient {
         );
         return new (class extends FluidContainer {
             /**
-             * See {@link FluidContainer.attach}
+             * @see {@link FluidContainer.attach}
              *
              * @remarks This is required since the FluidContainer doesn't have knowledge of how the attach will happen
              * or the id that will be returned.

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -125,7 +125,7 @@ export interface AzureContainerServices {
  * Since Azure provides user names for all of its members, we extend the
  * {@link @fluidframework/protocol-definitions#IUser} interface to include this service-specific value. *
  *
- * @typeParam T - @see {@link AzureUser.additionalDetails}.
+ * @typeParam T - See {@link AzureUser.additionalDetails}.
  * Note: must be JSON-serializable.
  * Passing a non-serializable object (e.g. a `class`) will result in undefined behavior.
  */
@@ -146,7 +146,7 @@ export interface AzureUser<T = any> extends IUser {
  * {@link @fluidframework/protocol-definitions#IMember} interface to include this service-specific value.
  * It will be returned for all audience members connected to Azure.
  *
- * @typeParam T - @see {@link AzureMember.additionalDetails}.
+ * @typeParam T - See {@link AzureMember.additionalDetails}.
  * Note: must be JSON-serializable.
  * Passing a non-serializable object (e.g. a `class`) will result in undefined behavior.
  */

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -125,7 +125,7 @@ export interface AzureContainerServices {
  * Since Azure provides user names for all of its members, we extend the
  * {@link @fluidframework/protocol-definitions#IUser} interface to include this service-specific value. *
  *
- * @typeParam T - See {@link AzureUser.additionalDetails}.
+ * @typeParam T - @see {@link AzureUser.additionalDetails}.
  * Note: must be JSON-serializable.
  * Passing a non-serializable object (e.g. a `class`) will result in undefined behavior.
  */
@@ -146,7 +146,7 @@ export interface AzureUser<T = any> extends IUser {
  * {@link @fluidframework/protocol-definitions#IMember} interface to include this service-specific value.
  * It will be returned for all audience members connected to Azure.
  *
- * @typeParam T - See {@link AzureMember.additionalDetails}.
+ * @typeParam T - @see {@link AzureMember.additionalDetails}.
  * Note: must be JSON-serializable.
  * Passing a non-serializable object (e.g. a `class`) will result in undefined behavior.
  */

--- a/azure/packages/azure-service-utils/src/generateToken.ts
+++ b/azure/packages/azure-service-utils/src/generateToken.ts
@@ -32,20 +32,20 @@ import { v4 as uuid } from "uuid";
  * ({@link https://www.npmjs.com/package/jsrsasign | jsrsasign}) and may only be used in client (browser) context.
  * It is **not** Node.js-compatible.
  *
- * @param tenantId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
+ * @param tenantId - See {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
  * @param key - API key to authenticate user. Must be {@link https://en.wikipedia.org/wiki/UTF-8 | UTF-8}-encoded.
- * @param scopes - @see {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
- * @param documentId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
+ * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
+ * @param documentId - See {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
  * If not specified, the token will not be associated with a document, and an empty string will be used.
  * @param user - User with whom generated tokens will be associated.
  * If not specified, the token will not be associated with a user, and a randomly generated mock user will be
  * used instead.
- * @see {@link @fluidframework/protocol-definitions#ITokenClaims.user}
+ * See {@link @fluidframework/protocol-definitions#ITokenClaims.user}
  * @param lifetime - Used to generate the {@link @fluidframework/protocol-definitions#ITokenClaims.exp | expiration}.
  * Expiration = now + lifetime.
  * Expressed in seconds.
  * Default: 3600 (1 hour).
- * @param ver - @see {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
+ * @param ver - See {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
  * Default: `1.0`.
  */
 export function generateToken(

--- a/azure/packages/azure-service-utils/src/generateToken.ts
+++ b/azure/packages/azure-service-utils/src/generateToken.ts
@@ -32,20 +32,20 @@ import { v4 as uuid } from "uuid";
  * ({@link https://www.npmjs.com/package/jsrsasign | jsrsasign}) and may only be used in client (browser) context.
  * It is **not** Node.js-compatible.
  *
- * @param tenantId - See {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
+ * @param tenantId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
  * @param key - API key to authenticate user. Must be {@link https://en.wikipedia.org/wiki/UTF-8 | UTF-8}-encoded.
- * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
- * @param documentId - See {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
+ * @param scopes - @see {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
+ * @param documentId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
  * If not specified, the token will not be associated with a document, and an empty string will be used.
  * @param user - User with whom generated tokens will be associated.
  * If not specified, the token will not be associated with a user, and a randomly generated mock user will be
  * used instead.
- * See {@link @fluidframework/protocol-definitions#ITokenClaims.user}
+ * @see {@link @fluidframework/protocol-definitions#ITokenClaims.user}
  * @param lifetime - Used to generate the {@link @fluidframework/protocol-definitions#ITokenClaims.exp | expiration}.
  * Expiration = now + lifetime.
  * Expressed in seconds.
  * Default: 3600 (1 hour).
- * @param ver - See {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
+ * @param ver - @see {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
  * Default: `1.0`.
  */
 export function generateToken(

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -8,7 +8,7 @@ import { IUser } from "./users";
 /**
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
- * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
  */
 export interface ITokenClaims {
     /**
@@ -38,7 +38,7 @@ export interface ITokenClaims {
      * Indicates when the authentication for this token occurred.
      * Expressed in {@link https://en.wikipedia.org/wiki/Unix_time | Unix Time}.
      *
-     * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6}
+     * @see {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6}
      */
     iat: number;
 
@@ -47,7 +47,7 @@ export interface ITokenClaims {
      * Identifies the expiration time on or after which the token must not be accepted for processing.
      * Expressed in {@link https://en.wikipedia.org/wiki/Unix_time | Unix Time}.
      *
-     * See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+     * @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
      */
     exp: number;
 
@@ -61,7 +61,7 @@ export interface ITokenClaims {
      * "JWT ID"
      * A unique identifier for the token.
      *
-     * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7}
+     * @see {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7}
      */
     jti?: string;
 }

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -47,7 +47,7 @@ export interface ITokenClaims {
      * Identifies the expiration time on or after which the token must not be accepted for processing.
      * Expressed in {@link https://en.wikipedia.org/wiki/Unix_time | Unix Time}.
      *
-     * See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+     * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4}
      */
     exp: number;
 

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -8,7 +8,7 @@ import { IUser } from "./users";
 /**
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
+ * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
  */
 export interface ITokenClaims {
     /**
@@ -38,7 +38,7 @@ export interface ITokenClaims {
      * Indicates when the authentication for this token occurred.
      * Expressed in {@link https://en.wikipedia.org/wiki/Unix_time | Unix Time}.
      *
-     * @see {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6}
+     * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6}
      */
     iat: number;
 
@@ -47,7 +47,7 @@ export interface ITokenClaims {
      * Identifies the expiration time on or after which the token must not be accepted for processing.
      * Expressed in {@link https://en.wikipedia.org/wiki/Unix_time | Unix Time}.
      *
-     * @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+     * See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
      */
     exp: number;
 
@@ -61,7 +61,7 @@ export interface ITokenClaims {
      * "JWT ID"
      * A unique identifier for the token.
      *
-     * @see {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7}
+     * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7}
      */
     jti?: string;
 }

--- a/experimental/PropertyDDS/packages/property-common/src/error_objects/operationError.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/error_objects/operationError.ts
@@ -7,7 +7,7 @@
  * An operation error maintains additional information compared to a plain {@link #Error}:
  * - The operation name
  * - A status code
- * - Extensible flags. {@see ExtendedError.FLAGS}.
+ * - Extensible flags. See {@link ExtendedError.FLAGS}.
  */
 import _ from "lodash";
 import { FlaggedError } from "./flaggedError";

--- a/experimental/PropertyDDS/packages/property-common/src/error_objects/operationError.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/error_objects/operationError.ts
@@ -7,7 +7,7 @@
  * An operation error maintains additional information compared to a plain {@link #Error}:
  * - The operation name
  * - A status code
- * - Extensible flags. See {@link ExtendedError.FLAGS}.
+ * - Extensible flags. {@see ExtendedError.FLAGS}.
  */
 import _ from "lodash";
 import { FlaggedError } from "./flaggedError";

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
@@ -324,7 +324,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
     /**
      * Given an object that mirrors a PSet Template, assigns the properties to the values
      * found in that object.
-     * @see {setValues}
+     * See {@link setValues}
      * @param {object} in_values The object containing the nested values to assign
      * @param {boolean} in_typed Whether the values are typed/polymorphic.
      * @param {boolean} in_initial  - Whether we are setting default/initial values

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
@@ -324,7 +324,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
     /**
      * Given an object that mirrors a PSet Template, assigns the properties to the values
      * found in that object.
-     * @see {setValues}
+     * See {@link setValues}
      * @param {object} in_values The object containing the nested values to assign
      * @param {boolean} in_typed Whether the values are typed/polymorphic.
      * @param {boolean} in_initial  - Whether we are setting default/initial values
@@ -560,7 +560,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
         in_dirtinessType = in_dirtinessType === undefined ?
             BaseProperty.MODIFIED_STATE_FLAGS.PENDING_CHANGE : in_dirtinessType;
 
-        this._traverseStaticProperties(function(in_node, in_pathFromTraversalStart) {
+        this._traverseStaticProperties(function (in_node, in_pathFromTraversalStart) {
             if (in_dirtyOnly && !in_node._isDirty(in_dirtinessType)) {
                 return;
             }
@@ -609,7 +609,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
         var changeSet = {};
 
         // Traverse all properties of this template
-        this._traverseStaticProperties(function(in_node, in_pathFromTraversalStart) {
+        this._traverseStaticProperties(function (in_node, in_pathFromTraversalStart) {
             // We do not deserialize base properties, since the traverseStatic function
             // already traverses recursively
             if (in_node.getTypeid() === 'ContainerProperty' && in_node.getContext() === 'single') {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
@@ -324,7 +324,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
     /**
      * Given an object that mirrors a PSet Template, assigns the properties to the values
      * found in that object.
-     * See {@link setValues}
+     * @see {setValues}
      * @param {object} in_values The object containing the nested values to assign
      * @param {boolean} in_typed Whether the values are typed/polymorphic.
      * @param {boolean} in_initial  - Whether we are setting default/initial values

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/abstractStaticCollectionProperty.js
@@ -560,7 +560,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
         in_dirtinessType = in_dirtinessType === undefined ?
             BaseProperty.MODIFIED_STATE_FLAGS.PENDING_CHANGE : in_dirtinessType;
 
-        this._traverseStaticProperties(function (in_node, in_pathFromTraversalStart) {
+        this._traverseStaticProperties(function(in_node, in_pathFromTraversalStart) {
             if (in_dirtyOnly && !in_node._isDirty(in_dirtinessType)) {
                 return;
             }
@@ -609,7 +609,7 @@ export class AbstractStaticCollectionProperty extends BaseProperty {
         var changeSet = {};
 
         // Traverse all properties of this template
-        this._traverseStaticProperties(function (in_node, in_pathFromTraversalStart) {
+        this._traverseStaticProperties(function(in_node, in_pathFromTraversalStart) {
             // We do not deserialize base properties, since the traverseStatic function
             // already traverses recursively
             if (in_node.getTypeid() === 'ContainerProperty' && in_node.getContext() === 'single') {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -349,7 +349,9 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     /**
      * Sets the values of items in the array.
      * If values are typed, iterates through the values and creates a property with the defined type and value.
-     * @see {setValues}
+     *
+     * See {@link ArrayProperty.setValues}
+     *
      * @param {Array<*>} in_values  - The list of typed values.
      * @param {Bool} in_typed  - Whether the values are typed/polymorphic.
      * @param {Bool} in_initial  - Whether we are setting default/initial values
@@ -385,8 +387,9 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     }
 
     /**
+     * See {@link ArrayProperty.setValues}
+     *
      * @param {Array<*>|Object} in_values an array or object containing the values to be set.
-     * @see {setValues}
      */
     _setValuesInternal(in_values) {
         this._checkIsNotReadOnly(true);
@@ -1272,15 +1275,15 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     _serializeArray(in_array) {
         var len = in_array.length;
         var result = new Array(len);
-    if (this._isPrimitive) {
-        for (var i = 0; i < len; i++) {
-            result[i] = this._serializeValue(in_array[i]);
+        if (this._isPrimitive) {
+            for (var i = 0; i < len; i++) {
+                result[i] = this._serializeValue(in_array[i]);
+            }
+        } else {
+            for (var i = 0; i < len; i++) {
+                result[i] = {};
+            }
         }
-    } else {
-        for (var i = 0; i < len; i++) {
-            result[i] = {};
-        }
-    }
         return result;
     }
 

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -70,7 +70,7 @@ var PATH_TOKENS = BaseProperty.PATH_TOKENS;
  * @return {Array.<Number>} List of the selected segments, given as indices of the segments
  * @private
  */
-var _getLongestIncreasingSubsequenceSegments = function(in_segmentStarts, in_segmentLengths) {
+var _getLongestIncreasingSubsequenceSegments = function (in_segmentStarts, in_segmentLengths) {
     if (in_segmentStarts.length === 0) {
         return [];
     }
@@ -349,7 +349,9 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     /**
      * Sets the values of items in the array.
      * If values are typed, iterates through the values and creates a property with the defined type and value.
-     * @see {setValues}
+     *
+     * See {@link ArrayProperty.setValues}
+     *
      * @param {Array<*>} in_values  - The list of typed values.
      * @param {Bool} in_typed  - Whether the values are typed/polymorphic.
      * @param {Bool} in_initial  - Whether we are setting default/initial values
@@ -385,8 +387,9 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     }
 
     /**
+     * See {@link ArrayProperty.setValues}
+     *
      * @param {Array<*>|Object} in_values an array or object containing the values to be set.
-     * @see {setValues}
      */
     _setValuesInternal(in_values) {
         this._checkIsNotReadOnly(true);
@@ -405,7 +408,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
 
             var that = this;
             var maxIndex = this._dataArrayGetLength() - 1;
-            _.each(in_values, function(value, index) {
+            _.each(in_values, function (value, index) {
                 if (index > maxIndex) {
                     that.insert(index, value);
                 } else {
@@ -1208,7 +1211,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
             for (var j = 0; j < segmentLength; j++) {
                 var existingEntry = this._dataArrayGetValue(startPointInInitialArray + j + offset);
                 var entryChanges = existingEntry._deserialize(targetArray[startPointInTargetArray + j],
-                                                              false, undefined, true);
+                    false, undefined, true);
 
                 // We had changes which we have to report back
                 if (!ChangeSet.isEmptyChangeSet(entryChanges)) {
@@ -1272,15 +1275,15 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     _serializeArray(in_array) {
         var len = in_array.length;
         var result = new Array(len);
-    if (this._isPrimitive) {
-        for (var i = 0; i < len; i++) {
-            result[i] = this._serializeValue(in_array[i]);
+        if (this._isPrimitive) {
+            for (var i = 0; i < len; i++) {
+                result[i] = this._serializeValue(in_array[i]);
+            }
+        } else {
+            for (var i = 0; i < len; i++) {
+                result[i] = {};
+            }
         }
-    } else {
-        for (var i = 0; i < len; i++) {
-            result[i] = {};
-        }
-    }
         return result;
     }
 

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -349,9 +349,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     /**
      * Sets the values of items in the array.
      * If values are typed, iterates through the values and creates a property with the defined type and value.
-     *
-     * See {@link ArrayProperty.setValues}
-     *
+     * @see {setValues}
      * @param {Array<*>} in_values  - The list of typed values.
      * @param {Bool} in_typed  - Whether the values are typed/polymorphic.
      * @param {Bool} in_initial  - Whether we are setting default/initial values
@@ -387,9 +385,8 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     }
 
     /**
-     * See {@link ArrayProperty.setValues}
-     *
      * @param {Array<*>|Object} in_values an array or object containing the values to be set.
+     * @see {setValues}
      */
     _setValuesInternal(in_values) {
         this._checkIsNotReadOnly(true);
@@ -1211,7 +1208,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
             for (var j = 0; j < segmentLength; j++) {
                 var existingEntry = this._dataArrayGetValue(startPointInInitialArray + j + offset);
                 var entryChanges = existingEntry._deserialize(targetArray[startPointInTargetArray + j],
-                    false, undefined, true);
+                                                              false, undefined, true);
 
                 // We had changes which we have to report back
                 if (!ChangeSet.isEmptyChangeSet(entryChanges)) {
@@ -1275,15 +1272,15 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     _serializeArray(in_array) {
         var len = in_array.length;
         var result = new Array(len);
-        if (this._isPrimitive) {
-            for (var i = 0; i < len; i++) {
-                result[i] = this._serializeValue(in_array[i]);
-            }
-        } else {
-            for (var i = 0; i < len; i++) {
-                result[i] = {};
-            }
+    if (this._isPrimitive) {
+        for (var i = 0; i < len; i++) {
+            result[i] = this._serializeValue(in_array[i]);
         }
+    } else {
+        for (var i = 0; i < len; i++) {
+            result[i] = {};
+        }
+    }
         return result;
     }
 

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -70,7 +70,7 @@ var PATH_TOKENS = BaseProperty.PATH_TOKENS;
  * @return {Array.<Number>} List of the selected segments, given as indices of the segments
  * @private
  */
-var _getLongestIncreasingSubsequenceSegments = function (in_segmentStarts, in_segmentLengths) {
+var _getLongestIncreasingSubsequenceSegments = function(in_segmentStarts, in_segmentLengths) {
     if (in_segmentStarts.length === 0) {
         return [];
     }
@@ -408,7 +408,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
 
             var that = this;
             var maxIndex = this._dataArrayGetLength() - 1;
-            _.each(in_values, function (value, index) {
+            _.each(in_values, function(value, index) {
                 if (index > maxIndex) {
                     that.insert(index, value);
                 } else {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
@@ -74,10 +74,11 @@ export class MapProperty extends IndexedCollectionBaseProperty {
     /**
      * Sets multiple values in a map.
      *
+     * See {@link MapProperty.setValues}
+     *
      * @param {object} in_values to assign to the collection
      * @param {Boolean} in_typed - If the map's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).
-     * @see {setValues}
      * @private
      */
     _setValuesInternal(in_values, in_typed) {
@@ -123,11 +124,12 @@ export class MapProperty extends IndexedCollectionBaseProperty {
     /**
      * Sets multiple values in a map.
      *
+     * See {@link MapProperty.setValues}
+     *
      * @param {object} in_values to assign to the collection
      * @param {Bool} in_typed  - Whether the values are typed/polymorphic.
      * @param {Bool} in_initial  - Whether we are setting default/initial values
      *   or if the function is called directly with the values to set.
-     * @see {setValues}
      * @override
      */
     _setValues(in_values, in_typed, in_initial) {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
@@ -84,7 +84,7 @@ export class MapProperty extends IndexedCollectionBaseProperty {
     _setValuesInternal(in_values, in_typed) {
         if (this._containsPrimitiveTypes) {
             var that = this;
-            _.each(in_values, function (value, key) {
+            _.each(in_values, function(value, key) {
                 if (that.has(key)) {
                     that.remove(key);
                 }
@@ -93,7 +93,7 @@ export class MapProperty extends IndexedCollectionBaseProperty {
             });
         } else {
             var that = this;
-            _.each(in_values, function (value, key) {
+            _.each(in_values, function(value, key) {
                 var property = that.get(String(key), { referenceResolutionMode: BaseProperty.REFERENCE_RESOLUTION.NEVER });
                 // if key exists in set replace its value else insert a new key/value
                 if (property) {
@@ -404,7 +404,7 @@ export class MapProperty extends IndexedCollectionBaseProperty {
      */
     clear() {
         var that = this;
-        this.getIds().forEach(function (id) {
+        this.getIds().forEach(function(id) {
             that.remove(id);
         });
     }

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
@@ -74,16 +74,17 @@ export class MapProperty extends IndexedCollectionBaseProperty {
     /**
      * Sets multiple values in a map.
      *
+     * See {@link MapProperty.setValues}
+     *
      * @param {object} in_values to assign to the collection
      * @param {Boolean} in_typed - If the map's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).
-     * @see {setValues}
      * @private
      */
     _setValuesInternal(in_values, in_typed) {
         if (this._containsPrimitiveTypes) {
             var that = this;
-            _.each(in_values, function(value, key) {
+            _.each(in_values, function (value, key) {
                 if (that.has(key)) {
                     that.remove(key);
                 }
@@ -92,7 +93,7 @@ export class MapProperty extends IndexedCollectionBaseProperty {
             });
         } else {
             var that = this;
-            _.each(in_values, function(value, key) {
+            _.each(in_values, function (value, key) {
                 var property = that.get(String(key), { referenceResolutionMode: BaseProperty.REFERENCE_RESOLUTION.NEVER });
                 // if key exists in set replace its value else insert a new key/value
                 if (property) {
@@ -123,11 +124,12 @@ export class MapProperty extends IndexedCollectionBaseProperty {
     /**
      * Sets multiple values in a map.
      *
+     * See {@link MapProperty.setValues}
+     *
      * @param {object} in_values to assign to the collection
      * @param {Bool} in_typed  - Whether the values are typed/polymorphic.
      * @param {Bool} in_initial  - Whether we are setting default/initial values
      *   or if the function is called directly with the values to set.
-     * @see {setValues}
      * @override
      */
     _setValues(in_values, in_typed, in_initial) {
@@ -402,7 +404,7 @@ export class MapProperty extends IndexedCollectionBaseProperty {
      */
     clear() {
         var that = this;
-        this.getIds().forEach(function(id) {
+        this.getIds().forEach(function (id) {
             that.remove(id);
         });
     }

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/mapProperty.js
@@ -74,11 +74,10 @@ export class MapProperty extends IndexedCollectionBaseProperty {
     /**
      * Sets multiple values in a map.
      *
-     * See {@link MapProperty.setValues}
-     *
      * @param {object} in_values to assign to the collection
      * @param {Boolean} in_typed - If the map's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).
+     * @see {setValues}
      * @private
      */
     _setValuesInternal(in_values, in_typed) {
@@ -124,12 +123,11 @@ export class MapProperty extends IndexedCollectionBaseProperty {
     /**
      * Sets multiple values in a map.
      *
-     * See {@link MapProperty.setValues}
-     *
      * @param {object} in_values to assign to the collection
      * @param {Bool} in_typed  - Whether the values are typed/polymorphic.
      * @param {Bool} in_initial  - Whether we are setting default/initial values
      *   or if the function is called directly with the values to set.
+     * @see {setValues}
      * @override
      */
     _setValues(in_values, in_typed, in_initial) {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
@@ -248,7 +248,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
 
     /**
      * Adds a list of properties to the set.
-     * @see {setValues}
+     * See {@link SetProperty.setValues}
      * @param {NamedProperty[]|NamedNodeProperty[]|Object[]} in_properties - The list of properties to add to the list
      * @param {Boolean} in_typed - If the set's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).
@@ -276,7 +276,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
 
     /**
      * Adds a list of properties to the set.
-     * @see {setValues}
+     * See {@link SetProperty.setValues}
      * @param {NamedProperty[]|NamedNodeProperty[]|Object[]} in_properties - The list of properties to add to the list
      * @param {Boolean} in_typed - If the set's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
@@ -248,7 +248,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
 
     /**
      * Adds a list of properties to the set.
-     * See {@link SetProperty.setValues}
+     * @see {setValues}
      * @param {NamedProperty[]|NamedNodeProperty[]|Object[]} in_properties - The list of properties to add to the list
      * @param {Boolean} in_typed - If the set's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).
@@ -276,7 +276,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
 
     /**
      * Adds a list of properties to the set.
-     * See {@link SetProperty.setValues}
+     * @see {setValues}
      * @param {NamedProperty[]|NamedNodeProperty[]|Object[]} in_properties - The list of properties to add to the list
      * @param {Boolean} in_typed - If the set's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
@@ -258,7 +258,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
         this._checkIsNotReadOnly(true);
 
         var that = this;
-        _.each(in_properties, function (property) {
+        _.each(in_properties, function(property) {
             if (property instanceof BaseProperty) {
                 that.set(property);
             } else {
@@ -344,7 +344,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
      */
     clear() {
         var that = this;
-        this.getIds().forEach(function (id) {
+        this.getIds().forEach(function(id) {
             that.remove(id);
         });
     }

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/setProperty.js
@@ -248,7 +248,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
 
     /**
      * Adds a list of properties to the set.
-     * @see {setValues}
+     * See {@link SetProperty.setValues}
      * @param {NamedProperty[]|NamedNodeProperty[]|Object[]} in_properties - The list of properties to add to the list
      * @param {Boolean} in_typed - If the set's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).
@@ -258,7 +258,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
         this._checkIsNotReadOnly(true);
 
         var that = this;
-        _.each(in_properties, function(property) {
+        _.each(in_properties, function (property) {
             if (property instanceof BaseProperty) {
                 that.set(property);
             } else {
@@ -276,7 +276,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
 
     /**
      * Adds a list of properties to the set.
-     * @see {setValues}
+     * See {@link SetProperty.setValues}
      * @param {NamedProperty[]|NamedNodeProperty[]|Object[]} in_properties - The list of properties to add to the list
      * @param {Boolean} in_typed - If the set's items have a typeid and a value then create the
      *   properties with that typeid, else use the set's typeid (support polymorphic items).
@@ -344,7 +344,7 @@ export class SetProperty extends IndexedCollectionBaseProperty {
      */
     clear() {
         var that = this;
-        this.getIds().forEach(function(id) {
+        this.getIds().forEach(function (id) {
             that.remove(id);
         });
     }

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
@@ -322,10 +322,10 @@ export class StringProperty extends ValueArrayProperty {
     }
 
     /**
+     * See {@link StringProperty.setValues}
      * @param {string} in_values the new values
      * @param {Bool} in_initial  - Whether we are setting default/initial values
      *   or if the function is called directly with the values to set.
-     * @see {setValues}
      */
     _setValues(in_values, in_initial) {
         throw new Error(MSG.NO_VALUE_PROPERTY_SETVALUES);

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
@@ -220,7 +220,7 @@ export class StringProperty extends ValueArrayProperty {
      * @inheritdoc
      */
     _deserialize(in_serializedObj, in_reportToView,
-        in_filteringOptions, in_createChangeSet) {
+                 in_filteringOptions, in_createChangeSet) {
         if ((in_serializedObj.remove && in_serializedObj.remove.length > 0) ||
             (in_serializedObj.modify && in_serializedObj.modify.length > 0) ||
             (in_serializedObj.insert &&
@@ -322,10 +322,10 @@ export class StringProperty extends ValueArrayProperty {
     }
 
     /**
-     * See {@link StringProperty.setValues}
      * @param {string} in_values the new values
      * @param {Bool} in_initial  - Whether we are setting default/initial values
      *   or if the function is called directly with the values to set.
+     * @see {setValues}
      */
     _setValues(in_values, in_initial) {
         throw new Error(MSG.NO_VALUE_PROPERTY_SETVALUES);

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
@@ -220,7 +220,7 @@ export class StringProperty extends ValueArrayProperty {
      * @inheritdoc
      */
     _deserialize(in_serializedObj, in_reportToView,
-                 in_filteringOptions, in_createChangeSet) {
+        in_filteringOptions, in_createChangeSet) {
         if ((in_serializedObj.remove && in_serializedObj.remove.length > 0) ||
             (in_serializedObj.modify && in_serializedObj.modify.length > 0) ||
             (in_serializedObj.insert &&
@@ -322,10 +322,10 @@ export class StringProperty extends ValueArrayProperty {
     }
 
     /**
+     * See {@link StringProperty.setValues}
      * @param {string} in_values the new values
      * @param {Bool} in_initial  - Whether we are setting default/initial values
      *   or if the function is called directly with the values to set.
-     * @see {setValues}
      */
     _setValues(in_values, in_initial) {
         throw new Error(MSG.NO_VALUE_PROPERTY_SETVALUES);

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/credential_rotation.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/credential_rotation.js
@@ -13,7 +13,7 @@ const DeferredPromise = require('@fluid-experimental/property-common').DeferredP
  * @fileOverview
  * Manages temporary AWS access with credential rotation.
  * This class requires static initialization.
- * @see {@link CredentialRotation#init}
+ * See {@link CredentialRotation#init}
  */
 class CredentialRotation {
   /**

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/credential_rotation.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/credential_rotation.js
@@ -13,107 +13,107 @@ const DeferredPromise = require('@fluid-experimental/property-common').DeferredP
  * @fileOverview
  * Manages temporary AWS access with credential rotation.
  * This class requires static initialization.
- * See {@link CredentialRotation#init}
+ * @see {@link CredentialRotation#init}
  */
 class CredentialRotation {
-    /**
-     * Create a new temporary access class that handles credential rotation.
-     */
-    constructor() {
-        const ddbSettings = settings.get('store-dynamodb');
-        if (ddbSettings && ddbSettings.awsRole &&
-            ddbSettings.awsRole.arn && ddbSettings.awsRole.prefix
-        ) {
-            this._role = _.clone(ddbSettings.awsRole);
-            logger.info('Credentials will rotate using the configured AWS role');
-        }
-
-        this._onRotation = this._onRotation.bind(this);
+  /**
+   * Create a new temporary access class that handles credential rotation.
+   */
+  constructor() {
+    const ddbSettings = settings.get('store-dynamodb');
+    if (ddbSettings && ddbSettings.awsRole &&
+      ddbSettings.awsRole.arn && ddbSettings.awsRole.prefix
+    ) {
+      this._role = _.clone(ddbSettings.awsRole);
+      logger.info('Credentials will rotate using the configured AWS role');
     }
 
-    /**
-     * @return {DynamoDBClient} A DynamoDBClient to use to access DynamoDB. The returned instance is
-     *   periodically changed to rotate permission, so it should not be cached.
-     */
-    get ddbClient() {
-        return this._ddbClient;
+    this._onRotation = this._onRotation.bind(this);
+  }
+
+  /**
+   * @return {DynamoDBClient} A DynamoDBClient to use to access DynamoDB. The returned instance is
+   *   periodically changed to rotate permission, so it should not be cached.
+   */
+  get ddbClient() {
+    return this._ddbClient;
+  }
+
+  /**
+   * @return {boolean} Whether or not the {@link #ddbClient} property is ready for use.
+   */
+  get isStarted() {
+    return !!this._ddbClient;
+  }
+
+  /**
+   * Initializes the CredentialRotation instance with what it needs to create new DynamoDBClients
+   * every time the credentials get rotated.
+   * @param {object} awsConfig The AWS configuration.
+   * @param {object} storeConfig Additional non-AWS config.
+   */
+  init(awsConfig, storeConfig) {
+    this._awsConfig = _.clone(awsConfig);
+    this._config = _.clone(storeConfig);
+    this._credsRotation = require('../../../server/utils/creds_rotation');
+  }
+
+  /**
+   * Start the credential rotation task.
+   * @async
+   */
+  async start() {
+    if (this._role) {
+      this._initPromise = new DeferredPromise();
+      this._credsRotation.addRotation(this._role, this._onRotation);
+      await this._initPromise;
+    } else {
+      this._ddbClient = new DynamoDBClient(this._awsConfig, this._config);
+      await this._ddbClient.connect();
+      logger.info('Using static AWS config: credentials will not rotate.');
+    }
+  }
+
+  /**
+   * Stops the credential rotation task.
+   * @async
+   */
+  async stop() {
+    if (this._role) {
+      this._credsRotation.removeRotation(this._role, this._onRotation);
     }
 
-    /**
-     * @return {boolean} Whether or not the {@link #ddbClient} property is ready for use.
-     */
-    get isStarted() {
-        return !!this._ddbClient;
+    if (this._ddbClient) {
+      await this._ddbClient.disconnect();
+      delete this._ddbClient;
+    }
+  }
+
+  /**
+   * Callback that will be called when the credentials get rotated.
+   * @param {Error|null} error Error object.
+   * @param {object|null} creds Temporary AWS credentials.
+   * @async
+   */
+  async _onRotation(error, creds) {
+    if (error) {
+      this._initPromise.reject(error); // can fail only on start
+      return;
     }
 
-    /**
-     * Initializes the CredentialRotation instance with what it needs to create new DynamoDBClients
-     * every time the credentials get rotated.
-     * @param {object} awsConfig The AWS configuration.
-     * @param {object} storeConfig Additional non-AWS config.
-     */
-    init(awsConfig, storeConfig) {
-        this._awsConfig = _.clone(awsConfig);
-        this._config = _.clone(storeConfig);
-        this._credsRotation = require('../../../server/utils/creds_rotation');
+    try {
+      const ddbCreds = _stsCredentialsToDynamoDBCreds.call(this, creds);
+      const ddbClient = new DynamoDBClient(ddbCreds, this._config);
+      await ddbClient.connect();
+      this._ddbClient = ddbClient;
+      this._initPromise.resolve();
+      logger.info(`Successfully connected with renewed credentials using ${JSON.stringify(this._role)}. ` +
+        JSON.stringify(_.pick(ddbCreds, 'endpoint', 'region')));
+    } catch (connectError) {
+      logger.error(`Failed to connect with renewed credentials using ${JSON.stringify(this._role)}:`, connectError);
+      this._initPromise.reject(connectError); // can fail only on start
     }
-
-    /**
-     * Start the credential rotation task.
-     * @async
-     */
-    async start() {
-        if (this._role) {
-            this._initPromise = new DeferredPromise();
-            this._credsRotation.addRotation(this._role, this._onRotation);
-            await this._initPromise;
-        } else {
-            this._ddbClient = new DynamoDBClient(this._awsConfig, this._config);
-            await this._ddbClient.connect();
-            logger.info('Using static AWS config: credentials will not rotate.');
-        }
-    }
-
-    /**
-     * Stops the credential rotation task.
-     * @async
-     */
-    async stop() {
-        if (this._role) {
-            this._credsRotation.removeRotation(this._role, this._onRotation);
-        }
-
-        if (this._ddbClient) {
-            await this._ddbClient.disconnect();
-            delete this._ddbClient;
-        }
-    }
-
-    /**
-     * Callback that will be called when the credentials get rotated.
-     * @param {Error|null} error Error object.
-     * @param {object|null} creds Temporary AWS credentials.
-     * @async
-     */
-    async _onRotation(error, creds) {
-        if (error) {
-            this._initPromise.reject(error); // can fail only on start
-            return;
-        }
-
-        try {
-            const ddbCreds = _stsCredentialsToDynamoDBCreds.call(this, creds);
-            const ddbClient = new DynamoDBClient(ddbCreds, this._config);
-            await ddbClient.connect();
-            this._ddbClient = ddbClient;
-            this._initPromise.resolve();
-            logger.info(`Successfully connected with renewed credentials using ${JSON.stringify(this._role)}. ` +
-                JSON.stringify(_.pick(ddbCreds, 'endpoint', 'region')));
-        } catch (connectError) {
-            logger.error(`Failed to connect with renewed credentials using ${JSON.stringify(this._role)}:`, connectError);
-            this._initPromise.reject(connectError); // can fail only on start
-        }
-    }
+  }
 }
 
 /**
@@ -124,26 +124,26 @@ class CredentialRotation {
  * @this CredentialsRotation
  */
 function _stsCredentialsToDynamoDBCreds(stsCredentials) {
-    const ddbCredentials = {};
-    if (stsCredentials.AccessKeyId) {
-        ddbCredentials.accessKeyId = stsCredentials.AccessKeyId;
-    }
-    if (stsCredentials.SecretAccessKey) {
-        ddbCredentials.secretAccessKey = stsCredentials.SecretAccessKey;
-    }
-    if (stsCredentials.SessionToken) {
-        ddbCredentials.sessionToken = stsCredentials.SessionToken;
-    }
+  const ddbCredentials = {};
+  if (stsCredentials.AccessKeyId) {
+    ddbCredentials.accessKeyId = stsCredentials.AccessKeyId;
+  }
+  if (stsCredentials.SecretAccessKey) {
+    ddbCredentials.secretAccessKey = stsCredentials.SecretAccessKey;
+  }
+  if (stsCredentials.SessionToken) {
+    ddbCredentials.sessionToken = stsCredentials.SessionToken;
+  }
 
-    if (this._awsConfig.endpoint) {
-        ddbCredentials.endpoint = this._awsConfig.endpoint;
-    }
+  if (this._awsConfig.endpoint) {
+    ddbCredentials.endpoint = this._awsConfig.endpoint;
+  }
 
-    if (this._awsConfig.region) {
-        ddbCredentials.region = this._awsConfig.region;
-    }
+  if (this._awsConfig.region) {
+    ddbCredentials.region = this._awsConfig.region;
+  }
 
-    return ddbCredentials;
+  return ddbCredentials;
 }
 
 module.exports = new CredentialRotation();

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/credential_rotation.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/credential_rotation.js
@@ -13,107 +13,107 @@ const DeferredPromise = require('@fluid-experimental/property-common').DeferredP
  * @fileOverview
  * Manages temporary AWS access with credential rotation.
  * This class requires static initialization.
- * @see {@link CredentialRotation#init}
+ * See {@link CredentialRotation#init}
  */
 class CredentialRotation {
-  /**
-   * Create a new temporary access class that handles credential rotation.
-   */
-  constructor() {
-    const ddbSettings = settings.get('store-dynamodb');
-    if (ddbSettings && ddbSettings.awsRole &&
-      ddbSettings.awsRole.arn && ddbSettings.awsRole.prefix
-    ) {
-      this._role = _.clone(ddbSettings.awsRole);
-      logger.info('Credentials will rotate using the configured AWS role');
+    /**
+     * Create a new temporary access class that handles credential rotation.
+     */
+    constructor() {
+        const ddbSettings = settings.get('store-dynamodb');
+        if (ddbSettings && ddbSettings.awsRole &&
+            ddbSettings.awsRole.arn && ddbSettings.awsRole.prefix
+        ) {
+            this._role = _.clone(ddbSettings.awsRole);
+            logger.info('Credentials will rotate using the configured AWS role');
+        }
+
+        this._onRotation = this._onRotation.bind(this);
     }
 
-    this._onRotation = this._onRotation.bind(this);
-  }
-
-  /**
-   * @return {DynamoDBClient} A DynamoDBClient to use to access DynamoDB. The returned instance is
-   *   periodically changed to rotate permission, so it should not be cached.
-   */
-  get ddbClient() {
-    return this._ddbClient;
-  }
-
-  /**
-   * @return {boolean} Whether or not the {@link #ddbClient} property is ready for use.
-   */
-  get isStarted() {
-    return !!this._ddbClient;
-  }
-
-  /**
-   * Initializes the CredentialRotation instance with what it needs to create new DynamoDBClients
-   * every time the credentials get rotated.
-   * @param {object} awsConfig The AWS configuration.
-   * @param {object} storeConfig Additional non-AWS config.
-   */
-  init(awsConfig, storeConfig) {
-    this._awsConfig = _.clone(awsConfig);
-    this._config = _.clone(storeConfig);
-    this._credsRotation = require('../../../server/utils/creds_rotation');
-  }
-
-  /**
-   * Start the credential rotation task.
-   * @async
-   */
-  async start() {
-    if (this._role) {
-      this._initPromise = new DeferredPromise();
-      this._credsRotation.addRotation(this._role, this._onRotation);
-      await this._initPromise;
-    } else {
-      this._ddbClient = new DynamoDBClient(this._awsConfig, this._config);
-      await this._ddbClient.connect();
-      logger.info('Using static AWS config: credentials will not rotate.');
-    }
-  }
-
-  /**
-   * Stops the credential rotation task.
-   * @async
-   */
-  async stop() {
-    if (this._role) {
-      this._credsRotation.removeRotation(this._role, this._onRotation);
+    /**
+     * @return {DynamoDBClient} A DynamoDBClient to use to access DynamoDB. The returned instance is
+     *   periodically changed to rotate permission, so it should not be cached.
+     */
+    get ddbClient() {
+        return this._ddbClient;
     }
 
-    if (this._ddbClient) {
-      await this._ddbClient.disconnect();
-      delete this._ddbClient;
-    }
-  }
-
-  /**
-   * Callback that will be called when the credentials get rotated.
-   * @param {Error|null} error Error object.
-   * @param {object|null} creds Temporary AWS credentials.
-   * @async
-   */
-  async _onRotation(error, creds) {
-    if (error) {
-      this._initPromise.reject(error); // can fail only on start
-      return;
+    /**
+     * @return {boolean} Whether or not the {@link #ddbClient} property is ready for use.
+     */
+    get isStarted() {
+        return !!this._ddbClient;
     }
 
-    try {
-      const ddbCreds = _stsCredentialsToDynamoDBCreds.call(this, creds);
-      const ddbClient = new DynamoDBClient(ddbCreds, this._config);
-      await ddbClient.connect();
-      this._ddbClient = ddbClient;
-      this._initPromise.resolve();
-      logger.info(`Successfully connected with renewed credentials using ${JSON.stringify(this._role)}. ` +
-        JSON.stringify(_.pick(ddbCreds, 'endpoint', 'region')));
-    } catch (connectError) {
-      logger.error(`Failed to connect with renewed credentials using ${JSON.stringify(this._role)}:`, connectError);
-      this._initPromise.reject(connectError); // can fail only on start
+    /**
+     * Initializes the CredentialRotation instance with what it needs to create new DynamoDBClients
+     * every time the credentials get rotated.
+     * @param {object} awsConfig The AWS configuration.
+     * @param {object} storeConfig Additional non-AWS config.
+     */
+    init(awsConfig, storeConfig) {
+        this._awsConfig = _.clone(awsConfig);
+        this._config = _.clone(storeConfig);
+        this._credsRotation = require('../../../server/utils/creds_rotation');
     }
-  }
+
+    /**
+     * Start the credential rotation task.
+     * @async
+     */
+    async start() {
+        if (this._role) {
+            this._initPromise = new DeferredPromise();
+            this._credsRotation.addRotation(this._role, this._onRotation);
+            await this._initPromise;
+        } else {
+            this._ddbClient = new DynamoDBClient(this._awsConfig, this._config);
+            await this._ddbClient.connect();
+            logger.info('Using static AWS config: credentials will not rotate.');
+        }
+    }
+
+    /**
+     * Stops the credential rotation task.
+     * @async
+     */
+    async stop() {
+        if (this._role) {
+            this._credsRotation.removeRotation(this._role, this._onRotation);
+        }
+
+        if (this._ddbClient) {
+            await this._ddbClient.disconnect();
+            delete this._ddbClient;
+        }
+    }
+
+    /**
+     * Callback that will be called when the credentials get rotated.
+     * @param {Error|null} error Error object.
+     * @param {object|null} creds Temporary AWS credentials.
+     * @async
+     */
+    async _onRotation(error, creds) {
+        if (error) {
+            this._initPromise.reject(error); // can fail only on start
+            return;
+        }
+
+        try {
+            const ddbCreds = _stsCredentialsToDynamoDBCreds.call(this, creds);
+            const ddbClient = new DynamoDBClient(ddbCreds, this._config);
+            await ddbClient.connect();
+            this._ddbClient = ddbClient;
+            this._initPromise.resolve();
+            logger.info(`Successfully connected with renewed credentials using ${JSON.stringify(this._role)}. ` +
+                JSON.stringify(_.pick(ddbCreds, 'endpoint', 'region')));
+        } catch (connectError) {
+            logger.error(`Failed to connect with renewed credentials using ${JSON.stringify(this._role)}:`, connectError);
+            this._initPromise.reject(connectError); // can fail only on start
+        }
+    }
 }
 
 /**
@@ -124,26 +124,26 @@ class CredentialRotation {
  * @this CredentialsRotation
  */
 function _stsCredentialsToDynamoDBCreds(stsCredentials) {
-  const ddbCredentials = {};
-  if (stsCredentials.AccessKeyId) {
-    ddbCredentials.accessKeyId = stsCredentials.AccessKeyId;
-  }
-  if (stsCredentials.SecretAccessKey) {
-    ddbCredentials.secretAccessKey = stsCredentials.SecretAccessKey;
-  }
-  if (stsCredentials.SessionToken) {
-    ddbCredentials.sessionToken = stsCredentials.SessionToken;
-  }
+    const ddbCredentials = {};
+    if (stsCredentials.AccessKeyId) {
+        ddbCredentials.accessKeyId = stsCredentials.AccessKeyId;
+    }
+    if (stsCredentials.SecretAccessKey) {
+        ddbCredentials.secretAccessKey = stsCredentials.SecretAccessKey;
+    }
+    if (stsCredentials.SessionToken) {
+        ddbCredentials.sessionToken = stsCredentials.SessionToken;
+    }
 
-  if (this._awsConfig.endpoint) {
-    ddbCredentials.endpoint = this._awsConfig.endpoint;
-  }
+    if (this._awsConfig.endpoint) {
+        ddbCredentials.endpoint = this._awsConfig.endpoint;
+    }
 
-  if (this._awsConfig.region) {
-    ddbCredentials.region = this._awsConfig.region;
-  }
+    if (this._awsConfig.region) {
+        ddbCredentials.region = this._awsConfig.region;
+    }
 
-  return ddbCredentials;
+    return ddbCredentials;
 }
 
 module.exports = new CredentialRotation();

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_client.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_client.js
@@ -67,9 +67,10 @@ let WriteTransaction;
 class DynamoDBClient {
   /**
    * Instantiates the DynamoDB client, given an AWS configuration used to access DynamoDB.
+   * See {@link https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property}
+   *
    * @param {object} awsConfig The AWS configuration.
    * @param {object} storeConfig Additional non-AWS config.
-   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property
    */
   constructor(awsConfig, storeConfig) {
     if (!BatchWriter) {
@@ -280,7 +281,7 @@ class DynamoDBClient {
    *       id: '...'
    *     }]
    *   }
-   * @see {@link #putItem} for a description of the item parameters.
+   * See {@link DynamoDBClient.putItem} for a description of the item parameters.
    * @param {Array<object>} batchParams.tableName An array
    */
   async batchWriteItem(batchParams) {

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_client.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_client.js
@@ -29,27 +29,27 @@ const PluginManager = require('../../../plugins/PluginManager');
  * Expected statuses of live tables:
  */
 const LIVE_TABLE_STATUSES = {
-    ACTIVE: true,
-    UPDATING: true
+  ACTIVE: true,
+  UPDATING: true
 };
 
 /**
  * Operations that do not execute in constant time (generally O(n)).
  */
 const NON_CONST_TIME_OPERATIONS = {
-    'delete': true,
-    getSegmentHistoryLatest: true,
-    getCommitRange: true,
-    getCommitHistory: true,
-    getMergeInfo: true
+  'delete': true,
+  getSegmentHistoryLatest: true,
+  getCommitRange: true,
+  getCommitHistory: true,
+  getMergeInfo: true
 };
 
 /**
  * Whether the batched operations are read or write.
  */
 const BATCH_TYPE = {
-    READ: 0,  // batchGetItem
-    WRITE: 1  // batchWriteItem
+  READ: 0,  // batchGetItem
+  WRITE: 1  // batchWriteItem
 };
 
 // Don't require PagedQuery here to avoid circular dependency:
@@ -65,988 +65,988 @@ let WriteTransaction;
  * DynamoDB client.
  */
 class DynamoDBClient {
-    /**
-     * Instantiates the DynamoDB client, given an AWS configuration used to access DynamoDB.
-     * See {@link https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property}
-     * @param {object} awsConfig The AWS configuration.
-     * @param {object} storeConfig Additional non-AWS config.
-     */
-    constructor(awsConfig, storeConfig) {
-        if (!BatchWriter) {
-            BatchWriter = require(path.join(__dirname, 'batch_writer'));
-        }
-
-        if (!BatchReader) {
-            BatchReader = require(path.join(__dirname, 'batch_reader'));
-        }
-
-        if (!BufferedPagedQuery) {
-            BufferedPagedQuery = require(path.join(__dirname, 'buffered_paged_query'));
-        }
-
-        if (!PagedQuery) {
-            PagedQuery = require(path.join(__dirname, 'paged_query'));
-        }
-
-        if (!WriteTransaction) {
-            WriteTransaction = require(path.join(__dirname, 'write_transaction'));
-        }
-
-        const awsConfigCopy = _.clone(awsConfig);
-        const regEx = new RegExp('^https://', 'i');
-        const isHttps = _.isUndefined(awsConfigCopy.endpoint) || regEx.test(awsConfigCopy.endpoint);
-
-        const Agent = isHttps ? require('https').Agent : require('http').Agent;
-        this._agent = new Agent(storeConfig.httpAgent);
-        _.extend(awsConfigCopy, { httpOptions: { agent: this._agent } });
-        this._dynamodb = new AWS.DynamoDB(awsConfigCopy);
-        this._config = storeConfig;
-        this._paramFactory = new ParamFactory(storeConfig);
+  /**
+   * Instantiates the DynamoDB client, given an AWS configuration used to access DynamoDB.
+   * @param {object} awsConfig The AWS configuration.
+   * @param {object} storeConfig Additional non-AWS config.
+   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property
+   */
+  constructor(awsConfig, storeConfig) {
+    if (!BatchWriter) {
+      BatchWriter = require(path.join(__dirname, 'batch_writer'));
     }
 
-    /**
-     * @return {AWS.DynamoDB} The AWS DynamoDB client. This client should not be cached, because its
-     *   credentials expire after a while.
-     */
-    get awsClient() {
-        return this._dynamodb;
+    if (!BatchReader) {
+      BatchReader = require(path.join(__dirname, 'batch_reader'));
     }
 
-    /**
-     * @return {object} The DynamoDBStore configuration.
-     */
-    get config() {
-        return this._config;
+    if (!BufferedPagedQuery) {
+      BufferedPagedQuery = require(path.join(__dirname, 'buffered_paged_query'));
     }
 
-    /**
-     * @return {object} The free, inuse, and queued dynamodb connections in the pool.
-     */
-    get connectionPoolInfo() {
-        const getInfo = (data) => {
-            return _.mapValues(data, (d) => {
-                return d.length;
-            });
-        };
-
-        const agent = this._agent || {};
-        return {
-            max: agent.maxSockets || 0,
-            maxFree: agent.maxFreeSockets || 0,
-            free: getInfo(agent.freeSockets || {}),
-            inuse: getInfo(agent.sockets || {}),
-            queued: getInfo(agent.requests || {})
-        };
+    if (!PagedQuery) {
+      PagedQuery = require(path.join(__dirname, 'paged_query'));
     }
 
-    /**
-     * @return {DynamoDBParams} Exposes the class that allows fetching the parameters required to
-     *  make common DynamoDB calls using the AWS client.
-     */
-    get paramFactory() {
-        return this._paramFactory;
+    if (!WriteTransaction) {
+      WriteTransaction = require(path.join(__dirname, 'write_transaction'));
     }
 
-    /**
-     * Executes a DynamoDB API call, such as 'putItem', 'getItem', etc.
-     * Input and output are logged to the 'HFDM.PropertyGraphStore.DynamoDB' logger at trace level,
-     * tagged with an 'opId' attribute whose unique value matches inputs to their corresponding output.
-     * @param {string} fnName The DynamoDB API function name.
-     * @return {object} The DynamoDB API call result.
-     */
-    async _ddbApiCall(fnName) {
-        const args = Array.prototype.slice.call(arguments, 1);
-        let opId; // <-- Unique operation id, for tracing purposes
-        const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
+    const awsConfigCopy = _.clone(awsConfig);
+    const regEx = new RegExp('^https://', 'i');
+    const isHttps = _.isUndefined(awsConfigCopy.endpoint) || regEx.test(awsConfigCopy.endpoint);
 
-        if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
-            opId = newGuid();
-            let filteredLog = Logging.filterLogObject(args, Logging.filterKeys.input);
-            filteredLog.opId = opId;
-            logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbInStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`);  // eslint-disable-line
+    const Agent = isHttps ? require('https').Agent : require('http').Agent;
+    this._agent = new Agent(storeConfig.httpAgent);
+    _.extend(awsConfigCopy, {httpOptions: {agent: this._agent}});
+    this._dynamodb = new AWS.DynamoDB(awsConfigCopy);
+    this._config = storeConfig;
+    this._paramFactory = new ParamFactory(storeConfig);
+  }
+
+  /**
+   * @return {AWS.DynamoDB} The AWS DynamoDB client. This client should not be cached, because its
+   *   credentials expire after a while.
+   */
+  get awsClient() {
+    return this._dynamodb;
+  }
+
+  /**
+   * @return {object} The DynamoDBStore configuration.
+   */
+  get config() {
+    return this._config;
+  }
+
+  /**
+   * @return {object} The free, inuse, and queued dynamodb connections in the pool.
+   */
+  get connectionPoolInfo() {
+    const getInfo = (data) => {
+      return _.mapValues(data, (d) => {
+        return d.length;
+      });
+    };
+
+    const agent = this._agent || {};
+    return {
+      max: agent.maxSockets || 0,
+      maxFree: agent.maxFreeSockets || 0,
+      free: getInfo(agent.freeSockets || {}),
+      inuse: getInfo(agent.sockets || {}),
+      queued: getInfo(agent.requests || {})
+    };
+  }
+
+  /**
+   * @return {DynamoDBParams} Exposes the class that allows fetching the parameters required to
+   *  make common DynamoDB calls using the AWS client.
+   */
+  get paramFactory() {
+    return this._paramFactory;
+  }
+
+  /**
+   * Executes a DynamoDB API call, such as 'putItem', 'getItem', etc.
+   * Input and output are logged to the 'HFDM.PropertyGraphStore.DynamoDB' logger at trace level,
+   * tagged with an 'opId' attribute whose unique value matches inputs to their corresponding output.
+   * @param {string} fnName The DynamoDB API function name.
+   * @return {object} The DynamoDB API call result.
+   */
+  async _ddbApiCall(fnName) {
+    const args = Array.prototype.slice.call(arguments, 1);
+    let opId; // <-- Unique operation id, for tracing purposes
+    const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
+
+    if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
+      opId = newGuid();
+      let filteredLog = Logging.filterLogObject(args, Logging.filterKeys.input);
+      filteredLog.opId = opId;
+      logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbInStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`);  // eslint-disable-line
+    }
+
+    const timedResult = await _timedApiCall.call(this, tableName, fnName, args);
+
+    if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
+      let filteredLog = Logging.filterLogObject(timedResult.result, Logging.filterKeys.output);
+      filteredLog.opId = opId;
+      filteredLog.elapsedMilliSec = timedResult.elapsedMilliSec.toFixed(0);
+      logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbOutStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`); // eslint-disable-line
+    }
+
+    return timedResult.result;
+  }
+
+  /**
+   * Fetches multiple records in a single query, or in multiple queries if the request rate on the
+   * source table(s) is too high.
+   * @param {object} batchParams An object keyed by table name, whose value is an array of
+   *   partition key objects. For example, to get two rows from the 'branches' table: {
+   *     branches: [
+   *       { branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12' },
+   *       { branch: '73634787-5b0b-c503-df5d-6827803c97a3' }
+   *     ]
+   *   }
+   * @param {object} [options] Optional batch parameters.
+   * @param {object} [options.consistentRead=false] Whether or not to issue a consistent batch read
+   *   for all the tables.
+   * @param {boolean} [options.columns=undefined] A list of columns to get. Undefined to get all
+   *   columns.
+   * @return {object}  An object keyed by table name, whose value is an array of branch rows.
+   *   For example: {
+   *     branches: [{
+   *       branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12',
+   *       repository: '9f1d9b1b-d745-ee68-4b34-70de94993e63',
+   *       created: '2018-04-05T20:36:18.661Z',
+   *       meta: { ... },
+   *       ...
+   *     },
+   *     {
+   *       ...
+   *     }]
+   *   }
+   */
+  async batchGetItem(batchParams, options = { consistentRead: false }) {
+    options.consistentRead = _.isUndefined(options.consistentRead) ? false : options.consistentRead;
+
+    const ddbParams = {
+      RequestItems: {},
+      ReturnConsumedCapacity: this._config.returnConsumedCapacity
+    };
+    const rq = ddbParams.RequestItems;
+
+    _.mapValues(batchParams, (pks, tableName) => {
+      if (!rq[tableName]) {
+        rq[tableName] = { Keys: [], ConsistentRead: options.consistentRead };
+        if (options.columns) {
+          const vars = _createGetVars(options.columns);
+          rq[tableName].ProjectionExpression = vars.projectionExpression;
+          rq[tableName].ExpressionAttributeNames = vars.expressionAttributeNames;
         }
+      }
 
-        const timedResult = await _timedApiCall.call(this, tableName, fnName, args);
+      _.each(pks, pk => {
+        rq[tableName].Keys.push(AWS.DynamoDB.Converter.marshall(pk));
+      });
+    });
 
-        if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
-            let filteredLog = Logging.filterLogObject(timedResult.result, Logging.filterKeys.output);
-            filteredLog.opId = opId;
-            filteredLog.elapsedMilliSec = timedResult.elapsedMilliSec.toFixed(0);
-            logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbOutStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`); // eslint-disable-line
-        }
+    const rowsPerTable = {};
 
-        return timedResult.result;
-    }
-
-    /**
-     * Fetches multiple records in a single query, or in multiple queries if the request rate on the
-     * source table(s) is too high.
-     * @param {object} batchParams An object keyed by table name, whose value is an array of
-     *   partition key objects. For example, to get two rows from the 'branches' table: {
-     *     branches: [
-     *       { branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12' },
-     *       { branch: '73634787-5b0b-c503-df5d-6827803c97a3' }
-     *     ]
-     *   }
-     * @param {object} [options] Optional batch parameters.
-     * @param {object} [options.consistentRead=false] Whether or not to issue a consistent batch read
-     *   for all the tables.
-     * @param {boolean} [options.columns=undefined] A list of columns to get. Undefined to get all
-     *   columns.
-     * @return {object}  An object keyed by table name, whose value is an array of branch rows.
-     *   For example: {
-     *     branches: [{
-     *       branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12',
-     *       repository: '9f1d9b1b-d745-ee68-4b34-70de94993e63',
-     *       created: '2018-04-05T20:36:18.661Z',
-     *       meta: { ... },
-     *       ...
-     *     },
-     *     {
-     *       ...
-     *     }]
-     *   }
-     */
-    async batchGetItem(batchParams, options = { consistentRead: false }) {
-        options.consistentRead = _.isUndefined(options.consistentRead) ? false : options.consistentRead;
-
-        const ddbParams = {
-            RequestItems: {},
-            ReturnConsumedCapacity: this._config.returnConsumedCapacity
-        };
-        const rq = ddbParams.RequestItems;
-
-        _.mapValues(batchParams, (pks, tableName) => {
-            if (!rq[tableName]) {
-                rq[tableName] = { Keys: [], ConsistentRead: options.consistentRead };
-                if (options.columns) {
-                    const vars = _createGetVars(options.columns);
-                    rq[tableName].ProjectionExpression = vars.projectionExpression;
-                    rq[tableName].ExpressionAttributeNames = vars.expressionAttributeNames;
-                }
-            }
-
-            _.each(pks, pk => {
-                rq[tableName].Keys.push(AWS.DynamoDB.Converter.marshall(pk));
-            });
+    // A callback that fails if the batch returns a partial result set, to trigger a retry with
+    // backoff for the remaining items.
+    const taskCb = async retryCount => {
+      try {
+        const result = await this._ddbApiCall('batchGetItem', ddbParams);
+        _.mapValues(result.Responses, (marshalledRows, tableName) => {
+          rowsPerTable[tableName] = rowsPerTable[tableName] ? rowsPerTable[tableName] : [];
+          const unmarshalledRows = rowsPerTable[tableName];
+          _.each(marshalledRows, marshalledRow => {
+            unmarshalledRows.push(AWS.DynamoDB.Converter.unmarshall(marshalledRow));
+          });
         });
 
-        const rowsPerTable = {};
+        if (!_.isEmpty(result.UnprocessedKeys)) {
+          ddbParams.RequestItems = result.UnprocessedKeys;
+          throw DynamoDBException.getProvisionedThroughputExceededException(
+            'batchGetItem: missing results due to throttling');
+        }
+      } catch (error) {
+        await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.READ);
+      }
+    };
 
-        // A callback that fails if the batch returns a partial result set, to trigger a retry with
-        // backoff for the remaining items.
-        const taskCb = async retryCount => {
-            try {
-                const result = await this._ddbApiCall('batchGetItem', ddbParams);
-                _.mapValues(result.Responses, (marshalledRows, tableName) => {
-                    rowsPerTable[tableName] = rowsPerTable[tableName] ? rowsPerTable[tableName] : [];
-                    const unmarshalledRows = rowsPerTable[tableName];
-                    _.each(marshalledRows, marshalledRow => {
-                        unmarshalledRows.push(AWS.DynamoDB.Converter.unmarshall(marshalledRow));
-                    });
-                });
+    const fnName = 'batchGetItem';
+    const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
+    const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
+    await task.start();
+    return rowsPerTable;
+  }
 
-                if (!_.isEmpty(result.UnprocessedKeys)) {
-                    ddbParams.RequestItems = result.UnprocessedKeys;
-                    throw DynamoDBException.getProvisionedThroughputExceededException(
-                        'batchGetItem: missing results due to throttling');
-                }
-            } catch (error) {
-                await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.READ);
+  /**
+   * Insert or delete multiple items to multiple tables in a single DynamoDB call, or in multiple
+   * calls if the request rate on the target table(s) is too high.
+   * Existing items are overwritten. This method cannot be used to update existing items.
+   * @param {object} batchParams Maps table name to an array of params: {
+   *     songs:
+   *      operation: 'insert',
+   *      items: [{
+   *       album: '...',
+   *       artist: '...'
+   *     }],
+   *     stats:
+   *      operation: 'delete',
+   *      items: [{
+   *       id: '...'
+   *     }]
+   *   }
+   * @see {@link #putItem} for a description of the item parameters.
+   * @param {Array<object>} batchParams.tableName An array
+   */
+  async batchWriteItem(batchParams) {
+    const ddbParams = {
+      RequestItems: {},
+      ReturnConsumedCapacity: this._config.returnConsumedCapacity
+    };
+    const rq = ddbParams.RequestItems;
+
+    _.mapValues(batchParams, (tableParams, tableName) => {
+      if (!rq[tableName]) {
+        rq[tableName] = [];
+      }
+
+      if (tableParams.operation === 'delete') {
+        _.each(tableParams.items, params => {
+          rq[tableName].push({
+            DeleteRequest: {
+              Key: AWS.DynamoDB.Converter.marshall(params)
             }
-        };
-
-        const fnName = 'batchGetItem';
-        const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
-        const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
-        await task.start();
-        return rowsPerTable;
-    }
-
-    /**
-     * Insert or delete multiple items to multiple tables in a single DynamoDB call, or in multiple
-     * calls if the request rate on the target table(s) is too high.
-     * Existing items are overwritten. This method cannot be used to update existing items.
-     * @param {object} batchParams Maps table name to an array of params: {
-     *     songs:
-     *      operation: 'insert',
-     *      items: [{
-     *       album: '...',
-     *       artist: '...'
-     *     }],
-     *     stats:
-     *      operation: 'delete',
-     *      items: [{
-     *       id: '...'
-     *     }]
-     *   }
-     * See {@link DynamoDBClient.putItem} for a description of the item parameters.
-     * @param {Array<object>} batchParams.tableName An array
-     */
-    async batchWriteItem(batchParams) {
-        const ddbParams = {
-            RequestItems: {},
-            ReturnConsumedCapacity: this._config.returnConsumedCapacity
-        };
-        const rq = ddbParams.RequestItems;
-
-        _.mapValues(batchParams, (tableParams, tableName) => {
-            if (!rq[tableName]) {
-                rq[tableName] = [];
-            }
-
-            if (tableParams.operation === 'delete') {
-                _.each(tableParams.items, params => {
-                    rq[tableName].push({
-                        DeleteRequest: {
-                            Key: AWS.DynamoDB.Converter.marshall(params)
-                        }
-                    });
-                });
-            } else {
-                _.each(tableParams.items, params => {
-                    rq[tableName].push({
-                        PutRequest: {
-                            Item: AWS.DynamoDB.Converter.marshall(params)
-                        }
-                    });
-                });
-            }
+          });
         });
-
-        // A callback that fails if the batch returns a partial result set, to trigger a retry with
-        // backoff for the remaining items.
-        const taskCb = async retryCount => {
-            try {
-                const result = await this._ddbApiCall('batchWriteItem', ddbParams);
-                if (!_.isEmpty(result.UnprocessedItems)) {
-                    ddbParams.RequestItems = result.UnprocessedItems;
-                    throw DynamoDBException.getProvisionedThroughputExceededException(
-                        'batchWriteItem: some items were not persisted due to throttling');
-                }
-            } catch (error) {
-                await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.WRITE);
+      } else {
+        _.each(tableParams.items, params => {
+          rq[tableName].push({
+            PutRequest: {
+              Item: AWS.DynamoDB.Converter.marshall(params)
             }
-        };
-
-        const fnName = 'batchWriteItem';
-        const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
-        const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
-        await task.start();
-    }
-
-    /**
-     * There is no "connection" to DynamoDB. DB operations are stateless.
-     * Make sure DynamoDB is properly configured by checking for the existence of the 'business'
-     * table.
-     */
-    async connect() {
-        const tableName = Table.BUSINESS.name;
-        const params = {
-            TableName: tableName
-        };
-
-        const operation = 'describeTable';
-        let result;
-        try {
-            result = await this._ddbApiCall(operation, params);
-        } catch (error) {
-            logger.error(`Failed to describe table: ${tableName}: ${error.message ? error.message : error}`);
-            throw error;
-        }
-
-        const tableStatus = result.Table ? result.Table.TableStatus : undefined;
-        if (!LIVE_TABLE_STATUSES[tableStatus]) {
-            throw new OperationError(
-                `Table ${params.TableName} status '${tableStatus}' is not one of: ` +
-                JSON.stringify(_.keys(LIVE_TABLE_STATUSES)),
-                operation, HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    /**
-     * Disconnects from DynamoDB.
-     */
-    disconnect() {
-        // Intentionally empty
-    }
-
-    /**
-     * Construct a new BatchWriter.
-     * @param {string} tableName The DynamoDB table name against which to run the batch.
-     * @param {string} [operation] One of: 'insert', 'delete'. Defaults to 'insert'.
-     * @return {BatchWriter} A batch writer.
-     */
-    createBatchWriter(tableName, operation = 'insert') {
-        return new BatchWriter(tableName, this._config, operation);
-    }
-
-    /**
-     * An asynchronous callback that is called once for each row read from the db.
-     * If the rowHandler function throw, batch reader will stop reading and throw the error.
-     * @callback BatchReaderRowHandler
-     * @param {object} row A row that was read from the db.
-     */
-
-    /**
-     * Construct a new BatchReader.
-     * @param {string} tableName The DynamoDB table name against which to run the batch.
-     * @param {BatchReaderRowHandler} rowHandler A function that is called once for each row read by the BatchReader.
-     * @param {object} [options] Optional batch parameters.
-     * @param {object} [options.consistentRead] Whether or not to issue a consistent batch read
-     *   for all the tables.
-     * @return {BatchReader} A batch reader.
-     */
-    createBatchReader(tableName, rowHandler, options) {
-        return new BatchReader(tableName, rowHandler, this._config, options);
-    }
-
-    /**
-     * Creates a new table.
-     * @param {object} ddbParams The input parameters, in the same format as the table definitions in DynamoDBStoreSchema
-     * @param {string} ddbParams.TableName The name of the table to create
-     * @param {Array} ddbParams.AttributeDefinitions A list of each table column in the key or an index. Example:
-     *  [
-     *    {AttributeName: 'columnName', AttributeType: 'S'},
-     *    {AttributeName: 'columnName2', AttributeType: 'S'}
-     *  ]
-     * @param {Array} ddbParams.KeySchema A list of the attributes that comprise the primary key of the table. Example:
-     *  [
-     *    {AttributeName: 'id', KeyType: 'HASH'}
-     *  ]
-     * @param {object} ddbParams.ProvisionedThroughput The read and write capacity units of the table
-     * @param {number} ddbParams.ProvisionedThroughput.ReadCapacityUnits The read capacity of the table
-     * @param {number} ddbParams.ProvisionedThroughput.WriteCapacityUnits The write capacity of the table
-     * @param {Array} ddbParams.GlobalSecondaryIndexes A list of the global secondary indexes of the table. Example:
-     *  [
-     *    {
-     *      IndexNAme: 'indexName',
-     *      KeySchema: [{AttributeName: 'attr1', KeyType: 'HASH'}],
-     *      Projection: {ProjectionType: 'KEYS_ONLY'},
-     *      ProvisionedThroughput: {ReadCapacityUnits: 5, WriteCapacityUnits: 5}
-     *    }
-     *  ]
-     * @param {Array} ddbParams.LocalSecondaryIndexes A list of the local secondary index configurations of the table
-     */
-    async createTable(ddbParams) {
-        const params = ddbParams;
-        logger.info(`Creating table: ${ddbParams.TableName}`);
-        await this._ddbApiCall('createTable', params);
-    }
-
-    /**
-     * @return {WriteTransaction} A write transaction to accumulate calls to conditionally put,
-     *   update, and delete DynamoDB records, and execute them in a single transaction.
-     */
-    createWriteTransaction() {
-        return new WriteTransaction(this._paramFactory);
-    }
-
-    /**
-     * A function that throws an error if there is no results from a DynamoDB query, or optionally if
-     * the result is missing expected columns.
-     * @param {?string=} msg The optional error message to use if 'results' is empty or missing
-     *   columns.
-     * @param {Object} results The results of a DynamoDB query.
-     * @param {Array<string>} [columns=undefined] An optional array of column names that must be
-     *   present in the results.
-     */
-    expectResults(msg, results, columns) {
-        const failFn = () => {
-            // If the error bubbles up all the way up to a REST endpoint, it will return a 404:
-            throw new OperationError(msg, 'expectResults', HttpStatus.NOT_FOUND);
-        };
-
-        if (!results) {
-            failFn();
-        }
-
-        if (columns) {
-            _.each(columns, columnName => {
-                if (_.isUndefined(results[columnName])) {
-                    msg += `. Missing expected column: ${columnName}`;
-                    failFn();
-                }
-            });
-        }
-    }
-
-    /**
-     * Delete an item from a table
-     * @param {string} tableName Table name
-     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} [options] Delete options.
-     * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
-     */
-    async deleteItem(tableName, pk, options = { keyMustExist: true }) {
-        const ddbParams = this._paramFactory.createDeleteItem(tableName, pk, options);
-        const operation = 'deleteItem';
-
-        try {
-            await _retryableDdbApiCall.call(this, operation, ddbParams);
-        } catch (error) {
-            if (options.keyMustExist && error.code === 'ConditionalCheckFailedException') {
-                throw new OperationError(
-                    `Failed to delete ${JSON.stringify(pk)} from table ${tableName}: not found.`,
-                    operation, HttpStatus.NOT_FOUND
-                );
-            }
-
-            throw error;
-        }
-    }
-
-    /**
-     * Starts a table deletion.
-     * @param {string} tableName The table to delete.
-     */
-    async deleteTable(tableName) {
-        const params = { TableName: tableName };
-        await _retryableDdbApiCall.call(this, 'deleteTable', params);
-        logger.info(`Table deletion started: ${tableName}`);
-    }
-
-    /**
-     * Describe a table by name.
-     * @param {string} tableName Table name
-     * @return {object} The database table description
-     */
-    async describeTable(tableName) {
-        const params = {
-            TableName: tableName
-        };
-
-        const operation = 'describeTable';
-        const data = await _retryableDdbApiCall.call(this, operation, params);
-        if (!data || !data.Table) {
-            throw new OperationError(
-                'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
-                operation, HttpStatus.BAD_REQUEST
-            );
-        }
-
-        return data;
-    }
-
-    /**
-     * Fetches business related information, such as the db schema layout version.
-     * @param {string} fieldName The name of the db field to query. For example, use
-     *   'BusinessField.LAYOUT' to query the db layout version.
-     * @return {Promise} A Promise to be fulfilled with the requested field value if it exists.
-     *   The promise is rejected if the requested field is not found.
-     * @private
-     * @this DynamoDBClient
-     */
-    async getBusinessField(fieldName) {
-        const pk = { id: fieldName };
-        const options = { columns: ['value'] };
-        const result = await this.getItem(Table.BUSINESS.name, pk, options);
-        this.expectResults(`Business field not found: ${fieldName}`, result, options.columns);
-        return result.value;
-    }
-
-    /**
-     * Fetches a row from a DynamoDB table.
-     * @param {string} tableName The table name.
-     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} [options=undefined] Get options.
-     * @param {boolean} [options.consistentRead=false] Set to true to issue a consistent read. Set is
-     *   to false or leave undefined to issue an eventually consistent read.
-     * @param {Array<string>} [options.columns=undefined] An array of column names to get from
-     *   the row identified by 'pk'. When specified, only the requested columns are fetched from the
-     *   db. When left undefined, all the columns are fetched.
-     * @return {object|undefined} The requested item if found, or undefined otherwise.
-     */
-    async getItem(tableName, pk, options) {
-        if (options) {
-            options.consistentRead = !!options.consistentRead;
-        } else {
-            options = { consistentRead: false };
-        }
-
-        let ddbParams = {
-            Key: AWS.DynamoDB.Converter.marshall(pk),
-            TableName: tableName,
-            ConsistentRead: options.consistentRead,
-            ReturnConsumedCapacity: this._config.returnConsumedCapacity
-        };
-
-        if (options.columns && options.columns.length > 0) {
-            const vars = _createGetVars(options.columns);
-            ddbParams.ProjectionExpression = vars.projectionExpression;
-            ddbParams.ExpressionAttributeNames = vars.expressionAttributeNames;
-        }
-
-        let result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
-        if (!result.Item && !options.consistentRead) {
-            logger.info(`Retrying getItem ${JSON.stringify(pk)} on table ${tableName} with consistent read`);
-            ddbParams.ConsistentRead = true;
-            result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
-        }
-        return result.Item ? AWS.DynamoDB.Converter.unmarshall(result.Item) : undefined;
-    }
-
-    /**
-     * Queries the db to get the primary key of a table.
-     * @param {string} tableName Table name
-     * @return {Array<string>} An array of pk attribute names for the requested table.
-     */
-    async getPKColumns(tableName) {
-        const data = await this.describeTable(tableName);
-        return _.map(data.Table.KeySchema, attributeObj => attributeObj.AttributeName);
-    }
-
-    /**
-     * Fetches the table name from DynamoDB arguments.
-     * @param {string} fnName The DynamoDB API function name.
-     * @param {object} ddbParams DynamoDB parameters that contain the table name.
-     * @return {string|undefined} A table name extracted from DynamoDB arguments.
-     * @static
-     */
-    static getTableNameFromArgs(fnName, ddbParams) {
-        let tableName;
-
-        if (ddbParams) {
-            tableName = ddbParams.TableName;
-            if (!tableName) {
-                tableName = ddbParams.RequestItems && Object.keys(ddbParams.RequestItems)[0];
-            }
-        }
-
-        return tableName;
-    }
-
-    /**
-     * Persist a record to DynamoDB.
-     * @param {string} tableName The table name.
-     * @param {object} params A row to persist in the table. At a minimum, the row must contain
-     *   attributes matching the table's primary key.
-     * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
-     *   and an item with the same key already exists, the operation fails. Defaults to undefined,
-     *   which overwrites existing entries.
-     * @return {object} The DynamoDB 'putItem' result.
-     */
-    async putItem(tableName, params, protectedAttrs) {
-        const ddbParams = this._paramFactory.createPutItem(tableName, params, protectedAttrs);
-        return await _retryableDdbApiCall.call(this, 'putItem', ddbParams);
-    }
-
-    /**
-     * An asynchronous callback that is called once for each row paged from the db.
-     * The function must either return a promise or be declared with the `async` keyword.
-     * @callback rowCb
-     * @param {object} row A row from the db.
-     */
-
-    /**
-     * Query a series of DynamoDB records
-     * @param {string} tableName The table name.
-     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} params The query parameters.
-     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-     *   from the db.
-     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-     *   by 'pk'. Example: {
-     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-     *     variables: [
-     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-     *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
-     *     ]
-     *   }
-     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-     *   consistent reads.
-     * @return {PagedQuery} A PagedQuery instance to iterate over results.
-     */
-    query(tableName, pk, params) {
-        this.setQueryParams(tableName, pk, params);
-        return new PagedQuery(params);
-    }
-
-    /**
-     * Query a series of DynamoDB records and buffers the results. Buffering adds the ability to
-     * pause and resume paging, which the plain PagedQuery (returned by {@link #query}) cannot do.
-     * @param {string} tableName The table name.
-     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} params The query parameters.
-     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-     *   from the db.
-     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-     *   by 'pk'. Example: {
-     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-     *     variables: [
-     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-     *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
-     *     ]
-     *   }
-     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-     *   consistent reads.
-     * @return {PagedQuery} A PagedQuery instance to iterate over results.
-     */
-    bufferedQuery(tableName, pk, params) {
-        this.setQueryParams(tableName, pk, params);
-        return new BufferedPagedQuery(params);
-    }
-
-    /**
-     * Sets a business field by name.
-     * @param {string} fieldName The name of the business field to set.
-     * @param {string} value The field value to set.
-     */
-    async setBusinessField(fieldName, value) {
-        const params = {
-            id: fieldName,
-            value: value,
-            created: monotonicDate.now().toISOString()
-        };
-        await this.putItem(Table.BUSINESS.name, params);
-    }
-
-    /**
-     * Sets the params so it can be used in a PagedQuery or BufferedPagedQuery.
-     * @param {string} tableName The table name.
-     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} params The query parameters.
-     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-     *   from the db.
-     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-     *   by 'pk'. Example: {
-     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-     *     variables: [
-     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-     *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
-     *     ]
-     *   }
-     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-     *   consistent reads.
-     */
-    setQueryParams(tableName, pk, params) {
-        params.ddbParams = _.extend({
-            TableName: tableName,
-            ReturnConsumedCapacity: this._config.returnConsumedCapacity,
-            ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
-        }, params.ddbParams);
-
-        let conditionalExpressions = [];
-        let conditionValueMap = {};
-        let valueIndex = 0;
-
-        _.mapValues(pk, (value, key) => {
-            const valueVarName = `:v${valueIndex++}`;
-            conditionValueMap[valueVarName] = value;
-            conditionalExpressions.push(`${key} = ${valueVarName}`);
+          });
         });
+      }
+    });
 
-        if (params.condition) {
-            _.each(params.condition.variables, conditionVar => {
-                _.mapValues(conditionVar, (value, key) => {
-                    conditionValueMap[`:${key}`] = value;
-                });
-            });
-            conditionalExpressions.push(params.condition.expression);
+    // A callback that fails if the batch returns a partial result set, to trigger a retry with
+    // backoff for the remaining items.
+    const taskCb = async retryCount => {
+      try {
+        const result = await this._ddbApiCall('batchWriteItem', ddbParams);
+        if (!_.isEmpty(result.UnprocessedItems)) {
+          ddbParams.RequestItems = result.UnprocessedItems;
+          throw DynamoDBException.getProvisionedThroughputExceededException(
+            'batchWriteItem: some items were not persisted due to throttling');
         }
+      } catch (error) {
+        await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.WRITE);
+      }
+    };
 
-        params.ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
-        params.ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
+    const fnName = 'batchWriteItem';
+    const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
+    const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
+    await task.start();
+  }
+
+  /**
+   * There is no "connection" to DynamoDB. DB operations are stateless.
+   * Make sure DynamoDB is properly configured by checking for the existence of the 'business'
+   * table.
+   */
+  async connect() {
+    const tableName = Table.BUSINESS.name;
+    const params = {
+      TableName: tableName
+    };
+
+    const operation = 'describeTable';
+    let result;
+    try {
+      result = await this._ddbApiCall(operation, params);
+    } catch (error) {
+      logger.error(`Failed to describe table: ${tableName}: ${error.message ? error.message : error}`);
+      throw error;
     }
 
-    /**
-     * Sets the params so it can be used in a scan PagedQuery.
-     * @param {string} tableName The table name.
-     * @param {object} params The query parameters.
-     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-     *   from the db.
-     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-     *   consistent reads.
-     */
-    setScanParams(tableName, params) {
-        params.queryType = 'scan';
-        params.ddbParams = _.extend({
-            TableName: tableName,
-            ReturnConsumedCapacity: this._config.returnConsumedCapacity,
-            ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
-        }, params.ddbParams);
+    const tableStatus = result.Table ? result.Table.TableStatus : undefined;
+    if (!LIVE_TABLE_STATUSES[tableStatus]) {
+      throw new OperationError(
+        `Table ${params.TableName} status '${tableStatus}' is not one of: ` +
+          JSON.stringify(_.keys(LIVE_TABLE_STATUSES)),
+        operation, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Disconnects from DynamoDB.
+   */
+  disconnect() {
+    // Intentionally empty
+  }
+
+  /**
+   * Construct a new BatchWriter.
+   * @param {string} tableName The DynamoDB table name against which to run the batch.
+   * @param {string} [operation] One of: 'insert', 'delete'. Defaults to 'insert'.
+   * @return {BatchWriter} A batch writer.
+   */
+  createBatchWriter(tableName, operation = 'insert') {
+    return new BatchWriter(tableName, this._config, operation);
+  }
+
+  /**
+   * An asynchronous callback that is called once for each row read from the db.
+   * If the rowHandler function throw, batch reader will stop reading and throw the error.
+   * @callback BatchReaderRowHandler
+   * @param {object} row A row that was read from the db.
+   */
+
+  /**
+   * Construct a new BatchReader.
+   * @param {string} tableName The DynamoDB table name against which to run the batch.
+   * @param {BatchReaderRowHandler} rowHandler A function that is called once for each row read by the BatchReader.
+   * @param {object} [options] Optional batch parameters.
+   * @param {object} [options.consistentRead] Whether or not to issue a consistent batch read
+   *   for all the tables.
+   * @return {BatchReader} A batch reader.
+   */
+  createBatchReader(tableName, rowHandler, options) {
+    return new BatchReader(tableName, rowHandler, this._config, options);
+  }
+
+  /**
+   * Creates a new table.
+   * @param {object} ddbParams The input parameters, in the same format as the table definitions in DynamoDBStoreSchema
+   * @param {string} ddbParams.TableName The name of the table to create
+   * @param {Array} ddbParams.AttributeDefinitions A list of each table column in the key or an index. Example:
+   *  [
+   *    {AttributeName: 'columnName', AttributeType: 'S'},
+   *    {AttributeName: 'columnName2', AttributeType: 'S'}
+   *  ]
+   * @param {Array} ddbParams.KeySchema A list of the attributes that comprise the primary key of the table. Example:
+   *  [
+   *    {AttributeName: 'id', KeyType: 'HASH'}
+   *  ]
+   * @param {object} ddbParams.ProvisionedThroughput The read and write capacity units of the table
+   * @param {number} ddbParams.ProvisionedThroughput.ReadCapacityUnits The read capacity of the table
+   * @param {number} ddbParams.ProvisionedThroughput.WriteCapacityUnits The write capacity of the table
+   * @param {Array} ddbParams.GlobalSecondaryIndexes A list of the global secondary indexes of the table. Example:
+   *  [
+   *    {
+   *      IndexNAme: 'indexName',
+   *      KeySchema: [{AttributeName: 'attr1', KeyType: 'HASH'}],
+   *      Projection: {ProjectionType: 'KEYS_ONLY'},
+   *      ProvisionedThroughput: {ReadCapacityUnits: 5, WriteCapacityUnits: 5}
+   *    }
+   *  ]
+   * @param {Array} ddbParams.LocalSecondaryIndexes A list of the local secondary index configurations of the table
+   */
+  async createTable(ddbParams) {
+    const params = ddbParams;
+    logger.info(`Creating table: ${ddbParams.TableName}`);
+    await this._ddbApiCall('createTable', params);
+  }
+
+  /**
+   * @return {WriteTransaction} A write transaction to accumulate calls to conditionally put,
+   *   update, and delete DynamoDB records, and execute them in a single transaction.
+   */
+  createWriteTransaction() {
+    return new WriteTransaction(this._paramFactory);
+  }
+
+  /**
+   * A function that throws an error if there is no results from a DynamoDB query, or optionally if
+   * the result is missing expected columns.
+   * @param {?string=} msg The optional error message to use if 'results' is empty or missing
+   *   columns.
+   * @param {Object} results The results of a DynamoDB query.
+   * @param {Array<string>} [columns=undefined] An optional array of column names that must be
+   *   present in the results.
+   */
+  expectResults(msg, results, columns) {
+    const failFn = () => {
+      // If the error bubbles up all the way up to a REST endpoint, it will return a 404:
+      throw new OperationError(msg, 'expectResults', HttpStatus.NOT_FOUND);
+    };
+
+    if (!results) {
+      failFn();
     }
 
-    /**
-     * Executes a count query on a series of DynamoDB records
-     * @param {string} tableName The table name.
-     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} params The query parameters.
-     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-     *   by 'pk'. Example: {
-     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-     *     variables: [
-     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-     *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
-     *     ]
-     *   }
-     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-     * @return {integer} The count of results matching the key and optional condition in the table.
-     */
-    async count(tableName, pk, params) {
-        const ddbParams = _.extend({
-            TableName: tableName,
-            ReturnConsumedCapacity: this._config.returnConsumedCapacity,
-            Select: 'COUNT'
-        }, params.ddbParams);
-
-        let conditionalExpressions = [];
-        let conditionValueMap = {};
-        let valueIndex = 0;
-
-        _.mapValues(pk, (value, key) => {
-            const valueVarName = `:v${valueIndex++}`;
-            conditionValueMap[valueVarName] = value;
-            conditionalExpressions.push(`${key} = ${valueVarName}`);
-        });
-
-        if (params.condition) {
-            _.each(params.condition.variables, conditionVar => {
-                _.mapValues(conditionVar, (value, key) => {
-                    conditionValueMap[`:${key}`] = value;
-                });
-            });
-            conditionalExpressions.push(params.condition.expression);
+    if (columns) {
+      _.each(columns, columnName => {
+        if (_.isUndefined(results[columnName])) {
+          msg += `. Missing expected column: ${columnName}`;
+          failFn();
         }
-
-        ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
-        ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
-
-        const result = await this._ddbApiCall('query', ddbParams);
-        return result.Count;
+      });
     }
+  }
 
-    /**
-     * Test for the existence of a table. Does not check the table state.
-     * @param {string} tableName The table name.
-     * @return {boolean} True if the table exists in dynamodb, false otherwise.
-     */
-    async tableExists(tableName) {
-        try {
-            await this.describeTable(tableName);
-            return true;
-        } catch (error) {
-            if (error.code !== 'ResourceNotFoundException') {
-                throw error;
-            }
+  /**
+   * Delete an item from a table
+   * @param {string} tableName Table name
+   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} [options] Delete options.
+   * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
+   */
+  async deleteItem(tableName, pk, options = { keyMustExist: true }) {
+    const ddbParams = this._paramFactory.createDeleteItem(tableName, pk, options);
+    const operation = 'deleteItem';
 
-            return false;
-        }
-    }
-
-    /**
-     * Update a row in a DynamoDB table.
-     * @param {string} tableName The table name.
-     * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
-     *   composite (partition key and sort key).
-     * @param {object} [updates=undefined] A map of column names to their update value.
-     * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
-     *   Example: {
-     *     keyMustExist: true,
-     *     expression: 'sequence = :value',
-     *     variables: {
-     *       value: 3
-     *     }
-     *   }
-     * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
-     *   'pk' doesn't exist.
-     * @param {string} condition.expression A DynamoDB ConditionExpression string.
-     * @param {object} condition.variables A map of variable names to their value, that are in the
-     *   condition expression.
-     * @param {object} [removeArray=undefined] A list of attributes to remove.
-     * @return {object|undefined} A map of attribute names to their old value, before being updated.
-     *   Can be undefined when new values are being set (when no old value is replaced).
-     */
-    async updateItem(tableName, pk, updates, condition, removeArray) {
-        const ddbParams = this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray);
-        let result = await _retryableDdbApiCall.call(this, 'updateItem', ddbParams);
-        return result.Attributes ? AWS.DynamoDB.Converter.unmarshall(result.Attributes) : undefined;
-    }
-
-    /**
-     * Delete a Global Secondary Index.
-     * @param {string} tableName Table name
-     * @param {string} indexName Global Secondary Index name
-     * @param {object} ddbAttributeDefinitions DynamoDB attribute definitions
-     * @param {object} ddbIndexCreateParams DynamoDB GSI creation parameters
-     */
-    async createIndex(tableName, indexName, ddbAttributeDefinitions, ddbIndexCreateParams) {
-        const ddbParams = {
-            TableName: tableName,
-            AttributeDefinitions: ddbAttributeDefinitions,
-            GlobalSecondaryIndexUpdates: [{
-                Create: {
-                    IndexName: indexName
-                }
-            }]
-        };
-
-        _.defaults(ddbParams.GlobalSecondaryIndexUpdates[0].Create, ddbIndexCreateParams);
-
-        logger.info(`createIndex ${tableName}.${indexName}`);
-        await this._ddbApiCall('updateTable', ddbParams);
-    }
-
-    /**
-     * Delete a Global Secondary Index.
-     * @param {string} tableName Table name
-     * @param {string} indexName Global Secondary Index name
-     */
-    async deleteIndex(tableName, indexName) {
-        const ddbParams = {
-            TableName: tableName,
-            GlobalSecondaryIndexUpdates: [{
-                Delete: {
-                    IndexName: indexName
-                }
-            }]
-        };
-
-        logger.info(`Index deletion started: ${tableName}.${indexName}`);
-        await this._ddbApiCall('updateTable', ddbParams);
-    }
-
-    /**
-     * Scan all records of a DynamoDB table.
-     * @param {string} tableName The table name.
-     * @param {object} params The query parameters.
-     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-     *   from the db.
-     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-     *   consistent reads.
-     * @return {PagedQuery} A PagedQuery instance to iterate over results.
-     */
-    scan(tableName, params) {
-        this.setScanParams(tableName, params);
-        return new PagedQuery(params);
-    }
-
-    /**
-     * Wait for a table to reach a state that indicates it can be used, by polling for the table
-     * status every second.
-     * @param {string} tableName Table name.
-     * @param {string} indexName Global Secondary Index name
-     * @param {string} action Action to wait on. One of: ['delete', 'create'].
-     * @param {number} [maxWaitTimeMilliSec=Number.MAX_SAFE_INTEGER] How long to wait for the GSI
-     *   to be deleted or active.
-     */
-    async waitForIndex(tableName, indexName, action, maxWaitTimeMilliSec = Number.MAX_SAFE_INTEGER) {
-        const operation = 'describeTable';
-        let chrono = new Chronometer();
-        while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
-            const data = await this.describeTable(tableName);
-
-            if (action === 'delete') {
-                if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
-                    return;
-                }
-
-                const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
-                if (!gsiEntry) {
-                    return;
-                }
-            } else if (action === 'create') {
-                if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
-                    throw new OperationError(
-                        `waitForIndex: GSI not found ${tableName}.${indexName}`,
-                        operation, HttpStatus.NOT_FOUND
-                    );
-                }
-
-                const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
-                if (!gsiEntry || !gsiEntry.IndexStatus) {
-                    throw new OperationError(
-                        `waitForIndex: GSI not found ${tableName}.${indexName}`,
-                        operation, HttpStatus.NOT_FOUND
-                    );
-                }
-
-                if (gsiEntry.IndexStatus === 'DELETING') {
-                    throw new OperationError(
-                        `waitForIndex: GSI is being deleted ${tableName}.${indexName}`,
-                        operation, HttpStatus.GONE
-                    );
-                }
-
-                if (gsiEntry.IndexStatus === 'ACTIVE') {
-                    return;
-                }
-            } else {
-                throw new Error(`waitForIndex: Unexpected action: ${action}`);
-            }
-
-            await sleep(this._config.waitForTablePollTimeoutMS);
-        }
-
+    try {
+      await _retryableDdbApiCall.call(this, operation, ddbParams);
+    } catch (error) {
+      if (options.keyMustExist && error.code === 'ConditionalCheckFailedException') {
         throw new OperationError(
-            `Timeout waiting for index to be ${action === 'delete' ? 'deleted' : 'created'}: ` +
-            `${tableName}.${indexName} ` +
-            `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
-            operation, HttpStatus.SERVICE_UNAVAILABLE);
+          `Failed to delete ${JSON.stringify(pk)} from table ${tableName}: not found.`,
+          operation, HttpStatus.NOT_FOUND
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Starts a table deletion.
+   * @param {string} tableName The table to delete.
+   */
+  async deleteTable(tableName) {
+    const params = { TableName: tableName };
+    await _retryableDdbApiCall.call(this, 'deleteTable', params);
+    logger.info(`Table deletion started: ${tableName}`);
+  }
+
+  /**
+   * Describe a table by name.
+   * @param {string} tableName Table name
+   * @return {object} The database table description
+   */
+  async describeTable(tableName) {
+    const params = {
+      TableName: tableName
+    };
+
+    const operation = 'describeTable';
+    const data = await _retryableDdbApiCall.call(this, operation, params);
+    if (!data || !data.Table) {
+      throw new OperationError(
+        'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
+        operation, HttpStatus.BAD_REQUEST
+      );
     }
 
-    /**
-     * Wait for a table to reach a state that indicates it can be used, by polling for the table
-     * status every second.
-     * @param {string} tableName Table name.
-     * @param {number} maxWaitTimeMilliSec How long to wait for the table to become active. The call
-     *   will after that.
-     */
-    async waitForTable(tableName, maxWaitTimeMilliSec) {
-        const operation = 'describeTable';
-        let chrono = new Chronometer();
-        while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
-            try {
-                let data = await this.describeTable(tableName);
-                if (!data.Table.TableStatus) {
-                    throw new OperationError(
-                        'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
-                        operation, HttpStatus.BAD_REQUEST
-                    );
-                }
+    return data;
+  }
 
-                if (LIVE_TABLE_STATUSES[data.Table.TableStatus]) {
-                    return;
-                }
+  /**
+   * Fetches business related information, such as the db schema layout version.
+   * @param {string} fieldName The name of the db field to query. For example, use
+   *   'BusinessField.LAYOUT' to query the db layout version.
+   * @return {Promise} A Promise to be fulfilled with the requested field value if it exists.
+   *   The promise is rejected if the requested field is not found.
+   * @private
+   * @this DynamoDBClient
+   */
+  async getBusinessField(fieldName) {
+    const pk = { id: fieldName };
+    const options = { columns: ['value'] };
+    const result = await this.getItem(Table.BUSINESS.name, pk, options);
+    this.expectResults(`Business field not found: ${fieldName}`, result, options.columns);
+    return result.value;
+  }
 
-                if (data.Table.TableStatus === 'DELETING') {
-                    throw new OperationError(
-                        `waitForTable ${tableName}: table is being deleted`,
-                        operation, HttpStatus.GONE
-                    );
-                }
-            } catch (error) {
-                throw error;
-            }
+  /**
+   * Fetches a row from a DynamoDB table.
+   * @param {string} tableName The table name.
+   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} [options=undefined] Get options.
+   * @param {boolean} [options.consistentRead=false] Set to true to issue a consistent read. Set is
+   *   to false or leave undefined to issue an eventually consistent read.
+   * @param {Array<string>} [options.columns=undefined] An array of column names to get from
+   *   the row identified by 'pk'. When specified, only the requested columns are fetched from the
+   *   db. When left undefined, all the columns are fetched.
+   * @return {object|undefined} The requested item if found, or undefined otherwise.
+   */
+  async getItem(tableName, pk, options) {
+    if (options) {
+      options.consistentRead = !!options.consistentRead;
+    } else {
+      options = { consistentRead: false };
+    }
 
-            await sleep(this._config.waitForTablePollTimeoutMS);
+    let ddbParams = {
+      Key: AWS.DynamoDB.Converter.marshall(pk),
+      TableName: tableName,
+      ConsistentRead: options.consistentRead,
+      ReturnConsumedCapacity: this._config.returnConsumedCapacity
+    };
+
+    if (options.columns && options.columns.length > 0) {
+      const vars = _createGetVars(options.columns);
+      ddbParams.ProjectionExpression = vars.projectionExpression;
+      ddbParams.ExpressionAttributeNames = vars.expressionAttributeNames;
+    }
+
+    let result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
+    if (!result.Item && !options.consistentRead) {
+      logger.info(`Retrying getItem ${JSON.stringify(pk)} on table ${tableName} with consistent read`);
+      ddbParams.ConsistentRead = true;
+      result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
+    }
+    return result.Item ? AWS.DynamoDB.Converter.unmarshall(result.Item) : undefined;
+  }
+
+  /**
+   * Queries the db to get the primary key of a table.
+   * @param {string} tableName Table name
+   * @return {Array<string>} An array of pk attribute names for the requested table.
+   */
+  async getPKColumns(tableName) {
+    const data = await this.describeTable(tableName);
+    return _.map(data.Table.KeySchema, attributeObj => attributeObj.AttributeName);
+  }
+
+  /**
+   * Fetches the table name from DynamoDB arguments.
+   * @param {string} fnName The DynamoDB API function name.
+   * @param {object} ddbParams DynamoDB parameters that contain the table name.
+   * @return {string|undefined} A table name extracted from DynamoDB arguments.
+   * @static
+   */
+  static getTableNameFromArgs(fnName, ddbParams) {
+    let tableName;
+
+    if (ddbParams) {
+      tableName = ddbParams.TableName;
+      if (!tableName) {
+        tableName = ddbParams.RequestItems && Object.keys(ddbParams.RequestItems)[0];
+      }
+    }
+
+    return tableName;
+  }
+
+  /**
+   * Persist a record to DynamoDB.
+   * @param {string} tableName The table name.
+   * @param {object} params A row to persist in the table. At a minimum, the row must contain
+   *   attributes matching the table's primary key.
+   * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
+   *   and an item with the same key already exists, the operation fails. Defaults to undefined,
+   *   which overwrites existing entries.
+   * @return {object} The DynamoDB 'putItem' result.
+   */
+  async putItem(tableName, params, protectedAttrs) {
+    const ddbParams = this._paramFactory.createPutItem(tableName, params, protectedAttrs);
+    return await _retryableDdbApiCall.call(this, 'putItem', ddbParams);
+  }
+
+  /**
+   * An asynchronous callback that is called once for each row paged from the db.
+   * The function must either return a promise or be declared with the `async` keyword.
+   * @callback rowCb
+   * @param {object} row A row from the db.
+   */
+
+  /**
+   * Query a series of DynamoDB records
+   * @param {string} tableName The table name.
+   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} params The query parameters.
+   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+   *   from the db.
+   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+   *   by 'pk'. Example: {
+   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+   *     variables: [
+   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+   *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
+   *     ]
+   *   }
+   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+   *   consistent reads.
+   * @return {PagedQuery} A PagedQuery instance to iterate over results.
+   */
+  query(tableName, pk, params) {
+    this.setQueryParams(tableName, pk, params);
+    return new PagedQuery(params);
+  }
+
+  /**
+   * Query a series of DynamoDB records and buffers the results. Buffering adds the ability to
+   * pause and resume paging, which the plain PagedQuery (returned by {@link #query}) cannot do.
+   * @param {string} tableName The table name.
+   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} params The query parameters.
+   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+   *   from the db.
+   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+   *   by 'pk'. Example: {
+   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+   *     variables: [
+   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+   *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
+   *     ]
+   *   }
+   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+   *   consistent reads.
+   * @return {PagedQuery} A PagedQuery instance to iterate over results.
+   */
+  bufferedQuery(tableName, pk, params) {
+    this.setQueryParams(tableName, pk, params);
+    return new BufferedPagedQuery(params);
+  }
+
+  /**
+   * Sets a business field by name.
+   * @param {string} fieldName The name of the business field to set.
+   * @param {string} value The field value to set.
+   */
+  async setBusinessField(fieldName, value) {
+    const params = {
+      id: fieldName,
+      value: value,
+      created: monotonicDate.now().toISOString()
+    };
+    await this.putItem(Table.BUSINESS.name, params);
+  }
+
+  /**
+   * Sets the params so it can be used in a PagedQuery or BufferedPagedQuery.
+   * @param {string} tableName The table name.
+   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} params The query parameters.
+   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+   *   from the db.
+   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+   *   by 'pk'. Example: {
+   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+   *     variables: [
+   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+   *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
+   *     ]
+   *   }
+   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+   *   consistent reads.
+   */
+  setQueryParams(tableName, pk, params) {
+    params.ddbParams = _.extend({
+      TableName: tableName,
+      ReturnConsumedCapacity: this._config.returnConsumedCapacity,
+      ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
+    }, params.ddbParams);
+
+    let conditionalExpressions = [];
+    let conditionValueMap = {};
+    let valueIndex = 0;
+
+    _.mapValues(pk, (value, key) => {
+      const valueVarName = `:v${valueIndex++}`;
+      conditionValueMap[valueVarName] = value;
+      conditionalExpressions.push(`${key} = ${valueVarName}`);
+    });
+
+    if (params.condition) {
+      _.each(params.condition.variables, conditionVar => {
+        _.mapValues(conditionVar, (value, key) => {
+          conditionValueMap[`:${key}`] = value;
+        });
+      });
+      conditionalExpressions.push(params.condition.expression);
+    }
+
+    params.ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
+    params.ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
+  }
+
+  /**
+   * Sets the params so it can be used in a scan PagedQuery.
+   * @param {string} tableName The table name.
+   * @param {object} params The query parameters.
+   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+   *   from the db.
+   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+   *   consistent reads.
+   */
+  setScanParams(tableName, params) {
+    params.queryType = 'scan';
+    params.ddbParams = _.extend({
+      TableName: tableName,
+      ReturnConsumedCapacity: this._config.returnConsumedCapacity,
+      ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
+    }, params.ddbParams);
+  }
+
+  /**
+   * Executes a count query on a series of DynamoDB records
+   * @param {string} tableName The table name.
+   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} params The query parameters.
+   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+   *   by 'pk'. Example: {
+   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+   *     variables: [
+   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+   *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
+   *     ]
+   *   }
+   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+   * @return {integer} The count of results matching the key and optional condition in the table.
+   */
+  async count(tableName, pk, params) {
+    const ddbParams = _.extend({
+      TableName: tableName,
+      ReturnConsumedCapacity: this._config.returnConsumedCapacity,
+      Select: 'COUNT'
+    }, params.ddbParams);
+
+    let conditionalExpressions = [];
+    let conditionValueMap = {};
+    let valueIndex = 0;
+
+    _.mapValues(pk, (value, key) => {
+      const valueVarName = `:v${valueIndex++}`;
+      conditionValueMap[valueVarName] = value;
+      conditionalExpressions.push(`${key} = ${valueVarName}`);
+    });
+
+    if (params.condition) {
+      _.each(params.condition.variables, conditionVar => {
+        _.mapValues(conditionVar, (value, key) => {
+          conditionValueMap[`:${key}`] = value;
+        });
+      });
+      conditionalExpressions.push(params.condition.expression);
+    }
+
+    ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
+    ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
+
+    const result = await this._ddbApiCall('query', ddbParams);
+    return result.Count;
+  }
+
+  /**
+   * Test for the existence of a table. Does not check the table state.
+   * @param {string} tableName The table name.
+   * @return {boolean} True if the table exists in dynamodb, false otherwise.
+   */
+  async tableExists(tableName) {
+    try {
+      await this.describeTable(tableName);
+      return true;
+    } catch (error) {
+      if (error.code !== 'ResourceNotFoundException') {
+        throw error;
+      }
+
+      return false;
+    }
+  }
+
+  /**
+   * Update a row in a DynamoDB table.
+   * @param {string} tableName The table name.
+   * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
+   *   composite (partition key and sort key).
+   * @param {object} [updates=undefined] A map of column names to their update value.
+   * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
+   *   Example: {
+   *     keyMustExist: true,
+   *     expression: 'sequence = :value',
+   *     variables: {
+   *       value: 3
+   *     }
+   *   }
+   * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
+   *   'pk' doesn't exist.
+   * @param {string} condition.expression A DynamoDB ConditionExpression string.
+   * @param {object} condition.variables A map of variable names to their value, that are in the
+   *   condition expression.
+   * @param {object} [removeArray=undefined] A list of attributes to remove.
+   * @return {object|undefined} A map of attribute names to their old value, before being updated.
+   *   Can be undefined when new values are being set (when no old value is replaced).
+   */
+  async updateItem(tableName, pk, updates, condition, removeArray) {
+    const ddbParams = this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray);
+    let result = await _retryableDdbApiCall.call(this, 'updateItem', ddbParams);
+    return result.Attributes ? AWS.DynamoDB.Converter.unmarshall(result.Attributes) : undefined;
+  }
+
+  /**
+   * Delete a Global Secondary Index.
+   * @param {string} tableName Table name
+   * @param {string} indexName Global Secondary Index name
+   * @param {object} ddbAttributeDefinitions DynamoDB attribute definitions
+   * @param {object} ddbIndexCreateParams DynamoDB GSI creation parameters
+   */
+  async createIndex(tableName, indexName, ddbAttributeDefinitions, ddbIndexCreateParams) {
+    const ddbParams = {
+      TableName: tableName,
+      AttributeDefinitions: ddbAttributeDefinitions,
+      GlobalSecondaryIndexUpdates: [{
+        Create: {
+          IndexName: indexName
+        }
+      }]
+    };
+
+    _.defaults(ddbParams.GlobalSecondaryIndexUpdates[0].Create, ddbIndexCreateParams);
+
+    logger.info(`createIndex ${tableName}.${indexName}`);
+    await this._ddbApiCall('updateTable', ddbParams);
+  }
+
+  /**
+   * Delete a Global Secondary Index.
+   * @param {string} tableName Table name
+   * @param {string} indexName Global Secondary Index name
+   */
+  async deleteIndex(tableName, indexName) {
+    const ddbParams = {
+      TableName: tableName,
+      GlobalSecondaryIndexUpdates: [{
+        Delete: {
+          IndexName: indexName
+        }
+      }]
+    };
+
+    logger.info(`Index deletion started: ${tableName}.${indexName}`);
+    await this._ddbApiCall('updateTable', ddbParams);
+  }
+
+  /**
+   * Scan all records of a DynamoDB table.
+   * @param {string} tableName The table name.
+   * @param {object} params The query parameters.
+   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+   *   from the db.
+   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+   *   consistent reads.
+   * @return {PagedQuery} A PagedQuery instance to iterate over results.
+   */
+  scan(tableName, params) {
+    this.setScanParams(tableName, params);
+    return new PagedQuery(params);
+  }
+
+  /**
+   * Wait for a table to reach a state that indicates it can be used, by polling for the table
+   * status every second.
+   * @param {string} tableName Table name.
+   * @param {string} indexName Global Secondary Index name
+   * @param {string} action Action to wait on. One of: ['delete', 'create'].
+   * @param {number} [maxWaitTimeMilliSec=Number.MAX_SAFE_INTEGER] How long to wait for the GSI
+   *   to be deleted or active.
+   */
+  async waitForIndex(tableName, indexName, action, maxWaitTimeMilliSec = Number.MAX_SAFE_INTEGER) {
+    const operation = 'describeTable';
+    let chrono = new Chronometer();
+    while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
+      const data = await this.describeTable(tableName);
+
+      if (action === 'delete') {
+        if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
+          return;
         }
 
-        throw new OperationError(`Timeout waiting for table to become ready: ${tableName}. ` +
-            `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
-            operation, HttpStatus.SERVICE_UNAVAILABLE);
+        const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
+        if (!gsiEntry) {
+          return;
+        }
+      } else if (action === 'create') {
+        if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
+          throw new OperationError(
+            `waitForIndex: GSI not found ${tableName}.${indexName}`,
+            operation, HttpStatus.NOT_FOUND
+          );
+        }
+
+        const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
+        if (!gsiEntry || !gsiEntry.IndexStatus) {
+          throw new OperationError(
+            `waitForIndex: GSI not found ${tableName}.${indexName}`,
+            operation, HttpStatus.NOT_FOUND
+          );
+        }
+
+        if (gsiEntry.IndexStatus === 'DELETING') {
+          throw new OperationError(
+            `waitForIndex: GSI is being deleted ${tableName}.${indexName}`,
+            operation, HttpStatus.GONE
+          );
+        }
+
+        if (gsiEntry.IndexStatus === 'ACTIVE') {
+          return;
+        }
+      } else {
+        throw new Error(`waitForIndex: Unexpected action: ${action}`);
+      }
+
+      await sleep(this._config.waitForTablePollTimeoutMS);
     }
+
+    throw new OperationError(
+      `Timeout waiting for index to be ${action === 'delete' ? 'deleted' : 'created'}: ` +
+        `${tableName}.${indexName} ` +
+        `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
+      operation, HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  /**
+   * Wait for a table to reach a state that indicates it can be used, by polling for the table
+   * status every second.
+   * @param {string} tableName Table name.
+   * @param {number} maxWaitTimeMilliSec How long to wait for the table to become active. The call
+   *   will after that.
+   */
+  async waitForTable(tableName, maxWaitTimeMilliSec) {
+    const operation = 'describeTable';
+    let chrono = new Chronometer();
+    while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
+      try {
+        let data = await this.describeTable(tableName);
+        if (!data.Table.TableStatus) {
+          throw new OperationError(
+            'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
+            operation, HttpStatus.BAD_REQUEST
+          );
+        }
+
+        if (LIVE_TABLE_STATUSES[data.Table.TableStatus]) {
+          return;
+        }
+
+        if (data.Table.TableStatus === 'DELETING') {
+          throw new OperationError(
+            `waitForTable ${tableName}: table is being deleted`,
+            operation, HttpStatus.GONE
+          );
+        }
+      } catch (error) {
+        throw error;
+      }
+
+      await sleep(this._config.waitForTablePollTimeoutMS);
+    }
+
+    throw new OperationError(`Timeout waiting for table to become ready: ${tableName}. ` +
+      `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
+      operation, HttpStatus.SERVICE_UNAVAILABLE);
+  }
 }
 
 /**
@@ -1055,19 +1055,19 @@ class DynamoDBClient {
  * @return {object} The ProjectionExpression and ExpressionAttributeNames
  */
 function _createGetVars(columns) {
-    let projections = [];
-    let attributeNames = {};
+  let projections = [];
+  let attributeNames = {};
 
-    let index = 0;
-    _.each(columns, name => {
-        projections.push(`#p${index}`);
-        attributeNames[`#p${index++}`] = name;
-    });
+  let index = 0;
+  _.each(columns, name => {
+    projections.push(`#p${index}`);
+    attributeNames[`#p${index++}`] = name;
+  });
 
-    return {
-        projectionExpression: projections.join(', '),
-        expressionAttributeNames: attributeNames
-    };
+  return {
+    projectionExpression: projections.join(', '),
+    expressionAttributeNames: attributeNames
+  };
 }
 
 /**
@@ -1082,70 +1082,70 @@ function _createGetVars(columns) {
  * @this DynamoDBClient
  */
 async function _batchErrorHandler(error, ddbParams, batchType) {
-    try {
-        // See if the error is a duplicate key
-        if (DynamoDBException.isDuplicateKey(error)) {
-            // Find out which keys are dups:
-            const tableNames = Object.keys(ddbParams.RequestItems);
-            const dupItemsPerTable = {};
-            for (let tableName of tableNames) {
-                const tableKeys = batchType === BATCH_TYPE.READ ?
-                    ddbParams.RequestItems[tableName].Keys :
-                    ddbParams.RequestItems[tableName];
-                let pkColumns;
-                try {
-                    // Get the table's primary key attributes from the known Table instance if available.
-                    // If not, get the PKs by describing the table in DynamoDB
-                    const table = Table.fromName(tableName);
-                    pkColumns = table ? table.pkColumns : await this.getPKColumns(tableName);
+  try {
+    // See if the error is a duplicate key
+    if (DynamoDBException.isDuplicateKey(error)) {
+      // Find out which keys are dups:
+      const tableNames = Object.keys(ddbParams.RequestItems);
+      const dupItemsPerTable = {};
+      for (let tableName of tableNames) {
+        const tableKeys = batchType === BATCH_TYPE.READ ?
+          ddbParams.RequestItems[tableName].Keys :
+          ddbParams.RequestItems[tableName];
+        let pkColumns;
+        try {
+          // Get the table's primary key attributes from the known Table instance if available.
+          // If not, get the PKs by describing the table in DynamoDB
+          const table = Table.fromName(tableName);
+          pkColumns = table ? table.pkColumns : await this.getPKColumns(tableName);
 
-                    // Build sets of unique and duplicate keys
-                    const uniquePKs = new Set();
-                    const dupPKs = new Set();
+          // Build sets of unique and duplicate keys
+          const uniquePKs = new Set();
+          const dupPKs = new Set();
 
-                    // The item handler is invoked once per item in the batch:
-                    const itemHandler = marshalledItem => {
-                        const item = AWS.DynamoDB.Converter.unmarshall(marshalledItem);
-                        const pk = JSON.stringify(_.pick(item, pkColumns));  // Set will not compare correctly with objects
-                        if (uniquePKs.has(pk)) {
-                            dupPKs.add(pk);
-                        } else {
-                            uniquePKs.add(pk);
-                        }
-                    };
-
-                    // A generic get function that can get an item from a read or write batch:
-                    const getItem = batchType === BATCH_TYPE.READ ?
-                        tableKey => tableKey :
-                        tableKey => _.map(tableKey, putOrDelete => putOrDelete.Item)[0];
-
-                    // Enumerate all items in the batch, invoking the item handler for each one:
-                    for (let tableKey of tableKeys) {
-                        const marshalledItem = getItem(tableKey);
-                        itemHandler(marshalledItem);
-                    }
-
-                    if (dupPKs.size < 1) {
-                        // Should not happen:
-                        throw new Error('Failed to find duplicate keys in ddbParams');
-                    }
-
-                    dupItemsPerTable[tableName] = _.map([...dupPKs], dupPK => JSON.parse(dupPK));
-                } catch (e2) {
-                    // Unable to describe the table. Dump all keys without analyzing the duplicates:
-                    logger.warn(e2);
-                    error.message += `. ddbParams: ${JSON.stringify(ddbParams)}`;
-                    throw e2;
-                }
+          // The item handler is invoked once per item in the batch:
+          const itemHandler = marshalledItem => {
+            const item = AWS.DynamoDB.Converter.unmarshall(marshalledItem);
+            const pk = JSON.stringify(_.pick(item, pkColumns));  // Set will not compare correctly with objects
+            if (uniquePKs.has(pk)) {
+              dupPKs.add(pk);
+            } else {
+              uniquePKs.add(pk);
             }
+          };
 
-            // Append to message: 'Provided list of item keys contains duplicates':
-            error.message += `: ${JSON.stringify(dupItemsPerTable)}`;
+          // A generic get function that can get an item from a read or write batch:
+          const getItem = batchType === BATCH_TYPE.READ ?
+            tableKey => tableKey :
+            tableKey => _.map(tableKey, putOrDelete => putOrDelete.Item)[0];
+
+          // Enumerate all items in the batch, invoking the item handler for each one:
+          for (let tableKey of tableKeys) {
+            const marshalledItem = getItem(tableKey);
+            itemHandler(marshalledItem);
+          }
+
+          if (dupPKs.size < 1) {
+            // Should not happen:
+            throw new Error('Failed to find duplicate keys in ddbParams');
+          }
+
+          dupItemsPerTable[tableName] = _.map([...dupPKs], dupPK => JSON.parse(dupPK));
+        } catch (e2) {
+          // Unable to describe the table. Dump all keys without analyzing the duplicates:
+          logger.warn(e2);
+          error.message += `. ddbParams: ${JSON.stringify(ddbParams)}`;
+          throw e2;
         }
-    } finally {
-        // Make sure the original error is rethrown no matter what:
-        throw error;
+      }
+
+      // Append to message: 'Provided list of item keys contains duplicates':
+      error.message += `: ${JSON.stringify(dupItemsPerTable)}`;
     }
+  } finally {
+    // Make sure the original error is rethrown no matter what:
+    throw error;
+  }
 }
 
 /**
@@ -1158,10 +1158,10 @@ async function _batchErrorHandler(error, ddbParams, batchType) {
  * @this DynamoDBClient
  */
 async function _retryableDdbApiCall(fnName) {
-    const taskCb = retryCount => (this._ddbApiCall.apply(this, arguments));
-    const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
-    const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
-    return await task.start();
+  const taskCb = retryCount => (this._ddbApiCall.apply(this, arguments));
+  const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
+  const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
+  return await task.start();
 }
 
 
@@ -1176,40 +1176,40 @@ async function _retryableDdbApiCall(fnName) {
  * }
  */
 async function _timedApiCall(tableName, fnName, args) {
-    let result;
-    let elapsedMilliSec;
+  let result;
+  let elapsedMilliSec;
 
-    const segmentName = `ddb:${fnName}${tableName ? ':' + tableName : ''}`;
-    await PluginManager.instance.systemMonitor.startSegment(segmentName, true, async () => {
-        const chrono = new Chronometer();
+  const segmentName = `ddb:${fnName}${tableName ? ':' + tableName : ''}`;
+  await PluginManager.instance.systemMonitor.startSegment(segmentName, true, async () => {
+    const chrono = new Chronometer();
 
-        try {
-            result = await this._dynamodb[fnName].apply(this._dynamodb, args).promise();
-        } finally {
-            elapsedMilliSec = chrono.stop().elapsedMilliSec();
+    try {
+      result = await this._dynamodb[fnName].apply(this._dynamodb, args).promise();
+    } finally {
+      elapsedMilliSec = chrono.stop().elapsedMilliSec();
 
-            if (elapsedMilliSec >= this._config.elapsedWarningThresholdMilliSec) {
-                const logFn = NON_CONST_TIME_OPERATIONS[fnName] ?
-                    logger.debug.bind(logger) : logger.warn.bind(logger);
-                const requestId = result && result['$response'] ? result['$response'].requestId : undefined;
-                if (requestId) {
-                    const diags = {
-                        operation: fnName,
-                        elapsedMilliSec: elapsedMilliSec.toFixed(0),
-                        requestId: requestId
-                    };
+      if (elapsedMilliSec >= this._config.elapsedWarningThresholdMilliSec ) {
+        const logFn = NON_CONST_TIME_OPERATIONS[fnName] ?
+          logger.debug.bind(logger) : logger.warn.bind(logger);
+        const requestId = result && result['$response'] ? result['$response'].requestId : undefined;
+        if (requestId) {
+          const diags = {
+            operation: fnName,
+            elapsedMilliSec: elapsedMilliSec.toFixed(0),
+            requestId: requestId
+          };
 
-                    if (tableName) {
-                        diags.table = tableName;
-                    }
+          if (tableName) {
+            diags.table = tableName;
+          }
 
-                    logFn('Time limit exceeded: ' + JSON.stringify(diags));
-                }
-            }
+          logFn('Time limit exceeded: ' + JSON.stringify(diags));
         }
-    });
+      }
+    }
+  });
 
-    return { result, elapsedMilliSec };
+  return { result, elapsedMilliSec };
 }
 
 module.exports = DynamoDBClient;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_client.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_client.js
@@ -29,27 +29,27 @@ const PluginManager = require('../../../plugins/PluginManager');
  * Expected statuses of live tables:
  */
 const LIVE_TABLE_STATUSES = {
-  ACTIVE: true,
-  UPDATING: true
+    ACTIVE: true,
+    UPDATING: true
 };
 
 /**
  * Operations that do not execute in constant time (generally O(n)).
  */
 const NON_CONST_TIME_OPERATIONS = {
-  'delete': true,
-  getSegmentHistoryLatest: true,
-  getCommitRange: true,
-  getCommitHistory: true,
-  getMergeInfo: true
+    'delete': true,
+    getSegmentHistoryLatest: true,
+    getCommitRange: true,
+    getCommitHistory: true,
+    getMergeInfo: true
 };
 
 /**
  * Whether the batched operations are read or write.
  */
 const BATCH_TYPE = {
-  READ: 0,  // batchGetItem
-  WRITE: 1  // batchWriteItem
+    READ: 0,  // batchGetItem
+    WRITE: 1  // batchWriteItem
 };
 
 // Don't require PagedQuery here to avoid circular dependency:
@@ -65,988 +65,988 @@ let WriteTransaction;
  * DynamoDB client.
  */
 class DynamoDBClient {
-  /**
-   * Instantiates the DynamoDB client, given an AWS configuration used to access DynamoDB.
-   * @param {object} awsConfig The AWS configuration.
-   * @param {object} storeConfig Additional non-AWS config.
-   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property
-   */
-  constructor(awsConfig, storeConfig) {
-    if (!BatchWriter) {
-      BatchWriter = require(path.join(__dirname, 'batch_writer'));
-    }
-
-    if (!BatchReader) {
-      BatchReader = require(path.join(__dirname, 'batch_reader'));
-    }
-
-    if (!BufferedPagedQuery) {
-      BufferedPagedQuery = require(path.join(__dirname, 'buffered_paged_query'));
-    }
-
-    if (!PagedQuery) {
-      PagedQuery = require(path.join(__dirname, 'paged_query'));
-    }
-
-    if (!WriteTransaction) {
-      WriteTransaction = require(path.join(__dirname, 'write_transaction'));
-    }
-
-    const awsConfigCopy = _.clone(awsConfig);
-    const regEx = new RegExp('^https://', 'i');
-    const isHttps = _.isUndefined(awsConfigCopy.endpoint) || regEx.test(awsConfigCopy.endpoint);
-
-    const Agent = isHttps ? require('https').Agent : require('http').Agent;
-    this._agent = new Agent(storeConfig.httpAgent);
-    _.extend(awsConfigCopy, {httpOptions: {agent: this._agent}});
-    this._dynamodb = new AWS.DynamoDB(awsConfigCopy);
-    this._config = storeConfig;
-    this._paramFactory = new ParamFactory(storeConfig);
-  }
-
-  /**
-   * @return {AWS.DynamoDB} The AWS DynamoDB client. This client should not be cached, because its
-   *   credentials expire after a while.
-   */
-  get awsClient() {
-    return this._dynamodb;
-  }
-
-  /**
-   * @return {object} The DynamoDBStore configuration.
-   */
-  get config() {
-    return this._config;
-  }
-
-  /**
-   * @return {object} The free, inuse, and queued dynamodb connections in the pool.
-   */
-  get connectionPoolInfo() {
-    const getInfo = (data) => {
-      return _.mapValues(data, (d) => {
-        return d.length;
-      });
-    };
-
-    const agent = this._agent || {};
-    return {
-      max: agent.maxSockets || 0,
-      maxFree: agent.maxFreeSockets || 0,
-      free: getInfo(agent.freeSockets || {}),
-      inuse: getInfo(agent.sockets || {}),
-      queued: getInfo(agent.requests || {})
-    };
-  }
-
-  /**
-   * @return {DynamoDBParams} Exposes the class that allows fetching the parameters required to
-   *  make common DynamoDB calls using the AWS client.
-   */
-  get paramFactory() {
-    return this._paramFactory;
-  }
-
-  /**
-   * Executes a DynamoDB API call, such as 'putItem', 'getItem', etc.
-   * Input and output are logged to the 'HFDM.PropertyGraphStore.DynamoDB' logger at trace level,
-   * tagged with an 'opId' attribute whose unique value matches inputs to their corresponding output.
-   * @param {string} fnName The DynamoDB API function name.
-   * @return {object} The DynamoDB API call result.
-   */
-  async _ddbApiCall(fnName) {
-    const args = Array.prototype.slice.call(arguments, 1);
-    let opId; // <-- Unique operation id, for tracing purposes
-    const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
-
-    if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
-      opId = newGuid();
-      let filteredLog = Logging.filterLogObject(args, Logging.filterKeys.input);
-      filteredLog.opId = opId;
-      logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbInStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`);  // eslint-disable-line
-    }
-
-    const timedResult = await _timedApiCall.call(this, tableName, fnName, args);
-
-    if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
-      let filteredLog = Logging.filterLogObject(timedResult.result, Logging.filterKeys.output);
-      filteredLog.opId = opId;
-      filteredLog.elapsedMilliSec = timedResult.elapsedMilliSec.toFixed(0);
-      logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbOutStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`); // eslint-disable-line
-    }
-
-    return timedResult.result;
-  }
-
-  /**
-   * Fetches multiple records in a single query, or in multiple queries if the request rate on the
-   * source table(s) is too high.
-   * @param {object} batchParams An object keyed by table name, whose value is an array of
-   *   partition key objects. For example, to get two rows from the 'branches' table: {
-   *     branches: [
-   *       { branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12' },
-   *       { branch: '73634787-5b0b-c503-df5d-6827803c97a3' }
-   *     ]
-   *   }
-   * @param {object} [options] Optional batch parameters.
-   * @param {object} [options.consistentRead=false] Whether or not to issue a consistent batch read
-   *   for all the tables.
-   * @param {boolean} [options.columns=undefined] A list of columns to get. Undefined to get all
-   *   columns.
-   * @return {object}  An object keyed by table name, whose value is an array of branch rows.
-   *   For example: {
-   *     branches: [{
-   *       branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12',
-   *       repository: '9f1d9b1b-d745-ee68-4b34-70de94993e63',
-   *       created: '2018-04-05T20:36:18.661Z',
-   *       meta: { ... },
-   *       ...
-   *     },
-   *     {
-   *       ...
-   *     }]
-   *   }
-   */
-  async batchGetItem(batchParams, options = { consistentRead: false }) {
-    options.consistentRead = _.isUndefined(options.consistentRead) ? false : options.consistentRead;
-
-    const ddbParams = {
-      RequestItems: {},
-      ReturnConsumedCapacity: this._config.returnConsumedCapacity
-    };
-    const rq = ddbParams.RequestItems;
-
-    _.mapValues(batchParams, (pks, tableName) => {
-      if (!rq[tableName]) {
-        rq[tableName] = { Keys: [], ConsistentRead: options.consistentRead };
-        if (options.columns) {
-          const vars = _createGetVars(options.columns);
-          rq[tableName].ProjectionExpression = vars.projectionExpression;
-          rq[tableName].ExpressionAttributeNames = vars.expressionAttributeNames;
+    /**
+     * Instantiates the DynamoDB client, given an AWS configuration used to access DynamoDB.
+     * See {@link https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property}
+     * @param {object} awsConfig The AWS configuration.
+     * @param {object} storeConfig Additional non-AWS config.
+     */
+    constructor(awsConfig, storeConfig) {
+        if (!BatchWriter) {
+            BatchWriter = require(path.join(__dirname, 'batch_writer'));
         }
-      }
 
-      _.each(pks, pk => {
-        rq[tableName].Keys.push(AWS.DynamoDB.Converter.marshall(pk));
-      });
-    });
-
-    const rowsPerTable = {};
-
-    // A callback that fails if the batch returns a partial result set, to trigger a retry with
-    // backoff for the remaining items.
-    const taskCb = async retryCount => {
-      try {
-        const result = await this._ddbApiCall('batchGetItem', ddbParams);
-        _.mapValues(result.Responses, (marshalledRows, tableName) => {
-          rowsPerTable[tableName] = rowsPerTable[tableName] ? rowsPerTable[tableName] : [];
-          const unmarshalledRows = rowsPerTable[tableName];
-          _.each(marshalledRows, marshalledRow => {
-            unmarshalledRows.push(AWS.DynamoDB.Converter.unmarshall(marshalledRow));
-          });
-        });
-
-        if (!_.isEmpty(result.UnprocessedKeys)) {
-          ddbParams.RequestItems = result.UnprocessedKeys;
-          throw DynamoDBException.getProvisionedThroughputExceededException(
-            'batchGetItem: missing results due to throttling');
+        if (!BatchReader) {
+            BatchReader = require(path.join(__dirname, 'batch_reader'));
         }
-      } catch (error) {
-        await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.READ);
-      }
-    };
 
-    const fnName = 'batchGetItem';
-    const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
-    const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
-    await task.start();
-    return rowsPerTable;
-  }
+        if (!BufferedPagedQuery) {
+            BufferedPagedQuery = require(path.join(__dirname, 'buffered_paged_query'));
+        }
 
-  /**
-   * Insert or delete multiple items to multiple tables in a single DynamoDB call, or in multiple
-   * calls if the request rate on the target table(s) is too high.
-   * Existing items are overwritten. This method cannot be used to update existing items.
-   * @param {object} batchParams Maps table name to an array of params: {
-   *     songs:
-   *      operation: 'insert',
-   *      items: [{
-   *       album: '...',
-   *       artist: '...'
-   *     }],
-   *     stats:
-   *      operation: 'delete',
-   *      items: [{
-   *       id: '...'
-   *     }]
-   *   }
-   * @see {@link #putItem} for a description of the item parameters.
-   * @param {Array<object>} batchParams.tableName An array
-   */
-  async batchWriteItem(batchParams) {
-    const ddbParams = {
-      RequestItems: {},
-      ReturnConsumedCapacity: this._config.returnConsumedCapacity
-    };
-    const rq = ddbParams.RequestItems;
+        if (!PagedQuery) {
+            PagedQuery = require(path.join(__dirname, 'paged_query'));
+        }
 
-    _.mapValues(batchParams, (tableParams, tableName) => {
-      if (!rq[tableName]) {
-        rq[tableName] = [];
-      }
+        if (!WriteTransaction) {
+            WriteTransaction = require(path.join(__dirname, 'write_transaction'));
+        }
 
-      if (tableParams.operation === 'delete') {
-        _.each(tableParams.items, params => {
-          rq[tableName].push({
-            DeleteRequest: {
-              Key: AWS.DynamoDB.Converter.marshall(params)
+        const awsConfigCopy = _.clone(awsConfig);
+        const regEx = new RegExp('^https://', 'i');
+        const isHttps = _.isUndefined(awsConfigCopy.endpoint) || regEx.test(awsConfigCopy.endpoint);
+
+        const Agent = isHttps ? require('https').Agent : require('http').Agent;
+        this._agent = new Agent(storeConfig.httpAgent);
+        _.extend(awsConfigCopy, { httpOptions: { agent: this._agent } });
+        this._dynamodb = new AWS.DynamoDB(awsConfigCopy);
+        this._config = storeConfig;
+        this._paramFactory = new ParamFactory(storeConfig);
+    }
+
+    /**
+     * @return {AWS.DynamoDB} The AWS DynamoDB client. This client should not be cached, because its
+     *   credentials expire after a while.
+     */
+    get awsClient() {
+        return this._dynamodb;
+    }
+
+    /**
+     * @return {object} The DynamoDBStore configuration.
+     */
+    get config() {
+        return this._config;
+    }
+
+    /**
+     * @return {object} The free, inuse, and queued dynamodb connections in the pool.
+     */
+    get connectionPoolInfo() {
+        const getInfo = (data) => {
+            return _.mapValues(data, (d) => {
+                return d.length;
+            });
+        };
+
+        const agent = this._agent || {};
+        return {
+            max: agent.maxSockets || 0,
+            maxFree: agent.maxFreeSockets || 0,
+            free: getInfo(agent.freeSockets || {}),
+            inuse: getInfo(agent.sockets || {}),
+            queued: getInfo(agent.requests || {})
+        };
+    }
+
+    /**
+     * @return {DynamoDBParams} Exposes the class that allows fetching the parameters required to
+     *  make common DynamoDB calls using the AWS client.
+     */
+    get paramFactory() {
+        return this._paramFactory;
+    }
+
+    /**
+     * Executes a DynamoDB API call, such as 'putItem', 'getItem', etc.
+     * Input and output are logged to the 'HFDM.PropertyGraphStore.DynamoDB' logger at trace level,
+     * tagged with an 'opId' attribute whose unique value matches inputs to their corresponding output.
+     * @param {string} fnName The DynamoDB API function name.
+     * @return {object} The DynamoDB API call result.
+     */
+    async _ddbApiCall(fnName) {
+        const args = Array.prototype.slice.call(arguments, 1);
+        let opId; // <-- Unique operation id, for tracing purposes
+        const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
+
+        if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
+            opId = newGuid();
+            let filteredLog = Logging.filterLogObject(args, Logging.filterKeys.input);
+            filteredLog.opId = opId;
+            logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbInStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`);  // eslint-disable-line
+        }
+
+        const timedResult = await _timedApiCall.call(this, tableName, fnName, args);
+
+        if (logger.isLevelEnabled(ModuleLogger.levels.TRACE)) {
+            let filteredLog = Logging.filterLogObject(timedResult.result, Logging.filterKeys.output);
+            filteredLog.opId = opId;
+            filteredLog.elapsedMilliSec = timedResult.elapsedMilliSec.toFixed(0);
+            logger.trace(`${fnName}${tableName ? ':' + tableName : ''} ${Logging.getDbOutStyle()} ${JsonUtils.stringify(filteredLog, null, 2)}`); // eslint-disable-line
+        }
+
+        return timedResult.result;
+    }
+
+    /**
+     * Fetches multiple records in a single query, or in multiple queries if the request rate on the
+     * source table(s) is too high.
+     * @param {object} batchParams An object keyed by table name, whose value is an array of
+     *   partition key objects. For example, to get two rows from the 'branches' table: {
+     *     branches: [
+     *       { branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12' },
+     *       { branch: '73634787-5b0b-c503-df5d-6827803c97a3' }
+     *     ]
+     *   }
+     * @param {object} [options] Optional batch parameters.
+     * @param {object} [options.consistentRead=false] Whether or not to issue a consistent batch read
+     *   for all the tables.
+     * @param {boolean} [options.columns=undefined] A list of columns to get. Undefined to get all
+     *   columns.
+     * @return {object}  An object keyed by table name, whose value is an array of branch rows.
+     *   For example: {
+     *     branches: [{
+     *       branch: '252ff2b9-aa3e-e0cb-e80d-54651e231a12',
+     *       repository: '9f1d9b1b-d745-ee68-4b34-70de94993e63',
+     *       created: '2018-04-05T20:36:18.661Z',
+     *       meta: { ... },
+     *       ...
+     *     },
+     *     {
+     *       ...
+     *     }]
+     *   }
+     */
+    async batchGetItem(batchParams, options = { consistentRead: false }) {
+        options.consistentRead = _.isUndefined(options.consistentRead) ? false : options.consistentRead;
+
+        const ddbParams = {
+            RequestItems: {},
+            ReturnConsumedCapacity: this._config.returnConsumedCapacity
+        };
+        const rq = ddbParams.RequestItems;
+
+        _.mapValues(batchParams, (pks, tableName) => {
+            if (!rq[tableName]) {
+                rq[tableName] = { Keys: [], ConsistentRead: options.consistentRead };
+                if (options.columns) {
+                    const vars = _createGetVars(options.columns);
+                    rq[tableName].ProjectionExpression = vars.projectionExpression;
+                    rq[tableName].ExpressionAttributeNames = vars.expressionAttributeNames;
+                }
             }
-          });
+
+            _.each(pks, pk => {
+                rq[tableName].Keys.push(AWS.DynamoDB.Converter.marshall(pk));
+            });
         });
-      } else {
-        _.each(tableParams.items, params => {
-          rq[tableName].push({
-            PutRequest: {
-              Item: AWS.DynamoDB.Converter.marshall(params)
+
+        const rowsPerTable = {};
+
+        // A callback that fails if the batch returns a partial result set, to trigger a retry with
+        // backoff for the remaining items.
+        const taskCb = async retryCount => {
+            try {
+                const result = await this._ddbApiCall('batchGetItem', ddbParams);
+                _.mapValues(result.Responses, (marshalledRows, tableName) => {
+                    rowsPerTable[tableName] = rowsPerTable[tableName] ? rowsPerTable[tableName] : [];
+                    const unmarshalledRows = rowsPerTable[tableName];
+                    _.each(marshalledRows, marshalledRow => {
+                        unmarshalledRows.push(AWS.DynamoDB.Converter.unmarshall(marshalledRow));
+                    });
+                });
+
+                if (!_.isEmpty(result.UnprocessedKeys)) {
+                    ddbParams.RequestItems = result.UnprocessedKeys;
+                    throw DynamoDBException.getProvisionedThroughputExceededException(
+                        'batchGetItem: missing results due to throttling');
+                }
+            } catch (error) {
+                await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.READ);
             }
-          });
+        };
+
+        const fnName = 'batchGetItem';
+        const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
+        const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
+        await task.start();
+        return rowsPerTable;
+    }
+
+    /**
+     * Insert or delete multiple items to multiple tables in a single DynamoDB call, or in multiple
+     * calls if the request rate on the target table(s) is too high.
+     * Existing items are overwritten. This method cannot be used to update existing items.
+     * @param {object} batchParams Maps table name to an array of params: {
+     *     songs:
+     *      operation: 'insert',
+     *      items: [{
+     *       album: '...',
+     *       artist: '...'
+     *     }],
+     *     stats:
+     *      operation: 'delete',
+     *      items: [{
+     *       id: '...'
+     *     }]
+     *   }
+     * See {@link DynamoDBClient.putItem} for a description of the item parameters.
+     * @param {Array<object>} batchParams.tableName An array
+     */
+    async batchWriteItem(batchParams) {
+        const ddbParams = {
+            RequestItems: {},
+            ReturnConsumedCapacity: this._config.returnConsumedCapacity
+        };
+        const rq = ddbParams.RequestItems;
+
+        _.mapValues(batchParams, (tableParams, tableName) => {
+            if (!rq[tableName]) {
+                rq[tableName] = [];
+            }
+
+            if (tableParams.operation === 'delete') {
+                _.each(tableParams.items, params => {
+                    rq[tableName].push({
+                        DeleteRequest: {
+                            Key: AWS.DynamoDB.Converter.marshall(params)
+                        }
+                    });
+                });
+            } else {
+                _.each(tableParams.items, params => {
+                    rq[tableName].push({
+                        PutRequest: {
+                            Item: AWS.DynamoDB.Converter.marshall(params)
+                        }
+                    });
+                });
+            }
         });
-      }
-    });
 
-    // A callback that fails if the batch returns a partial result set, to trigger a retry with
-    // backoff for the remaining items.
-    const taskCb = async retryCount => {
-      try {
-        const result = await this._ddbApiCall('batchWriteItem', ddbParams);
-        if (!_.isEmpty(result.UnprocessedItems)) {
-          ddbParams.RequestItems = result.UnprocessedItems;
-          throw DynamoDBException.getProvisionedThroughputExceededException(
-            'batchWriteItem: some items were not persisted due to throttling');
+        // A callback that fails if the batch returns a partial result set, to trigger a retry with
+        // backoff for the remaining items.
+        const taskCb = async retryCount => {
+            try {
+                const result = await this._ddbApiCall('batchWriteItem', ddbParams);
+                if (!_.isEmpty(result.UnprocessedItems)) {
+                    ddbParams.RequestItems = result.UnprocessedItems;
+                    throw DynamoDBException.getProvisionedThroughputExceededException(
+                        'batchWriteItem: some items were not persisted due to throttling');
+                }
+            } catch (error) {
+                await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.WRITE);
+            }
+        };
+
+        const fnName = 'batchWriteItem';
+        const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
+        const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
+        await task.start();
+    }
+
+    /**
+     * There is no "connection" to DynamoDB. DB operations are stateless.
+     * Make sure DynamoDB is properly configured by checking for the existence of the 'business'
+     * table.
+     */
+    async connect() {
+        const tableName = Table.BUSINESS.name;
+        const params = {
+            TableName: tableName
+        };
+
+        const operation = 'describeTable';
+        let result;
+        try {
+            result = await this._ddbApiCall(operation, params);
+        } catch (error) {
+            logger.error(`Failed to describe table: ${tableName}: ${error.message ? error.message : error}`);
+            throw error;
         }
-      } catch (error) {
-        await _batchErrorHandler.call(this, error, ddbParams, BATCH_TYPE.WRITE);
-      }
-    };
 
-    const fnName = 'batchWriteItem';
-    const tableName = DynamoDBClient.getTableNameFromArgs(fnName, ddbParams);
-    const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
-    await task.start();
-  }
-
-  /**
-   * There is no "connection" to DynamoDB. DB operations are stateless.
-   * Make sure DynamoDB is properly configured by checking for the existence of the 'business'
-   * table.
-   */
-  async connect() {
-    const tableName = Table.BUSINESS.name;
-    const params = {
-      TableName: tableName
-    };
-
-    const operation = 'describeTable';
-    let result;
-    try {
-      result = await this._ddbApiCall(operation, params);
-    } catch (error) {
-      logger.error(`Failed to describe table: ${tableName}: ${error.message ? error.message : error}`);
-      throw error;
-    }
-
-    const tableStatus = result.Table ? result.Table.TableStatus : undefined;
-    if (!LIVE_TABLE_STATUSES[tableStatus]) {
-      throw new OperationError(
-        `Table ${params.TableName} status '${tableStatus}' is not one of: ` +
-          JSON.stringify(_.keys(LIVE_TABLE_STATUSES)),
-        operation, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  /**
-   * Disconnects from DynamoDB.
-   */
-  disconnect() {
-    // Intentionally empty
-  }
-
-  /**
-   * Construct a new BatchWriter.
-   * @param {string} tableName The DynamoDB table name against which to run the batch.
-   * @param {string} [operation] One of: 'insert', 'delete'. Defaults to 'insert'.
-   * @return {BatchWriter} A batch writer.
-   */
-  createBatchWriter(tableName, operation = 'insert') {
-    return new BatchWriter(tableName, this._config, operation);
-  }
-
-  /**
-   * An asynchronous callback that is called once for each row read from the db.
-   * If the rowHandler function throw, batch reader will stop reading and throw the error.
-   * @callback BatchReaderRowHandler
-   * @param {object} row A row that was read from the db.
-   */
-
-  /**
-   * Construct a new BatchReader.
-   * @param {string} tableName The DynamoDB table name against which to run the batch.
-   * @param {BatchReaderRowHandler} rowHandler A function that is called once for each row read by the BatchReader.
-   * @param {object} [options] Optional batch parameters.
-   * @param {object} [options.consistentRead] Whether or not to issue a consistent batch read
-   *   for all the tables.
-   * @return {BatchReader} A batch reader.
-   */
-  createBatchReader(tableName, rowHandler, options) {
-    return new BatchReader(tableName, rowHandler, this._config, options);
-  }
-
-  /**
-   * Creates a new table.
-   * @param {object} ddbParams The input parameters, in the same format as the table definitions in DynamoDBStoreSchema
-   * @param {string} ddbParams.TableName The name of the table to create
-   * @param {Array} ddbParams.AttributeDefinitions A list of each table column in the key or an index. Example:
-   *  [
-   *    {AttributeName: 'columnName', AttributeType: 'S'},
-   *    {AttributeName: 'columnName2', AttributeType: 'S'}
-   *  ]
-   * @param {Array} ddbParams.KeySchema A list of the attributes that comprise the primary key of the table. Example:
-   *  [
-   *    {AttributeName: 'id', KeyType: 'HASH'}
-   *  ]
-   * @param {object} ddbParams.ProvisionedThroughput The read and write capacity units of the table
-   * @param {number} ddbParams.ProvisionedThroughput.ReadCapacityUnits The read capacity of the table
-   * @param {number} ddbParams.ProvisionedThroughput.WriteCapacityUnits The write capacity of the table
-   * @param {Array} ddbParams.GlobalSecondaryIndexes A list of the global secondary indexes of the table. Example:
-   *  [
-   *    {
-   *      IndexNAme: 'indexName',
-   *      KeySchema: [{AttributeName: 'attr1', KeyType: 'HASH'}],
-   *      Projection: {ProjectionType: 'KEYS_ONLY'},
-   *      ProvisionedThroughput: {ReadCapacityUnits: 5, WriteCapacityUnits: 5}
-   *    }
-   *  ]
-   * @param {Array} ddbParams.LocalSecondaryIndexes A list of the local secondary index configurations of the table
-   */
-  async createTable(ddbParams) {
-    const params = ddbParams;
-    logger.info(`Creating table: ${ddbParams.TableName}`);
-    await this._ddbApiCall('createTable', params);
-  }
-
-  /**
-   * @return {WriteTransaction} A write transaction to accumulate calls to conditionally put,
-   *   update, and delete DynamoDB records, and execute them in a single transaction.
-   */
-  createWriteTransaction() {
-    return new WriteTransaction(this._paramFactory);
-  }
-
-  /**
-   * A function that throws an error if there is no results from a DynamoDB query, or optionally if
-   * the result is missing expected columns.
-   * @param {?string=} msg The optional error message to use if 'results' is empty or missing
-   *   columns.
-   * @param {Object} results The results of a DynamoDB query.
-   * @param {Array<string>} [columns=undefined] An optional array of column names that must be
-   *   present in the results.
-   */
-  expectResults(msg, results, columns) {
-    const failFn = () => {
-      // If the error bubbles up all the way up to a REST endpoint, it will return a 404:
-      throw new OperationError(msg, 'expectResults', HttpStatus.NOT_FOUND);
-    };
-
-    if (!results) {
-      failFn();
-    }
-
-    if (columns) {
-      _.each(columns, columnName => {
-        if (_.isUndefined(results[columnName])) {
-          msg += `. Missing expected column: ${columnName}`;
-          failFn();
+        const tableStatus = result.Table ? result.Table.TableStatus : undefined;
+        if (!LIVE_TABLE_STATUSES[tableStatus]) {
+            throw new OperationError(
+                `Table ${params.TableName} status '${tableStatus}' is not one of: ` +
+                JSON.stringify(_.keys(LIVE_TABLE_STATUSES)),
+                operation, HttpStatus.INTERNAL_SERVER_ERROR);
         }
-      });
     }
-  }
 
-  /**
-   * Delete an item from a table
-   * @param {string} tableName Table name
-   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} [options] Delete options.
-   * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
-   */
-  async deleteItem(tableName, pk, options = { keyMustExist: true }) {
-    const ddbParams = this._paramFactory.createDeleteItem(tableName, pk, options);
-    const operation = 'deleteItem';
+    /**
+     * Disconnects from DynamoDB.
+     */
+    disconnect() {
+        // Intentionally empty
+    }
 
-    try {
-      await _retryableDdbApiCall.call(this, operation, ddbParams);
-    } catch (error) {
-      if (options.keyMustExist && error.code === 'ConditionalCheckFailedException') {
+    /**
+     * Construct a new BatchWriter.
+     * @param {string} tableName The DynamoDB table name against which to run the batch.
+     * @param {string} [operation] One of: 'insert', 'delete'. Defaults to 'insert'.
+     * @return {BatchWriter} A batch writer.
+     */
+    createBatchWriter(tableName, operation = 'insert') {
+        return new BatchWriter(tableName, this._config, operation);
+    }
+
+    /**
+     * An asynchronous callback that is called once for each row read from the db.
+     * If the rowHandler function throw, batch reader will stop reading and throw the error.
+     * @callback BatchReaderRowHandler
+     * @param {object} row A row that was read from the db.
+     */
+
+    /**
+     * Construct a new BatchReader.
+     * @param {string} tableName The DynamoDB table name against which to run the batch.
+     * @param {BatchReaderRowHandler} rowHandler A function that is called once for each row read by the BatchReader.
+     * @param {object} [options] Optional batch parameters.
+     * @param {object} [options.consistentRead] Whether or not to issue a consistent batch read
+     *   for all the tables.
+     * @return {BatchReader} A batch reader.
+     */
+    createBatchReader(tableName, rowHandler, options) {
+        return new BatchReader(tableName, rowHandler, this._config, options);
+    }
+
+    /**
+     * Creates a new table.
+     * @param {object} ddbParams The input parameters, in the same format as the table definitions in DynamoDBStoreSchema
+     * @param {string} ddbParams.TableName The name of the table to create
+     * @param {Array} ddbParams.AttributeDefinitions A list of each table column in the key or an index. Example:
+     *  [
+     *    {AttributeName: 'columnName', AttributeType: 'S'},
+     *    {AttributeName: 'columnName2', AttributeType: 'S'}
+     *  ]
+     * @param {Array} ddbParams.KeySchema A list of the attributes that comprise the primary key of the table. Example:
+     *  [
+     *    {AttributeName: 'id', KeyType: 'HASH'}
+     *  ]
+     * @param {object} ddbParams.ProvisionedThroughput The read and write capacity units of the table
+     * @param {number} ddbParams.ProvisionedThroughput.ReadCapacityUnits The read capacity of the table
+     * @param {number} ddbParams.ProvisionedThroughput.WriteCapacityUnits The write capacity of the table
+     * @param {Array} ddbParams.GlobalSecondaryIndexes A list of the global secondary indexes of the table. Example:
+     *  [
+     *    {
+     *      IndexNAme: 'indexName',
+     *      KeySchema: [{AttributeName: 'attr1', KeyType: 'HASH'}],
+     *      Projection: {ProjectionType: 'KEYS_ONLY'},
+     *      ProvisionedThroughput: {ReadCapacityUnits: 5, WriteCapacityUnits: 5}
+     *    }
+     *  ]
+     * @param {Array} ddbParams.LocalSecondaryIndexes A list of the local secondary index configurations of the table
+     */
+    async createTable(ddbParams) {
+        const params = ddbParams;
+        logger.info(`Creating table: ${ddbParams.TableName}`);
+        await this._ddbApiCall('createTable', params);
+    }
+
+    /**
+     * @return {WriteTransaction} A write transaction to accumulate calls to conditionally put,
+     *   update, and delete DynamoDB records, and execute them in a single transaction.
+     */
+    createWriteTransaction() {
+        return new WriteTransaction(this._paramFactory);
+    }
+
+    /**
+     * A function that throws an error if there is no results from a DynamoDB query, or optionally if
+     * the result is missing expected columns.
+     * @param {?string=} msg The optional error message to use if 'results' is empty or missing
+     *   columns.
+     * @param {Object} results The results of a DynamoDB query.
+     * @param {Array<string>} [columns=undefined] An optional array of column names that must be
+     *   present in the results.
+     */
+    expectResults(msg, results, columns) {
+        const failFn = () => {
+            // If the error bubbles up all the way up to a REST endpoint, it will return a 404:
+            throw new OperationError(msg, 'expectResults', HttpStatus.NOT_FOUND);
+        };
+
+        if (!results) {
+            failFn();
+        }
+
+        if (columns) {
+            _.each(columns, columnName => {
+                if (_.isUndefined(results[columnName])) {
+                    msg += `. Missing expected column: ${columnName}`;
+                    failFn();
+                }
+            });
+        }
+    }
+
+    /**
+     * Delete an item from a table
+     * @param {string} tableName Table name
+     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} [options] Delete options.
+     * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
+     */
+    async deleteItem(tableName, pk, options = { keyMustExist: true }) {
+        const ddbParams = this._paramFactory.createDeleteItem(tableName, pk, options);
+        const operation = 'deleteItem';
+
+        try {
+            await _retryableDdbApiCall.call(this, operation, ddbParams);
+        } catch (error) {
+            if (options.keyMustExist && error.code === 'ConditionalCheckFailedException') {
+                throw new OperationError(
+                    `Failed to delete ${JSON.stringify(pk)} from table ${tableName}: not found.`,
+                    operation, HttpStatus.NOT_FOUND
+                );
+            }
+
+            throw error;
+        }
+    }
+
+    /**
+     * Starts a table deletion.
+     * @param {string} tableName The table to delete.
+     */
+    async deleteTable(tableName) {
+        const params = { TableName: tableName };
+        await _retryableDdbApiCall.call(this, 'deleteTable', params);
+        logger.info(`Table deletion started: ${tableName}`);
+    }
+
+    /**
+     * Describe a table by name.
+     * @param {string} tableName Table name
+     * @return {object} The database table description
+     */
+    async describeTable(tableName) {
+        const params = {
+            TableName: tableName
+        };
+
+        const operation = 'describeTable';
+        const data = await _retryableDdbApiCall.call(this, operation, params);
+        if (!data || !data.Table) {
+            throw new OperationError(
+                'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
+                operation, HttpStatus.BAD_REQUEST
+            );
+        }
+
+        return data;
+    }
+
+    /**
+     * Fetches business related information, such as the db schema layout version.
+     * @param {string} fieldName The name of the db field to query. For example, use
+     *   'BusinessField.LAYOUT' to query the db layout version.
+     * @return {Promise} A Promise to be fulfilled with the requested field value if it exists.
+     *   The promise is rejected if the requested field is not found.
+     * @private
+     * @this DynamoDBClient
+     */
+    async getBusinessField(fieldName) {
+        const pk = { id: fieldName };
+        const options = { columns: ['value'] };
+        const result = await this.getItem(Table.BUSINESS.name, pk, options);
+        this.expectResults(`Business field not found: ${fieldName}`, result, options.columns);
+        return result.value;
+    }
+
+    /**
+     * Fetches a row from a DynamoDB table.
+     * @param {string} tableName The table name.
+     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} [options=undefined] Get options.
+     * @param {boolean} [options.consistentRead=false] Set to true to issue a consistent read. Set is
+     *   to false or leave undefined to issue an eventually consistent read.
+     * @param {Array<string>} [options.columns=undefined] An array of column names to get from
+     *   the row identified by 'pk'. When specified, only the requested columns are fetched from the
+     *   db. When left undefined, all the columns are fetched.
+     * @return {object|undefined} The requested item if found, or undefined otherwise.
+     */
+    async getItem(tableName, pk, options) {
+        if (options) {
+            options.consistentRead = !!options.consistentRead;
+        } else {
+            options = { consistentRead: false };
+        }
+
+        let ddbParams = {
+            Key: AWS.DynamoDB.Converter.marshall(pk),
+            TableName: tableName,
+            ConsistentRead: options.consistentRead,
+            ReturnConsumedCapacity: this._config.returnConsumedCapacity
+        };
+
+        if (options.columns && options.columns.length > 0) {
+            const vars = _createGetVars(options.columns);
+            ddbParams.ProjectionExpression = vars.projectionExpression;
+            ddbParams.ExpressionAttributeNames = vars.expressionAttributeNames;
+        }
+
+        let result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
+        if (!result.Item && !options.consistentRead) {
+            logger.info(`Retrying getItem ${JSON.stringify(pk)} on table ${tableName} with consistent read`);
+            ddbParams.ConsistentRead = true;
+            result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
+        }
+        return result.Item ? AWS.DynamoDB.Converter.unmarshall(result.Item) : undefined;
+    }
+
+    /**
+     * Queries the db to get the primary key of a table.
+     * @param {string} tableName Table name
+     * @return {Array<string>} An array of pk attribute names for the requested table.
+     */
+    async getPKColumns(tableName) {
+        const data = await this.describeTable(tableName);
+        return _.map(data.Table.KeySchema, attributeObj => attributeObj.AttributeName);
+    }
+
+    /**
+     * Fetches the table name from DynamoDB arguments.
+     * @param {string} fnName The DynamoDB API function name.
+     * @param {object} ddbParams DynamoDB parameters that contain the table name.
+     * @return {string|undefined} A table name extracted from DynamoDB arguments.
+     * @static
+     */
+    static getTableNameFromArgs(fnName, ddbParams) {
+        let tableName;
+
+        if (ddbParams) {
+            tableName = ddbParams.TableName;
+            if (!tableName) {
+                tableName = ddbParams.RequestItems && Object.keys(ddbParams.RequestItems)[0];
+            }
+        }
+
+        return tableName;
+    }
+
+    /**
+     * Persist a record to DynamoDB.
+     * @param {string} tableName The table name.
+     * @param {object} params A row to persist in the table. At a minimum, the row must contain
+     *   attributes matching the table's primary key.
+     * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
+     *   and an item with the same key already exists, the operation fails. Defaults to undefined,
+     *   which overwrites existing entries.
+     * @return {object} The DynamoDB 'putItem' result.
+     */
+    async putItem(tableName, params, protectedAttrs) {
+        const ddbParams = this._paramFactory.createPutItem(tableName, params, protectedAttrs);
+        return await _retryableDdbApiCall.call(this, 'putItem', ddbParams);
+    }
+
+    /**
+     * An asynchronous callback that is called once for each row paged from the db.
+     * The function must either return a promise or be declared with the `async` keyword.
+     * @callback rowCb
+     * @param {object} row A row from the db.
+     */
+
+    /**
+     * Query a series of DynamoDB records
+     * @param {string} tableName The table name.
+     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} params The query parameters.
+     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+     *   from the db.
+     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+     *   by 'pk'. Example: {
+     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+     *     variables: [
+     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+     *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
+     *     ]
+     *   }
+     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+     *   consistent reads.
+     * @return {PagedQuery} A PagedQuery instance to iterate over results.
+     */
+    query(tableName, pk, params) {
+        this.setQueryParams(tableName, pk, params);
+        return new PagedQuery(params);
+    }
+
+    /**
+     * Query a series of DynamoDB records and buffers the results. Buffering adds the ability to
+     * pause and resume paging, which the plain PagedQuery (returned by {@link #query}) cannot do.
+     * @param {string} tableName The table name.
+     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} params The query parameters.
+     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+     *   from the db.
+     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+     *   by 'pk'. Example: {
+     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+     *     variables: [
+     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+     *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
+     *     ]
+     *   }
+     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+     *   consistent reads.
+     * @return {PagedQuery} A PagedQuery instance to iterate over results.
+     */
+    bufferedQuery(tableName, pk, params) {
+        this.setQueryParams(tableName, pk, params);
+        return new BufferedPagedQuery(params);
+    }
+
+    /**
+     * Sets a business field by name.
+     * @param {string} fieldName The name of the business field to set.
+     * @param {string} value The field value to set.
+     */
+    async setBusinessField(fieldName, value) {
+        const params = {
+            id: fieldName,
+            value: value,
+            created: monotonicDate.now().toISOString()
+        };
+        await this.putItem(Table.BUSINESS.name, params);
+    }
+
+    /**
+     * Sets the params so it can be used in a PagedQuery or BufferedPagedQuery.
+     * @param {string} tableName The table name.
+     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} params The query parameters.
+     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+     *   from the db.
+     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+     *   by 'pk'. Example: {
+     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+     *     variables: [
+     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+     *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
+     *     ]
+     *   }
+     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+     *   consistent reads.
+     */
+    setQueryParams(tableName, pk, params) {
+        params.ddbParams = _.extend({
+            TableName: tableName,
+            ReturnConsumedCapacity: this._config.returnConsumedCapacity,
+            ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
+        }, params.ddbParams);
+
+        let conditionalExpressions = [];
+        let conditionValueMap = {};
+        let valueIndex = 0;
+
+        _.mapValues(pk, (value, key) => {
+            const valueVarName = `:v${valueIndex++}`;
+            conditionValueMap[valueVarName] = value;
+            conditionalExpressions.push(`${key} = ${valueVarName}`);
+        });
+
+        if (params.condition) {
+            _.each(params.condition.variables, conditionVar => {
+                _.mapValues(conditionVar, (value, key) => {
+                    conditionValueMap[`:${key}`] = value;
+                });
+            });
+            conditionalExpressions.push(params.condition.expression);
+        }
+
+        params.ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
+        params.ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
+    }
+
+    /**
+     * Sets the params so it can be used in a scan PagedQuery.
+     * @param {string} tableName The table name.
+     * @param {object} params The query parameters.
+     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+     *   from the db.
+     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+     *   consistent reads.
+     */
+    setScanParams(tableName, params) {
+        params.queryType = 'scan';
+        params.ddbParams = _.extend({
+            TableName: tableName,
+            ReturnConsumedCapacity: this._config.returnConsumedCapacity,
+            ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
+        }, params.ddbParams);
+    }
+
+    /**
+     * Executes a count query on a series of DynamoDB records
+     * @param {string} tableName The table name.
+     * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} params The query parameters.
+     * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
+     *   set within the specified partition key (pk). May be undefined to fetch all rows identified
+     *   by 'pk'. Example: {
+     *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
+     *     variables: [
+     *       { minSK: 2018-10-05T14:48:00.000Z_889 },
+     *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
+     *     ]
+     *   }
+     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+     * @return {integer} The count of results matching the key and optional condition in the table.
+     */
+    async count(tableName, pk, params) {
+        const ddbParams = _.extend({
+            TableName: tableName,
+            ReturnConsumedCapacity: this._config.returnConsumedCapacity,
+            Select: 'COUNT'
+        }, params.ddbParams);
+
+        let conditionalExpressions = [];
+        let conditionValueMap = {};
+        let valueIndex = 0;
+
+        _.mapValues(pk, (value, key) => {
+            const valueVarName = `:v${valueIndex++}`;
+            conditionValueMap[valueVarName] = value;
+            conditionalExpressions.push(`${key} = ${valueVarName}`);
+        });
+
+        if (params.condition) {
+            _.each(params.condition.variables, conditionVar => {
+                _.mapValues(conditionVar, (value, key) => {
+                    conditionValueMap[`:${key}`] = value;
+                });
+            });
+            conditionalExpressions.push(params.condition.expression);
+        }
+
+        ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
+        ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
+
+        const result = await this._ddbApiCall('query', ddbParams);
+        return result.Count;
+    }
+
+    /**
+     * Test for the existence of a table. Does not check the table state.
+     * @param {string} tableName The table name.
+     * @return {boolean} True if the table exists in dynamodb, false otherwise.
+     */
+    async tableExists(tableName) {
+        try {
+            await this.describeTable(tableName);
+            return true;
+        } catch (error) {
+            if (error.code !== 'ResourceNotFoundException') {
+                throw error;
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Update a row in a DynamoDB table.
+     * @param {string} tableName The table name.
+     * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
+     *   composite (partition key and sort key).
+     * @param {object} [updates=undefined] A map of column names to their update value.
+     * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
+     *   Example: {
+     *     keyMustExist: true,
+     *     expression: 'sequence = :value',
+     *     variables: {
+     *       value: 3
+     *     }
+     *   }
+     * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
+     *   'pk' doesn't exist.
+     * @param {string} condition.expression A DynamoDB ConditionExpression string.
+     * @param {object} condition.variables A map of variable names to their value, that are in the
+     *   condition expression.
+     * @param {object} [removeArray=undefined] A list of attributes to remove.
+     * @return {object|undefined} A map of attribute names to their old value, before being updated.
+     *   Can be undefined when new values are being set (when no old value is replaced).
+     */
+    async updateItem(tableName, pk, updates, condition, removeArray) {
+        const ddbParams = this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray);
+        let result = await _retryableDdbApiCall.call(this, 'updateItem', ddbParams);
+        return result.Attributes ? AWS.DynamoDB.Converter.unmarshall(result.Attributes) : undefined;
+    }
+
+    /**
+     * Delete a Global Secondary Index.
+     * @param {string} tableName Table name
+     * @param {string} indexName Global Secondary Index name
+     * @param {object} ddbAttributeDefinitions DynamoDB attribute definitions
+     * @param {object} ddbIndexCreateParams DynamoDB GSI creation parameters
+     */
+    async createIndex(tableName, indexName, ddbAttributeDefinitions, ddbIndexCreateParams) {
+        const ddbParams = {
+            TableName: tableName,
+            AttributeDefinitions: ddbAttributeDefinitions,
+            GlobalSecondaryIndexUpdates: [{
+                Create: {
+                    IndexName: indexName
+                }
+            }]
+        };
+
+        _.defaults(ddbParams.GlobalSecondaryIndexUpdates[0].Create, ddbIndexCreateParams);
+
+        logger.info(`createIndex ${tableName}.${indexName}`);
+        await this._ddbApiCall('updateTable', ddbParams);
+    }
+
+    /**
+     * Delete a Global Secondary Index.
+     * @param {string} tableName Table name
+     * @param {string} indexName Global Secondary Index name
+     */
+    async deleteIndex(tableName, indexName) {
+        const ddbParams = {
+            TableName: tableName,
+            GlobalSecondaryIndexUpdates: [{
+                Delete: {
+                    IndexName: indexName
+                }
+            }]
+        };
+
+        logger.info(`Index deletion started: ${tableName}.${indexName}`);
+        await this._ddbApiCall('updateTable', ddbParams);
+    }
+
+    /**
+     * Scan all records of a DynamoDB table.
+     * @param {string} tableName The table name.
+     * @param {object} params The query parameters.
+     * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
+     *   from the db.
+     * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
+     * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
+     * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
+     *   consistent reads.
+     * @return {PagedQuery} A PagedQuery instance to iterate over results.
+     */
+    scan(tableName, params) {
+        this.setScanParams(tableName, params);
+        return new PagedQuery(params);
+    }
+
+    /**
+     * Wait for a table to reach a state that indicates it can be used, by polling for the table
+     * status every second.
+     * @param {string} tableName Table name.
+     * @param {string} indexName Global Secondary Index name
+     * @param {string} action Action to wait on. One of: ['delete', 'create'].
+     * @param {number} [maxWaitTimeMilliSec=Number.MAX_SAFE_INTEGER] How long to wait for the GSI
+     *   to be deleted or active.
+     */
+    async waitForIndex(tableName, indexName, action, maxWaitTimeMilliSec = Number.MAX_SAFE_INTEGER) {
+        const operation = 'describeTable';
+        let chrono = new Chronometer();
+        while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
+            const data = await this.describeTable(tableName);
+
+            if (action === 'delete') {
+                if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
+                    return;
+                }
+
+                const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
+                if (!gsiEntry) {
+                    return;
+                }
+            } else if (action === 'create') {
+                if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
+                    throw new OperationError(
+                        `waitForIndex: GSI not found ${tableName}.${indexName}`,
+                        operation, HttpStatus.NOT_FOUND
+                    );
+                }
+
+                const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
+                if (!gsiEntry || !gsiEntry.IndexStatus) {
+                    throw new OperationError(
+                        `waitForIndex: GSI not found ${tableName}.${indexName}`,
+                        operation, HttpStatus.NOT_FOUND
+                    );
+                }
+
+                if (gsiEntry.IndexStatus === 'DELETING') {
+                    throw new OperationError(
+                        `waitForIndex: GSI is being deleted ${tableName}.${indexName}`,
+                        operation, HttpStatus.GONE
+                    );
+                }
+
+                if (gsiEntry.IndexStatus === 'ACTIVE') {
+                    return;
+                }
+            } else {
+                throw new Error(`waitForIndex: Unexpected action: ${action}`);
+            }
+
+            await sleep(this._config.waitForTablePollTimeoutMS);
+        }
+
         throw new OperationError(
-          `Failed to delete ${JSON.stringify(pk)} from table ${tableName}: not found.`,
-          operation, HttpStatus.NOT_FOUND
-        );
-      }
-
-      throw error;
-    }
-  }
-
-  /**
-   * Starts a table deletion.
-   * @param {string} tableName The table to delete.
-   */
-  async deleteTable(tableName) {
-    const params = { TableName: tableName };
-    await _retryableDdbApiCall.call(this, 'deleteTable', params);
-    logger.info(`Table deletion started: ${tableName}`);
-  }
-
-  /**
-   * Describe a table by name.
-   * @param {string} tableName Table name
-   * @return {object} The database table description
-   */
-  async describeTable(tableName) {
-    const params = {
-      TableName: tableName
-    };
-
-    const operation = 'describeTable';
-    const data = await _retryableDdbApiCall.call(this, operation, params);
-    if (!data || !data.Table) {
-      throw new OperationError(
-        'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
-        operation, HttpStatus.BAD_REQUEST
-      );
+            `Timeout waiting for index to be ${action === 'delete' ? 'deleted' : 'created'}: ` +
+            `${tableName}.${indexName} ` +
+            `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
+            operation, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
-    return data;
-  }
+    /**
+     * Wait for a table to reach a state that indicates it can be used, by polling for the table
+     * status every second.
+     * @param {string} tableName Table name.
+     * @param {number} maxWaitTimeMilliSec How long to wait for the table to become active. The call
+     *   will after that.
+     */
+    async waitForTable(tableName, maxWaitTimeMilliSec) {
+        const operation = 'describeTable';
+        let chrono = new Chronometer();
+        while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
+            try {
+                let data = await this.describeTable(tableName);
+                if (!data.Table.TableStatus) {
+                    throw new OperationError(
+                        'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
+                        operation, HttpStatus.BAD_REQUEST
+                    );
+                }
 
-  /**
-   * Fetches business related information, such as the db schema layout version.
-   * @param {string} fieldName The name of the db field to query. For example, use
-   *   'BusinessField.LAYOUT' to query the db layout version.
-   * @return {Promise} A Promise to be fulfilled with the requested field value if it exists.
-   *   The promise is rejected if the requested field is not found.
-   * @private
-   * @this DynamoDBClient
-   */
-  async getBusinessField(fieldName) {
-    const pk = { id: fieldName };
-    const options = { columns: ['value'] };
-    const result = await this.getItem(Table.BUSINESS.name, pk, options);
-    this.expectResults(`Business field not found: ${fieldName}`, result, options.columns);
-    return result.value;
-  }
+                if (LIVE_TABLE_STATUSES[data.Table.TableStatus]) {
+                    return;
+                }
 
-  /**
-   * Fetches a row from a DynamoDB table.
-   * @param {string} tableName The table name.
-   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} [options=undefined] Get options.
-   * @param {boolean} [options.consistentRead=false] Set to true to issue a consistent read. Set is
-   *   to false or leave undefined to issue an eventually consistent read.
-   * @param {Array<string>} [options.columns=undefined] An array of column names to get from
-   *   the row identified by 'pk'. When specified, only the requested columns are fetched from the
-   *   db. When left undefined, all the columns are fetched.
-   * @return {object|undefined} The requested item if found, or undefined otherwise.
-   */
-  async getItem(tableName, pk, options) {
-    if (options) {
-      options.consistentRead = !!options.consistentRead;
-    } else {
-      options = { consistentRead: false };
+                if (data.Table.TableStatus === 'DELETING') {
+                    throw new OperationError(
+                        `waitForTable ${tableName}: table is being deleted`,
+                        operation, HttpStatus.GONE
+                    );
+                }
+            } catch (error) {
+                throw error;
+            }
+
+            await sleep(this._config.waitForTablePollTimeoutMS);
+        }
+
+        throw new OperationError(`Timeout waiting for table to become ready: ${tableName}. ` +
+            `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
+            operation, HttpStatus.SERVICE_UNAVAILABLE);
     }
-
-    let ddbParams = {
-      Key: AWS.DynamoDB.Converter.marshall(pk),
-      TableName: tableName,
-      ConsistentRead: options.consistentRead,
-      ReturnConsumedCapacity: this._config.returnConsumedCapacity
-    };
-
-    if (options.columns && options.columns.length > 0) {
-      const vars = _createGetVars(options.columns);
-      ddbParams.ProjectionExpression = vars.projectionExpression;
-      ddbParams.ExpressionAttributeNames = vars.expressionAttributeNames;
-    }
-
-    let result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
-    if (!result.Item && !options.consistentRead) {
-      logger.info(`Retrying getItem ${JSON.stringify(pk)} on table ${tableName} with consistent read`);
-      ddbParams.ConsistentRead = true;
-      result = await _retryableDdbApiCall.call(this, 'getItem', ddbParams);
-    }
-    return result.Item ? AWS.DynamoDB.Converter.unmarshall(result.Item) : undefined;
-  }
-
-  /**
-   * Queries the db to get the primary key of a table.
-   * @param {string} tableName Table name
-   * @return {Array<string>} An array of pk attribute names for the requested table.
-   */
-  async getPKColumns(tableName) {
-    const data = await this.describeTable(tableName);
-    return _.map(data.Table.KeySchema, attributeObj => attributeObj.AttributeName);
-  }
-
-  /**
-   * Fetches the table name from DynamoDB arguments.
-   * @param {string} fnName The DynamoDB API function name.
-   * @param {object} ddbParams DynamoDB parameters that contain the table name.
-   * @return {string|undefined} A table name extracted from DynamoDB arguments.
-   * @static
-   */
-  static getTableNameFromArgs(fnName, ddbParams) {
-    let tableName;
-
-    if (ddbParams) {
-      tableName = ddbParams.TableName;
-      if (!tableName) {
-        tableName = ddbParams.RequestItems && Object.keys(ddbParams.RequestItems)[0];
-      }
-    }
-
-    return tableName;
-  }
-
-  /**
-   * Persist a record to DynamoDB.
-   * @param {string} tableName The table name.
-   * @param {object} params A row to persist in the table. At a minimum, the row must contain
-   *   attributes matching the table's primary key.
-   * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
-   *   and an item with the same key already exists, the operation fails. Defaults to undefined,
-   *   which overwrites existing entries.
-   * @return {object} The DynamoDB 'putItem' result.
-   */
-  async putItem(tableName, params, protectedAttrs) {
-    const ddbParams = this._paramFactory.createPutItem(tableName, params, protectedAttrs);
-    return await _retryableDdbApiCall.call(this, 'putItem', ddbParams);
-  }
-
-  /**
-   * An asynchronous callback that is called once for each row paged from the db.
-   * The function must either return a promise or be declared with the `async` keyword.
-   * @callback rowCb
-   * @param {object} row A row from the db.
-   */
-
-  /**
-   * Query a series of DynamoDB records
-   * @param {string} tableName The table name.
-   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} params The query parameters.
-   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-   *   from the db.
-   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-   *   by 'pk'. Example: {
-   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-   *     variables: [
-   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-   *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
-   *     ]
-   *   }
-   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-   *   consistent reads.
-   * @return {PagedQuery} A PagedQuery instance to iterate over results.
-   */
-  query(tableName, pk, params) {
-    this.setQueryParams(tableName, pk, params);
-    return new PagedQuery(params);
-  }
-
-  /**
-   * Query a series of DynamoDB records and buffers the results. Buffering adds the ability to
-   * pause and resume paging, which the plain PagedQuery (returned by {@link #query}) cannot do.
-   * @param {string} tableName The table name.
-   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} params The query parameters.
-   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-   *   from the db.
-   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-   *   by 'pk'. Example: {
-   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-   *     variables: [
-   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-   *       { maxSK: 2018-10-05T14:51:10.920Z_898 }
-   *     ]
-   *   }
-   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-   *   consistent reads.
-   * @return {PagedQuery} A PagedQuery instance to iterate over results.
-   */
-  bufferedQuery(tableName, pk, params) {
-    this.setQueryParams(tableName, pk, params);
-    return new BufferedPagedQuery(params);
-  }
-
-  /**
-   * Sets a business field by name.
-   * @param {string} fieldName The name of the business field to set.
-   * @param {string} value The field value to set.
-   */
-  async setBusinessField(fieldName, value) {
-    const params = {
-      id: fieldName,
-      value: value,
-      created: monotonicDate.now().toISOString()
-    };
-    await this.putItem(Table.BUSINESS.name, params);
-  }
-
-  /**
-   * Sets the params so it can be used in a PagedQuery or BufferedPagedQuery.
-   * @param {string} tableName The table name.
-   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} params The query parameters.
-   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-   *   from the db.
-   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-   *   by 'pk'. Example: {
-   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-   *     variables: [
-   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-   *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
-   *     ]
-   *   }
-   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-   *   consistent reads.
-   */
-  setQueryParams(tableName, pk, params) {
-    params.ddbParams = _.extend({
-      TableName: tableName,
-      ReturnConsumedCapacity: this._config.returnConsumedCapacity,
-      ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
-    }, params.ddbParams);
-
-    let conditionalExpressions = [];
-    let conditionValueMap = {};
-    let valueIndex = 0;
-
-    _.mapValues(pk, (value, key) => {
-      const valueVarName = `:v${valueIndex++}`;
-      conditionValueMap[valueVarName] = value;
-      conditionalExpressions.push(`${key} = ${valueVarName}`);
-    });
-
-    if (params.condition) {
-      _.each(params.condition.variables, conditionVar => {
-        _.mapValues(conditionVar, (value, key) => {
-          conditionValueMap[`:${key}`] = value;
-        });
-      });
-      conditionalExpressions.push(params.condition.expression);
-    }
-
-    params.ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
-    params.ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
-  }
-
-  /**
-   * Sets the params so it can be used in a scan PagedQuery.
-   * @param {string} tableName The table name.
-   * @param {object} params The query parameters.
-   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-   *   from the db.
-   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-   *   consistent reads.
-   */
-  setScanParams(tableName, params) {
-    params.queryType = 'scan';
-    params.ddbParams = _.extend({
-      TableName: tableName,
-      ReturnConsumedCapacity: this._config.returnConsumedCapacity,
-      ConsistentRead: _.isUndefined(params.consistentRead) ? false : params.consistentRead
-    }, params.ddbParams);
-  }
-
-  /**
-   * Executes a count query on a series of DynamoDB records
-   * @param {string} tableName The table name.
-   * @param {object} pk The primary key to query. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} params The query parameters.
-   * @param {object} [params.condition=undefined] An optional condition to fetch a partial result
-   *   set within the specified partition key (pk). May be undefined to fetch all rows identified
-   *   by 'pk'. Example: {
-   *     expression: 'idxTopologySK BETWEEN :minSK AND :maxSK',
-   *     variables: [
-   *       { minSK: 2018-10-05T14:48:00.000Z_889 },
-   *       { maxSK: 2018-10-05T14:51:10.920Z_898 },
-   *     ]
-   *   }
-   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-   * @return {integer} The count of results matching the key and optional condition in the table.
-   */
-  async count(tableName, pk, params) {
-    const ddbParams = _.extend({
-      TableName: tableName,
-      ReturnConsumedCapacity: this._config.returnConsumedCapacity,
-      Select: 'COUNT'
-    }, params.ddbParams);
-
-    let conditionalExpressions = [];
-    let conditionValueMap = {};
-    let valueIndex = 0;
-
-    _.mapValues(pk, (value, key) => {
-      const valueVarName = `:v${valueIndex++}`;
-      conditionValueMap[valueVarName] = value;
-      conditionalExpressions.push(`${key} = ${valueVarName}`);
-    });
-
-    if (params.condition) {
-      _.each(params.condition.variables, conditionVar => {
-        _.mapValues(conditionVar, (value, key) => {
-          conditionValueMap[`:${key}`] = value;
-        });
-      });
-      conditionalExpressions.push(params.condition.expression);
-    }
-
-    ddbParams.ExpressionAttributeValues = AWS.DynamoDB.Converter.marshall(conditionValueMap);
-    ddbParams.KeyConditionExpression = conditionalExpressions.join(' AND ');
-
-    const result = await this._ddbApiCall('query', ddbParams);
-    return result.Count;
-  }
-
-  /**
-   * Test for the existence of a table. Does not check the table state.
-   * @param {string} tableName The table name.
-   * @return {boolean} True if the table exists in dynamodb, false otherwise.
-   */
-  async tableExists(tableName) {
-    try {
-      await this.describeTable(tableName);
-      return true;
-    } catch (error) {
-      if (error.code !== 'ResourceNotFoundException') {
-        throw error;
-      }
-
-      return false;
-    }
-  }
-
-  /**
-   * Update a row in a DynamoDB table.
-   * @param {string} tableName The table name.
-   * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
-   *   composite (partition key and sort key).
-   * @param {object} [updates=undefined] A map of column names to their update value.
-   * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
-   *   Example: {
-   *     keyMustExist: true,
-   *     expression: 'sequence = :value',
-   *     variables: {
-   *       value: 3
-   *     }
-   *   }
-   * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
-   *   'pk' doesn't exist.
-   * @param {string} condition.expression A DynamoDB ConditionExpression string.
-   * @param {object} condition.variables A map of variable names to their value, that are in the
-   *   condition expression.
-   * @param {object} [removeArray=undefined] A list of attributes to remove.
-   * @return {object|undefined} A map of attribute names to their old value, before being updated.
-   *   Can be undefined when new values are being set (when no old value is replaced).
-   */
-  async updateItem(tableName, pk, updates, condition, removeArray) {
-    const ddbParams = this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray);
-    let result = await _retryableDdbApiCall.call(this, 'updateItem', ddbParams);
-    return result.Attributes ? AWS.DynamoDB.Converter.unmarshall(result.Attributes) : undefined;
-  }
-
-  /**
-   * Delete a Global Secondary Index.
-   * @param {string} tableName Table name
-   * @param {string} indexName Global Secondary Index name
-   * @param {object} ddbAttributeDefinitions DynamoDB attribute definitions
-   * @param {object} ddbIndexCreateParams DynamoDB GSI creation parameters
-   */
-  async createIndex(tableName, indexName, ddbAttributeDefinitions, ddbIndexCreateParams) {
-    const ddbParams = {
-      TableName: tableName,
-      AttributeDefinitions: ddbAttributeDefinitions,
-      GlobalSecondaryIndexUpdates: [{
-        Create: {
-          IndexName: indexName
-        }
-      }]
-    };
-
-    _.defaults(ddbParams.GlobalSecondaryIndexUpdates[0].Create, ddbIndexCreateParams);
-
-    logger.info(`createIndex ${tableName}.${indexName}`);
-    await this._ddbApiCall('updateTable', ddbParams);
-  }
-
-  /**
-   * Delete a Global Secondary Index.
-   * @param {string} tableName Table name
-   * @param {string} indexName Global Secondary Index name
-   */
-  async deleteIndex(tableName, indexName) {
-    const ddbParams = {
-      TableName: tableName,
-      GlobalSecondaryIndexUpdates: [{
-        Delete: {
-          IndexName: indexName
-        }
-      }]
-    };
-
-    logger.info(`Index deletion started: ${tableName}.${indexName}`);
-    await this._ddbApiCall('updateTable', ddbParams);
-  }
-
-  /**
-   * Scan all records of a DynamoDB table.
-   * @param {string} tableName The table name.
-   * @param {object} params The query parameters.
-   * @param {rowCb} params.rowCb An asynchronous callback that is called once for each row paged
-   *   from the db.
-   * @param {object} [params.ddbParams=undefined] Additional DynamoDB options.
-   * @param {string} [params.queryName=undefined] A friendly name for the query. Used in logs.
-   * @param {boolean} [params.consistentRead=false] Whether or not the query will use strongly
-   *   consistent reads.
-   * @return {PagedQuery} A PagedQuery instance to iterate over results.
-   */
-  scan(tableName, params) {
-    this.setScanParams(tableName, params);
-    return new PagedQuery(params);
-  }
-
-  /**
-   * Wait for a table to reach a state that indicates it can be used, by polling for the table
-   * status every second.
-   * @param {string} tableName Table name.
-   * @param {string} indexName Global Secondary Index name
-   * @param {string} action Action to wait on. One of: ['delete', 'create'].
-   * @param {number} [maxWaitTimeMilliSec=Number.MAX_SAFE_INTEGER] How long to wait for the GSI
-   *   to be deleted or active.
-   */
-  async waitForIndex(tableName, indexName, action, maxWaitTimeMilliSec = Number.MAX_SAFE_INTEGER) {
-    const operation = 'describeTable';
-    let chrono = new Chronometer();
-    while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
-      const data = await this.describeTable(tableName);
-
-      if (action === 'delete') {
-        if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
-          return;
-        }
-
-        const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
-        if (!gsiEntry) {
-          return;
-        }
-      } else if (action === 'create') {
-        if (!data.Table.GlobalSecondaryIndexes || data.Table.GlobalSecondaryIndexes.length === 0) {
-          throw new OperationError(
-            `waitForIndex: GSI not found ${tableName}.${indexName}`,
-            operation, HttpStatus.NOT_FOUND
-          );
-        }
-
-        const gsiEntry = _.find(data.Table.GlobalSecondaryIndexes, gsi => gsi.IndexName === indexName);
-        if (!gsiEntry || !gsiEntry.IndexStatus) {
-          throw new OperationError(
-            `waitForIndex: GSI not found ${tableName}.${indexName}`,
-            operation, HttpStatus.NOT_FOUND
-          );
-        }
-
-        if (gsiEntry.IndexStatus === 'DELETING') {
-          throw new OperationError(
-            `waitForIndex: GSI is being deleted ${tableName}.${indexName}`,
-            operation, HttpStatus.GONE
-          );
-        }
-
-        if (gsiEntry.IndexStatus === 'ACTIVE') {
-          return;
-        }
-      } else {
-        throw new Error(`waitForIndex: Unexpected action: ${action}`);
-      }
-
-      await sleep(this._config.waitForTablePollTimeoutMS);
-    }
-
-    throw new OperationError(
-      `Timeout waiting for index to be ${action === 'delete' ? 'deleted' : 'created'}: ` +
-        `${tableName}.${indexName} ` +
-        `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
-      operation, HttpStatus.SERVICE_UNAVAILABLE);
-  }
-
-  /**
-   * Wait for a table to reach a state that indicates it can be used, by polling for the table
-   * status every second.
-   * @param {string} tableName Table name.
-   * @param {number} maxWaitTimeMilliSec How long to wait for the table to become active. The call
-   *   will after that.
-   */
-  async waitForTable(tableName, maxWaitTimeMilliSec) {
-    const operation = 'describeTable';
-    let chrono = new Chronometer();
-    while (chrono.stop().elapsedMilliSec() < maxWaitTimeMilliSec) {
-      try {
-        let data = await this.describeTable(tableName);
-        if (!data.Table.TableStatus) {
-          throw new OperationError(
-            'Unexpected describeTable reply: ' + JsonUtils.stringify(data, null, 2),
-            operation, HttpStatus.BAD_REQUEST
-          );
-        }
-
-        if (LIVE_TABLE_STATUSES[data.Table.TableStatus]) {
-          return;
-        }
-
-        if (data.Table.TableStatus === 'DELETING') {
-          throw new OperationError(
-            `waitForTable ${tableName}: table is being deleted`,
-            operation, HttpStatus.GONE
-          );
-        }
-      } catch (error) {
-        throw error;
-      }
-
-      await sleep(this._config.waitForTablePollTimeoutMS);
-    }
-
-    throw new OperationError(`Timeout waiting for table to become ready: ${tableName}. ` +
-      `Elapsed: ${chrono.elapsedMilliSec().toFixed(0)} ms`,
-      operation, HttpStatus.SERVICE_UNAVAILABLE);
-  }
 }
 
 /**
@@ -1055,19 +1055,19 @@ class DynamoDBClient {
  * @return {object} The ProjectionExpression and ExpressionAttributeNames
  */
 function _createGetVars(columns) {
-  let projections = [];
-  let attributeNames = {};
+    let projections = [];
+    let attributeNames = {};
 
-  let index = 0;
-  _.each(columns, name => {
-    projections.push(`#p${index}`);
-    attributeNames[`#p${index++}`] = name;
-  });
+    let index = 0;
+    _.each(columns, name => {
+        projections.push(`#p${index}`);
+        attributeNames[`#p${index++}`] = name;
+    });
 
-  return {
-    projectionExpression: projections.join(', '),
-    expressionAttributeNames: attributeNames
-  };
+    return {
+        projectionExpression: projections.join(', '),
+        expressionAttributeNames: attributeNames
+    };
 }
 
 /**
@@ -1082,70 +1082,70 @@ function _createGetVars(columns) {
  * @this DynamoDBClient
  */
 async function _batchErrorHandler(error, ddbParams, batchType) {
-  try {
-    // See if the error is a duplicate key
-    if (DynamoDBException.isDuplicateKey(error)) {
-      // Find out which keys are dups:
-      const tableNames = Object.keys(ddbParams.RequestItems);
-      const dupItemsPerTable = {};
-      for (let tableName of tableNames) {
-        const tableKeys = batchType === BATCH_TYPE.READ ?
-          ddbParams.RequestItems[tableName].Keys :
-          ddbParams.RequestItems[tableName];
-        let pkColumns;
-        try {
-          // Get the table's primary key attributes from the known Table instance if available.
-          // If not, get the PKs by describing the table in DynamoDB
-          const table = Table.fromName(tableName);
-          pkColumns = table ? table.pkColumns : await this.getPKColumns(tableName);
+    try {
+        // See if the error is a duplicate key
+        if (DynamoDBException.isDuplicateKey(error)) {
+            // Find out which keys are dups:
+            const tableNames = Object.keys(ddbParams.RequestItems);
+            const dupItemsPerTable = {};
+            for (let tableName of tableNames) {
+                const tableKeys = batchType === BATCH_TYPE.READ ?
+                    ddbParams.RequestItems[tableName].Keys :
+                    ddbParams.RequestItems[tableName];
+                let pkColumns;
+                try {
+                    // Get the table's primary key attributes from the known Table instance if available.
+                    // If not, get the PKs by describing the table in DynamoDB
+                    const table = Table.fromName(tableName);
+                    pkColumns = table ? table.pkColumns : await this.getPKColumns(tableName);
 
-          // Build sets of unique and duplicate keys
-          const uniquePKs = new Set();
-          const dupPKs = new Set();
+                    // Build sets of unique and duplicate keys
+                    const uniquePKs = new Set();
+                    const dupPKs = new Set();
 
-          // The item handler is invoked once per item in the batch:
-          const itemHandler = marshalledItem => {
-            const item = AWS.DynamoDB.Converter.unmarshall(marshalledItem);
-            const pk = JSON.stringify(_.pick(item, pkColumns));  // Set will not compare correctly with objects
-            if (uniquePKs.has(pk)) {
-              dupPKs.add(pk);
-            } else {
-              uniquePKs.add(pk);
+                    // The item handler is invoked once per item in the batch:
+                    const itemHandler = marshalledItem => {
+                        const item = AWS.DynamoDB.Converter.unmarshall(marshalledItem);
+                        const pk = JSON.stringify(_.pick(item, pkColumns));  // Set will not compare correctly with objects
+                        if (uniquePKs.has(pk)) {
+                            dupPKs.add(pk);
+                        } else {
+                            uniquePKs.add(pk);
+                        }
+                    };
+
+                    // A generic get function that can get an item from a read or write batch:
+                    const getItem = batchType === BATCH_TYPE.READ ?
+                        tableKey => tableKey :
+                        tableKey => _.map(tableKey, putOrDelete => putOrDelete.Item)[0];
+
+                    // Enumerate all items in the batch, invoking the item handler for each one:
+                    for (let tableKey of tableKeys) {
+                        const marshalledItem = getItem(tableKey);
+                        itemHandler(marshalledItem);
+                    }
+
+                    if (dupPKs.size < 1) {
+                        // Should not happen:
+                        throw new Error('Failed to find duplicate keys in ddbParams');
+                    }
+
+                    dupItemsPerTable[tableName] = _.map([...dupPKs], dupPK => JSON.parse(dupPK));
+                } catch (e2) {
+                    // Unable to describe the table. Dump all keys without analyzing the duplicates:
+                    logger.warn(e2);
+                    error.message += `. ddbParams: ${JSON.stringify(ddbParams)}`;
+                    throw e2;
+                }
             }
-          };
 
-          // A generic get function that can get an item from a read or write batch:
-          const getItem = batchType === BATCH_TYPE.READ ?
-            tableKey => tableKey :
-            tableKey => _.map(tableKey, putOrDelete => putOrDelete.Item)[0];
-
-          // Enumerate all items in the batch, invoking the item handler for each one:
-          for (let tableKey of tableKeys) {
-            const marshalledItem = getItem(tableKey);
-            itemHandler(marshalledItem);
-          }
-
-          if (dupPKs.size < 1) {
-            // Should not happen:
-            throw new Error('Failed to find duplicate keys in ddbParams');
-          }
-
-          dupItemsPerTable[tableName] = _.map([...dupPKs], dupPK => JSON.parse(dupPK));
-        } catch (e2) {
-          // Unable to describe the table. Dump all keys without analyzing the duplicates:
-          logger.warn(e2);
-          error.message += `. ddbParams: ${JSON.stringify(ddbParams)}`;
-          throw e2;
+            // Append to message: 'Provided list of item keys contains duplicates':
+            error.message += `: ${JSON.stringify(dupItemsPerTable)}`;
         }
-      }
-
-      // Append to message: 'Provided list of item keys contains duplicates':
-      error.message += `: ${JSON.stringify(dupItemsPerTable)}`;
+    } finally {
+        // Make sure the original error is rethrown no matter what:
+        throw error;
     }
-  } finally {
-    // Make sure the original error is rethrown no matter what:
-    throw error;
-  }
 }
 
 /**
@@ -1158,10 +1158,10 @@ async function _batchErrorHandler(error, ddbParams, batchType) {
  * @this DynamoDBClient
  */
 async function _retryableDdbApiCall(fnName) {
-  const taskCb = retryCount => (this._ddbApiCall.apply(this, arguments));
-  const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
-  const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
-  return await task.start();
+    const taskCb = retryCount => (this._ddbApiCall.apply(this, arguments));
+    const tableName = DynamoDBClient.getTableNameFromArgs.apply(null, arguments);
+    const task = new MetricsRetryTask(this._config.retry, taskCb, fnName, tableName);
+    return await task.start();
 }
 
 
@@ -1176,40 +1176,40 @@ async function _retryableDdbApiCall(fnName) {
  * }
  */
 async function _timedApiCall(tableName, fnName, args) {
-  let result;
-  let elapsedMilliSec;
+    let result;
+    let elapsedMilliSec;
 
-  const segmentName = `ddb:${fnName}${tableName ? ':' + tableName : ''}`;
-  await PluginManager.instance.systemMonitor.startSegment(segmentName, true, async () => {
-    const chrono = new Chronometer();
+    const segmentName = `ddb:${fnName}${tableName ? ':' + tableName : ''}`;
+    await PluginManager.instance.systemMonitor.startSegment(segmentName, true, async () => {
+        const chrono = new Chronometer();
 
-    try {
-      result = await this._dynamodb[fnName].apply(this._dynamodb, args).promise();
-    } finally {
-      elapsedMilliSec = chrono.stop().elapsedMilliSec();
+        try {
+            result = await this._dynamodb[fnName].apply(this._dynamodb, args).promise();
+        } finally {
+            elapsedMilliSec = chrono.stop().elapsedMilliSec();
 
-      if (elapsedMilliSec >= this._config.elapsedWarningThresholdMilliSec ) {
-        const logFn = NON_CONST_TIME_OPERATIONS[fnName] ?
-          logger.debug.bind(logger) : logger.warn.bind(logger);
-        const requestId = result && result['$response'] ? result['$response'].requestId : undefined;
-        if (requestId) {
-          const diags = {
-            operation: fnName,
-            elapsedMilliSec: elapsedMilliSec.toFixed(0),
-            requestId: requestId
-          };
+            if (elapsedMilliSec >= this._config.elapsedWarningThresholdMilliSec) {
+                const logFn = NON_CONST_TIME_OPERATIONS[fnName] ?
+                    logger.debug.bind(logger) : logger.warn.bind(logger);
+                const requestId = result && result['$response'] ? result['$response'].requestId : undefined;
+                if (requestId) {
+                    const diags = {
+                        operation: fnName,
+                        elapsedMilliSec: elapsedMilliSec.toFixed(0),
+                        requestId: requestId
+                    };
 
-          if (tableName) {
-            diags.table = tableName;
-          }
+                    if (tableName) {
+                        diags.table = tableName;
+                    }
 
-          logFn('Time limit exceeded: ' + JSON.stringify(diags));
+                    logFn('Time limit exceeded: ' + JSON.stringify(diags));
+                }
+            }
         }
-      }
-    }
-  });
+    });
 
-  return { result, elapsedMilliSec };
+    return { result, elapsedMilliSec };
 }
 
 module.exports = DynamoDBClient;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_exception.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_exception.js
@@ -12,59 +12,59 @@ const duplicateKeyRE = new RegExp('Provided list of item keys contains duplicate
  * A class to categorize DynamoDB exceptions.
  */
 class DynamoDBException {
-  /**
-   * Create a new DynamoDBException that can be used to determine if an error is transient or not.
-   * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
-   */
-  constructor(error) {
-    this._error = error;
-  }
+    /**
+     * Create a new DynamoDBException that can be used to determine if an error is transient or not.
+     * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
+     */
+    constructor(error) {
+        this._error = error;
+    }
 
-  /**
-   * @param {string} message The error message.
-   * @return {Error} An error whose code and statusCode properties are those of a DynamoDB
-   * ProvisionedThroughputExceededException.
-   * @static
-   */
-  static getProvisionedThroughputExceededException(message) {
-    return _createError('ProvisionedThroughputExceededException', HttpStatus.BAD_REQUEST, message);
-  }
+    /**
+     * @param {string} message The error message.
+     * @return {Error} An error whose code and statusCode properties are those of a DynamoDB
+     * ProvisionedThroughputExceededException.
+     * @static
+     */
+    static getProvisionedThroughputExceededException(message) {
+        return _createError('ProvisionedThroughputExceededException', HttpStatus.BAD_REQUEST, message);
+    }
 
-  /**
-   * Examine an error to determine if it is transient.
-   * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
-   * that are not transient, such as 'UnrecognizedClientException'.
-   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html
-   * @return {boolean} Whether or not the error is transient.
-   */
-  isTransient() {
-    return DynamoDBException.isTransient(this._error);
-  }
+    /**
+     * Examine an error to determine if it is transient.
+     * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
+     * that are not transient, such as 'UnrecognizedClientException'.
+     * See {@link https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html}
+     * @return {boolean} Whether or not the error is transient.
+     */
+    isTransient() {
+        return DynamoDBException.isTransient(this._error);
+    }
 
-  /**
-   * Examine an error to determine if it is transient.
-   * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
-   * that are not transient, such as 'UnrecognizedClientException'.
-   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html
-   * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
-   * @return {boolean} Whether or not the error is transient.
-   * @static
-   */
-  static isTransient(error) {
-    return (!_.isUndefined(error.statusCode) && error.statusCode >= 500 && error.statusCode < 600) ||
-      error.code === 'ProvisionedThroughputExceededException' ||
-      error.code === 'ThrottlingException';
-  }
+    /**
+     * Examine an error to determine if it is transient.
+     * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
+     * that are not transient, such as 'UnrecognizedClientException'.
+     * See {@link https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html}
+     * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
+     * @return {boolean} Whether or not the error is transient.
+     * @static
+     */
+    static isTransient(error) {
+        return (!_.isUndefined(error.statusCode) && error.statusCode >= 500 && error.statusCode < 600) ||
+            error.code === 'ProvisionedThroughputExceededException' ||
+            error.code === 'ThrottlingException';
+    }
 
-  /**
-   * @param {Error} error An error instance
-   * @return {boolean} Whether or not the error is a DynamoDB duplicate key error.
-   */
-  static isDuplicateKey(error) {
-    return error.statusCode === HttpStatus.BAD_REQUEST &&
-      error.code === 'ValidationException' &&
-      duplicateKeyRE.test(error.message);
-  }
+    /**
+     * @param {Error} error An error instance
+     * @return {boolean} Whether or not the error is a DynamoDB duplicate key error.
+     */
+    static isDuplicateKey(error) {
+        return error.statusCode === HttpStatus.BAD_REQUEST &&
+            error.code === 'ValidationException' &&
+            duplicateKeyRE.test(error.message);
+    }
 }
 
 /**
@@ -75,10 +75,10 @@ class DynamoDBException {
  * @return {Error} An error whose code and statusCode properties are those of a DynamoDB exception.
  */
 function _createError(code, statusCode, message) {
-  const error = new Error(message);
-  error.code = code;
-  error.statusCode = statusCode;
-  return error;
+    const error = new Error(message);
+    error.code = code;
+    error.statusCode = statusCode;
+    return error;
 }
 
 module.exports = DynamoDBException;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_exception.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/dynamodb_exception.js
@@ -12,59 +12,59 @@ const duplicateKeyRE = new RegExp('Provided list of item keys contains duplicate
  * A class to categorize DynamoDB exceptions.
  */
 class DynamoDBException {
-    /**
-     * Create a new DynamoDBException that can be used to determine if an error is transient or not.
-     * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
-     */
-    constructor(error) {
-        this._error = error;
-    }
+  /**
+   * Create a new DynamoDBException that can be used to determine if an error is transient or not.
+   * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
+   */
+  constructor(error) {
+    this._error = error;
+  }
 
-    /**
-     * @param {string} message The error message.
-     * @return {Error} An error whose code and statusCode properties are those of a DynamoDB
-     * ProvisionedThroughputExceededException.
-     * @static
-     */
-    static getProvisionedThroughputExceededException(message) {
-        return _createError('ProvisionedThroughputExceededException', HttpStatus.BAD_REQUEST, message);
-    }
+  /**
+   * @param {string} message The error message.
+   * @return {Error} An error whose code and statusCode properties are those of a DynamoDB
+   * ProvisionedThroughputExceededException.
+   * @static
+   */
+  static getProvisionedThroughputExceededException(message) {
+    return _createError('ProvisionedThroughputExceededException', HttpStatus.BAD_REQUEST, message);
+  }
 
-    /**
-     * Examine an error to determine if it is transient.
-     * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
-     * that are not transient, such as 'UnrecognizedClientException'.
-     * See {@link https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html}
-     * @return {boolean} Whether or not the error is transient.
-     */
-    isTransient() {
-        return DynamoDBException.isTransient(this._error);
-    }
+  /**
+   * Examine an error to determine if it is transient.
+   * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
+   * that are not transient, such as 'UnrecognizedClientException'.
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html
+   * @return {boolean} Whether or not the error is transient.
+   */
+  isTransient() {
+    return DynamoDBException.isTransient(this._error);
+  }
 
-    /**
-     * Examine an error to determine if it is transient.
-     * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
-     * that are not transient, such as 'UnrecognizedClientException'.
-     * See {@link https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html}
-     * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
-     * @return {boolean} Whether or not the error is transient.
-     * @static
-     */
-    static isTransient(error) {
-        return (!_.isUndefined(error.statusCode) && error.statusCode >= 500 && error.statusCode < 600) ||
-            error.code === 'ProvisionedThroughputExceededException' ||
-            error.code === 'ThrottlingException';
-    }
+  /**
+   * Examine an error to determine if it is transient.
+   * The 'retryable' flag is ignored because some errors are flagged as retryable in the AWS SDK
+   * that are not transient, such as 'UnrecognizedClientException'.
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html
+   * @param {Error} error An error from a call to DynamoDB in the AWS SDK.
+   * @return {boolean} Whether or not the error is transient.
+   * @static
+   */
+  static isTransient(error) {
+    return (!_.isUndefined(error.statusCode) && error.statusCode >= 500 && error.statusCode < 600) ||
+      error.code === 'ProvisionedThroughputExceededException' ||
+      error.code === 'ThrottlingException';
+  }
 
-    /**
-     * @param {Error} error An error instance
-     * @return {boolean} Whether or not the error is a DynamoDB duplicate key error.
-     */
-    static isDuplicateKey(error) {
-        return error.statusCode === HttpStatus.BAD_REQUEST &&
-            error.code === 'ValidationException' &&
-            duplicateKeyRE.test(error.message);
-    }
+  /**
+   * @param {Error} error An error instance
+   * @return {boolean} Whether or not the error is a DynamoDB duplicate key error.
+   */
+  static isDuplicateKey(error) {
+    return error.statusCode === HttpStatus.BAD_REQUEST &&
+      error.code === 'ValidationException' &&
+      duplicateKeyRE.test(error.message);
+  }
 }
 
 /**
@@ -75,10 +75,10 @@ class DynamoDBException {
  * @return {Error} An error whose code and statusCode properties are those of a DynamoDB exception.
  */
 function _createError(code, statusCode, message) {
-    const error = new Error(message);
-    error.code = code;
-    error.statusCode = statusCode;
-    return error;
+  const error = new Error(message);
+  error.code = code;
+  error.statusCode = statusCode;
+  return error;
 }
 
 module.exports = DynamoDBException;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/metrics_retry_task.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/metrics_retry_task.js
@@ -13,11 +13,11 @@ const metricsEmitter = require('./metrics_emitter');
  */
 class MetricsRetryTask extends RetryTask {
   /**
-   * @see {@link RetryTask#constructor}
-   * @param {object} config @see {@link RetryTask#constructor}
-   * @param {taskFunction} taskFn @see {@link RetryTask#constructor}
-   * @param {string} taskName @see {@link RetryTask#constructor}
-   * @param {string} tableName The table name to use in the metrics.
+   * See {@link RetryTask.constructor}
+   * @param {object} config - See {@link RetryTask.constructor}
+   * @param {taskFunction} taskFn - See {@link RetryTask.constructor}
+   * @param {string} taskName - See {@link RetryTask.constructor}
+   * @param {string} tableName - The table name to use in the metrics.
    */
   constructor(config, taskFn, taskName, tableName) {
     config.intervalFn = retryCount => (

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/metrics_retry_task.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/metrics_retry_task.js
@@ -12,39 +12,39 @@ const metricsEmitter = require('./metrics_emitter');
  * Wraps a RetryTask to emit metrics on the retry count.
  */
 class MetricsRetryTask extends RetryTask {
-  /**
-   * @see {@link RetryTask#constructor}
-   * @param {object} config @see {@link RetryTask#constructor}
-   * @param {taskFunction} taskFn @see {@link RetryTask#constructor}
-   * @param {string} taskName @see {@link RetryTask#constructor}
-   * @param {string} tableName The table name to use in the metrics.
-   */
-  constructor(config, taskFn, taskName, tableName) {
-    config.intervalFn = retryCount => (
-      (config.firstTimeoutMilliSec / config.backoffRate) * Math.pow(config.backoffRate, retryCount)
-    );
-    config.errorFilter = DynamoDBException.isTransient;
-    super(config, taskFn, taskName);
-    this._tableName = tableName;
-  }
-
-  /**
-   * Start a retryable task and emits metrics on the retry count.
-   * @return {*} The result of the taskCb.
-   */
-  async start() {
-    let event;
-    try {
-      const taskResult = await super.start();
-      event = _metricEventFactory.call(this, true, taskResult.retryCount);
-      return taskResult.result;
-    } catch (error) {
-      event = _metricEventFactory.call(this, false, error.retryCount);
-      throw error;
-    } finally {
-      metricsEmitter.emit(event.name, event.payload);
+    /**
+     * See {@link RetryTask#constructor}
+     * @param {object} config See {@link RetryTask#constructor}
+     * @param {taskFunction} taskFn See {@link RetryTask#constructor}
+     * @param {string} taskName See {@link RetryTask#constructor}
+     * @param {string} tableName The table name to use in the metrics.
+     */
+    constructor(config, taskFn, taskName, tableName) {
+        config.intervalFn = retryCount => (
+            (config.firstTimeoutMilliSec / config.backoffRate) * Math.pow(config.backoffRate, retryCount)
+        );
+        config.errorFilter = DynamoDBException.isTransient;
+        super(config, taskFn, taskName);
+        this._tableName = tableName;
     }
-  }
+
+    /**
+     * Start a retryable task and emits metrics on the retry count.
+     * @return {*} The result of the taskCb.
+     */
+    async start() {
+        let event;
+        try {
+            const taskResult = await super.start();
+            event = _metricEventFactory.call(this, true, taskResult.retryCount);
+            return taskResult.result;
+        } catch (error) {
+            event = _metricEventFactory.call(this, false, error.retryCount);
+            throw error;
+        } finally {
+            metricsEmitter.emit(event.name, event.payload);
+        }
+    }
 }
 
 /**
@@ -54,15 +54,15 @@ class MetricsRetryTask extends RetryTask {
  * @return {object} An metric event object to emit.
  */
 function _metricEventFactory(success, retryCount) {
-  return {
-    name: 'dynamodb.retries',
-    payload: {
-      table: this._tableName,
-      operation: this._taskName,
-      success: success,
-      count: retryCount
-    }
-  };
+    return {
+        name: 'dynamodb.retries',
+        payload: {
+            table: this._tableName,
+            operation: this._taskName,
+            success: success,
+            count: retryCount
+        }
+    };
 }
 
 module.exports = MetricsRetryTask;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/metrics_retry_task.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/metrics_retry_task.js
@@ -12,39 +12,39 @@ const metricsEmitter = require('./metrics_emitter');
  * Wraps a RetryTask to emit metrics on the retry count.
  */
 class MetricsRetryTask extends RetryTask {
-    /**
-     * See {@link RetryTask#constructor}
-     * @param {object} config See {@link RetryTask#constructor}
-     * @param {taskFunction} taskFn See {@link RetryTask#constructor}
-     * @param {string} taskName See {@link RetryTask#constructor}
-     * @param {string} tableName The table name to use in the metrics.
-     */
-    constructor(config, taskFn, taskName, tableName) {
-        config.intervalFn = retryCount => (
-            (config.firstTimeoutMilliSec / config.backoffRate) * Math.pow(config.backoffRate, retryCount)
-        );
-        config.errorFilter = DynamoDBException.isTransient;
-        super(config, taskFn, taskName);
-        this._tableName = tableName;
-    }
+  /**
+   * @see {@link RetryTask#constructor}
+   * @param {object} config @see {@link RetryTask#constructor}
+   * @param {taskFunction} taskFn @see {@link RetryTask#constructor}
+   * @param {string} taskName @see {@link RetryTask#constructor}
+   * @param {string} tableName The table name to use in the metrics.
+   */
+  constructor(config, taskFn, taskName, tableName) {
+    config.intervalFn = retryCount => (
+      (config.firstTimeoutMilliSec / config.backoffRate) * Math.pow(config.backoffRate, retryCount)
+    );
+    config.errorFilter = DynamoDBException.isTransient;
+    super(config, taskFn, taskName);
+    this._tableName = tableName;
+  }
 
-    /**
-     * Start a retryable task and emits metrics on the retry count.
-     * @return {*} The result of the taskCb.
-     */
-    async start() {
-        let event;
-        try {
-            const taskResult = await super.start();
-            event = _metricEventFactory.call(this, true, taskResult.retryCount);
-            return taskResult.result;
-        } catch (error) {
-            event = _metricEventFactory.call(this, false, error.retryCount);
-            throw error;
-        } finally {
-            metricsEmitter.emit(event.name, event.payload);
-        }
+  /**
+   * Start a retryable task and emits metrics on the retry count.
+   * @return {*} The result of the taskCb.
+   */
+  async start() {
+    let event;
+    try {
+      const taskResult = await super.start();
+      event = _metricEventFactory.call(this, true, taskResult.retryCount);
+      return taskResult.result;
+    } catch (error) {
+      event = _metricEventFactory.call(this, false, error.retryCount);
+      throw error;
+    } finally {
+      metricsEmitter.emit(event.name, event.payload);
     }
+  }
 }
 
 /**
@@ -54,15 +54,15 @@ class MetricsRetryTask extends RetryTask {
  * @return {object} An metric event object to emit.
  */
 function _metricEventFactory(success, retryCount) {
-    return {
-        name: 'dynamodb.retries',
-        payload: {
-            table: this._tableName,
-            operation: this._taskName,
-            success: success,
-            count: retryCount
-        }
-    };
+  return {
+    name: 'dynamodb.retries',
+    payload: {
+      table: this._tableName,
+      operation: this._taskName,
+      success: success,
+      count: retryCount
+    }
+  };
 }
 
 module.exports = MetricsRetryTask;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/param_factory.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/param_factory.js
@@ -135,7 +135,7 @@ class ParamFactory {
 
   /**
    * Prepare parameters to call AWS.DynamoDB.putItem.
-   * @see http://docs.aws.amazon.com/goto/AWSJavaScriptSDK/dynamodb-2012-08-10/PutItem
+   * See {@link http://docs.aws.amazon.com/goto/AWSJavaScriptSDK/dynamodb-2012-08-10/PutItem}
    * @param {string} tableName The table name.
    * @param {object} params A row to persist in the table. At a minimum, the row must contain
    *   attributes matching the table's primary key.

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/param_factory.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/param_factory.js
@@ -9,228 +9,228 @@ const AWS = require('aws-sdk');
  * A helper class to retrieve the parameters required to make common DynamoDB calls.
  */
 class ParamFactory {
-    /**
-     * @param {object} config The DynamoDB configuration.
-     */
-    constructor(config) {
-        this._config = _.clone(config);
-        delete this._config.returnConsumedCapacity;
+  /**
+   * @param {object} config The DynamoDB configuration.
+   */
+  constructor(config) {
+    this._config = _.clone(config);
+    delete this._config.returnConsumedCapacity;
+  }
+
+  /**
+   * Escape reserved DynamoDB names.
+   * @param {Array<string>} names Array of names to escape.
+   * @return {object} A map of escaped to unescaped names.
+   * @private
+   */
+  static escapeReservedNames(names) {
+    let i = 0;
+    let attributeNames = {};
+    _.each(names, name => {
+      attributeNames[`#r${i++}`] = name;
+    });
+
+    return attributeNames;
+  }
+
+  /**
+   * Builds the DynamoDB updateItem expression that splits the update expression, the column names
+   * and their values in separate fields.
+   * @param {object} updates A map of column names to their update value.
+   * @param {object} removeArray A list of attributes to remove.
+   * @param {object} condition A condition to set for the update to succeed.
+   *   Example: {
+   *     keyMustExist: true,
+   *     expression: 'sequence = :value',
+   *     variables: {
+   *       value: 3
+   *     }
+   *   }
+   * @param {object} [condition.variables=undefined] A map of variable names to their value, that are
+   *   in the condition expression. May be undefined when no condition is set for the updateItem
+   *   operation.
+   * @return {object} The UpdateExpression, along with its ExpressionAttributeNames and
+   *   ExpressionAttributeValues.
+   */
+  static getUpdateExpression(updates, removeArray, condition) {
+    const result = { updateExpression: '' };
+
+    let attributeNames = {};
+    let attributeValues = {};
+    let updateExpressions = [];
+    let i = 0;
+
+    if (updates) {
+      _.map(updates, (value, columnName) => {
+        attributeNames[`#p${i}`] = columnName;
+        attributeValues[`:p${i}`] = value;
+        updateExpressions.push(`#p${i} = :p${i++}`);
+      });
+
+      i = 0;
+      _.map(condition.variables, (value, varName) => {
+        // Use a placeholder instead of the variable name to avoid conflicts with DynamoDB reserved
+        // keywords:
+        const placeholder = `#v${i++}`;
+        attributeNames[placeholder] = varName;
+        attributeValues[`:${varName}`] = value;
+
+        // Match all the naked variable references in the condition expression:
+        // 'value = :value' <== will match 'value' but not ':value'.
+        const re = new RegExp(`(^|[^:])${varName}`, 'g');
+        // Replace all variable references with the placeholder that doesn't conflict with reserved
+        // DynamoDB names:
+        condition.expression = condition.expression.replace(re, `$1${placeholder}`);
+      });
+
+      result.expressionAttributeValues = AWS.DynamoDB.Converter.marshall(attributeValues);
+      result.updateExpression = `SET ${updateExpressions.join(', ')}`;
     }
 
-    /**
-     * Escape reserved DynamoDB names.
-     * @param {Array<string>} names Array of names to escape.
-     * @return {object} A map of escaped to unescaped names.
-     * @private
-     */
-    static escapeReservedNames(names) {
-        let i = 0;
-        let attributeNames = {};
-        _.each(names, name => {
-            attributeNames[`#r${i++}`] = name;
-        });
+    result.expressionAttributeNames = attributeNames;
 
-        return attributeNames;
+    if (removeArray && removeArray.length > 0) {
+      const SEPARATOR = result.updateExpression.length > 0 ? ' ' : '';
+      result.updateExpression =
+        `${result.updateExpression}${SEPARATOR}REMOVE ${removeArray.join(', ')}`;
     }
 
-    /**
-     * Builds the DynamoDB updateItem expression that splits the update expression, the column names
-     * and their values in separate fields.
-     * @param {object} updates A map of column names to their update value.
-     * @param {object} removeArray A list of attributes to remove.
-     * @param {object} condition A condition to set for the update to succeed.
-     *   Example: {
-     *     keyMustExist: true,
-     *     expression: 'sequence = :value',
-     *     variables: {
-     *       value: 3
-     *     }
-     *   }
-     * @param {object} [condition.variables=undefined] A map of variable names to their value, that are
-     *   in the condition expression. May be undefined when no condition is set for the updateItem
-     *   operation.
-     * @return {object} The UpdateExpression, along with its ExpressionAttributeNames and
-     *   ExpressionAttributeValues.
-     */
-    static getUpdateExpression(updates, removeArray, condition) {
-        const result = { updateExpression: '' };
+    return result;
+  }
 
-        let attributeNames = {};
-        let attributeValues = {};
-        let updateExpressions = [];
-        let i = 0;
+  /**
+   * Prepare parameters to call AWS.DynamoDB.deleteItem.
+   * @param {string} tableName Table name
+   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} options Delete options.
+   * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
+   * @return {object} The deleteItem DynamoDB parameters.
+   */
+  createDeleteItem(tableName, pk, options) {
+    options.keyMustExist = _.isUndefined(options.keyMustExist) ? true : options.keyMustExist;
 
-        if (updates) {
-            _.map(updates, (value, columnName) => {
-                attributeNames[`#p${i}`] = columnName;
-                attributeValues[`:p${i}`] = value;
-                updateExpressions.push(`#p${i} = :p${i++}`);
-            });
+    let ddbParams = {
+      Key: AWS.DynamoDB.Converter.marshall(pk),
+      TableName: tableName
+    };
 
-            i = 0;
-            _.map(condition.variables, (value, varName) => {
-                // Use a placeholder instead of the variable name to avoid conflicts with DynamoDB reserved
-                // keywords:
-                const placeholder = `#v${i++}`;
-                attributeNames[placeholder] = varName;
-                attributeValues[`:${varName}`] = value;
-
-                // Match all the naked variable references in the condition expression:
-                // 'value = :value' <== will match 'value' but not ':value'.
-                const re = new RegExp(`(^|[^:])${varName}`, 'g');
-                // Replace all variable references with the placeholder that doesn't conflict with reserved
-                // DynamoDB names:
-                condition.expression = condition.expression.replace(re, `$1${placeholder}`);
-            });
-
-            result.expressionAttributeValues = AWS.DynamoDB.Converter.marshall(attributeValues);
-            result.updateExpression = `SET ${updateExpressions.join(', ')}`;
-        }
-
-        result.expressionAttributeNames = attributeNames;
-
-        if (removeArray && removeArray.length > 0) {
-            const SEPARATOR = result.updateExpression.length > 0 ? ' ' : '';
-            result.updateExpression =
-                `${result.updateExpression}${SEPARATOR}REMOVE ${removeArray.join(', ')}`;
-        }
-
-        return result;
+    if (this._config.returnConsumedCapacity) {
+      ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
     }
 
-    /**
-     * Prepare parameters to call AWS.DynamoDB.deleteItem.
-     * @param {string} tableName Table name
-     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} options Delete options.
-     * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
-     * @return {object} The deleteItem DynamoDB parameters.
-     */
-    createDeleteItem(tableName, pk, options) {
-        options.keyMustExist = _.isUndefined(options.keyMustExist) ? true : options.keyMustExist;
-
-        let ddbParams = {
-            Key: AWS.DynamoDB.Converter.marshall(pk),
-            TableName: tableName
-        };
-
-        if (this._config.returnConsumedCapacity) {
-            ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
-        }
-
-        if (options.keyMustExist) {
-            const pkColumnNames = _.map(pk, (value, columnName) => {
-                return columnName;
-            });
-            ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(pkColumnNames);
-            const attrs = _.map(ddbParams.ExpressionAttributeNames, (columnName, escapedName) => {
-                return `attribute_exists(${escapedName})`;
-            });
-            ddbParams.ConditionExpression = attrs.join(' AND ');
-        }
-
-        return ddbParams;
+    if (options.keyMustExist) {
+      const pkColumnNames = _.map(pk, (value, columnName) => {
+        return columnName;
+      });
+      ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(pkColumnNames);
+      const attrs = _.map(ddbParams.ExpressionAttributeNames, (columnName, escapedName) => {
+        return `attribute_exists(${escapedName})`;
+      });
+      ddbParams.ConditionExpression = attrs.join(' AND ');
     }
 
-    /**
-     * Prepare parameters to call AWS.DynamoDB.putItem.
-     * See {@link http://docs.aws.amazon.com/goto/AWSJavaScriptSDK/dynamodb-2012-08-10/PutItem}
-     * @param {string} tableName The table name.
-     * @param {object} params A row to persist in the table. At a minimum, the row must contain
-     *   attributes matching the table's primary key.
-     * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
-     *   and an item with the same key already exists, the operation fails. Defaults to undefined,
-     *   which overwrites existing entries.
-     * @return {object} The putItem DynamoDB parameters.
-     */
-    createPutItem(tableName, params, protectedAttrs) {
-        const ddbParams = {
-            Item: AWS.DynamoDB.Converter.marshall(params),
-            TableName: tableName
-        };
+    return ddbParams;
+  }
 
-        if (this._config.returnConsumedCapacity) {
-            ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
-        }
+  /**
+   * Prepare parameters to call AWS.DynamoDB.putItem.
+   * @see http://docs.aws.amazon.com/goto/AWSJavaScriptSDK/dynamodb-2012-08-10/PutItem
+   * @param {string} tableName The table name.
+   * @param {object} params A row to persist in the table. At a minimum, the row must contain
+   *   attributes matching the table's primary key.
+   * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
+   *   and an item with the same key already exists, the operation fails. Defaults to undefined,
+   *   which overwrites existing entries.
+   * @return {object} The putItem DynamoDB parameters.
+   */
+  createPutItem(tableName, params, protectedAttrs) {
+    const ddbParams = {
+      Item: AWS.DynamoDB.Converter.marshall(params),
+      TableName: tableName
+    };
 
-        if (protectedAttrs) {
-            ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(protectedAttrs);
-            const attrs = _.map(ddbParams.ExpressionAttributeNames, (value, attr) => {
-                return `attribute_not_exists(${attr})`;
-            });
-            ddbParams.ConditionExpression = attrs.join(' AND ');
-        }
-
-        return ddbParams;
+    if (this._config.returnConsumedCapacity) {
+      ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
     }
 
-    /**
-     * Prepare parameters to call AWS.DynamoDB.updateItem.
-     * @param {string} tableName The table name.
-     * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
-     *   composite (partition key and sort key).
-     * @param {object} [updates=undefined] A map of column names to their update value.
-     * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
-     *   Example: {
-     *     keyMustExist: true,
-     *     expression: 'sequence = :value',
-     *     variables: {
-     *       value: 3
-     *     }
-     *   }
-     * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
-     *   'pk' doesn't exist.
-     * @param {string} condition.expression A DynamoDB ConditionExpression string.
-     * @param {object} condition.variables A map of variable names to their value, that are in the
-     *   condition expression.
-     * @param {object} [removeArray=undefined] A list of attributes to remove.
-     * @return {object} The updateItem DynamoDB parameters.
-     */
-    createUpdateItem(tableName, pk, updates, condition, removeArray) {
-        if (condition) {
-            condition.keyMustExist = _.isUndefined(condition.keyMustExist) ? true : condition.keyMustExist;
-        } else {
-            condition = { keyMustExist: true };
-        }
-
-        let ddbParams = {
-            Key: AWS.DynamoDB.Converter.marshall(pk),
-            TableName: tableName,
-            ReturnValues: 'UPDATED_OLD'
-        };
-
-        // Build the DynamoDB update expression:
-        const updateExp = ParamFactory.getUpdateExpression(updates, removeArray, condition);
-        ddbParams.ExpressionAttributeNames = updateExp.expressionAttributeNames;
-        ddbParams.ExpressionAttributeValues = updateExp.expressionAttributeValues;
-        ddbParams.UpdateExpression = updateExp.updateExpression;
-
-        let conditionalExpressions = [];
-
-        if (condition.keyMustExist) {
-            let i = 0;
-            // Add the PK constraint to the conditional expressions.
-
-            conditionalExpressions = _.map(pk, (value, columnName) => {
-                const placeholder = `#r${i++}`;
-                ddbParams.ExpressionAttributeNames[placeholder] = columnName;
-                return `attribute_exists(${placeholder})`;
-            });
-        }
-
-        if (condition.expression) {
-            // Add the specified (arbitrary) conditional expression.
-            conditionalExpressions.push(`(${condition.expression})`);
-        }
-
-        if (conditionalExpressions.length > 0) {
-            // Join all conditional expressions.
-            ddbParams.ConditionExpression = conditionalExpressions.join(' AND ');
-        }
-
-        return ddbParams;
+    if (protectedAttrs) {
+      ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(protectedAttrs);
+      const attrs = _.map(ddbParams.ExpressionAttributeNames, (value, attr) => {
+        return `attribute_not_exists(${attr})`;
+      });
+      ddbParams.ConditionExpression = attrs.join(' AND ');
     }
+
+    return ddbParams;
+  }
+
+  /**
+   * Prepare parameters to call AWS.DynamoDB.updateItem.
+   * @param {string} tableName The table name.
+   * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
+   *   composite (partition key and sort key).
+   * @param {object} [updates=undefined] A map of column names to their update value.
+   * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
+   *   Example: {
+   *     keyMustExist: true,
+   *     expression: 'sequence = :value',
+   *     variables: {
+   *       value: 3
+   *     }
+   *   }
+   * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
+   *   'pk' doesn't exist.
+   * @param {string} condition.expression A DynamoDB ConditionExpression string.
+   * @param {object} condition.variables A map of variable names to their value, that are in the
+   *   condition expression.
+   * @param {object} [removeArray=undefined] A list of attributes to remove.
+   * @return {object} The updateItem DynamoDB parameters.
+   */
+  createUpdateItem(tableName, pk, updates, condition, removeArray) {
+    if (condition) {
+      condition.keyMustExist = _.isUndefined(condition.keyMustExist) ? true : condition.keyMustExist;
+    } else {
+      condition = { keyMustExist: true };
+    }
+
+    let ddbParams = {
+      Key: AWS.DynamoDB.Converter.marshall(pk),
+      TableName: tableName,
+      ReturnValues: 'UPDATED_OLD'
+    };
+
+    // Build the DynamoDB update expression:
+    const updateExp = ParamFactory.getUpdateExpression(updates, removeArray, condition);
+    ddbParams.ExpressionAttributeNames = updateExp.expressionAttributeNames;
+    ddbParams.ExpressionAttributeValues = updateExp.expressionAttributeValues;
+    ddbParams.UpdateExpression = updateExp.updateExpression;
+
+    let conditionalExpressions = [];
+
+    if (condition.keyMustExist) {
+      let i = 0;
+      // Add the PK constraint to the conditional expressions.
+
+      conditionalExpressions = _.map(pk, (value, columnName)  => {
+        const placeholder = `#r${i++}`;
+        ddbParams.ExpressionAttributeNames[placeholder] = columnName;
+        return `attribute_exists(${placeholder})`;
+      });
+    }
+
+    if (condition.expression) {
+      // Add the specified (arbitrary) conditional expression.
+      conditionalExpressions.push(`(${condition.expression})`);
+    }
+
+    if (conditionalExpressions.length > 0) {
+      // Join all conditional expressions.
+      ddbParams.ConditionExpression = conditionalExpressions.join(' AND ');
+    }
+
+    return ddbParams;
+  }
 }
 
 module.exports = ParamFactory;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/param_factory.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/param_factory.js
@@ -9,228 +9,228 @@ const AWS = require('aws-sdk');
  * A helper class to retrieve the parameters required to make common DynamoDB calls.
  */
 class ParamFactory {
-  /**
-   * @param {object} config The DynamoDB configuration.
-   */
-  constructor(config) {
-    this._config = _.clone(config);
-    delete this._config.returnConsumedCapacity;
-  }
-
-  /**
-   * Escape reserved DynamoDB names.
-   * @param {Array<string>} names Array of names to escape.
-   * @return {object} A map of escaped to unescaped names.
-   * @private
-   */
-  static escapeReservedNames(names) {
-    let i = 0;
-    let attributeNames = {};
-    _.each(names, name => {
-      attributeNames[`#r${i++}`] = name;
-    });
-
-    return attributeNames;
-  }
-
-  /**
-   * Builds the DynamoDB updateItem expression that splits the update expression, the column names
-   * and their values in separate fields.
-   * @param {object} updates A map of column names to their update value.
-   * @param {object} removeArray A list of attributes to remove.
-   * @param {object} condition A condition to set for the update to succeed.
-   *   Example: {
-   *     keyMustExist: true,
-   *     expression: 'sequence = :value',
-   *     variables: {
-   *       value: 3
-   *     }
-   *   }
-   * @param {object} [condition.variables=undefined] A map of variable names to their value, that are
-   *   in the condition expression. May be undefined when no condition is set for the updateItem
-   *   operation.
-   * @return {object} The UpdateExpression, along with its ExpressionAttributeNames and
-   *   ExpressionAttributeValues.
-   */
-  static getUpdateExpression(updates, removeArray, condition) {
-    const result = { updateExpression: '' };
-
-    let attributeNames = {};
-    let attributeValues = {};
-    let updateExpressions = [];
-    let i = 0;
-
-    if (updates) {
-      _.map(updates, (value, columnName) => {
-        attributeNames[`#p${i}`] = columnName;
-        attributeValues[`:p${i}`] = value;
-        updateExpressions.push(`#p${i} = :p${i++}`);
-      });
-
-      i = 0;
-      _.map(condition.variables, (value, varName) => {
-        // Use a placeholder instead of the variable name to avoid conflicts with DynamoDB reserved
-        // keywords:
-        const placeholder = `#v${i++}`;
-        attributeNames[placeholder] = varName;
-        attributeValues[`:${varName}`] = value;
-
-        // Match all the naked variable references in the condition expression:
-        // 'value = :value' <== will match 'value' but not ':value'.
-        const re = new RegExp(`(^|[^:])${varName}`, 'g');
-        // Replace all variable references with the placeholder that doesn't conflict with reserved
-        // DynamoDB names:
-        condition.expression = condition.expression.replace(re, `$1${placeholder}`);
-      });
-
-      result.expressionAttributeValues = AWS.DynamoDB.Converter.marshall(attributeValues);
-      result.updateExpression = `SET ${updateExpressions.join(', ')}`;
+    /**
+     * @param {object} config The DynamoDB configuration.
+     */
+    constructor(config) {
+        this._config = _.clone(config);
+        delete this._config.returnConsumedCapacity;
     }
 
-    result.expressionAttributeNames = attributeNames;
+    /**
+     * Escape reserved DynamoDB names.
+     * @param {Array<string>} names Array of names to escape.
+     * @return {object} A map of escaped to unescaped names.
+     * @private
+     */
+    static escapeReservedNames(names) {
+        let i = 0;
+        let attributeNames = {};
+        _.each(names, name => {
+            attributeNames[`#r${i++}`] = name;
+        });
 
-    if (removeArray && removeArray.length > 0) {
-      const SEPARATOR = result.updateExpression.length > 0 ? ' ' : '';
-      result.updateExpression =
-        `${result.updateExpression}${SEPARATOR}REMOVE ${removeArray.join(', ')}`;
+        return attributeNames;
     }
 
-    return result;
-  }
+    /**
+     * Builds the DynamoDB updateItem expression that splits the update expression, the column names
+     * and their values in separate fields.
+     * @param {object} updates A map of column names to their update value.
+     * @param {object} removeArray A list of attributes to remove.
+     * @param {object} condition A condition to set for the update to succeed.
+     *   Example: {
+     *     keyMustExist: true,
+     *     expression: 'sequence = :value',
+     *     variables: {
+     *       value: 3
+     *     }
+     *   }
+     * @param {object} [condition.variables=undefined] A map of variable names to their value, that are
+     *   in the condition expression. May be undefined when no condition is set for the updateItem
+     *   operation.
+     * @return {object} The UpdateExpression, along with its ExpressionAttributeNames and
+     *   ExpressionAttributeValues.
+     */
+    static getUpdateExpression(updates, removeArray, condition) {
+        const result = { updateExpression: '' };
 
-  /**
-   * Prepare parameters to call AWS.DynamoDB.deleteItem.
-   * @param {string} tableName Table name
-   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} options Delete options.
-   * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
-   * @return {object} The deleteItem DynamoDB parameters.
-   */
-  createDeleteItem(tableName, pk, options) {
-    options.keyMustExist = _.isUndefined(options.keyMustExist) ? true : options.keyMustExist;
+        let attributeNames = {};
+        let attributeValues = {};
+        let updateExpressions = [];
+        let i = 0;
 
-    let ddbParams = {
-      Key: AWS.DynamoDB.Converter.marshall(pk),
-      TableName: tableName
-    };
+        if (updates) {
+            _.map(updates, (value, columnName) => {
+                attributeNames[`#p${i}`] = columnName;
+                attributeValues[`:p${i}`] = value;
+                updateExpressions.push(`#p${i} = :p${i++}`);
+            });
 
-    if (this._config.returnConsumedCapacity) {
-      ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
+            i = 0;
+            _.map(condition.variables, (value, varName) => {
+                // Use a placeholder instead of the variable name to avoid conflicts with DynamoDB reserved
+                // keywords:
+                const placeholder = `#v${i++}`;
+                attributeNames[placeholder] = varName;
+                attributeValues[`:${varName}`] = value;
+
+                // Match all the naked variable references in the condition expression:
+                // 'value = :value' <== will match 'value' but not ':value'.
+                const re = new RegExp(`(^|[^:])${varName}`, 'g');
+                // Replace all variable references with the placeholder that doesn't conflict with reserved
+                // DynamoDB names:
+                condition.expression = condition.expression.replace(re, `$1${placeholder}`);
+            });
+
+            result.expressionAttributeValues = AWS.DynamoDB.Converter.marshall(attributeValues);
+            result.updateExpression = `SET ${updateExpressions.join(', ')}`;
+        }
+
+        result.expressionAttributeNames = attributeNames;
+
+        if (removeArray && removeArray.length > 0) {
+            const SEPARATOR = result.updateExpression.length > 0 ? ' ' : '';
+            result.updateExpression =
+                `${result.updateExpression}${SEPARATOR}REMOVE ${removeArray.join(', ')}`;
+        }
+
+        return result;
     }
 
-    if (options.keyMustExist) {
-      const pkColumnNames = _.map(pk, (value, columnName) => {
-        return columnName;
-      });
-      ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(pkColumnNames);
-      const attrs = _.map(ddbParams.ExpressionAttributeNames, (columnName, escapedName) => {
-        return `attribute_exists(${escapedName})`;
-      });
-      ddbParams.ConditionExpression = attrs.join(' AND ');
+    /**
+     * Prepare parameters to call AWS.DynamoDB.deleteItem.
+     * @param {string} tableName Table name
+     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} options Delete options.
+     * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
+     * @return {object} The deleteItem DynamoDB parameters.
+     */
+    createDeleteItem(tableName, pk, options) {
+        options.keyMustExist = _.isUndefined(options.keyMustExist) ? true : options.keyMustExist;
+
+        let ddbParams = {
+            Key: AWS.DynamoDB.Converter.marshall(pk),
+            TableName: tableName
+        };
+
+        if (this._config.returnConsumedCapacity) {
+            ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
+        }
+
+        if (options.keyMustExist) {
+            const pkColumnNames = _.map(pk, (value, columnName) => {
+                return columnName;
+            });
+            ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(pkColumnNames);
+            const attrs = _.map(ddbParams.ExpressionAttributeNames, (columnName, escapedName) => {
+                return `attribute_exists(${escapedName})`;
+            });
+            ddbParams.ConditionExpression = attrs.join(' AND ');
+        }
+
+        return ddbParams;
     }
 
-    return ddbParams;
-  }
+    /**
+     * Prepare parameters to call AWS.DynamoDB.putItem.
+     * See {@link http://docs.aws.amazon.com/goto/AWSJavaScriptSDK/dynamodb-2012-08-10/PutItem}
+     * @param {string} tableName The table name.
+     * @param {object} params A row to persist in the table. At a minimum, the row must contain
+     *   attributes matching the table's primary key.
+     * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
+     *   and an item with the same key already exists, the operation fails. Defaults to undefined,
+     *   which overwrites existing entries.
+     * @return {object} The putItem DynamoDB parameters.
+     */
+    createPutItem(tableName, params, protectedAttrs) {
+        const ddbParams = {
+            Item: AWS.DynamoDB.Converter.marshall(params),
+            TableName: tableName
+        };
 
-  /**
-   * Prepare parameters to call AWS.DynamoDB.putItem.
-   * @see http://docs.aws.amazon.com/goto/AWSJavaScriptSDK/dynamodb-2012-08-10/PutItem
-   * @param {string} tableName The table name.
-   * @param {object} params A row to persist in the table. At a minimum, the row must contain
-   *   attributes matching the table's primary key.
-   * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
-   *   and an item with the same key already exists, the operation fails. Defaults to undefined,
-   *   which overwrites existing entries.
-   * @return {object} The putItem DynamoDB parameters.
-   */
-  createPutItem(tableName, params, protectedAttrs) {
-    const ddbParams = {
-      Item: AWS.DynamoDB.Converter.marshall(params),
-      TableName: tableName
-    };
+        if (this._config.returnConsumedCapacity) {
+            ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
+        }
 
-    if (this._config.returnConsumedCapacity) {
-      ddbParams.ReturnConsumedCapacity = this._config.returnConsumedCapacity;
+        if (protectedAttrs) {
+            ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(protectedAttrs);
+            const attrs = _.map(ddbParams.ExpressionAttributeNames, (value, attr) => {
+                return `attribute_not_exists(${attr})`;
+            });
+            ddbParams.ConditionExpression = attrs.join(' AND ');
+        }
+
+        return ddbParams;
     }
 
-    if (protectedAttrs) {
-      ddbParams.ExpressionAttributeNames = ParamFactory.escapeReservedNames(protectedAttrs);
-      const attrs = _.map(ddbParams.ExpressionAttributeNames, (value, attr) => {
-        return `attribute_not_exists(${attr})`;
-      });
-      ddbParams.ConditionExpression = attrs.join(' AND ');
+    /**
+     * Prepare parameters to call AWS.DynamoDB.updateItem.
+     * @param {string} tableName The table name.
+     * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
+     *   composite (partition key and sort key).
+     * @param {object} [updates=undefined] A map of column names to their update value.
+     * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
+     *   Example: {
+     *     keyMustExist: true,
+     *     expression: 'sequence = :value',
+     *     variables: {
+     *       value: 3
+     *     }
+     *   }
+     * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
+     *   'pk' doesn't exist.
+     * @param {string} condition.expression A DynamoDB ConditionExpression string.
+     * @param {object} condition.variables A map of variable names to their value, that are in the
+     *   condition expression.
+     * @param {object} [removeArray=undefined] A list of attributes to remove.
+     * @return {object} The updateItem DynamoDB parameters.
+     */
+    createUpdateItem(tableName, pk, updates, condition, removeArray) {
+        if (condition) {
+            condition.keyMustExist = _.isUndefined(condition.keyMustExist) ? true : condition.keyMustExist;
+        } else {
+            condition = { keyMustExist: true };
+        }
+
+        let ddbParams = {
+            Key: AWS.DynamoDB.Converter.marshall(pk),
+            TableName: tableName,
+            ReturnValues: 'UPDATED_OLD'
+        };
+
+        // Build the DynamoDB update expression:
+        const updateExp = ParamFactory.getUpdateExpression(updates, removeArray, condition);
+        ddbParams.ExpressionAttributeNames = updateExp.expressionAttributeNames;
+        ddbParams.ExpressionAttributeValues = updateExp.expressionAttributeValues;
+        ddbParams.UpdateExpression = updateExp.updateExpression;
+
+        let conditionalExpressions = [];
+
+        if (condition.keyMustExist) {
+            let i = 0;
+            // Add the PK constraint to the conditional expressions.
+
+            conditionalExpressions = _.map(pk, (value, columnName) => {
+                const placeholder = `#r${i++}`;
+                ddbParams.ExpressionAttributeNames[placeholder] = columnName;
+                return `attribute_exists(${placeholder})`;
+            });
+        }
+
+        if (condition.expression) {
+            // Add the specified (arbitrary) conditional expression.
+            conditionalExpressions.push(`(${condition.expression})`);
+        }
+
+        if (conditionalExpressions.length > 0) {
+            // Join all conditional expressions.
+            ddbParams.ConditionExpression = conditionalExpressions.join(' AND ');
+        }
+
+        return ddbParams;
     }
-
-    return ddbParams;
-  }
-
-  /**
-   * Prepare parameters to call AWS.DynamoDB.updateItem.
-   * @param {string} tableName The table name.
-   * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
-   *   composite (partition key and sort key).
-   * @param {object} [updates=undefined] A map of column names to their update value.
-   * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
-   *   Example: {
-   *     keyMustExist: true,
-   *     expression: 'sequence = :value',
-   *     variables: {
-   *       value: 3
-   *     }
-   *   }
-   * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
-   *   'pk' doesn't exist.
-   * @param {string} condition.expression A DynamoDB ConditionExpression string.
-   * @param {object} condition.variables A map of variable names to their value, that are in the
-   *   condition expression.
-   * @param {object} [removeArray=undefined] A list of attributes to remove.
-   * @return {object} The updateItem DynamoDB parameters.
-   */
-  createUpdateItem(tableName, pk, updates, condition, removeArray) {
-    if (condition) {
-      condition.keyMustExist = _.isUndefined(condition.keyMustExist) ? true : condition.keyMustExist;
-    } else {
-      condition = { keyMustExist: true };
-    }
-
-    let ddbParams = {
-      Key: AWS.DynamoDB.Converter.marshall(pk),
-      TableName: tableName,
-      ReturnValues: 'UPDATED_OLD'
-    };
-
-    // Build the DynamoDB update expression:
-    const updateExp = ParamFactory.getUpdateExpression(updates, removeArray, condition);
-    ddbParams.ExpressionAttributeNames = updateExp.expressionAttributeNames;
-    ddbParams.ExpressionAttributeValues = updateExp.expressionAttributeValues;
-    ddbParams.UpdateExpression = updateExp.updateExpression;
-
-    let conditionalExpressions = [];
-
-    if (condition.keyMustExist) {
-      let i = 0;
-      // Add the PK constraint to the conditional expressions.
-
-      conditionalExpressions = _.map(pk, (value, columnName)  => {
-        const placeholder = `#r${i++}`;
-        ddbParams.ExpressionAttributeNames[placeholder] = columnName;
-        return `attribute_exists(${placeholder})`;
-      });
-    }
-
-    if (condition.expression) {
-      // Add the specified (arbitrary) conditional expression.
-      conditionalExpressions.push(`(${condition.expression})`);
-    }
-
-    if (conditionalExpressions.length > 0) {
-      // Join all conditional expressions.
-      ddbParams.ConditionExpression = conditionalExpressions.join(' AND ');
-    }
-
-    return ddbParams;
-  }
 }
 
 module.exports = ParamFactory;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/write_transaction.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/write_transaction.js
@@ -12,7 +12,7 @@ const OperationError = require('@fluid-experimental/property-common').OperationE
  * A write transaction accumulates calls to conditionally put, update, and delete DynamoDB records,
  * and executes them in a single transaction. The transaction is subject to all the limitations
  * documented in DynamoDB for transactWriteItems.
- * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html
+ * See {@link https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html}
  */
 class WriteTransaction {
   /**

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/write_transaction.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/write_transaction.js
@@ -12,100 +12,100 @@ const OperationError = require('@fluid-experimental/property-common').OperationE
  * A write transaction accumulates calls to conditionally put, update, and delete DynamoDB records,
  * and executes them in a single transaction. The transaction is subject to all the limitations
  * documented in DynamoDB for transactWriteItems.
- * See {@link https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html}
+ * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html
  */
 class WriteTransaction {
-    /**
-     *
-     * @param {ParamFactory} paramFactory A ParamFactory instance used to create the DynamoDB
-     *   parameters used in calls to the AWS.DynamoDB library.
-     */
-    constructor(paramFactory) {
-        this._paramFactory = paramFactory;
-        this._transactItems = [];
-        this._clientRequestToken = newGuid();
-    }
+  /**
+   *
+   * @param {ParamFactory} paramFactory A ParamFactory instance used to create the DynamoDB
+   *   parameters used in calls to the AWS.DynamoDB library.
+   */
+  constructor(paramFactory) {
+    this._paramFactory = paramFactory;
+    this._transactItems = [];
+    this._clientRequestToken = newGuid();
+  }
 
-    /**
-     * Adds a condition check to the write transaction. Call {@link #execute} to execute the transaction.
-     */
-    conditionCheck() {
-        throw new OperationError(`WriteTransaction.conditionCheck is not implemented`,
-            'WriteTransaction.conditionCheck', HttpStatus.NOT_IMPLEMENTED);
-    }
+  /**
+   * Adds a condition check to the write transaction. Call {@link #execute} to execute the transaction.
+   */
+  conditionCheck() {
+    throw new OperationError(`WriteTransaction.conditionCheck is not implemented`,
+      'WriteTransaction.conditionCheck', HttpStatus.NOT_IMPLEMENTED);
+  }
 
-    /**
-     * Adds a deleteItem to the write transaction. Call {@link #execute} to execute the transaction.
-     * @param {string} tableName Table name
-     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-     *   (partition key and sort key).
-     * @param {object} [options] Delete options.
-     * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
-     */
-    deleteItem(tableName, pk, options = { keyMustExist: true }) {
-        const ddbParams = {
-            Delete: this._paramFactory.createDeleteItem(tableName, pk, options)
-        };
-        this._transactItems.push(ddbParams);
-    }
+  /**
+   * Adds a deleteItem to the write transaction. Call {@link #execute} to execute the transaction.
+   * @param {string} tableName Table name
+   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+   *   (partition key and sort key).
+   * @param {object} [options] Delete options.
+   * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
+   */
+  deleteItem(tableName, pk, options = { keyMustExist: true }) {
+    const ddbParams = {
+      Delete: this._paramFactory.createDeleteItem(tableName, pk, options)
+    };
+    this._transactItems.push(ddbParams);
+  }
 
-    /**
-     * Adds a putItem to the write transaction. Call {@link #execute} to execute the transaction.
-     * @param {string} tableName The table name.
-     * @param {object} params A row to persist in the table. At a minimum, the row must contain
-     *   attributes matching the table's primary key.
-     * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
-     *   and an item with the same key already exists, the operation fails. Defaults to undefined,
-     *   which overwrites existing entries.
-     */
-    putItem(tableName, params, protectedAttrs) {
-        const ddbParams = {
-            Put: this._paramFactory.createPutItem(tableName, params, protectedAttrs)
-        };
-        this._transactItems.push(ddbParams);
-    }
+  /**
+   * Adds a putItem to the write transaction. Call {@link #execute} to execute the transaction.
+   * @param {string} tableName The table name.
+   * @param {object} params A row to persist in the table. At a minimum, the row must contain
+   *   attributes matching the table's primary key.
+   * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
+   *   and an item with the same key already exists, the operation fails. Defaults to undefined,
+   *   which overwrites existing entries.
+   */
+  putItem(tableName, params, protectedAttrs) {
+    const ddbParams = {
+      Put: this._paramFactory.createPutItem(tableName, params, protectedAttrs)
+    };
+    this._transactItems.push(ddbParams);
+  }
 
-    /**
-     * Adds an updateItem action to the write transaction. Call {@link #execute} to execute the transaction.
-     * @param {string} tableName The table name.
-     * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
-     *   composite (partition key and sort key).
-     * @param {object} [updates=undefined] A map of column names to their update value.
-     * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
-     *   Example: {
-     *     keyMustExist: true,
-     *     expression: 'sequence = :value',
-     *     variables: {
-     *       value: 3
-     *     }
-     *   }
-     * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
-     *   'pk' doesn't exist.
-     * @param {string} condition.expression A DynamoDB ConditionExpression string.
-     * @param {object} condition.variables A map of variable names to their value, that are in the
-     *   condition expression.
-     * @param {object} [removeArray=undefined] A list of attributes to remove.
-      */
-    updateItem(tableName, pk, updates, condition, removeArray) {
-        const ddbParams = {
-            Update: this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray)
-        };
-        delete ddbParams.Update.ReturnValues; // <-- This option is not used in transactions
-        this._transactItems.push(ddbParams);
-    }
+  /**
+   * Adds an updateItem action to the write transaction. Call {@link #execute} to execute the transaction.
+   * @param {string} tableName The table name.
+   * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
+   *   composite (partition key and sort key).
+   * @param {object} [updates=undefined] A map of column names to their update value.
+   * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
+   *   Example: {
+   *     keyMustExist: true,
+   *     expression: 'sequence = :value',
+   *     variables: {
+   *       value: 3
+   *     }
+   *   }
+   * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
+   *   'pk' doesn't exist.
+   * @param {string} condition.expression A DynamoDB ConditionExpression string.
+   * @param {object} condition.variables A map of variable names to their value, that are in the
+   *   condition expression.
+   * @param {object} [removeArray=undefined] A list of attributes to remove.
+    */
+  updateItem(tableName, pk, updates, condition, removeArray) {
+    const ddbParams = {
+      Update: this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray)
+    };
+    delete ddbParams.Update.ReturnValues; // <-- This option is not used in transactions
+    this._transactItems.push(ddbParams);
+  }
 
-    /**
-     * Execute the transaction. WriteTransaction instances cannot be reused except to retry a failed call.
-     * @return {object} The result of calling AWS.DynamoDB.transactWriteItems
-     */
-    async execute() {
-        const ddbParams = {
-            TransactItems: this._transactItems,
-            ClientRequestToken: this._clientRequestToken,
-            ReturnConsumedCapacity: credsRotation.ddbClient.config.returnConsumedCapacity
-        };
-        return await credsRotation.ddbClient._ddbApiCall('transactWriteItems', ddbParams);
-    }
+  /**
+   * Execute the transaction. WriteTransaction instances cannot be reused except to retry a failed call.
+   * @return {object} The result of calling AWS.DynamoDB.transactWriteItems
+   */
+  async execute() {
+    const ddbParams = {
+      TransactItems: this._transactItems,
+      ClientRequestToken: this._clientRequestToken,
+      ReturnConsumedCapacity: credsRotation.ddbClient.config.returnConsumedCapacity
+    };
+    return await credsRotation.ddbClient._ddbApiCall('transactWriteItems', ddbParams);
+  }
 }
 
 module.exports = WriteTransaction;

--- a/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/write_transaction.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/materialized_history_service/storage_backends/dynamodb_store/write_transaction.js
@@ -12,100 +12,100 @@ const OperationError = require('@fluid-experimental/property-common').OperationE
  * A write transaction accumulates calls to conditionally put, update, and delete DynamoDB records,
  * and executes them in a single transaction. The transaction is subject to all the limitations
  * documented in DynamoDB for transactWriteItems.
- * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html
+ * See {@link https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html}
  */
 class WriteTransaction {
-  /**
-   *
-   * @param {ParamFactory} paramFactory A ParamFactory instance used to create the DynamoDB
-   *   parameters used in calls to the AWS.DynamoDB library.
-   */
-  constructor(paramFactory) {
-    this._paramFactory = paramFactory;
-    this._transactItems = [];
-    this._clientRequestToken = newGuid();
-  }
+    /**
+     *
+     * @param {ParamFactory} paramFactory A ParamFactory instance used to create the DynamoDB
+     *   parameters used in calls to the AWS.DynamoDB library.
+     */
+    constructor(paramFactory) {
+        this._paramFactory = paramFactory;
+        this._transactItems = [];
+        this._clientRequestToken = newGuid();
+    }
 
-  /**
-   * Adds a condition check to the write transaction. Call {@link #execute} to execute the transaction.
-   */
-  conditionCheck() {
-    throw new OperationError(`WriteTransaction.conditionCheck is not implemented`,
-      'WriteTransaction.conditionCheck', HttpStatus.NOT_IMPLEMENTED);
-  }
+    /**
+     * Adds a condition check to the write transaction. Call {@link #execute} to execute the transaction.
+     */
+    conditionCheck() {
+        throw new OperationError(`WriteTransaction.conditionCheck is not implemented`,
+            'WriteTransaction.conditionCheck', HttpStatus.NOT_IMPLEMENTED);
+    }
 
-  /**
-   * Adds a deleteItem to the write transaction. Call {@link #execute} to execute the transaction.
-   * @param {string} tableName Table name
-   * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
-   *   (partition key and sort key).
-   * @param {object} [options] Delete options.
-   * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
-   */
-  deleteItem(tableName, pk, options = { keyMustExist: true }) {
-    const ddbParams = {
-      Delete: this._paramFactory.createDeleteItem(tableName, pk, options)
-    };
-    this._transactItems.push(ddbParams);
-  }
+    /**
+     * Adds a deleteItem to the write transaction. Call {@link #execute} to execute the transaction.
+     * @param {string} tableName Table name
+     * @param {object} pk The row's primary key. Can be simple (a partition key) or composite
+     *   (partition key and sort key).
+     * @param {object} [options] Delete options.
+     * @param {boolean} [options.keyMustExist=true] Set to true to fail the delete if the key doesn't exist.
+     */
+    deleteItem(tableName, pk, options = { keyMustExist: true }) {
+        const ddbParams = {
+            Delete: this._paramFactory.createDeleteItem(tableName, pk, options)
+        };
+        this._transactItems.push(ddbParams);
+    }
 
-  /**
-   * Adds a putItem to the write transaction. Call {@link #execute} to execute the transaction.
-   * @param {string} tableName The table name.
-   * @param {object} params A row to persist in the table. At a minimum, the row must contain
-   *   attributes matching the table's primary key.
-   * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
-   *   and an item with the same key already exists, the operation fails. Defaults to undefined,
-   *   which overwrites existing entries.
-   */
-  putItem(tableName, params, protectedAttrs) {
-    const ddbParams = {
-      Put: this._paramFactory.createPutItem(tableName, params, protectedAttrs)
-    };
-    this._transactItems.push(ddbParams);
-  }
+    /**
+     * Adds a putItem to the write transaction. Call {@link #execute} to execute the transaction.
+     * @param {string} tableName The table name.
+     * @param {object} params A row to persist in the table. At a minimum, the row must contain
+     *   attributes matching the table's primary key.
+     * @param {Array<string>} [protectedAttrs=undefined] When set to the name of the key attribute(s)
+     *   and an item with the same key already exists, the operation fails. Defaults to undefined,
+     *   which overwrites existing entries.
+     */
+    putItem(tableName, params, protectedAttrs) {
+        const ddbParams = {
+            Put: this._paramFactory.createPutItem(tableName, params, protectedAttrs)
+        };
+        this._transactItems.push(ddbParams);
+    }
 
-  /**
-   * Adds an updateItem action to the write transaction. Call {@link #execute} to execute the transaction.
-   * @param {string} tableName The table name.
-   * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
-   *   composite (partition key and sort key).
-   * @param {object} [updates=undefined] A map of column names to their update value.
-   * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
-   *   Example: {
-   *     keyMustExist: true,
-   *     expression: 'sequence = :value',
-   *     variables: {
-   *       value: 3
-   *     }
-   *   }
-   * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
-   *   'pk' doesn't exist.
-   * @param {string} condition.expression A DynamoDB ConditionExpression string.
-   * @param {object} condition.variables A map of variable names to their value, that are in the
-   *   condition expression.
-   * @param {object} [removeArray=undefined] A list of attributes to remove.
-    */
-  updateItem(tableName, pk, updates, condition, removeArray) {
-    const ddbParams = {
-      Update: this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray)
-    };
-    delete ddbParams.Update.ReturnValues; // <-- This option is not used in transactions
-    this._transactItems.push(ddbParams);
-  }
+    /**
+     * Adds an updateItem action to the write transaction. Call {@link #execute} to execute the transaction.
+     * @param {string} tableName The table name.
+     * @param {object} pk The primary key of the row to update. Can be simple (a partition key) or
+     *   composite (partition key and sort key).
+     * @param {object} [updates=undefined] A map of column names to their update value.
+     * @param {object} [condition=undefined] An optional condition to set for the update to succeed.
+     *   Example: {
+     *     keyMustExist: true,
+     *     expression: 'sequence = :value',
+     *     variables: {
+     *       value: 3
+     *     }
+     *   }
+     * @param {boolean} [condition.keyMustExist=true] Set to true to fail the update if the row identified by
+     *   'pk' doesn't exist.
+     * @param {string} condition.expression A DynamoDB ConditionExpression string.
+     * @param {object} condition.variables A map of variable names to their value, that are in the
+     *   condition expression.
+     * @param {object} [removeArray=undefined] A list of attributes to remove.
+      */
+    updateItem(tableName, pk, updates, condition, removeArray) {
+        const ddbParams = {
+            Update: this._paramFactory.createUpdateItem(tableName, pk, updates, condition, removeArray)
+        };
+        delete ddbParams.Update.ReturnValues; // <-- This option is not used in transactions
+        this._transactItems.push(ddbParams);
+    }
 
-  /**
-   * Execute the transaction. WriteTransaction instances cannot be reused except to retry a failed call.
-   * @return {object} The result of calling AWS.DynamoDB.transactWriteItems
-   */
-  async execute() {
-    const ddbParams = {
-      TransactItems: this._transactItems,
-      ClientRequestToken: this._clientRequestToken,
-      ReturnConsumedCapacity: credsRotation.ddbClient.config.returnConsumedCapacity
-    };
-    return await credsRotation.ddbClient._ddbApiCall('transactWriteItems', ddbParams);
-  }
+    /**
+     * Execute the transaction. WriteTransaction instances cannot be reused except to retry a failed call.
+     * @return {object} The result of calling AWS.DynamoDB.transactWriteItems
+     */
+    async execute() {
+        const ddbParams = {
+            TransactItems: this._transactItems,
+            ClientRequestToken: this._clientRequestToken,
+            ReturnConsumedCapacity: credsRotation.ddbClient.config.returnConsumedCapacity
+        };
+        return await credsRotation.ddbClient._ddbApiCall('transactWriteItems', ddbParams);
+    }
 }
 
 module.exports = WriteTransaction;

--- a/experimental/PropertyDDS/services/property-query-service/src/server/utils/logger_controller.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/server/utils/logger_controller.js
@@ -11,93 +11,93 @@ const LoggerSanitizer = require('./logger_sanitizer');
 /**
  * The LoggerController exposes an endpoint authenticated `/logger` route used to change the
  * logging levels on individual modules.
- * @see hfdm-logger#ModuleLogger
+ * See {@link hfdm-logger#ModuleLogger}
  * @fileoverview
  */
 class LoggerController extends BasicAuthController {
-  /**
-   *
-   * @param {HFDM.ServerUtils.BaseServer} baseServer An instance of HFDM.ServerUtils.BaseServer
-   * @param {Object} params List of parameters
-   * @param {string} params.basicAuth.username A username to authenticate
-   * @param {string} params.basicAuth.password A password to authenticate
-   * @param {Object[]} params.basicAuth.passwordList A password list to authenticate
-   *  { value: string , endAt: string ISO date}
-   *
-   * @constructor
-   */
-  constructor(baseServer, params) {
-    super(baseServer, params);
+    /**
+     *
+     * @param {HFDM.ServerUtils.BaseServer} baseServer An instance of HFDM.ServerUtils.BaseServer
+     * @param {Object} params List of parameters
+     * @param {string} params.basicAuth.username A username to authenticate
+     * @param {string} params.basicAuth.password A password to authenticate
+     * @param {Object[]} params.basicAuth.passwordList A password list to authenticate
+     *  { value: string , endAt: string ISO date}
+     *
+     * @constructor
+     */
+    constructor(baseServer, params) {
+        super(baseServer, params);
 
-    this.setupRoutes({
-      get: {
-        '/logger': this.getLogLevel.bind(this)
-      },
-      post: {
-        '/logger': this.setLogLevel.bind(this)
-      }
-    });
+        this.setupRoutes({
+            get: {
+                '/logger': this.getLogLevel.bind(this)
+            },
+            post: {
+                '/logger': this.setLogLevel.bind(this)
+            }
+        });
 
-    this._loggerSanitizer = sanitize(LoggerSanitizer);
-  }
-
-  /**
-   * Route invoked to query the log level of a specific module, or all modules.
-   * @param {Object} req The request.
-   * @param {?string} req.query.name An optional module name. When specified, the logging level is
-   *   returned only for that module. When left unspecified, all known module levels are outputted.
-   * @param {Object} res The response.
-   */
-  getLogLevel(req, res) {
-    var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
-    if (!name) {
-      if (req.query.name && req.query.name.length > 0) {
-        res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
-        res.write("invalid parameter: 'name'");
-      } else {
-        // Get a list of all registered loggers and their level
-        res.writeHead(HttpStatus.OK);
-        res.write(JSON.stringify(ModuleLogger.loggers));
-      }
-    } else {
-      this._logger.debug('GET /logger [' + name + ']');
-      var logger = ModuleLogger.getLogger(name);
-      res.writeHead(HttpStatus.OK);
-      res.write(JSON.stringify({module: name, level: logger.level.levelStr}));
+        this._loggerSanitizer = sanitize(LoggerSanitizer);
     }
 
-    res.end();
-  }
+    /**
+     * Route invoked to query the log level of a specific module, or all modules.
+     * @param {Object} req The request.
+     * @param {?string} req.query.name An optional module name. When specified, the logging level is
+     *   returned only for that module. When left unspecified, all known module levels are outputted.
+     * @param {Object} res The response.
+     */
+    getLogLevel(req, res) {
+        var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
+        if (!name) {
+            if (req.query.name && req.query.name.length > 0) {
+                res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
+                res.write("invalid parameter: 'name'");
+            } else {
+                // Get a list of all registered loggers and their level
+                res.writeHead(HttpStatus.OK);
+                res.write(JSON.stringify(ModuleLogger.loggers));
+            }
+        } else {
+            this._logger.debug('GET /logger [' + name + ']');
+            var logger = ModuleLogger.getLogger(name);
+            res.writeHead(HttpStatus.OK);
+            res.write(JSON.stringify({ module: name, level: logger.level.levelStr }));
+        }
 
-  /**
-   * Changes the log level for a given module.
-   * @param {Object} req The request.
-   * @param {string} req.query.name The module name for which to set the logging level.
-   * @param {string} req.query.level The desired logging level for that module.
-   *   One of: ['ALL', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL', 'OFF'].
-   * @param {Object} res The response contains the module's logging level after it's set.
-   */
-  setLogLevel(req, res) {
-    var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
-    var level = this._loggerSanitizer.value(req.query.level, 'logLevel');
-
-    if (!name) {
-      res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
-      res.write("Missing or invalid parameter: 'name'");
-    } else if (!level) {
-      res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
-      res.write("Missing or invalid parameter: 'level'");
-    } else {
-      this._logger.debug('POST /logger [' + name + '], level: [' + level + ']');
-
-      const logger = ModuleLogger.getLogger(name);
-      logger.setLevel(level);
-      res.writeHead(HttpStatus.OK);
-      res.write(JSON.stringify({module: name, level: logger.level.levelStr}));
+        res.end();
     }
 
-    res.end();
-  }
+    /**
+     * Changes the log level for a given module.
+     * @param {Object} req The request.
+     * @param {string} req.query.name The module name for which to set the logging level.
+     * @param {string} req.query.level The desired logging level for that module.
+     *   One of: ['ALL', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL', 'OFF'].
+     * @param {Object} res The response contains the module's logging level after it's set.
+     */
+    setLogLevel(req, res) {
+        var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
+        var level = this._loggerSanitizer.value(req.query.level, 'logLevel');
+
+        if (!name) {
+            res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
+            res.write("Missing or invalid parameter: 'name'");
+        } else if (!level) {
+            res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
+            res.write("Missing or invalid parameter: 'level'");
+        } else {
+            this._logger.debug('POST /logger [' + name + '], level: [' + level + ']');
+
+            const logger = ModuleLogger.getLogger(name);
+            logger.setLevel(level);
+            res.writeHead(HttpStatus.OK);
+            res.write(JSON.stringify({ module: name, level: logger.level.levelStr }));
+        }
+
+        res.end();
+    }
 }
 
 module.exports = LoggerController;

--- a/experimental/PropertyDDS/services/property-query-service/src/server/utils/logger_controller.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/server/utils/logger_controller.js
@@ -11,93 +11,93 @@ const LoggerSanitizer = require('./logger_sanitizer');
 /**
  * The LoggerController exposes an endpoint authenticated `/logger` route used to change the
  * logging levels on individual modules.
- * See {@link hfdm-logger#ModuleLogger}
+ * @see hfdm-logger#ModuleLogger
  * @fileoverview
  */
 class LoggerController extends BasicAuthController {
-    /**
-     *
-     * @param {HFDM.ServerUtils.BaseServer} baseServer An instance of HFDM.ServerUtils.BaseServer
-     * @param {Object} params List of parameters
-     * @param {string} params.basicAuth.username A username to authenticate
-     * @param {string} params.basicAuth.password A password to authenticate
-     * @param {Object[]} params.basicAuth.passwordList A password list to authenticate
-     *  { value: string , endAt: string ISO date}
-     *
-     * @constructor
-     */
-    constructor(baseServer, params) {
-        super(baseServer, params);
+  /**
+   *
+   * @param {HFDM.ServerUtils.BaseServer} baseServer An instance of HFDM.ServerUtils.BaseServer
+   * @param {Object} params List of parameters
+   * @param {string} params.basicAuth.username A username to authenticate
+   * @param {string} params.basicAuth.password A password to authenticate
+   * @param {Object[]} params.basicAuth.passwordList A password list to authenticate
+   *  { value: string , endAt: string ISO date}
+   *
+   * @constructor
+   */
+  constructor(baseServer, params) {
+    super(baseServer, params);
 
-        this.setupRoutes({
-            get: {
-                '/logger': this.getLogLevel.bind(this)
-            },
-            post: {
-                '/logger': this.setLogLevel.bind(this)
-            }
-        });
+    this.setupRoutes({
+      get: {
+        '/logger': this.getLogLevel.bind(this)
+      },
+      post: {
+        '/logger': this.setLogLevel.bind(this)
+      }
+    });
 
-        this._loggerSanitizer = sanitize(LoggerSanitizer);
+    this._loggerSanitizer = sanitize(LoggerSanitizer);
+  }
+
+  /**
+   * Route invoked to query the log level of a specific module, or all modules.
+   * @param {Object} req The request.
+   * @param {?string} req.query.name An optional module name. When specified, the logging level is
+   *   returned only for that module. When left unspecified, all known module levels are outputted.
+   * @param {Object} res The response.
+   */
+  getLogLevel(req, res) {
+    var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
+    if (!name) {
+      if (req.query.name && req.query.name.length > 0) {
+        res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
+        res.write("invalid parameter: 'name'");
+      } else {
+        // Get a list of all registered loggers and their level
+        res.writeHead(HttpStatus.OK);
+        res.write(JSON.stringify(ModuleLogger.loggers));
+      }
+    } else {
+      this._logger.debug('GET /logger [' + name + ']');
+      var logger = ModuleLogger.getLogger(name);
+      res.writeHead(HttpStatus.OK);
+      res.write(JSON.stringify({module: name, level: logger.level.levelStr}));
     }
 
-    /**
-     * Route invoked to query the log level of a specific module, or all modules.
-     * @param {Object} req The request.
-     * @param {?string} req.query.name An optional module name. When specified, the logging level is
-     *   returned only for that module. When left unspecified, all known module levels are outputted.
-     * @param {Object} res The response.
-     */
-    getLogLevel(req, res) {
-        var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
-        if (!name) {
-            if (req.query.name && req.query.name.length > 0) {
-                res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
-                res.write("invalid parameter: 'name'");
-            } else {
-                // Get a list of all registered loggers and their level
-                res.writeHead(HttpStatus.OK);
-                res.write(JSON.stringify(ModuleLogger.loggers));
-            }
-        } else {
-            this._logger.debug('GET /logger [' + name + ']');
-            var logger = ModuleLogger.getLogger(name);
-            res.writeHead(HttpStatus.OK);
-            res.write(JSON.stringify({ module: name, level: logger.level.levelStr }));
-        }
+    res.end();
+  }
 
-        res.end();
+  /**
+   * Changes the log level for a given module.
+   * @param {Object} req The request.
+   * @param {string} req.query.name The module name for which to set the logging level.
+   * @param {string} req.query.level The desired logging level for that module.
+   *   One of: ['ALL', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL', 'OFF'].
+   * @param {Object} res The response contains the module's logging level after it's set.
+   */
+  setLogLevel(req, res) {
+    var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
+    var level = this._loggerSanitizer.value(req.query.level, 'logLevel');
+
+    if (!name) {
+      res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
+      res.write("Missing or invalid parameter: 'name'");
+    } else if (!level) {
+      res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
+      res.write("Missing or invalid parameter: 'level'");
+    } else {
+      this._logger.debug('POST /logger [' + name + '], level: [' + level + ']');
+
+      const logger = ModuleLogger.getLogger(name);
+      logger.setLevel(level);
+      res.writeHead(HttpStatus.OK);
+      res.write(JSON.stringify({module: name, level: logger.level.levelStr}));
     }
 
-    /**
-     * Changes the log level for a given module.
-     * @param {Object} req The request.
-     * @param {string} req.query.name The module name for which to set the logging level.
-     * @param {string} req.query.level The desired logging level for that module.
-     *   One of: ['ALL', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL', 'OFF'].
-     * @param {Object} res The response contains the module's logging level after it's set.
-     */
-    setLogLevel(req, res) {
-        var name = this._loggerSanitizer.value(req.query.name, 'moduleName');
-        var level = this._loggerSanitizer.value(req.query.level, 'logLevel');
-
-        if (!name) {
-            res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
-            res.write("Missing or invalid parameter: 'name'");
-        } else if (!level) {
-            res.writeHead(HttpStatus.UNPROCESSABLE_ENTITY);
-            res.write("Missing or invalid parameter: 'level'");
-        } else {
-            this._logger.debug('POST /logger [' + name + '], level: [' + level + ']');
-
-            const logger = ModuleLogger.getLogger(name);
-            logger.setLevel(level);
-            res.writeHead(HttpStatus.OK);
-            res.write(JSON.stringify({ module: name, level: logger.level.levelStr }));
-        }
-
-        res.end();
-    }
+    res.end();
+  }
 }
 
 module.exports = LoggerController;

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1657,7 +1657,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -4638,14 +4638,14 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@0.59.4002",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.4002.tgz",
-			"integrity": "sha512-3KMmAK9D8uRTLOVYpTYRokT2hdVQDXoDO8d4xCZ+Qs7DGxQkqSwiuy4S+1PqGGz/uo641rEBsjNCEZoK27z6sg==",
+			"version": "npm:@fluidframework/undo-redo@0.59.4001",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.4001.tgz",
+			"integrity": "sha512-aPAnNPvdVXdVRVAoCmP3lfrG3hZDpgfO0hyjVEpRP9UQOXNZwl4cxyCfvIMSW2XIdVcjCKh0qtTkhqa3EsrNtw==",
 			"requires": {
-				"@fluidframework/map": "^0.59.4002",
-				"@fluidframework/matrix": "^0.59.4002",
-				"@fluidframework/merge-tree": "^0.59.4002",
-				"@fluidframework/sequence": "^0.59.4002"
+				"@fluidframework/map": "^0.59.4001",
+				"@fluidframework/matrix": "^0.59.4001",
+				"@fluidframework/merge-tree": "^0.59.4001",
+				"@fluidframework/sequence": "^0.59.4001"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -4660,53 +4660,53 @@
 					}
 				},
 				"@fluidframework/container-runtime": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.4002.tgz",
-					"integrity": "sha512-Zz2f7hR3lUd1lBR2imQF9OOvXqykO5/gYG//9qAcKIuvOs8O5WmbC95+Ab6cvInu9YgmXUOp3kxwU0IMiShJYw==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.4001.tgz",
+					"integrity": "sha512-K92Vc50UYQF/uY1HtSvPRxQIYu8mpdWK4pxcusdKu+i4wYbWR/iXTl5DvEPmfi2kKMQFg2ReJyaRGcCsGtpodQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime-definitions": "^0.59.4002",
-						"@fluidframework/container-utils": "^0.59.4002",
+						"@fluidframework/container-runtime-definitions": "^0.59.4001",
+						"@fluidframework/container-utils": "^0.59.4001",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore": "^0.59.4002",
+						"@fluidframework/datastore": "^0.59.4001",
 						"@fluidframework/driver-definitions": "^0.46.2000",
-						"@fluidframework/driver-utils": "^0.59.4002",
-						"@fluidframework/garbage-collector": "^0.59.4002",
+						"@fluidframework/driver-utils": "^0.59.4001",
+						"@fluidframework/garbage-collector": "^0.59.4001",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/runtime-utils": "^0.59.4002",
-						"@fluidframework/telemetry-utils": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-utils": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4001",
 						"double-ended-queue": "^2.1.0-0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.4002.tgz",
-					"integrity": "sha512-+6ObkheY8Ogw5rPdCXsSPXDnyQwZf5yopVkCQZfBMJ4XnDlymdvNVfOVYTZFoBohlY6cnu+nsEL1mx5W7Qq6Kw==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.4001.tgz",
+					"integrity": "sha512-ql78Rt8KRQt3sAFfHD1/rMCk/gr0NaP7PzmGObXKmYIr5ySdEelVOWyqTCM2t8GKJMkW9L+LV1oiiyORJnaHZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
 						"@types/node": "^14.18.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.4002.tgz",
-					"integrity": "sha512-jt80eaxsOOBrhHe+XeCwyZxCutdzt3Kqv/aaVgfVl5+J11CUPF3d6lerltX6cy3UfCv7MbX2kfoGJdyAnyyiVg==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.4001.tgz",
+					"integrity": "sha512-b5r1kQntAjG6j/VfEI3AJF99cglmiAeh7LRAlV1LfCWzhpXfx2LabZ/t0bHj4ZakvMKL6WdiDPu0M1WdZKtxug==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/telemetry-utils": "^0.59.4002"
+						"@fluidframework/telemetry-utils": "^0.59.4001"
 					}
 				},
 				"@fluidframework/core-interfaces": {
@@ -4715,39 +4715,39 @@
 					"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.4002.tgz",
-					"integrity": "sha512-miZ7fH8/A5Bcj5hG2VNyaBz7d6LqniMs1gsXqwAWFDD1J6ac1pYYM7Q9Ha5aBQf9tLJm4sMD10z8Ij+dUOSOOA==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.4001.tgz",
+					"integrity": "sha512-UR8reBhmDtN1NfRim13jY8WzEUphh3ns+YJHxLmixFWR8/+VGxfz5ml1IQRPjq+0dExQrHAwohUHuyrxfBSFTg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-utils": "^0.59.4002",
+						"@fluidframework/container-utils": "^0.59.4001",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4001",
 						"@fluidframework/driver-definitions": "^0.46.2000",
-						"@fluidframework/driver-utils": "^0.59.4002",
-						"@fluidframework/garbage-collector": "^0.59.4002",
+						"@fluidframework/driver-utils": "^0.59.4001",
+						"@fluidframework/garbage-collector": "^0.59.4001",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/runtime-utils": "^0.59.4002",
-						"@fluidframework/telemetry-utils": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-utils": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4001",
 						"lodash": "^4.17.21",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.4002.tgz",
-					"integrity": "sha512-stilyyhpZYSbHqbp8I2CwC5C4dW02w1miWp34FQdxy0yFro2yXyVCEfEPeTCRbAUE6UPd/muPSrwJ9pPxK5aWw==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.4001.tgz",
+					"integrity": "sha512-q7bYVzyDjvlaxjx82QXPcKJCwWnJNFtOBbZH7MOL3/VvLqsB3IhaGE28RbTouFZXZDgkbnRnP/H3yWRzDfxYCg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
 						"@types/node": "^14.18.0"
 					}
 				},
@@ -4762,9 +4762,9 @@
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.4002.tgz",
-					"integrity": "sha512-NsuamiiDWlCW1QioSU3DNkzO6LxYC3FR1jvfVDScXmv9xO41dUlaqB09tdF4RHGiRj4zd4G32fLuwYoX7T2c+w==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.4001.tgz",
+					"integrity": "sha512-1Y1CVYYMKerKdsFkEL9SRzNFGX81PoAukPVPG/yhP/bDAzztcO6YEp8Fg7eVMfGVVE9pPqSx5HKqpbMcuu+ffw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -4773,80 +4773,80 @@
 						"@fluidframework/gitresources": "^0.1036.4000",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/telemetry-utils": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4001",
 						"axios": "^0.26.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.4002.tgz",
-					"integrity": "sha512-0aZFcjicvUuPW5XNACqo9rZ0d92uBwlzvnRkSfepHHW2ZY/nKqmbYs87LO1wIG2fP7x8URhtdDCtwobXO0HE+Q==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.4001.tgz",
+					"integrity": "sha512-Owy1mTnIAmQHfbSfMF41katFA+B3iJrUS+81TnXwOpJWjDqnYEkdeF3ohY2Iv2xZqoTaLT8DCtoxyuAS1vm0ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/runtime-definitions": "^0.59.4002"
+						"@fluidframework/runtime-definitions": "^0.59.4001"
 					}
 				},
 				"@fluidframework/map": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.4002.tgz",
-					"integrity": "sha512-U+5uoKwL5O/4GtVBeXMeOi05qCAPJ4Pgx0gJKVmRsxyZvm8ZXSwOg7zj7glef5z1VLs24L5wrIRG2U+oIZzsaw==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.4001.tgz",
+					"integrity": "sha512-qyT7HOGOQcGD221N9kCSdghlOtpYuUPJYmBL8Izqa9iGvSzIRKxF4/3mgqWwsTJqrR9HjAZGTlJCRQyMcNkrYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/container-utils": "^0.59.4002",
+						"@fluidframework/container-utils": "^0.59.4001",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4002",
-						"@fluidframework/driver-utils": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/driver-utils": "^0.59.4001",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/runtime-utils": "^0.59.4002",
-						"@fluidframework/shared-object-base": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-utils": "^0.59.4001",
+						"@fluidframework/shared-object-base": "^0.59.4001",
 						"path-browserify": "^1.0.1"
 					}
 				},
 				"@fluidframework/matrix": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.4002.tgz",
-					"integrity": "sha512-DemcOc2Mb7x0sfEjTs6LxftOvWdR65gybb8afWSr6cIfxSsSIqtPIxsAxEOVVy6rO+ZJz2F6mEfWmr5SmxcgYw==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.4001.tgz",
+					"integrity": "sha512-4kdi0YGBYjtRZYOxtXKbrkBVHoWe2ojuOofa4v2FZyz7lBccPKD/ODoNgddildWrjw+tndClHcLe+1l4Lrx0zA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4002",
-						"@fluidframework/merge-tree": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/merge-tree": "^0.59.4001",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/runtime-utils": "^0.59.4002",
-						"@fluidframework/shared-object-base": "^0.59.4002",
-						"@fluidframework/telemetry-utils": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-utils": "^0.59.4001",
+						"@fluidframework/shared-object-base": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4001",
 						"@tiny-calc/nano": "0.0.0-alpha.5",
 						"tslib": "^1.10.0"
 					}
 				},
 				"@fluidframework/merge-tree": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.4002.tgz",
-					"integrity": "sha512-R/PyxBNlE53Q254r2z++zUh9CCu5EvmpMB/S1YvmlZsdYs0aOgSfkHN9jLGTsa9dYn5CJYGxyjZFIhq0UYbTrA==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.4001.tgz",
+					"integrity": "sha512-sEQg6Phj1O3y0c4ngbpdrWWoiVjbsI4DcTCLHkd57fCqmOrCYCglpWLhn+qF7OmQieqjR5HQ966/asnsHXiZEw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4001",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/runtime-utils": "^0.59.4002",
-						"@fluidframework/shared-object-base": "^0.59.4002",
-						"@fluidframework/telemetry-utils": "^0.59.4002"
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-utils": "^0.59.4001",
+						"@fluidframework/shared-object-base": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4001"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.4002.tgz",
-					"integrity": "sha512-Iq9dZ3ez9NUfWLSBeAhaKlGGDQn1om8g9+FCzj23WxOvzITLSMpHdXf5KXmcBXi2EZFe5vWM0z00VHOrNIdJrA==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.4001.tgz",
+					"integrity": "sha512-CP0fNsgOUfQwXfUy9mttueg9aGOxMU+gXZNBTzRe48VNui5laHPFROWLrOj658FoY5GmDJCEW67J7mWKxrY7Tg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -4858,65 +4858,65 @@
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.4002.tgz",
-					"integrity": "sha512-whJfMTZpSPxn56aKDX8WhrluwvQEW/4//VgbVS4VXAzSOfn5uKuMJ1W3XePGjAxn31y/09G3f2YvP4CrqRcUJA==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.4001.tgz",
+					"integrity": "sha512-OFbwZm3Op1isE5jkAupiyJmJ5F2pxnmJn7/zc5bhGl0sqVKs0/zhhe8q1XdmpIrEVlBhZkeLPmzT/AMD8Hr0+Q==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime-definitions": "^0.59.4002",
+						"@fluidframework/container-runtime-definitions": "^0.59.4001",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4002",
-						"@fluidframework/garbage-collector": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/garbage-collector": "^0.59.4001",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/telemetry-utils": "^0.59.4002"
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4001"
 					}
 				},
 				"@fluidframework/sequence": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.4002.tgz",
-					"integrity": "sha512-biFXkwn1A6yh/NMA1YhWRBf1IvfeXQfPzWTBACXoxdbLE0VBcj0xHwElBqJnLx48qpgnLtSrMd6+TgHN+WBO6w==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.4001.tgz",
+					"integrity": "sha512-pNS5pGYJgY6FkBIhN90sOfovgTQ6pMzt1NOWc54mLCVnRnSi/CUgbME/b2n4Sr4mK0mxGR/iBLbJhTBBpXizjw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4002",
-						"@fluidframework/merge-tree": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/merge-tree": "^0.59.4001",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/runtime-utils": "^0.59.4002",
-						"@fluidframework/shared-object-base": "^0.59.4002",
-						"@fluidframework/telemetry-utils": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-utils": "^0.59.4001",
+						"@fluidframework/shared-object-base": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4001",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.4002.tgz",
-					"integrity": "sha512-mDf/WcJFzkIVqF5DfhYeGFnU7hGb3rr30QJugd9wScSCF+uEIaHxQnzYr8jxFDtNwJkOD9IZV5wQ6Fgf9ZBWJw==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.4001.tgz",
+					"integrity": "sha512-p0tpIzmK+RInyjS8rW+UqjH+hX9bJG2vTrNXXLOF40DUp9DypFOP/Dbd1dE0r6AvltwqKO09gQhhafyXkzjoTQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime": "^0.59.4002",
-						"@fluidframework/container-utils": "^0.59.4002",
+						"@fluidframework/container-runtime": "^0.59.4001",
+						"@fluidframework/container-utils": "^0.59.4001",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore": "^0.59.4002",
-						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/datastore": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4001",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4002",
-						"@fluidframework/runtime-utils": "^0.59.4002",
-						"@fluidframework/telemetry-utils": "^0.59.4002",
+						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-utils": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4001",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.59.4002",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.4002.tgz",
-					"integrity": "sha512-lTs9zptGduRFH6rpDDsrMKwZ0tAkQNe/qpcnyxdVxknZyKD8yhh4zvSwyISbI2zHbgVyde9b/3Rw4rgy598pGA==",
+					"version": "0.59.4001",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.4001.tgz",
+					"integrity": "sha512-Zmu1dDcVhOhsISapBGQVuz8k2H7fCatjaWU2ia6gBPIildxbjzHyYGCyTJMHsbMK7h77FH3XSxbGoVYCBJ/QXg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -17675,7 +17675,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
 			"dev": true
 		},
 		"auto-bind": {
@@ -19144,7 +19144,7 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"dev": true
 		},
 		"buffer": {
@@ -19185,7 +19185,7 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
 		},
 		"buffer-fill": {
 			"version": "1.0.0",
@@ -24017,7 +24017,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
 		},
 		"es6-promise": {
 			"version": "4.2.8",
@@ -24027,7 +24027,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -24959,7 +24959,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -26031,7 +26031,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="
 		},
 		"fs-extra": {
 			"version": "9.1.0",
@@ -26371,7 +26371,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -27700,7 +27700,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
 				}
 			}
@@ -27785,7 +27785,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
+			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -27874,7 +27874,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
 		},
 		"immutable": {
 			"version": "3.7.6",
@@ -28225,7 +28225,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
 		},
 		"internal-slot": {
 			"version": "1.0.3",
@@ -28498,7 +28498,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -28604,7 +28604,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -31670,7 +31670,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
+			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -32353,7 +32353,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
 			"dev": true
 		},
 		"lodash.flatten": {
@@ -32379,7 +32379,7 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -32389,7 +32389,7 @@
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
@@ -32404,7 +32404,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -32415,23 +32415,23 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -32441,19 +32441,19 @@
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -32464,12 +32464,12 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
 		},
 		"lodash.snakecase": {
 			"version": "4.1.1",
@@ -32479,7 +32479,7 @@
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
 			"dev": true
 		},
 		"lodash.template": {
@@ -32504,7 +32504,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -34475,7 +34475,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
 			"requires": {
 				"event-lite": "^0.1.1",
 				"ieee754": "^1.1.8",
@@ -34486,7 +34486,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 				}
 			}
 		},
@@ -34803,7 +34803,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
 			"dev": true
 		},
 		"node-dir": {
@@ -36906,7 +36906,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
+			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
 			"dev": true
 		},
 		"p-all": {
@@ -37391,7 +37391,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="
 		},
 		"parse-path": {
 			"version": "4.0.3",
@@ -37647,7 +37647,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
+			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
 			"dev": true
 		},
 		"pirates": {
@@ -43150,7 +43150,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
 					"dev": true
 				},
 				"supports-color": {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1657,7 +1657,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -4638,14 +4638,14 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@0.59.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.4001.tgz",
-			"integrity": "sha512-aPAnNPvdVXdVRVAoCmP3lfrG3hZDpgfO0hyjVEpRP9UQOXNZwl4cxyCfvIMSW2XIdVcjCKh0qtTkhqa3EsrNtw==",
+			"version": "npm:@fluidframework/undo-redo@0.59.4002",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.4002.tgz",
+			"integrity": "sha512-3KMmAK9D8uRTLOVYpTYRokT2hdVQDXoDO8d4xCZ+Qs7DGxQkqSwiuy4S+1PqGGz/uo641rEBsjNCEZoK27z6sg==",
 			"requires": {
-				"@fluidframework/map": "^0.59.4001",
-				"@fluidframework/matrix": "^0.59.4001",
-				"@fluidframework/merge-tree": "^0.59.4001",
-				"@fluidframework/sequence": "^0.59.4001"
+				"@fluidframework/map": "^0.59.4002",
+				"@fluidframework/matrix": "^0.59.4002",
+				"@fluidframework/merge-tree": "^0.59.4002",
+				"@fluidframework/sequence": "^0.59.4002"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -4660,53 +4660,53 @@
 					}
 				},
 				"@fluidframework/container-runtime": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.4001.tgz",
-					"integrity": "sha512-K92Vc50UYQF/uY1HtSvPRxQIYu8mpdWK4pxcusdKu+i4wYbWR/iXTl5DvEPmfi2kKMQFg2ReJyaRGcCsGtpodQ==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.4002.tgz",
+					"integrity": "sha512-Zz2f7hR3lUd1lBR2imQF9OOvXqykO5/gYG//9qAcKIuvOs8O5WmbC95+Ab6cvInu9YgmXUOp3kxwU0IMiShJYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime-definitions": "^0.59.4001",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-runtime-definitions": "^0.59.4002",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore": "^0.59.4001",
+						"@fluidframework/datastore": "^0.59.4002",
 						"@fluidframework/driver-definitions": "^0.46.2000",
-						"@fluidframework/driver-utils": "^0.59.4001",
-						"@fluidframework/garbage-collector": "^0.59.4001",
+						"@fluidframework/driver-utils": "^0.59.4002",
+						"@fluidframework/garbage-collector": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"double-ended-queue": "^2.1.0-0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.4001.tgz",
-					"integrity": "sha512-ql78Rt8KRQt3sAFfHD1/rMCk/gr0NaP7PzmGObXKmYIr5ySdEelVOWyqTCM2t8GKJMkW9L+LV1oiiyORJnaHZw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.4002.tgz",
+					"integrity": "sha512-+6ObkheY8Ogw5rPdCXsSPXDnyQwZf5yopVkCQZfBMJ4XnDlymdvNVfOVYTZFoBohlY6cnu+nsEL1mx5W7Qq6Kw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
 						"@types/node": "^14.18.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.4001.tgz",
-					"integrity": "sha512-b5r1kQntAjG6j/VfEI3AJF99cglmiAeh7LRAlV1LfCWzhpXfx2LabZ/t0bHj4ZakvMKL6WdiDPu0M1WdZKtxug==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.4002.tgz",
+					"integrity": "sha512-jt80eaxsOOBrhHe+XeCwyZxCutdzt3Kqv/aaVgfVl5+J11CUPF3d6lerltX6cy3UfCv7MbX2kfoGJdyAnyyiVg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/telemetry-utils": "^0.59.4001"
+						"@fluidframework/telemetry-utils": "^0.59.4002"
 					}
 				},
 				"@fluidframework/core-interfaces": {
@@ -4715,39 +4715,39 @@
 					"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.4001.tgz",
-					"integrity": "sha512-UR8reBhmDtN1NfRim13jY8WzEUphh3ns+YJHxLmixFWR8/+VGxfz5ml1IQRPjq+0dExQrHAwohUHuyrxfBSFTg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.4002.tgz",
+					"integrity": "sha512-miZ7fH8/A5Bcj5hG2VNyaBz7d6LqniMs1gsXqwAWFDD1J6ac1pYYM7Q9Ha5aBQf9tLJm4sMD10z8Ij+dUOSOOA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
 						"@fluidframework/driver-definitions": "^0.46.2000",
-						"@fluidframework/driver-utils": "^0.59.4001",
-						"@fluidframework/garbage-collector": "^0.59.4001",
+						"@fluidframework/driver-utils": "^0.59.4002",
+						"@fluidframework/garbage-collector": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"lodash": "^4.17.21",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.4001.tgz",
-					"integrity": "sha512-q7bYVzyDjvlaxjx82QXPcKJCwWnJNFtOBbZH7MOL3/VvLqsB3IhaGE28RbTouFZXZDgkbnRnP/H3yWRzDfxYCg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.4002.tgz",
+					"integrity": "sha512-stilyyhpZYSbHqbp8I2CwC5C4dW02w1miWp34FQdxy0yFro2yXyVCEfEPeTCRbAUE6UPd/muPSrwJ9pPxK5aWw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
 						"@types/node": "^14.18.0"
 					}
 				},
@@ -4762,9 +4762,9 @@
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.4001.tgz",
-					"integrity": "sha512-1Y1CVYYMKerKdsFkEL9SRzNFGX81PoAukPVPG/yhP/bDAzztcO6YEp8Fg7eVMfGVVE9pPqSx5HKqpbMcuu+ffw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.4002.tgz",
+					"integrity": "sha512-NsuamiiDWlCW1QioSU3DNkzO6LxYC3FR1jvfVDScXmv9xO41dUlaqB09tdF4RHGiRj4zd4G32fLuwYoX7T2c+w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -4773,80 +4773,80 @@
 						"@fluidframework/gitresources": "^0.1036.4000",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"axios": "^0.26.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.4001.tgz",
-					"integrity": "sha512-Owy1mTnIAmQHfbSfMF41katFA+B3iJrUS+81TnXwOpJWjDqnYEkdeF3ohY2Iv2xZqoTaLT8DCtoxyuAS1vm0ZQ==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.4002.tgz",
+					"integrity": "sha512-0aZFcjicvUuPW5XNACqo9rZ0d92uBwlzvnRkSfepHHW2ZY/nKqmbYs87LO1wIG2fP7x8URhtdDCtwobXO0HE+Q==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/runtime-definitions": "^0.59.4001"
+						"@fluidframework/runtime-definitions": "^0.59.4002"
 					}
 				},
 				"@fluidframework/map": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.4001.tgz",
-					"integrity": "sha512-qyT7HOGOQcGD221N9kCSdghlOtpYuUPJYmBL8Izqa9iGvSzIRKxF4/3mgqWwsTJqrR9HjAZGTlJCRQyMcNkrYw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.4002.tgz",
+					"integrity": "sha512-U+5uoKwL5O/4GtVBeXMeOi05qCAPJ4Pgx0gJKVmRsxyZvm8ZXSwOg7zj7glef5z1VLs24L5wrIRG2U+oIZzsaw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/driver-utils": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/driver-utils": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
 						"path-browserify": "^1.0.1"
 					}
 				},
 				"@fluidframework/matrix": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.4001.tgz",
-					"integrity": "sha512-4kdi0YGBYjtRZYOxtXKbrkBVHoWe2ojuOofa4v2FZyz7lBccPKD/ODoNgddildWrjw+tndClHcLe+1l4Lrx0zA==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.4002.tgz",
+					"integrity": "sha512-DemcOc2Mb7x0sfEjTs6LxftOvWdR65gybb8afWSr6cIfxSsSIqtPIxsAxEOVVy6rO+ZJz2F6mEfWmr5SmxcgYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/merge-tree": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/merge-tree": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"@tiny-calc/nano": "0.0.0-alpha.5",
 						"tslib": "^1.10.0"
 					}
 				},
 				"@fluidframework/merge-tree": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.4001.tgz",
-					"integrity": "sha512-sEQg6Phj1O3y0c4ngbpdrWWoiVjbsI4DcTCLHkd57fCqmOrCYCglpWLhn+qF7OmQieqjR5HQ966/asnsHXiZEw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.4002.tgz",
+					"integrity": "sha512-R/PyxBNlE53Q254r2z++zUh9CCu5EvmpMB/S1YvmlZsdYs0aOgSfkHN9jLGTsa9dYn5CJYGxyjZFIhq0UYbTrA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001"
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.4001.tgz",
-					"integrity": "sha512-CP0fNsgOUfQwXfUy9mttueg9aGOxMU+gXZNBTzRe48VNui5laHPFROWLrOj658FoY5GmDJCEW67J7mWKxrY7Tg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.4002.tgz",
+					"integrity": "sha512-Iq9dZ3ez9NUfWLSBeAhaKlGGDQn1om8g9+FCzj23WxOvzITLSMpHdXf5KXmcBXi2EZFe5vWM0z00VHOrNIdJrA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -4858,65 +4858,65 @@
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.4001.tgz",
-					"integrity": "sha512-OFbwZm3Op1isE5jkAupiyJmJ5F2pxnmJn7/zc5bhGl0sqVKs0/zhhe8q1XdmpIrEVlBhZkeLPmzT/AMD8Hr0+Q==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.4002.tgz",
+					"integrity": "sha512-whJfMTZpSPxn56aKDX8WhrluwvQEW/4//VgbVS4VXAzSOfn5uKuMJ1W3XePGjAxn31y/09G3f2YvP4CrqRcUJA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime-definitions": "^0.59.4001",
+						"@fluidframework/container-runtime-definitions": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/garbage-collector": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/garbage-collector": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001"
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002"
 					}
 				},
 				"@fluidframework/sequence": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.4001.tgz",
-					"integrity": "sha512-pNS5pGYJgY6FkBIhN90sOfovgTQ6pMzt1NOWc54mLCVnRnSi/CUgbME/b2n4Sr4mK0mxGR/iBLbJhTBBpXizjw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.4002.tgz",
+					"integrity": "sha512-biFXkwn1A6yh/NMA1YhWRBf1IvfeXQfPzWTBACXoxdbLE0VBcj0xHwElBqJnLx48qpgnLtSrMd6+TgHN+WBO6w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/merge-tree": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/merge-tree": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.4001.tgz",
-					"integrity": "sha512-p0tpIzmK+RInyjS8rW+UqjH+hX9bJG2vTrNXXLOF40DUp9DypFOP/Dbd1dE0r6AvltwqKO09gQhhafyXkzjoTQ==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.4002.tgz",
+					"integrity": "sha512-mDf/WcJFzkIVqF5DfhYeGFnU7hGb3rr30QJugd9wScSCF+uEIaHxQnzYr8jxFDtNwJkOD9IZV5wQ6Fgf9ZBWJw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime": "^0.59.4001",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-runtime": "^0.59.4002",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore": "^0.59.4001",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/datastore": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.4001.tgz",
-					"integrity": "sha512-Zmu1dDcVhOhsISapBGQVuz8k2H7fCatjaWU2ia6gBPIildxbjzHyYGCyTJMHsbMK7h77FH3XSxbGoVYCBJ/QXg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.4002.tgz",
+					"integrity": "sha512-lTs9zptGduRFH6rpDDsrMKwZ0tAkQNe/qpcnyxdVxknZyKD8yhh4zvSwyISbI2zHbgVyde9b/3Rw4rgy598pGA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -17675,7 +17675,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
 		"auto-bind": {
@@ -19144,7 +19144,7 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
 			"dev": true
 		},
 		"buffer": {
@@ -19185,7 +19185,7 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"buffer-fill": {
 			"version": "1.0.0",
@@ -24017,7 +24017,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
 		},
 		"es6-promise": {
 			"version": "4.2.8",
@@ -24027,7 +24027,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -24959,7 +24959,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -26031,7 +26031,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
 		},
 		"fs-extra": {
 			"version": "9.1.0",
@@ -26371,7 +26371,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
+			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -27700,7 +27700,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -27785,7 +27785,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
+			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -27874,7 +27874,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"immutable": {
 			"version": "3.7.6",
@@ -28225,7 +28225,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
+			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
 		},
 		"internal-slot": {
 			"version": "1.0.3",
@@ -28498,7 +28498,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -28604,7 +28604,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
+			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -31670,7 +31670,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
+			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -32353,7 +32353,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
 			"dev": true
 		},
 		"lodash.flatten": {
@@ -32379,7 +32379,7 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -32389,7 +32389,7 @@
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
@@ -32404,7 +32404,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -32415,23 +32415,23 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -32441,19 +32441,19 @@
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -32464,12 +32464,12 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
 		},
 		"lodash.snakecase": {
 			"version": "4.1.1",
@@ -32479,7 +32479,7 @@
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"lodash.template": {
@@ -32504,7 +32504,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -34475,7 +34475,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
 			"requires": {
 				"event-lite": "^0.1.1",
 				"ieee754": "^1.1.8",
@@ -34486,7 +34486,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
 		},
@@ -34803,7 +34803,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
+			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
 			"dev": true
 		},
 		"node-dir": {
@@ -36906,7 +36906,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
+			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
 			"dev": true
 		},
 		"p-all": {
@@ -37391,7 +37391,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parse-path": {
 			"version": "4.0.3",
@@ -37647,7 +37647,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
+			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
 			"dev": true
 		},
 		"pirates": {
@@ -43150,7 +43150,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
 					"dev": true
 				},
 				"supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -3722,7 +3722,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
 			"dev": true
 		},
 		"available-typed-arrays": {
@@ -3796,13 +3796,13 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"dev": true
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"dev": true
 		},
 		"buffer-from": {
@@ -5424,7 +5424,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
 			"dev": true
 		},
 		"es6-promise": {
@@ -5436,7 +5436,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
 			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
@@ -5496,7 +5496,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -5680,7 +5680,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
 			"dev": true
 		},
 		"fs-extra": {
@@ -5988,7 +5988,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -6358,7 +6358,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
 				}
 			}
@@ -6407,7 +6407,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
+			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -6449,7 +6449,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
 			"dev": true
 		},
 		"import-fresh": {
@@ -6748,7 +6748,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM=",
+			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==",
 			"dev": true
 		},
 		"internal-slot": {
@@ -6858,7 +6858,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true
 		},
 		"is-extglob": {
@@ -6910,7 +6910,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -7584,7 +7584,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
+			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -7760,7 +7760,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
 			"dev": true
 		},
 		"lodash.get": {
@@ -7772,13 +7772,13 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
 			"dev": true
 		},
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
 			"dev": true
 		},
 		"lodash.isequal": {
@@ -7790,7 +7790,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
 			"dev": true
 		},
 		"lodash.ismatch": {
@@ -7802,43 +7802,43 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
 			"dev": true
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
 			"dev": true
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"dev": true
 		},
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -7850,19 +7850,19 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
 			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
 			"dev": true
 		},
 		"lodash.template": {
@@ -7887,7 +7887,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
 			"dev": true
 		},
 		"log-symbols": {
@@ -8633,7 +8633,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
 			"dev": true,
 			"requires": {
 				"event-lite": "^0.1.1",
@@ -8645,7 +8645,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 					"dev": true
 				}
 			}
@@ -8704,7 +8704,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
 			"dev": true
 		},
 		"node-fetch": {
@@ -9260,7 +9260,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
+			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
 			"dev": true
 		},
 		"p-finally": {
@@ -9548,7 +9548,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
 			"dev": true
 		},
 		"parse-path": {
@@ -9648,7 +9648,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
+			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
 			"dev": true
 		},
 		"plur": {
@@ -10694,7 +10694,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -3722,7 +3722,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
 		"available-typed-arrays": {
@@ -3796,13 +3796,13 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
 			"dev": true
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
 			"dev": true
 		},
 		"buffer-from": {
@@ -5424,7 +5424,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
 			"dev": true
 		},
 		"es6-promise": {
@@ -5436,7 +5436,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
@@ -5496,7 +5496,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -5680,7 +5680,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
 			"dev": true
 		},
 		"fs-extra": {
@@ -5988,7 +5988,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
+			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -6358,7 +6358,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -6407,7 +6407,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
+			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -6449,7 +6449,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
 			"dev": true
 		},
 		"import-fresh": {
@@ -6748,7 +6748,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==",
+			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM=",
 			"dev": true
 		},
 		"internal-slot": {
@@ -6858,7 +6858,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"dev": true
 		},
 		"is-extglob": {
@@ -6910,7 +6910,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
+			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -7584,7 +7584,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
+			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -7760,7 +7760,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
 			"dev": true
 		},
 		"lodash.get": {
@@ -7772,13 +7772,13 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
 			"dev": true
 		},
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
 			"dev": true
 		},
 		"lodash.isequal": {
@@ -7790,7 +7790,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
 			"dev": true
 		},
 		"lodash.ismatch": {
@@ -7802,43 +7802,43 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
 			"dev": true
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
 			"dev": true
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
 			"dev": true
 		},
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -7850,19 +7850,19 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
 			"dev": true
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
 			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"lodash.template": {
@@ -7887,7 +7887,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -8633,7 +8633,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
 			"dev": true,
 			"requires": {
 				"event-lite": "^0.1.1",
@@ -8645,7 +8645,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				}
 			}
@@ -8704,7 +8704,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
+			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
 			"dev": true
 		},
 		"node-fetch": {
@@ -9260,7 +9260,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
+			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
 			"dev": true
 		},
 		"p-finally": {
@@ -9548,7 +9548,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
 		"parse-path": {
@@ -9648,7 +9648,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
+			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
 			"dev": true
 		},
 		"plur": {
@@ -10694,7 +10694,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
 					"dev": true
 				}
 			}

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -60,14 +60,14 @@ export interface IFluidModuleWithDetails {
  * a package name and package version range.
  */
 export interface ICodeDetailsLoader
- extends Partial<IProvideFluidCodeDetailsComparer> {
- /**
-  * Load the code module (package) that is capable to interact with the document.
-  *
-  * @param source - Code proposal that articulates the current schema the document is written in.
-  * @returns - Code module entry point along with the code details associated with it.
-  */
- load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
+    extends Partial<IProvideFluidCodeDetailsComparer> {
+    /**
+     * Load the code module (package) that is capable to interact with the document.
+     *
+     * @param source - Code proposal that articulates the current schema the document is written in.
+     * @returns - Code module entry point along with the code details associated with it.
+     */
+    load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
 
 /**
@@ -142,15 +142,15 @@ export namespace ConnectionState {
      * The container is disconnected but actively trying to establish a new connection
      * PLEASE NOTE that this numerical value falls out of the order you may expect for this state
      */
-     export type EstablishingConnection = 3;
+    export type EstablishingConnection = 3;
 
-     /**
-     * The container has an inbound connection only, and is catching up to the latest known state from the service.
-     */
+    /**
+    * The container has an inbound connection only, and is catching up to the latest known state from the service.
+    */
     export type CatchingUp = 1;
 
     /**
-     * @see ConnectionState.CatchingUp, which is the new name for this state.
+     * See ConnectionState.CatchingUp, which is the new name for this state.
      * @deprecated - This state itself is not gone, just being renamed. Please use ConnectionState.CatchingUp.
      */
     export type Connecting = 1;
@@ -158,7 +158,7 @@ export namespace ConnectionState {
     /**
      * The container is fully connected and syncing
      */
-     export type Connected = 2;
+    export type Connected = 2;
 }
 
 /**
@@ -406,44 +406,44 @@ export enum LoaderHeader {
 
 export interface IContainerLoadMode {
     opsBeforeReturn?:
-        /*
-         * No trailing ops are applied before container is returned.
-         * Default value.
-         */
-        | undefined
-        /*
-         * Only cached trailing ops are applied before returning container.
-         * Caching is optional and could be implemented by the driver.
-         * If driver does not implement any kind of local caching strategy, this is same as above.
-         * Driver may cache a lot of ops, so care needs to be exercised (see below).
-         */
-        | "cached"
-        /*
-         * All trailing ops in storage are fetched and applied before container is returned
-         * This mode might have significant impact on boot speed (depends on storage perf characteristics)
-         * Also there might be a lot of trailing ops and applying them might take time, so hosts are
-         * recommended to have some progress UX / cancellation built into loading flow when using this option.
-         */
-        | "all";
+    /*
+     * No trailing ops are applied before container is returned.
+     * Default value.
+     */
+    | undefined
+    /*
+     * Only cached trailing ops are applied before returning container.
+     * Caching is optional and could be implemented by the driver.
+     * If driver does not implement any kind of local caching strategy, this is same as above.
+     * Driver may cache a lot of ops, so care needs to be exercised (see below).
+     */
+    | "cached"
+    /*
+     * All trailing ops in storage are fetched and applied before container is returned
+     * This mode might have significant impact on boot speed (depends on storage perf characteristics)
+     * Also there might be a lot of trailing ops and applying them might take time, so hosts are
+     * recommended to have some progress UX / cancellation built into loading flow when using this option.
+     */
+    | "all";
     deltaConnection?:
-        /*
-         * Connection to delta stream is made only when Container.connect() call is made. Op processing
-         * is paused (when container is returned from Loader.resolve()) until Container.connect() call is made.
-         */
-        | "none"
-        /*
-         * Connection to delta stream is made only when Container.connect() call is made.
-         * Op fetching from storage is performed and ops are applied as they come in.
-         * This is useful option if connection to delta stream is expensive and thus it's beneficial to move it
-         * out from critical boot sequence, but it's beneficial to allow catch up to happen as fast as possible.
-         */
-        | "delayed"
-        /*
-         * Connection to delta stream is made right away.
-         * Ops processing is enabled and ops are flowing through the system.
-         * Default value.
-         */
-        | undefined;
+    /*
+     * Connection to delta stream is made only when Container.connect() call is made. Op processing
+     * is paused (when container is returned from Loader.resolve()) until Container.connect() call is made.
+     */
+    | "none"
+    /*
+     * Connection to delta stream is made only when Container.connect() call is made.
+     * Op fetching from storage is performed and ops are applied as they come in.
+     * This is useful option if connection to delta stream is expensive and thus it's beneficial to move it
+     * out from critical boot sequence, but it's beneficial to allow catch up to happen as fast as possible.
+     */
+    | "delayed"
+    /*
+     * Connection to delta stream is made right away.
+     * Ops processing is enabled and ops are flowing through the system.
+     * Default value.
+     */
+    | undefined;
 }
 
 /**

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -60,14 +60,14 @@ export interface IFluidModuleWithDetails {
  * a package name and package version range.
  */
 export interface ICodeDetailsLoader
-    extends Partial<IProvideFluidCodeDetailsComparer> {
-    /**
-     * Load the code module (package) that is capable to interact with the document.
-     *
-     * @param source - Code proposal that articulates the current schema the document is written in.
-     * @returns - Code module entry point along with the code details associated with it.
-     */
-    load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
+ extends Partial<IProvideFluidCodeDetailsComparer> {
+ /**
+  * Load the code module (package) that is capable to interact with the document.
+  *
+  * @param source - Code proposal that articulates the current schema the document is written in.
+  * @returns - Code module entry point along with the code details associated with it.
+  */
+ load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
 
 /**
@@ -142,15 +142,15 @@ export namespace ConnectionState {
      * The container is disconnected but actively trying to establish a new connection
      * PLEASE NOTE that this numerical value falls out of the order you may expect for this state
      */
-    export type EstablishingConnection = 3;
+     export type EstablishingConnection = 3;
 
-    /**
-    * The container has an inbound connection only, and is catching up to the latest known state from the service.
-    */
+     /**
+     * The container has an inbound connection only, and is catching up to the latest known state from the service.
+     */
     export type CatchingUp = 1;
 
     /**
-     * See ConnectionState.CatchingUp, which is the new name for this state.
+     * @see ConnectionState.CatchingUp, which is the new name for this state.
      * @deprecated - This state itself is not gone, just being renamed. Please use ConnectionState.CatchingUp.
      */
     export type Connecting = 1;
@@ -158,7 +158,7 @@ export namespace ConnectionState {
     /**
      * The container is fully connected and syncing
      */
-    export type Connected = 2;
+     export type Connected = 2;
 }
 
 /**
@@ -406,44 +406,44 @@ export enum LoaderHeader {
 
 export interface IContainerLoadMode {
     opsBeforeReturn?:
-    /*
-     * No trailing ops are applied before container is returned.
-     * Default value.
-     */
-    | undefined
-    /*
-     * Only cached trailing ops are applied before returning container.
-     * Caching is optional and could be implemented by the driver.
-     * If driver does not implement any kind of local caching strategy, this is same as above.
-     * Driver may cache a lot of ops, so care needs to be exercised (see below).
-     */
-    | "cached"
-    /*
-     * All trailing ops in storage are fetched and applied before container is returned
-     * This mode might have significant impact on boot speed (depends on storage perf characteristics)
-     * Also there might be a lot of trailing ops and applying them might take time, so hosts are
-     * recommended to have some progress UX / cancellation built into loading flow when using this option.
-     */
-    | "all";
+        /*
+         * No trailing ops are applied before container is returned.
+         * Default value.
+         */
+        | undefined
+        /*
+         * Only cached trailing ops are applied before returning container.
+         * Caching is optional and could be implemented by the driver.
+         * If driver does not implement any kind of local caching strategy, this is same as above.
+         * Driver may cache a lot of ops, so care needs to be exercised (see below).
+         */
+        | "cached"
+        /*
+         * All trailing ops in storage are fetched and applied before container is returned
+         * This mode might have significant impact on boot speed (depends on storage perf characteristics)
+         * Also there might be a lot of trailing ops and applying them might take time, so hosts are
+         * recommended to have some progress UX / cancellation built into loading flow when using this option.
+         */
+        | "all";
     deltaConnection?:
-    /*
-     * Connection to delta stream is made only when Container.connect() call is made. Op processing
-     * is paused (when container is returned from Loader.resolve()) until Container.connect() call is made.
-     */
-    | "none"
-    /*
-     * Connection to delta stream is made only when Container.connect() call is made.
-     * Op fetching from storage is performed and ops are applied as they come in.
-     * This is useful option if connection to delta stream is expensive and thus it's beneficial to move it
-     * out from critical boot sequence, but it's beneficial to allow catch up to happen as fast as possible.
-     */
-    | "delayed"
-    /*
-     * Connection to delta stream is made right away.
-     * Ops processing is enabled and ops are flowing through the system.
-     * Default value.
-     */
-    | undefined;
+        /*
+         * Connection to delta stream is made only when Container.connect() call is made. Op processing
+         * is paused (when container is returned from Loader.resolve()) until Container.connect() call is made.
+         */
+        | "none"
+        /*
+         * Connection to delta stream is made only when Container.connect() call is made.
+         * Op fetching from storage is performed and ops are applied as they come in.
+         * This is useful option if connection to delta stream is expensive and thus it's beneficial to move it
+         * out from critical boot sequence, but it's beneficial to allow catch up to happen as fast as possible.
+         */
+        | "delayed"
+        /*
+         * Connection to delta stream is made right away.
+         * Ops processing is enabled and ops are flowing through the system.
+         * Default value.
+         */
+        | undefined;
 }
 
 /**

--- a/packages/common/core-interfaces/src/provider.ts
+++ b/packages/common/core-interfaces/src/provider.ts
@@ -4,12 +4,12 @@
  */
 
 /**
- * @internal
- * This utility type is meant for internal use by @see FluidObject
+ * This utility type is meant for internal use by {@link FluidObject}
  * Produces a valid FluidObject key given a type and a property.
  * A valid FluidObject key is a property that exists on the incoming type
- * as well as on the type of the property itself. For example, IProvideFoo.IFoo.IFoo
+ * as well as on the type of the property itself. For example: `IProvideFoo.IFoo.IFoo`
  * This aligns with the FluidObject pattern expected to be used with all FluidObjects.
+ *
  * For example:
  * ```
  * interface IProvideFoo{
@@ -21,8 +21,10 @@
  * ```
  * This pattern enables discovery, and delegation in a standard way which is central
  * to FluidObject pattern
+ *
+ * @internal
  */
- export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
+export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
     string extends TProp ? never : number extends TProp? never : // exclude indexers [key:string |number]: any
     TProp extends keyof Required<T>[TProp] // TProp is a property of T, and T[TProp]
         ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] // T[TProp] is the same type as T[TProp][TProp]
@@ -60,13 +62,15 @@
  * `FluidObject<IFoo & IBar>`
  *
  */
- export type FluidObject<T = unknown> = {
+export type FluidObject<T = unknown> = {
     [P in FluidObjectProviderKeys<T>]?: T[P];
 };
 
 /**
  * This utility type creates a type that is the union of all keys on the generic type
- * which implement the FluidObject pattern. @see FluidObject
+ * which implement the FluidObject pattern.
+ *
+ * See {@link FluidObject}
  *
  * For example `FluidObjectKeys<IFoo & IBar>` would result in `"IFoo" | "IBar"`
  *

--- a/packages/common/core-interfaces/src/provider.ts
+++ b/packages/common/core-interfaces/src/provider.ts
@@ -4,12 +4,12 @@
  */
 
 /**
- * @internal
- * This utility type is meant for internal use by @see FluidObject
+ * This utility type is meant for internal use by {@link FluidObject}
  * Produces a valid FluidObject key given a type and a property.
  * A valid FluidObject key is a property that exists on the incoming type
- * as well as on the type of the property itself. For example, IProvideFoo.IFoo.IFoo
+ * as well as on the type of the property itself. For example: `IProvideFoo.IFoo.IFoo`
  * This aligns with the FluidObject pattern expected to be used with all FluidObjects.
+ *
  * For example:
  * ```
  * interface IProvideFoo{
@@ -21,14 +21,16 @@
  * ```
  * This pattern enables discovery, and delegation in a standard way which is central
  * to FluidObject pattern
+ *
+ * @internal
  */
- export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
-    string extends TProp ? never : number extends TProp? never : // exclude indexers [key:string |number]: any
+export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
+    string extends TProp ? never : number extends TProp ? never : // exclude indexers [key:string |number]: any
     TProp extends keyof Required<T>[TProp] // TProp is a property of T, and T[TProp]
-        ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] // T[TProp] is the same type as T[TProp][TProp]
-            ? TProp
-            : never
-        : never;
+    ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] // T[TProp] is the same type as T[TProp][TProp]
+    ? TProp
+    : never
+    : never;
 
 /**
  * This utility type take interface(s) that follow the FluidObject pattern, and produces
@@ -38,6 +40,7 @@
  * A common way to specify a type implements the FluidObject pattern is to expose it as a
  * FluidObject without a generic argument.
  *
+ * @example
  * For example, if we have an interface like below
  * ```
  * interface IProvideFoo{
@@ -60,14 +63,17 @@
  * `FluidObject<IFoo & IBar>`
  *
  */
- export type FluidObject<T = unknown> = {
+export type FluidObject<T = unknown> = {
     [P in FluidObjectProviderKeys<T>]?: T[P];
 };
 
 /**
  * This utility type creates a type that is the union of all keys on the generic type
- * which implement the FluidObject pattern. @see FluidObject
+ * which implement the FluidObject pattern.
  *
+ * See {@link FluidObject}
+ *
+ * @example
  * For example `FluidObjectKeys<IFoo & IBar>` would result in `"IFoo" | "IBar"`
  *
  */

--- a/packages/common/core-interfaces/src/provider.ts
+++ b/packages/common/core-interfaces/src/provider.ts
@@ -4,12 +4,12 @@
  */
 
 /**
- * This utility type is meant for internal use by {@link FluidObject}
+ * @internal
+ * This utility type is meant for internal use by @see FluidObject
  * Produces a valid FluidObject key given a type and a property.
  * A valid FluidObject key is a property that exists on the incoming type
- * as well as on the type of the property itself. For example: `IProvideFoo.IFoo.IFoo`
+ * as well as on the type of the property itself. For example, IProvideFoo.IFoo.IFoo
  * This aligns with the FluidObject pattern expected to be used with all FluidObjects.
- *
  * For example:
  * ```
  * interface IProvideFoo{
@@ -21,16 +21,14 @@
  * ```
  * This pattern enables discovery, and delegation in a standard way which is central
  * to FluidObject pattern
- *
- * @internal
  */
-export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
-    string extends TProp ? never : number extends TProp ? never : // exclude indexers [key:string |number]: any
+ export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
+    string extends TProp ? never : number extends TProp? never : // exclude indexers [key:string |number]: any
     TProp extends keyof Required<T>[TProp] // TProp is a property of T, and T[TProp]
-    ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] // T[TProp] is the same type as T[TProp][TProp]
-    ? TProp
-    : never
-    : never;
+        ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] // T[TProp] is the same type as T[TProp][TProp]
+            ? TProp
+            : never
+        : never;
 
 /**
  * This utility type take interface(s) that follow the FluidObject pattern, and produces
@@ -40,7 +38,6 @@ export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
  * A common way to specify a type implements the FluidObject pattern is to expose it as a
  * FluidObject without a generic argument.
  *
- * @example
  * For example, if we have an interface like below
  * ```
  * interface IProvideFoo{
@@ -63,17 +60,14 @@ export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> =
  * `FluidObject<IFoo & IBar>`
  *
  */
-export type FluidObject<T = unknown> = {
+ export type FluidObject<T = unknown> = {
     [P in FluidObjectProviderKeys<T>]?: T[P];
 };
 
 /**
  * This utility type creates a type that is the union of all keys on the generic type
- * which implement the FluidObject pattern.
+ * which implement the FluidObject pattern. @see FluidObject
  *
- * See {@link FluidObject}
- *
- * @example
  * For example `FluidObjectKeys<IFoo & IBar>` would result in `"IFoo" | "IBar"`
  *
  */

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -65,7 +65,7 @@ export type IStreamResult<T> = { done: true; } | { done: false; value: T; };
 /**
  * Read interface for the Queue
  */
- export interface IStream<T> {
+export interface IStream<T> {
     read(): Promise<IStreamResult<T>>;
 }
 
@@ -83,7 +83,7 @@ export interface IDocumentDeltaStorageService {
      *  of Op on wire and known seq number. It should not contain any PII. It can be logged by
      *  spo which could help in debugging sessions if any issue occurs.
      */
-     fetchMessages(from: number,
+    fetchMessages(from: number,
         to: number | undefined,
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
@@ -305,7 +305,7 @@ export interface IDocumentServiceFactory {
     /**
      * Creates the document service after extracting different endpoints URLs from a resolved URL.
      *
-     * @param resolvedUrl - Endpoint URL data. @see {@link IResolvedUrl}.
+     * @param resolvedUrl - Endpoint URL data. See {@link IResolvedUrl}.
      * @param logger - Optional telemetry logger to which telemetry events will be forwarded.
      * @param clientIsSummarizer - Whether or not the client is the
      * {@link https://fluidframework.com/docs/concepts/summarizer/ | summarizer}.
@@ -313,7 +313,7 @@ export interface IDocumentServiceFactory {
      *
      * @returns An instance of {@link IDocumentService}.
      */
-     createDocumentService(
+    createDocumentService(
         resolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
         clientIsSummarizer?: boolean,
@@ -324,7 +324,7 @@ export interface IDocumentServiceFactory {
      *
      * @param createNewSummary - Summary used to create file. If undefined, an empty file will be created and a summary
      * should be posted later, before connecting to ordering service.
-     * @param createNewResolvedUrl - Endpoint URL data. @see {@link IResolvedUrl}.
+     * @param createNewResolvedUrl - Endpoint URL data. See {@link IResolvedUrl}.
      * @param logger - Optional telemetry logger to which telemetry events will be forwarded.
      * @param clientIsSummarizer - Whether or not the client is the
      * {@link https://fluidframework.com/docs/concepts/summarizer/ | summarizer}.

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -65,7 +65,7 @@ export type IStreamResult<T> = { done: true; } | { done: false; value: T; };
 /**
  * Read interface for the Queue
  */
-export interface IStream<T> {
+ export interface IStream<T> {
     read(): Promise<IStreamResult<T>>;
 }
 
@@ -83,7 +83,7 @@ export interface IDocumentDeltaStorageService {
      *  of Op on wire and known seq number. It should not contain any PII. It can be logged by
      *  spo which could help in debugging sessions if any issue occurs.
      */
-    fetchMessages(from: number,
+     fetchMessages(from: number,
         to: number | undefined,
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
@@ -305,7 +305,7 @@ export interface IDocumentServiceFactory {
     /**
      * Creates the document service after extracting different endpoints URLs from a resolved URL.
      *
-     * @param resolvedUrl - Endpoint URL data. See {@link IResolvedUrl}.
+     * @param resolvedUrl - Endpoint URL data. @see {@link IResolvedUrl}.
      * @param logger - Optional telemetry logger to which telemetry events will be forwarded.
      * @param clientIsSummarizer - Whether or not the client is the
      * {@link https://fluidframework.com/docs/concepts/summarizer/ | summarizer}.
@@ -313,7 +313,7 @@ export interface IDocumentServiceFactory {
      *
      * @returns An instance of {@link IDocumentService}.
      */
-    createDocumentService(
+     createDocumentService(
         resolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
         clientIsSummarizer?: boolean,
@@ -324,7 +324,7 @@ export interface IDocumentServiceFactory {
      *
      * @param createNewSummary - Summary used to create file. If undefined, an empty file will be created and a summary
      * should be posted later, before connecting to ordering service.
-     * @param createNewResolvedUrl - Endpoint URL data. See {@link IResolvedUrl}.
+     * @param createNewResolvedUrl - Endpoint URL data. @see {@link IResolvedUrl}.
      * @param logger - Optional telemetry logger to which telemetry events will be forwarded.
      * @param clientIsSummarizer - Whether or not the client is the
      * {@link https://fluidframework.com/docs/concepts/summarizer/ | summarizer}.

--- a/packages/dds/tree/src/dependency-tracking/cleanable.ts
+++ b/packages/dds/tree/src/dependency-tracking/cleanable.ts
@@ -33,7 +33,7 @@ export const cleanable: InvalidationToken = new CleanableToken("cleanable", fals
  * `Dependee` previously sent cleanable invalidation, and that cleaning has failed.
  * Unlike normal invalidation, cleaningFailed invalidation can be sent when updating/recomputing a cell.
  *
- * @see {@link Cleanable} for contract.
+ * See {@link Cleanable} for contract.
  *
  * @internal
  */
@@ -65,11 +65,11 @@ export interface Cleanable extends Dependee {
 	/**
 	 * Guarantees this dependee is not in the 'awaiting cleaning' state, attempting to clean this dependee if necessary.
 	 * If this cleaning fails (ex: cannot be updated, or updating results in changes),
-     * the implementation must call markInvalid with a
+	 * the implementation must call markInvalid with a
 	 * cleaningFailed token on all dependents.
 	 *
 	 * If `tryClean` undefined,
-     * this dependee is considered not to be Cleanable and must not send cleanable invalidation:
+	 * this dependee is considered not to be Cleanable and must not send cleanable invalidation:
 	 * dependents can assume that 'cleanable' invalidation only comes from dependees with a defined tryClean,
 	 * and thus any dependee without a tryClean is never in the 'awaiting cleaning' state.
 	 */

--- a/packages/dds/tree/src/dependency-tracking/cleanable.ts
+++ b/packages/dds/tree/src/dependency-tracking/cleanable.ts
@@ -13,13 +13,13 @@ import { Dependee, InvalidationToken } from "./dependencies";
  * InvalidationToken type to use for cleanable.
  * Using a subclass of InvalidationToken results in cleanable showing up better in the debugger.
  */
-class CleanableToken extends InvalidationToken {}
+class CleanableToken extends InvalidationToken { }
 
 /**
  * InvalidationToken type to use for cleanable.
  * Using a subclass of InvalidationToken results in cleanable showing up better in the debugger.
  */
-class CleaningFailedToken extends InvalidationToken {}
+class CleaningFailedToken extends InvalidationToken { }
 
 /**
  * `Dependee` might have changed and implements Cleanable.
@@ -33,7 +33,7 @@ export const cleanable: InvalidationToken = new CleanableToken("cleanable", fals
  * `Dependee` previously sent cleanable invalidation, and that cleaning has failed.
  * Unlike normal invalidation, cleaningFailed invalidation can be sent when updating/recomputing a cell.
  *
- * @see {@link Cleanable} for contract.
+ * See {@link Cleanable} for contract.
  *
  * @internal
  */
@@ -62,16 +62,16 @@ export const cleaningFailed: InvalidationToken = new CleaningFailedToken("cleani
  * @internal
  */
 export interface Cleanable extends Dependee {
-	/**
-	 * Guarantees this dependee is not in the 'awaiting cleaning' state, attempting to clean this dependee if necessary.
-	 * If this cleaning fails (ex: cannot be updated, or updating results in changes),
+    /**
+     * Guarantees this dependee is not in the 'awaiting cleaning' state, attempting to clean this dependee if necessary.
+     * If this cleaning fails (ex: cannot be updated, or updating results in changes),
      * the implementation must call markInvalid with a
-	 * cleaningFailed token on all dependents.
-	 *
-	 * If `tryClean` undefined,
+     * cleaningFailed token on all dependents.
+     *
+     * If `tryClean` undefined,
      * this dependee is considered not to be Cleanable and must not send cleanable invalidation:
-	 * dependents can assume that 'cleanable' invalidation only comes from dependees with a defined tryClean,
-	 * and thus any dependee without a tryClean is never in the 'awaiting cleaning' state.
-	 */
-	tryClean?(): void;
+     * dependents can assume that 'cleanable' invalidation only comes from dependees with a defined tryClean,
+     * and thus any dependee without a tryClean is never in the 'awaiting cleaning' state.
+     */
+    tryClean?(): void;
 }

--- a/packages/dds/tree/src/dependency-tracking/cleanable.ts
+++ b/packages/dds/tree/src/dependency-tracking/cleanable.ts
@@ -13,13 +13,13 @@ import { Dependee, InvalidationToken } from "./dependencies";
  * InvalidationToken type to use for cleanable.
  * Using a subclass of InvalidationToken results in cleanable showing up better in the debugger.
  */
-class CleanableToken extends InvalidationToken { }
+class CleanableToken extends InvalidationToken {}
 
 /**
  * InvalidationToken type to use for cleanable.
  * Using a subclass of InvalidationToken results in cleanable showing up better in the debugger.
  */
-class CleaningFailedToken extends InvalidationToken { }
+class CleaningFailedToken extends InvalidationToken {}
 
 /**
  * `Dependee` might have changed and implements Cleanable.
@@ -33,7 +33,7 @@ export const cleanable: InvalidationToken = new CleanableToken("cleanable", fals
  * `Dependee` previously sent cleanable invalidation, and that cleaning has failed.
  * Unlike normal invalidation, cleaningFailed invalidation can be sent when updating/recomputing a cell.
  *
- * See {@link Cleanable} for contract.
+ * @see {@link Cleanable} for contract.
  *
  * @internal
  */
@@ -62,16 +62,16 @@ export const cleaningFailed: InvalidationToken = new CleaningFailedToken("cleani
  * @internal
  */
 export interface Cleanable extends Dependee {
-    /**
-     * Guarantees this dependee is not in the 'awaiting cleaning' state, attempting to clean this dependee if necessary.
-     * If this cleaning fails (ex: cannot be updated, or updating results in changes),
+	/**
+	 * Guarantees this dependee is not in the 'awaiting cleaning' state, attempting to clean this dependee if necessary.
+	 * If this cleaning fails (ex: cannot be updated, or updating results in changes),
      * the implementation must call markInvalid with a
-     * cleaningFailed token on all dependents.
-     *
-     * If `tryClean` undefined,
+	 * cleaningFailed token on all dependents.
+	 *
+	 * If `tryClean` undefined,
      * this dependee is considered not to be Cleanable and must not send cleanable invalidation:
-     * dependents can assume that 'cleanable' invalidation only comes from dependees with a defined tryClean,
-     * and thus any dependee without a tryClean is never in the 'awaiting cleaning' state.
-     */
-    tryClean?(): void;
+	 * dependents can assume that 'cleanable' invalidation only comes from dependees with a defined tryClean,
+	 * and thus any dependee without a tryClean is never in the 'awaiting cleaning' state.
+	 */
+	tryClean?(): void;
 }

--- a/packages/dds/tree/src/util/typeCheck.ts
+++ b/packages/dds/tree/src/util/typeCheck.ts
@@ -121,7 +121,7 @@ export interface Covariant<T> {
  */
 export interface Bivariant<T> {
 	/**
-	 * @see {@link Bivariant}
+	 * See {@link Bivariant}
 	 */
 	_constrainToBivariant?(_: T): void;
 }

--- a/packages/dds/tree/src/util/typeCheck.ts
+++ b/packages/dds/tree/src/util/typeCheck.ts
@@ -90,7 +90,7 @@ export interface MakeNominal { }
  * @public
  */
 export interface Contravariant<T> {
-    _removeCovariance?: (_: T) => void;
+	_removeCovariance?: (_: T) => void;
 }
 
 /**
@@ -103,7 +103,7 @@ export interface Contravariant<T> {
  * @public
  */
 export interface Covariant<T> {
-    _removeContravariance?: T;
+	_removeContravariance?: T;
 }
 
 /**
@@ -120,10 +120,10 @@ export interface Covariant<T> {
  * @public
  */
 export interface Bivariant<T> {
-    /**
-     * See {@link Bivariant}
-     */
-    _constrainToBivariant?(_: T): void;
+	/**
+	 * @see {@link Bivariant}
+	 */
+	_constrainToBivariant?(_: T): void;
 }
 
 /**
@@ -161,10 +161,10 @@ export type requireFalse<_X extends false> = true;
  * @public
  */
 export type isAssignableTo<Source, Destination> = isAny<Source> extends true
-    ? true
-    : Source extends Destination
-    ? true
-    : false;
+	? true
+	: Source extends Destination
+	? true
+	: false;
 
 /**
  * Returns a type parameter that is true iff Subset is a strict subset of Superset.
@@ -172,10 +172,10 @@ export type isAssignableTo<Source, Destination> = isAny<Source> extends true
  * @public
  */
 export type isStrictSubset<Subset, Superset> = isAssignableTo<Subset, Superset> extends false
-    ? false
-    : isAssignableTo<Superset, Subset> extends true
-    ? false
-    : true;
+	? false
+	: isAssignableTo<Superset, Subset> extends true
+	? false
+	: true;
 
 /**
  * Returns a type parameter that is true iff A and B are assignable to each other, and neither is any.
@@ -184,10 +184,10 @@ export type isStrictSubset<Subset, Superset> = isAssignableTo<Subset, Superset> 
  * @public
  */
 export type areSafelyAssignable<A, B> = eitherIsAny<A, B> extends true
-    ? false
-    : isAssignableTo<A, B> extends true
-    ? isAssignableTo<B, A>
-    : false;
+	? false
+	: isAssignableTo<A, B> extends true
+	? isAssignableTo<B, A>
+	: false;
 
 /**
  * Returns a type parameter that is true iff A is any or B is any.

--- a/packages/dds/tree/src/util/typeCheck.ts
+++ b/packages/dds/tree/src/util/typeCheck.ts
@@ -90,7 +90,7 @@ export interface MakeNominal { }
  * @public
  */
 export interface Contravariant<T> {
-	_removeCovariance?: (_: T) => void;
+    _removeCovariance?: (_: T) => void;
 }
 
 /**
@@ -103,7 +103,7 @@ export interface Contravariant<T> {
  * @public
  */
 export interface Covariant<T> {
-	_removeContravariance?: T;
+    _removeContravariance?: T;
 }
 
 /**
@@ -120,10 +120,10 @@ export interface Covariant<T> {
  * @public
  */
 export interface Bivariant<T> {
-	/**
-	 * @see {@link Bivariant}
-	 */
-	_constrainToBivariant?(_: T): void;
+    /**
+     * See {@link Bivariant}
+     */
+    _constrainToBivariant?(_: T): void;
 }
 
 /**
@@ -161,10 +161,10 @@ export type requireFalse<_X extends false> = true;
  * @public
  */
 export type isAssignableTo<Source, Destination> = isAny<Source> extends true
-	? true
-	: Source extends Destination
-	? true
-	: false;
+    ? true
+    : Source extends Destination
+    ? true
+    : false;
 
 /**
  * Returns a type parameter that is true iff Subset is a strict subset of Superset.
@@ -172,10 +172,10 @@ export type isAssignableTo<Source, Destination> = isAny<Source> extends true
  * @public
  */
 export type isStrictSubset<Subset, Superset> = isAssignableTo<Subset, Superset> extends false
-	? false
-	: isAssignableTo<Superset, Subset> extends true
-	? false
-	: true;
+    ? false
+    : isAssignableTo<Superset, Subset> extends true
+    ? false
+    : true;
 
 /**
  * Returns a type parameter that is true iff A and B are assignable to each other, and neither is any.
@@ -184,10 +184,10 @@ export type isStrictSubset<Subset, Superset> = isAssignableTo<Subset, Superset> 
  * @public
  */
 export type areSafelyAssignable<A, B> = eitherIsAny<A, B> extends true
-	? false
-	: isAssignableTo<A, B> extends true
-	? isAssignableTo<B, A>
-	: false;
+    ? false
+    : isAssignableTo<A, B> extends true
+    ? isAssignableTo<B, A>
+    : false;
 
 /**
  * Returns a type parameter that is true iff A is any or B is any.

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -27,7 +27,7 @@ import { isDataObjectClass, isSharedObjectClass, parseDataObjectsFromSharedObjec
 export interface RootDataObjectProps {
     /**
      * Initial object structure with which the {@link RootDataObject} will be first-time initialized.
-     * @see {@link RootDataObject.initializingFirstTime}
+     * See {@link RootDataObject.initializingFirstTime}
      */
     initialObjects: LoadableObjectClassRecord;
 }
@@ -53,7 +53,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
      * The first time this object is initialized, creates each object identified in
      * {@link RootDataObjectProps.initialObjects} and stores them as unique values in the root directory.
      *
-     * @see {@link @fluidframework/aqueduct#PureDataObject.initializingFirstTime}
+     * See {@link @fluidframework/aqueduct#PureDataObject.initializingFirstTime}
      */
     protected async initializingFirstTime(props: RootDataObjectProps) {
         this.root.createSubDirectory(this.initialObjectsDirKey);
@@ -75,7 +75,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
      * Every time an instance is initialized, loads all of the initial objects in the root directory so they can be
      * accessed immediately.
      *
-     * @see {@link @fluidframework/aqueduct#PureDataObject.hasInitialized}
+     * See {@link @fluidframework/aqueduct#PureDataObject.hasInitialized}
      */
     protected async hasInitialized() {
         // We will always load the initial objects so they are available to the developer
@@ -93,7 +93,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
 
     /**
      * Provides a record of the initial objects defined on creation.
-     * @see {@link RootDataObject.initializingFirstTime}
+     * See {@link RootDataObject.initializingFirstTime}
      */
     public get initialObjects(): LoadableObjectRecord {
         if (Object.keys(this._initialObjects).length === 0) {

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -27,7 +27,7 @@ import { isDataObjectClass, isSharedObjectClass, parseDataObjectsFromSharedObjec
 export interface RootDataObjectProps {
     /**
      * Initial object structure with which the {@link RootDataObject} will be first-time initialized.
-     * See {@link RootDataObject.initializingFirstTime}
+     * @see {@link RootDataObject.initializingFirstTime}
      */
     initialObjects: LoadableObjectClassRecord;
 }
@@ -53,7 +53,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
      * The first time this object is initialized, creates each object identified in
      * {@link RootDataObjectProps.initialObjects} and stores them as unique values in the root directory.
      *
-     * See {@link @fluidframework/aqueduct#PureDataObject.initializingFirstTime}
+     * @see {@link @fluidframework/aqueduct#PureDataObject.initializingFirstTime}
      */
     protected async initializingFirstTime(props: RootDataObjectProps) {
         this.root.createSubDirectory(this.initialObjectsDirKey);
@@ -75,7 +75,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
      * Every time an instance is initialized, loads all of the initial objects in the root directory so they can be
      * accessed immediately.
      *
-     * See {@link @fluidframework/aqueduct#PureDataObject.hasInitialized}
+     * @see {@link @fluidframework/aqueduct#PureDataObject.hasInitialized}
      */
     protected async hasInitialized() {
         // We will always load the initial objects so they are available to the developer
@@ -93,7 +93,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
 
     /**
      * Provides a record of the initial objects defined on creation.
-     * See {@link RootDataObject.initializingFirstTime}
+     * @see {@link RootDataObject.initializingFirstTime}
      */
     public get initialObjects(): LoadableObjectRecord {
         if (Object.keys(this._initialObjects).length === 0) {

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -36,7 +36,7 @@ import { TinyliciousAudience } from "./TinyliciousAudience";
 /**
  * Provides the ability to have a Fluid object backed by a Tinylicious service.
  *
- * @see {@link https://fluidframework.com/docs/testing/tinylicious/}
+ * See {@link https://fluidframework.com/docs/testing/tinylicious/}
  */
 export class TinyliciousClient {
     private readonly documentServiceFactory: IDocumentServiceFactory;

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -36,7 +36,7 @@ import { TinyliciousAudience } from "./TinyliciousAudience";
 /**
  * Provides the ability to have a Fluid object backed by a Tinylicious service.
  *
- * See {@link https://fluidframework.com/docs/testing/tinylicious/}
+ * @see {@link https://fluidframework.com/docs/testing/tinylicious/}
  */
 export class TinyliciousClient {
     private readonly documentServiceFactory: IDocumentServiceFactory;

--- a/packages/framework/tinylicious-client/src/index.ts
+++ b/packages/framework/tinylicious-client/src/index.ts
@@ -9,7 +9,7 @@
  *
  * The Tinylicious service is a local, in-memory Fluid service intended for prototyping and development purposes.
  *
- * @see {@link https://fluidframework.com/docs/testing/tinylicious/}
+ * See {@link https://fluidframework.com/docs/testing/tinylicious/}
  *
  * @packageDocumentation
  */

--- a/packages/framework/tinylicious-client/src/index.ts
+++ b/packages/framework/tinylicious-client/src/index.ts
@@ -9,7 +9,7 @@
  *
  * The Tinylicious service is a local, in-memory Fluid service intended for prototyping and development purposes.
  *
- * See {@link https://fluidframework.com/docs/testing/tinylicious/}
+ * @see {@link https://fluidframework.com/docs/testing/tinylicious/}
  *
  * @packageDocumentation
  */

--- a/packages/loader/container-loader/src/connectionState.ts
+++ b/packages/loader/container-loader/src/connectionState.ts
@@ -18,8 +18,8 @@ export enum ConnectionState {
     EstablishingConnection = 3,
 
     /**
-     * @see ConnectionState.CatchingUp, which is the new name for this state.
-     * @deprecated - This state itself is not gone, just being renamed. Please use ConnectionState.CatchingUp.
+     * See {@link ConnectionState.CatchingUp}, which is the new name for this state.
+     * @deprecated - This state itself is not gone, just being renamed. Please use {@link ConnectionState.CatchingUp}.
      */
     Connecting = 1,
 

--- a/packages/loader/container-loader/src/connectionState.ts
+++ b/packages/loader/container-loader/src/connectionState.ts
@@ -18,8 +18,8 @@ export enum ConnectionState {
     EstablishingConnection = 3,
 
     /**
-     * See {@link ConnectionState.CatchingUp}, which is the new name for this state.
-     * @deprecated - This state itself is not gone, just being renamed. Please use {@link ConnectionState.CatchingUp}.
+     * @see ConnectionState.CatchingUp, which is the new name for this state.
+     * @deprecated - This state itself is not gone, just being renamed. Please use ConnectionState.CatchingUp.
      */
     Connecting = 1,
 

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -26,11 +26,11 @@ export interface IDataStoreAliasMessage {
 
 /**
  * Type guard that returns true if the given alias message is actually an instance of
- * a class which implements @see IDataStoreAliasMessage
+ * a class which implements {@link IDataStoreAliasMessage}
  * @param maybeDataStoreAliasMessage - message object to be validated
- * @returns True if the @see IDataStoreAliasMessage is fully implemented, false otherwise
+ * @returns True if the {@link IDataStoreAliasMessage} is fully implemented, false otherwise
  */
- export const isDataStoreAliasMessage = (
+export const isDataStoreAliasMessage = (
     maybeDataStoreAliasMessage: any,
 ): maybeDataStoreAliasMessage is IDataStoreAliasMessage => {
     return typeof maybeDataStoreAliasMessage?.internalId === "string"
@@ -153,7 +153,7 @@ class DataStore implements IDataStore {
 
     private async ackBasedPromise<T>(
         executor: (resolve: (value: T | PromiseLike<T>) => void,
-        reject: (reason?: any) => void) => void,
+            reject: (reason?: any) => void) => void,
     ): Promise<T> {
         let rejectBecauseDispose: () => void;
         return new Promise<T>((resolve, reject) => {

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -26,11 +26,11 @@ export interface IDataStoreAliasMessage {
 
 /**
  * Type guard that returns true if the given alias message is actually an instance of
- * a class which implements See {@link IDataStoreAliasMessage}
+ * a class which implements @see IDataStoreAliasMessage
  * @param maybeDataStoreAliasMessage - message object to be validated
- * @returns True if the {@link IDataStoreAliasMessage} is fully implemented, false otherwise
+ * @returns True if the @see IDataStoreAliasMessage is fully implemented, false otherwise
  */
-export const isDataStoreAliasMessage = (
+ export const isDataStoreAliasMessage = (
     maybeDataStoreAliasMessage: any,
 ): maybeDataStoreAliasMessage is IDataStoreAliasMessage => {
     return typeof maybeDataStoreAliasMessage?.internalId === "string"
@@ -153,7 +153,7 @@ class DataStore implements IDataStore {
 
     private async ackBasedPromise<T>(
         executor: (resolve: (value: T | PromiseLike<T>) => void,
-            reject: (reason?: any) => void) => void,
+        reject: (reason?: any) => void) => void,
     ): Promise<T> {
         let rejectBecauseDispose: () => void;
         return new Promise<T>((resolve, reject) => {

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -26,11 +26,11 @@ export interface IDataStoreAliasMessage {
 
 /**
  * Type guard that returns true if the given alias message is actually an instance of
- * a class which implements @see IDataStoreAliasMessage
+ * a class which implements See {@link IDataStoreAliasMessage}
  * @param maybeDataStoreAliasMessage - message object to be validated
- * @returns True if the @see IDataStoreAliasMessage is fully implemented, false otherwise
+ * @returns True if the {@link IDataStoreAliasMessage} is fully implemented, false otherwise
  */
- export const isDataStoreAliasMessage = (
+export const isDataStoreAliasMessage = (
     maybeDataStoreAliasMessage: any,
 ): maybeDataStoreAliasMessage is IDataStoreAliasMessage => {
     return typeof maybeDataStoreAliasMessage?.internalId === "string"
@@ -153,7 +153,7 @@ class DataStore implements IDataStore {
 
     private async ackBasedPromise<T>(
         executor: (resolve: (value: T | PromiseLike<T>) => void,
-        reject: (reason?: any) => void) => void,
+            reject: (reason?: any) => void) => void,
     ): Promise<T> {
         let rejectBecauseDispose: () => void;
         return new Promise<T>((resolve, reject) => {

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -152,7 +152,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly gcBlobNodeCount?: number;
     /** Sum of the sizes of all op contents since the last summary */
     readonly opsSizesSinceLastSummary: number;
-    /** Number of non-system ops since the last summary @see isSystemMessage */
+    /** Number of non-system ops since the last summary. See {@link @fluidframework/protocol-base#isSystemMessage} */
     readonly nonSystemOpsSinceLastSummary: number;
     /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
     readonly summaryNumber: number;
@@ -300,7 +300,7 @@ export interface ISummarizerEvents extends IEvent {
 }
 
 export interface ISummarizer extends
-    IEventProvider<ISummarizerEvents>, IFluidLoadable, Partial<IProvideSummarizer>{
+    IEventProvider<ISummarizerEvents>, IFluidLoadable, Partial<IProvideSummarizer> {
     /*
      * Asks summarizer to move to exit.
      * Summarizer will finish current processes, which may take a while.
@@ -428,7 +428,10 @@ type SummaryGeneratorOptionalTelemetryProperties =
     /** Delta in sum of op sizes between the current reference sequence number and the reference
      *  sequence number of the last summary */
     "opsSizesSinceLastSummary" |
-    /** Delta between the number of non-system ops since the last summary @see isSystemMessage */
+    /**
+     * Delta between the number of non-system ops since the last summary.
+     * See {@link @fluidframework/protocol-base#isSystemMessage}
+     */
     "nonSystemOpsSinceLastSummary" |
     /** Time it took to generate the summary tree and stats. */
     "generateDuration" |

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -152,7 +152,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly gcBlobNodeCount?: number;
     /** Sum of the sizes of all op contents since the last summary */
     readonly opsSizesSinceLastSummary: number;
-    /** Number of non-system ops since the last summary. See {@link @fluidframework/protocol-base#isSystemMessage} */
+    /** Number of non-system ops since the last summary @see isSystemMessage */
     readonly nonSystemOpsSinceLastSummary: number;
     /** The summary number for a container's summary. Incremented on summaries throughout its lifetime. */
     readonly summaryNumber: number;
@@ -300,7 +300,7 @@ export interface ISummarizerEvents extends IEvent {
 }
 
 export interface ISummarizer extends
-    IEventProvider<ISummarizerEvents>, IFluidLoadable, Partial<IProvideSummarizer> {
+    IEventProvider<ISummarizerEvents>, IFluidLoadable, Partial<IProvideSummarizer>{
     /*
      * Asks summarizer to move to exit.
      * Summarizer will finish current processes, which may take a while.
@@ -428,10 +428,7 @@ type SummaryGeneratorOptionalTelemetryProperties =
     /** Delta in sum of op sizes between the current reference sequence number and the reference
      *  sequence number of the last summary */
     "opsSizesSinceLastSummary" |
-    /**
-     * Delta between the number of non-system ops since the last summary.
-     * See {@link @fluidframework/protocol-base#isSystemMessage}
-     */
+    /** Delta between the number of non-system ops since the last summary @see isSystemMessage */
     "nonSystemOpsSinceLastSummary" |
     /** Time it took to generate the summary tree and stats. */
     "generateDuration" |

--- a/packages/runtime/test-runtime-utils/src/generateToken.ts
+++ b/packages/runtime/test-runtime-utils/src/generateToken.ts
@@ -32,20 +32,20 @@ import { v4 as uuid } from "uuid";
  * ({@link https://www.npmjs.com/package/jsrsasign | jsrsasign}) and may only be used in client (browser) context.
  * It is **not** Node.js-compatible.
  *
- * @param tenantId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
+ * @param tenantId - See {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
  * @param key - API key to authenticate user. Must be {@link https://en.wikipedia.org/wiki/UTF-8 | UTF-8}-encoded.
- * @param scopes - @see {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
- * @param documentId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
+ * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
+ * @param documentId - See {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
  * If not specified, the token will not be associated with a document, and an empty string will be used.
  * @param user - User with whom generated tokens will be associated.
  * If not specified, the token will not be associated with a user, and a randomly generated mock user will be
  * used instead.
- * @see {@link @fluidframework/protocol-definitions#ITokenClaims.user}
+ * See {@link @fluidframework/protocol-definitions#ITokenClaims.user}
  * @param lifetime - Used to generate the {@link @fluidframework/protocol-definitions#ITokenClaims.exp | expiration}.
  * Expiration = now + lifetime.
  * Expressed in seconds.
  * Default: 3600 (1 hour).
- * @param ver - @see {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
+ * @param ver - See {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
  * Default: `1.0`.
  */
 export function generateToken(

--- a/packages/runtime/test-runtime-utils/src/generateToken.ts
+++ b/packages/runtime/test-runtime-utils/src/generateToken.ts
@@ -32,20 +32,20 @@ import { v4 as uuid } from "uuid";
  * ({@link https://www.npmjs.com/package/jsrsasign | jsrsasign}) and may only be used in client (browser) context.
  * It is **not** Node.js-compatible.
  *
- * @param tenantId - See {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
+ * @param tenantId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.tenantId}
  * @param key - API key to authenticate user. Must be {@link https://en.wikipedia.org/wiki/UTF-8 | UTF-8}-encoded.
- * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
- * @param documentId - See {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
+ * @param scopes - @see {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
+ * @param documentId - @see {@link @fluidframework/protocol-definitions#ITokenClaims.documentId}.
  * If not specified, the token will not be associated with a document, and an empty string will be used.
  * @param user - User with whom generated tokens will be associated.
  * If not specified, the token will not be associated with a user, and a randomly generated mock user will be
  * used instead.
- * See {@link @fluidframework/protocol-definitions#ITokenClaims.user}
+ * @see {@link @fluidframework/protocol-definitions#ITokenClaims.user}
  * @param lifetime - Used to generate the {@link @fluidframework/protocol-definitions#ITokenClaims.exp | expiration}.
  * Expiration = now + lifetime.
  * Expressed in seconds.
  * Default: 3600 (1 hour).
- * @param ver - See {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
+ * @param ver - @see {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
  * Default: `1.0`.
  */
 export function generateToken(


### PR DESCRIPTION
Replaces usages of the `@see` tag in source-code comments. That tag is a part of the JSDoc spec, but not of TSDoc, which is what we use. Resulting documentation generation does not respect this tag, and ends up omitting referenced content.

This change replaces usages of that block with appropriate replacement syntax. 

Also includes a couple of related misc. fixes, and updates whitespace formatting for consistency.