### PR TITLE
Change DDSs to DDSes

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -835,7 +835,7 @@ Moved the following interfaces and const from `@fluidframework/core-interface` t
 They are deprecated from `@fluidframework/core-interface` and would be removed in future release. Please import them from `@fluidframework/container-definitions`.
 
 ### Deprecated `IFluidSerializer` in `IFluidDataStoreRuntime`
-`IFluidSerializer` should only be used by DDSes to serialize data and they should use the one created by `SharedObject`.
+`IFluidSerializer` should only be used by DDSs to serialize data and they should use the one created by `SharedObject`.
 
 ### Errors thrown to DDS event handlers
 Before this release, exceptions thrown from DDS event handlers resulted in Fluid Framework reporting non-error telemetry event and moving forward as if nothing happened. Starting with this release, such exceptions will result in critical error, i.e. container will be closed with such error and hosting app will be notified via Container's "closed" event. This will either happen immediately (if exception was thrown while processing remote op), or on later usage (if exception was thrown on local change). DDS will go into "broken" state and will keep throwing error on amy attempt to make local changes.
@@ -1811,10 +1811,10 @@ DataObject are now always created when Data Store is created. Full initializatio
 The impact of that change is that all changed objects would get loaded by summarizer container, but would not get initialized. Before this change, summarizer would not be loading any DataObjects.
 This change
 
-1. Ensures that initial summary generated for when data store attaches to container has fully initialized object, with all DDSes created. Before this change this initial snapshot was empty in most cases.
+1. Ensures that initial summary generated for when data store attaches to container has fully initialized object, with all DDSs created. Before this change this initial snapshot was empty in most cases.
 2. Allows DataObjects to modify FluidDataStoreRuntime behavior before it gets registered and used by the rest of the system, including setting various hooks.
 
-But it also puts more constraints on DataObject - its constructor should be light and not do any expensive work (all such work should be done in corresponding initialize methods), or access any data store runtime functionality that requires fully initialized runtime (like loading DDSes will not work in this state)
+But it also puts more constraints on DataObject - its constructor should be light and not do any expensive work (all such work should be done in corresponding initialize methods), or access any data store runtime functionality that requires fully initialized runtime (like loading DDSs will not work in this state)
 
 ### RequestParser
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -835,7 +835,7 @@ Moved the following interfaces and const from `@fluidframework/core-interface` t
 They are deprecated from `@fluidframework/core-interface` and would be removed in future release. Please import them from `@fluidframework/container-definitions`.
 
 ### Deprecated `IFluidSerializer` in `IFluidDataStoreRuntime`
-`IFluidSerializer` should only be used by DDSs to serialize data and they should use the one created by `SharedObject`.
+`IFluidSerializer` should only be used by DDSes to serialize data and they should use the one created by `SharedObject`.
 
 ### Errors thrown to DDS event handlers
 Before this release, exceptions thrown from DDS event handlers resulted in Fluid Framework reporting non-error telemetry event and moving forward as if nothing happened. Starting with this release, such exceptions will result in critical error, i.e. container will be closed with such error and hosting app will be notified via Container's "closed" event. This will either happen immediately (if exception was thrown while processing remote op), or on later usage (if exception was thrown on local change). DDS will go into "broken" state and will keep throwing error on amy attempt to make local changes.
@@ -1811,10 +1811,10 @@ DataObject are now always created when Data Store is created. Full initializatio
 The impact of that change is that all changed objects would get loaded by summarizer container, but would not get initialized. Before this change, summarizer would not be loading any DataObjects.
 This change
 
-1. Ensures that initial summary generated for when data store attaches to container has fully initialized object, with all DDSs created. Before this change this initial snapshot was empty in most cases.
+1. Ensures that initial summary generated for when data store attaches to container has fully initialized object, with all DDSes created. Before this change this initial snapshot was empty in most cases.
 2. Allows DataObjects to modify FluidDataStoreRuntime behavior before it gets registered and used by the rest of the system, including setting various hooks.
 
-But it also puts more constraints on DataObject - its constructor should be light and not do any expensive work (all such work should be done in corresponding initialize methods), or access any data store runtime functionality that requires fully initialized runtime (like loading DDSs will not work in this state)
+But it also puts more constraints on DataObject - its constructor should be light and not do any expensive work (all such work should be done in corresponding initialize methods), or access any data store runtime functionality that requires fully initialized runtime (like loading DDSes will not work in this state)
 
 ### RequestParser
 

--- a/docs/content/docs/deep/container-and-component-loading.md
+++ b/docs/content/docs/deep/container-and-component-loading.md
@@ -152,7 +152,7 @@ In the `instantiateComponent` call **(8.1)** the following is performed:
 2. Sets the `request` handler on the `ComponentRuntime` **(8.2)**
     - Requests that are sent to the `ComponentRuntime` are proxied to the `Component` object (more on this later)
 3. Provides a registry of Distributed Data Structures (DDS) / Sub-Component factories to the `ComponentRuntime` **(8.2)**
-    - This can be used to create new DDSes
+    - This can be used to create new DDSs
     - This can be used to create new Components that are not defined in the `ContainerRegistry`
 4. Create the `Component` object **(8.3)**
 
@@ -163,7 +163,7 @@ specific logic. In most cases the `instantiateComponent` call will provide the `
 `ComponentContext` **(8.3.1)**, and the `ComponentRuntime` **(8.3.2)** it created.
 
 The `Component` should use the `ComponentContext` to talk upwards to the `ContainerRuntime` **(8.3.1)**, and should use
-the `ComponentRuntime` to manage Fluid state of itself; mainly creating DDSes **(8.3.2)**.
+the `ComponentRuntime` to manage Fluid state of itself; mainly creating DDSs **(8.3.2)**.
 
 ![Image 9](/images/container-and-component-loading-9.jpg)
 

--- a/docs/content/docs/deep/container-and-component-loading.md
+++ b/docs/content/docs/deep/container-and-component-loading.md
@@ -152,7 +152,7 @@ In the `instantiateComponent` call **(8.1)** the following is performed:
 2. Sets the `request` handler on the `ComponentRuntime` **(8.2)**
     - Requests that are sent to the `ComponentRuntime` are proxied to the `Component` object (more on this later)
 3. Provides a registry of Distributed Data Structures (DDS) / Sub-Component factories to the `ComponentRuntime` **(8.2)**
-    - This can be used to create new DDSs
+    - This can be used to create new DDSes
     - This can be used to create new Components that are not defined in the `ContainerRegistry`
 4. Create the `Component` object **(8.3)**
 
@@ -163,7 +163,7 @@ specific logic. In most cases the `instantiateComponent` call will provide the `
 `ComponentContext` **(8.3.1)**, and the `ComponentRuntime` **(8.3.2)** it created.
 
 The `Component` should use the `ComponentContext` to talk upwards to the `ContainerRuntime` **(8.3.1)**, and should use
-the `ComponentRuntime` to manage Fluid state of itself; mainly creating DDSs **(8.3.2)**.
+the `ComponentRuntime` to manage Fluid state of itself; mainly creating DDSes **(8.3.2)**.
 
 ![Image 9](/images/container-and-component-loading-9.jpg)
 

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -18,7 +18,7 @@ import { create404Response, exceptionToResponse, responseToException } from "@fl
 /**
  * This handle is used to dynamically load a Fluid object on a remote client and is created on parsing a serialized
  * FluidObjectHandle.
- * This class is used to generate an IFluidHandle when de-serializing any all handles (including handles to DDSes, custom
+ * This class is used to generate an IFluidHandle when de-serializing any all handles (including handles to DDSs, custom
  * objects) that are stored in SharedObjects. The Data Store or SharedObject corresponding to the IFluidHandle can be
  * retrieved by calling `get` on it.
  */

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -18,7 +18,7 @@ import { create404Response, exceptionToResponse, responseToException } from "@fl
 /**
  * This handle is used to dynamically load a Fluid object on a remote client and is created on parsing a serialized
  * FluidObjectHandle.
- * This class is used to generate an IFluidHandle when de-serializing any all handles (including handles to DDSs, custom
+ * This class is used to generate an IFluidHandle when de-serializing any all handles (including handles to DDSes, custom
  * objects) that are stored in SharedObjects. The Data Store or SharedObject corresponding to the IFluidHandle can be
  * retrieved by calling `get` on it.
  */

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -18,9 +18,9 @@ import { create404Response, exceptionToResponse, responseToException } from "@fl
 /**
  * This handle is used to dynamically load a Fluid object on a remote client and is created on parsing a serialized
  * FluidObjectHandle.
- * This class is used to generate an IFluidHandle when de-serializing any all handles (including handles to DDSes, custom
- * objects) that are stored in SharedObjects. The Data Store or SharedObject corresponding to the IFluidHandle can be
- * retrieved by calling `get` on it.
+ * This class is used to generate an IFluidHandle when de-serializing any all handles (including handles to DDSes,
+ * custom objects) that are stored in SharedObjects. The Data Store or SharedObject corresponding to the
+ * IFluidHandle can be retrieved by calling `get` on it.
  */
 export class RemoteFluidObjectHandle implements IFluidHandle {
     public get IFluidRouter() { return this; }

--- a/packages/dds/test-dds-utils/README.md
+++ b/packages/dds/test-dds-utils/README.md
@@ -3,7 +3,7 @@
 Utilities for writing unit tests for DDS in Fluid Framework.
 
 ## Garbage Collection (GC) unit tests
-[gcTestRunner](./src/gcTestRunner.ts) provides a set of tests for validating that the DDSs return correct GC nodes.
+[gcTestRunner](./src/gcTestRunner.ts) provides a set of tests for validating that the DDSes return correct GC nodes.
 
 To write GC tests for a DDS, call `runGCTests` with a class that implements the following interface:
 ```typescript

--- a/packages/dds/test-dds-utils/README.md
+++ b/packages/dds/test-dds-utils/README.md
@@ -3,7 +3,7 @@
 Utilities for writing unit tests for DDS in Fluid Framework.
 
 ## Garbage Collection (GC) unit tests
-[gcTestRunner](./src/gcTestRunner.ts) provides a set of tests for validating that the DDSes return correct GC nodes.
+[gcTestRunner](./src/gcTestRunner.ts) provides a set of tests for validating that the DDSs return correct GC nodes.
 
 To write GC tests for a DDS, call `runGCTests` with a class that implements the following interface:
 ```typescript

--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -28,7 +28,7 @@ The current feature focus is on:
     - New field kinds to allow data-modeling with more specific merge semantics (ex: adding support for special collections like sets, or sorted sequences)
     - New services (ex: to support permissions, server side indexing etc.)
 
-## Whats missing from existing DDSs?
+## Whats missing from existing DDSes?
 
 `directory` and `map` can not provide merge resolution that guarantees well-formedness of trees while supporting the desired editing APIs (like subsequence move),
 and are missing (and cannot be practically extended to have) efficient ways to handle large data or schema.
@@ -51,7 +51,7 @@ For example, moving part of a sequence from one sequence DDS to another cannot b
 Cross DDS moves also currently can't be as efficient as moves withing a single DDS, and there isn't a good way to do cross DDS history or branching without major framework changes.
 There are also some significant per DDS performance and storage costs that make this approach much more costly than using a single DDS.
 
-One way to think about this new tree DDS is to try and mix some of the Fluid-Framework features (like the ability to checkout a subset of the data) with features from DDSs (ex: lower overhead per item, efficient moves of sub-sequences, transactions).
+One way to think about this new tree DDS is to try and mix some of the Fluid-Framework features (like the ability to checkout a subset of the data) with features from DDSes (ex: lower overhead per item, efficient moves of sub-sequences, transactions).
 If this effort is successful, it might reveal some improved abstractions for modularizing hierarchical collaborative data-structures (perhaps "field kinds"),
 which could make their way back into the framework, enabling some features specific to this tree (ex: history, branching, transactional moves, reduced overhead) to be framework features instead.
 

--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -28,7 +28,7 @@ The current feature focus is on:
     - New field kinds to allow data-modeling with more specific merge semantics (ex: adding support for special collections like sets, or sorted sequences)
     - New services (ex: to support permissions, server side indexing etc.)
 
-## Whats missing from existing DDSes?
+## Whats missing from existing DDSs?
 
 `directory` and `map` can not provide merge resolution that guarantees well-formedness of trees while supporting the desired editing APIs (like subsequence move),
 and are missing (and cannot be practically extended to have) efficient ways to handle large data or schema.
@@ -51,7 +51,7 @@ For example, moving part of a sequence from one sequence DDS to another cannot b
 Cross DDS moves also currently can't be as efficient as moves withing a single DDS, and there isn't a good way to do cross DDS history or branching without major framework changes.
 There are also some significant per DDS performance and storage costs that make this approach much more costly than using a single DDS.
 
-One way to think about this new tree DDS is to try and mix some of the Fluid-Framework features (like the ability to checkout a subset of the data) with features from DDSes (ex: lower overhead per item, efficient moves of sub-sequences, transactions).
+One way to think about this new tree DDS is to try and mix some of the Fluid-Framework features (like the ability to checkout a subset of the data) with features from DDSs (ex: lower overhead per item, efficient moves of sub-sequences, transactions).
 If this effort is successful, it might reveal some improved abstractions for modularizing hierarchical collaborative data-structures (perhaps "field kinds"),
 which could make their way back into the framework, enabling some features specific to this tree (ex: history, branching, transactional moves, reduced overhead) to be framework features instead.
 

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -74,7 +74,7 @@ async function createDataObject<TObj extends PureDataObject, I extends DataObjec
     // Create object right away.
     // This allows object to register various callbacks with runtime before runtime
     // becomes globally available. But it's not full initialization - constructor can't
-    // access DDSs or other services of runtime as objects are not fully initialized.
+    // access DDSes or other services of runtime as objects are not fully initialized.
     // In order to use object, we need to go through full initialization by calling finishInitialization().
     const scope: FluidObject<IFluidDependencySynthesizer> = context.scope;
     const dependencyContainer = new DependencyContainer(scope.IFluidDependencySynthesizer);
@@ -82,14 +82,14 @@ async function createDataObject<TObj extends PureDataObject, I extends DataObjec
     const instance = new ctor({ runtime, context, providers, initProps });
 
     // if it's a newly created object, we need to wait for it to finish initialization
-    // as that results in creation of DDSs, before it gets attached, providing atomic
+    // as that results in creation of DDSes, before it gets attached, providing atomic
     // guarantee of creation.
     // WARNING: we can't do the same (yet) for already existing PureDataObject!
     // This will result in deadlock, as it tries to resolve internal handles, but any
     // handle resolution goes through root (container runtime), which can't route it back
     // to this data store, as it's still not initialized and not known to container runtime yet.
     // In the future, we should address it by using relative paths for handles and be able to resolve
-    // local DDSs while data store is not fully initialized.
+    // local DDSes while data store is not fully initialized.
     if (!existing) {
         await instance.finishInitialization(existing);
     }

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -74,7 +74,7 @@ async function createDataObject<TObj extends PureDataObject, I extends DataObjec
     // Create object right away.
     // This allows object to register various callbacks with runtime before runtime
     // becomes globally available. But it's not full initialization - constructor can't
-    // access DDSes or other services of runtime as objects are not fully initialized.
+    // access DDSs or other services of runtime as objects are not fully initialized.
     // In order to use object, we need to go through full initialization by calling finishInitialization().
     const scope: FluidObject<IFluidDependencySynthesizer> = context.scope;
     const dependencyContainer = new DependencyContainer(scope.IFluidDependencySynthesizer);
@@ -82,14 +82,14 @@ async function createDataObject<TObj extends PureDataObject, I extends DataObjec
     const instance = new ctor({ runtime, context, providers, initProps });
 
     // if it's a newly created object, we need to wait for it to finish initialization
-    // as that results in creation of DDSes, before it gets attached, providing atomic
+    // as that results in creation of DDSs, before it gets attached, providing atomic
     // guarantee of creation.
     // WARNING: we can't do the same (yet) for already existing PureDataObject!
     // This will result in deadlock, as it tries to resolve internal handles, but any
     // handle resolution goes through root (container runtime), which can't route it back
     // to this data store, as it's still not initialized and not known to container runtime yet.
     // In the future, we should address it by using relative paths for handles and be able to resolve
-    // local DDSes while data store is not fully initialized.
+    // local DDSs while data store is not fully initialized.
     if (!existing) {
         await instance.finishInitialization(existing);
     }

--- a/packages/loader/container-loader/src/collabWindowTracker.ts
+++ b/packages/loader/container-loader/src/collabWindowTracker.ts
@@ -62,7 +62,7 @@ export class CollabWindowTracker {
 
         // We don't acknowledge no-ops to avoid acknowledgement cycles (i.e. ack the MSN
         // update, which updates the MSN, then ack the update, etc...).
-        // Intent here is for runtime (and DDSs) not to keep too much tracking state / memory
+        // Intent here is for runtime (and DDSes) not to keep too much tracking state / memory
         // due to runtime ops from other clients.
         if (!isRuntimeMessage(message)) {
             return;

--- a/packages/loader/container-loader/src/collabWindowTracker.ts
+++ b/packages/loader/container-loader/src/collabWindowTracker.ts
@@ -62,7 +62,7 @@ export class CollabWindowTracker {
 
         // We don't acknowledge no-ops to avoid acknowledgement cycles (i.e. ack the MSN
         // update, which updates the MSN, then ack the update, etc...).
-        // Intent here is for runtime (and DDSes) not to keep too much tracking state / memory
+        // Intent here is for runtime (and DDSs) not to keep too much tracking state / memory
         // due to runtime ops from other clients.
         if (!isRuntimeMessage(message)) {
             return;

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -832,7 +832,7 @@ export class ConnectionManager implements IConnectionManager {
                 this.logger.sendPerformanceEvent({ eventName: "ReadConnectionTransition" });
 
                 // Please see #8483 for more details on why maintaining connection further as is would not work.
-                // Short story - connection properties are immutable, and many processes (consensus DDSes, summarizer)
+                // Short story - connection properties are immutable, and many processes (consensus DDSs, summarizer)
                 // assume that connection stays "write" connection until disconnect, and act accordingly, which may
                 // not work well with de-facto "read" connection we are in after receiving own leave op on timeout.
                 // Clients need to be able to transition to "read" state after some time of inactivity!

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -832,7 +832,7 @@ export class ConnectionManager implements IConnectionManager {
                 this.logger.sendPerformanceEvent({ eventName: "ReadConnectionTransition" });
 
                 // Please see #8483 for more details on why maintaining connection further as is would not work.
-                // Short story - connection properties are immutable, and many processes (consensus DDSs, summarizer)
+                // Short story - connection properties are immutable, and many processes (consensus DDSes, summarizer)
                 // assume that connection stays "write" connection until disconnect, and act accordingly, which may
                 // not work well with de-facto "read" connection we are in after receiving own leave op on timeout.
                 // Clients need to be able to transition to "read" state after some time of inactivity!

--- a/packages/loader/driver-utils/src/blobAggregationStorage.ts
+++ b/packages/loader/driver-utils/src/blobAggregationStorage.ts
@@ -145,7 +145,7 @@ class SnapshotExtractorInPlace extends SnapshotExtractor {
  * When snapshot is read, it will unpack aggregated blobs and provide them transparently to caller.
  */
 export class BlobAggregationStorage extends SnapshotExtractor implements IDocumentStorageService {
-    // Tells data store if it can use incremental summary (i.e. reuse DDSs from previous summary
+    // Tells data store if it can use incremental summary (i.e. reuse DDSes from previous summary
     // when only one DDS changed).
     // The answer has to be know long before we enable actual packing. The reason for the is the following:
     // A the moment when we enable packing, we should assume that all clients out there wil already have bits

--- a/packages/loader/driver-utils/src/blobAggregationStorage.ts
+++ b/packages/loader/driver-utils/src/blobAggregationStorage.ts
@@ -145,7 +145,7 @@ class SnapshotExtractorInPlace extends SnapshotExtractor {
  * When snapshot is read, it will unpack aggregated blobs and provide them transparently to caller.
  */
 export class BlobAggregationStorage extends SnapshotExtractor implements IDocumentStorageService {
-    // Tells data store if it can use incremental summary (i.e. reuse DDSes from previous summary
+    // Tells data store if it can use incremental summary (i.e. reuse DDSs from previous summary
     // when only one DDS changed).
     // The answer has to be know long before we enable actual packing. The reason for the is the following:
     // A the moment when we enable packing, we should assume that all clients out there wil already have bits

--- a/packages/runtime/container-runtime/garbageCollection.md
+++ b/packages/runtime/container-runtime/garbageCollection.md
@@ -9,19 +9,19 @@ Before understanding the details of how GC works, lets take a look at how to add
 
     `Root` objects can never be deleted so be careful and only create them if they should live forever.
   - Store a handle ([IFluidHandle](../../../common/lib/core-interfaces/src/handles.ts)) to the object in a referenced DDS that supports handle in its data. For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
-- All references to unused Fluid objects should be removed so that they can be deleted by GC. To remove an object's reference, all its handles should be removed from referenced DDSs.
+- All references to unused Fluid objects should be removed so that they can be deleted by GC. To remove an object's reference, all its handles should be removed from referenced DDSes.
 
-> Note that there should be at least one `root` data store with one or more DDSs in a Fluid document so that other objects' handles can be stored in it.
+> Note that there should be at least one `root` data store with one or more DDSes in a Fluid document so that other objects' handles can be stored in it.
 
 ## GC algorithm
 The GC algorithm runs in two phases:
 
 ### Mark phase
 In this phase, the GC algorithm identifies all Fluid objects that are unreferenced and marks them as such:
-- It starts at the root data stores and marks them, and all their DDSs as referenced.
-    > Note: Currently all DDSs are considered as root so they are always referenced. This may change in the future.
-- It finds the handles stored in DDSs from #1 and marks the objects corresponding to the handles as referenced.
-- It finds the handles stored in DDSs from #2 and marks the objects corresponding to the handles as referenced and so on until it has scanned all objects.
+- It starts at the root data stores and marks them, and all their DDSes as referenced.
+    > Note: Currently all DDSes are considered as root so they are always referenced. This may change in the future.
+- It finds the handles stored in DDSes from #1 and marks the objects corresponding to the handles as referenced.
+- It finds the handles stored in DDSes from #2 and marks the objects corresponding to the handles as referenced and so on until it has scanned all objects.
 - All the objects in the system that are not marked as referenced in the above steps are marked as unreferenced.
 
 Mark phase is enabled by default for a container. It is enabled during creation of the container runtime and remains enabled throughout its lifetime. Basically, this setting is persisted in the summary and cannot be changed.

--- a/packages/runtime/container-runtime/garbageCollection.md
+++ b/packages/runtime/container-runtime/garbageCollection.md
@@ -9,19 +9,19 @@ Before understanding the details of how GC works, lets take a look at how to add
 
     `Root` objects can never be deleted so be careful and only create them if they should live forever.
   - Store a handle ([IFluidHandle](../../../common/lib/core-interfaces/src/handles.ts)) to the object in a referenced DDS that supports handle in its data. For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
-- All references to unused Fluid objects should be removed so that they can be deleted by GC. To remove an object's reference, all its handles should be removed from referenced DDSes.
+- All references to unused Fluid objects should be removed so that they can be deleted by GC. To remove an object's reference, all its handles should be removed from referenced DDSs.
 
-> Note that there should be at least one `root` data store with one or more DDSes in a Fluid document so that other objects' handles can be stored in it.
+> Note that there should be at least one `root` data store with one or more DDSs in a Fluid document so that other objects' handles can be stored in it.
 
 ## GC algorithm
 The GC algorithm runs in two phases:
 
 ### Mark phase
 In this phase, the GC algorithm identifies all Fluid objects that are unreferenced and marks them as such:
-- It starts at the root data stores and marks them, and all their DDSes as referenced.
-    > Note: Currently all DDSes are considered as root so they are always referenced. This may change in the future.
-- It finds the handles stored in DDSes from #1 and marks the objects corresponding to the handles as referenced.
-- It finds the handles stored in DDSes from #2 and marks the objects corresponding to the handles as referenced and so on until it has scanned all objects.
+- It starts at the root data stores and marks them, and all their DDSs as referenced.
+    > Note: Currently all DDSs are considered as root so they are always referenced. This may change in the future.
+- It finds the handles stored in DDSs from #1 and marks the objects corresponding to the handles as referenced.
+- It finds the handles stored in DDSs from #2 and marks the objects corresponding to the handles as referenced and so on until it has scanned all objects.
 - All the objects in the system that are not marked as referenced in the above steps are marked as unreferenced.
 
 Mark phase is enabled by default for a container. It is enabled during creation of the container runtime and remains enabled throughout its lifetime. Basically, this setting is persisted in the summary and cannot be changed.

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -650,8 +650,8 @@ export class DataStores implements IDisposable {
      * Called during GC to retrieve the package path of a data store node with the given path.
      */
     public getDataStorePackagePath(nodePath: string): readonly string[] | undefined {
-        // If the node belongs to a data store, return its package path if the data store is loaded. For DDSes, we return
-        // the package path of the data store that contains it.
+        // If the node belongs to a data store, return its package path if the data store is loaded. For DDSes, we
+        // return the package path of the data store that contains it.
         const context = this.contexts.get(nodePath.split("/")[1]);
         return context?.isLoaded ? context.packagePath : undefined;
     }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -650,7 +650,7 @@ export class DataStores implements IDisposable {
      * Called during GC to retrieve the package path of a data store node with the given path.
      */
     public getDataStorePackagePath(nodePath: string): readonly string[] | undefined {
-        // If the node belongs to a data store, return its package path if the data store is loaded. For DDSs, we return
+        // If the node belongs to a data store, return its package path if the data store is loaded. For DDSes, we return
         // the package path of the data store that contains it.
         const context = this.contexts.get(nodePath.split("/")[1]);
         return context?.isLoaded ? context.packagePath : undefined;

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -650,7 +650,7 @@ export class DataStores implements IDisposable {
      * Called during GC to retrieve the package path of a data store node with the given path.
      */
     public getDataStorePackagePath(nodePath: string): readonly string[] | undefined {
-        // If the node belongs to a data store, return its package path if the data store is loaded. For DDSes, we return
+        // If the node belongs to a data store, return its package path if the data store is loaded. For DDSs, we return
         // the package path of the data store that contains it.
         const context = this.contexts.get(nodePath.split("/")[1]);
         return context?.isLoaded ? context.packagePath : undefined;

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1009,10 +1009,10 @@ export class GarbageCollector implements IGarbageCollector {
          *    references added new outbound references before getting deleted, we need to detect them.
          * 2. We need new outbound references since last run because some of them may have been deleted later. If those
          *    references added new outbound references before getting deleted, we need to detect them.
-         * 3. We need data from the current run because currently we may not detect when DDSs are referenced:
-         *    - We don't require DDSs handles to be stored in a referenced DDS. For this, we need GC at DDS level
+         * 3. We need data from the current run because currently we may not detect when DDSes are referenced:
+         *    - We don't require DDSes handles to be stored in a referenced DDS. For this, we need GC at DDS level
          *      which is tracked by https://github.com/microsoft/FluidFramework/issues/8470.
-         *    - A new data store may have "root" DDSs already created and we don't detect them today.
+         *    - A new data store may have "root" DDSes already created and we don't detect them today.
          */
         const gcDataSuperSet = concatGarbageCollectionData(this.previousGCDataFromLastRun, currentGCData);
         this.newReferencesSinceLastRun.forEach((outboundRoutes: string[], sourceNodeId: string) => {

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1009,10 +1009,10 @@ export class GarbageCollector implements IGarbageCollector {
          *    references added new outbound references before getting deleted, we need to detect them.
          * 2. We need new outbound references since last run because some of them may have been deleted later. If those
          *    references added new outbound references before getting deleted, we need to detect them.
-         * 3. We need data from the current run because currently we may not detect when DDSes are referenced:
-         *    - We don't require DDSes handles to be stored in a referenced DDS. For this, we need GC at DDS level
+         * 3. We need data from the current run because currently we may not detect when DDSs are referenced:
+         *    - We don't require DDSs handles to be stored in a referenced DDS. For this, we need GC at DDS level
          *      which is tracked by https://github.com/microsoft/FluidFramework/issues/8470.
-         *    - A new data store may have "root" DDSes already created and we don't detect them today.
+         *    - A new data store may have "root" DDSs already created and we don't detect them today.
          */
         const gcDataSuperSet = concatGarbageCollectionData(this.previousGCDataFromLastRun, currentGCData);
         this.newReferencesSinceLastRun.forEach((outboundRoutes: string[], sourceNodeId: string) => {

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -145,7 +145,7 @@ export abstract class LocalChannelContextBase implements IChannelContext {
 
     public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {
         /**
-         * Currently, DDSs are always considered referenced and are not garbage collected.
+         * Currently, DDSes are always considered referenced and are not garbage collected.
          * Once we have GC at DDS level, this channel context's used routes will be updated as per the passed
          * value. See - https://github.com/microsoft/FluidFramework/issues/4611
          */

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -145,7 +145,7 @@ export abstract class LocalChannelContextBase implements IChannelContext {
 
     public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {
         /**
-         * Currently, DDSes are always considered referenced and are not garbage collected.
+         * Currently, DDSs are always considered referenced and are not garbage collected.
          * Once we have GC at DDS level, this channel context's used routes will be updated as per the passed
          * value. See - https://github.com/microsoft/FluidFramework/issues/4611
          */

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -305,7 +305,7 @@ export class RemoteChannelContext implements IChannelContext {
 
     public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {
         /**
-         * Currently, DDSs are always considered referenced and are not garbage collected. Update the summarizer node's
+         * Currently, DDSes are always considered referenced and are not garbage collected. Update the summarizer node's
          * used routes to contain a route to this channel context.
          * Once we have GC at DDS level, this will be updated to use the passed usedRoutes. See -
          * https://github.com/microsoft/FluidFramework/issues/4611

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -305,7 +305,7 @@ export class RemoteChannelContext implements IChannelContext {
 
     public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {
         /**
-         * Currently, DDSes are always considered referenced and are not garbage collected. Update the summarizer node's
+         * Currently, DDSs are always considered referenced and are not garbage collected. Update the summarizer node's
          * used routes to contain a route to this channel context.
          * Once we have GC at DDS level, this will be updated to use the passed usedRoutes. See -
          * https://github.com/microsoft/FluidFramework/issues/4611

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -15,7 +15,7 @@ import { defaultGCConfig } from "./gcTestConfigs";
 import { createSummarizer, summarizeNow, waitForContainerConnection } from "./gcTestSummaryUtils";
 
 /**
- * Validates this scenario: When two DDSs in the same datastore has one change, gets summarized, and then gc is called
+ * Validates this scenario: When two DDSes in the same datastore has one change, gets summarized, and then gc is called
  * from loading a new container. We do not want to allow duplicate GC routes to be created in this scenario.
  */
 describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
@@ -35,7 +35,7 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
         await waitForContainerConnection(mainContainer);
     });
 
-    it("Back routes added by GC are removed when passed from data stores to DDSs", async () => {
+    it("Back routes added by GC are removed when passed from data stores to DDSes", async () => {
         const dds = SharedMap.create(mainDataStore._runtime);
         mainDataStore._root.set("dds", dds.handle);
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -15,7 +15,7 @@ import { defaultGCConfig } from "./gcTestConfigs";
 import { createSummarizer, summarizeNow, waitForContainerConnection } from "./gcTestSummaryUtils";
 
 /**
- * Validates this scenario: When two DDSes in the same datastore has one change, gets summarized, and then gc is called
+ * Validates this scenario: When two DDSs in the same datastore has one change, gets summarized, and then gc is called
  * from loading a new container. We do not want to allow duplicate GC routes to be created in this scenario.
  */
 describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
@@ -35,7 +35,7 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
         await waitForContainerConnection(mainContainer);
     });
 
-    it("Back routes added by GC are removed when passed from data stores to DDSes", async () => {
+    it("Back routes added by GC are removed when passed from data stores to DDSs", async () => {
         const dds = SharedMap.create(mainDataStore._runtime);
         mainDataStore._root.set("dds", dds.handle);
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -203,7 +203,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
      * by verifying that their unreferenced timestamps are updated correctly.
      *
      * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
-     * The nodes are data stores / DDSs represented by alphabets A, B, C and so on.
+     * The nodes are data stores / DDSes represented by alphabets A, B, C and so on.
      */
     describe("References between summaries", () => {
         /*
@@ -608,7 +608,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         });
 
         /*
-         * Validates that DDSs are referenced even though we don't detect their referenced between summaries. Once we
+         * Validates that DDSes are referenced even though we don't detect their referenced between summaries. Once we
          * do GC at DDS level, this test will fail - https://github.com/microsoft/FluidFramework/issues/8470.
          * 1. Summary 1 at t1. V = [A*]. E = [].
          * 2. DDS B is created. No reference is added to it.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -203,7 +203,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
      * by verifying that their unreferenced timestamps are updated correctly.
      *
      * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
-     * The nodes are data stores / DDSes represented by alphabets A, B, C and so on.
+     * The nodes are data stores / DDSs represented by alphabets A, B, C and so on.
      */
     describe("References between summaries", () => {
         /*
@@ -608,7 +608,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         });
 
         /*
-         * Validates that DDSes are referenced even though we don't detect their referenced between summaries. Once we
+         * Validates that DDSs are referenced even though we don't detect their referenced between summaries. Once we
          * do GC at DDS level, this test will fail - https://github.com/microsoft/FluidFramework/issues/8470.
          * 1. Summary 1 at t1. V = [A*]. E = [].
          * 2. DDS B is created. No reference is added to it.

--- a/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
@@ -77,7 +77,7 @@ async function ensureContainerConnected(container: Container): Promise<void> {
 }
 
 /**
- * These tests validate that new Fluid objects such as data stores and DDSs become visible correctly. For example,
+ * These tests validate that new Fluid objects such as data stores and DDSes become visible correctly. For example,
  * new non-root data stores should not become visible (or reachable from root) until their handles are added to a
  * visible DDS.
  */
@@ -233,7 +233,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
          * Validates that DDSes created in non-root data stores become visible and can send ops when the data store
          * becomes globally visible to all clients.
          */
-         it("validates that DDSs in non-root data stores become visible correctly", async () => {
+         it("validates that DDSes in non-root data stores become visible correctly", async () => {
             const dataObject2 = await createNonRootDataObject(container1, containerRuntime1);
 
             // Create a DDS when data store is not visible and store its handle.
@@ -261,7 +261,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
             const dataObject1C2 = await requestTestObjectWithoutWait(container2, "default");
             const dataObject2C2 = await getAndValidateDataObject(dataObject1C2, "dataObject2", container2);
 
-            // Validate that the DDSs are present in the second container.
+            // Validate that the DDSes are present in the second container.
             const map1C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map1"))?.get();
             assert(map1C2 !== undefined, "map1 not found in second container");
             const map2C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map2"))?.get();
@@ -269,7 +269,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
             const map3C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map3"))?.get();
             assert(map3C2 !== undefined, "map3 not found in second container");
 
-            // Send ops for all the DDSs created above in both local and remote container and validate that the ops are
+            // Send ops for all the DDSes created above in both local and remote container and validate that the ops are
             // successfully processed.
             map1.set("key1", "value1");
             map1C2.set("key2", "value2");
@@ -290,7 +290,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
          * Validates that DDSes created in root data stores become visible and can send ops when the data store
          * becomes globally visible to all clients.
          */
-         it("validates that DDSs in root data stores become visible correctly", async () => {
+         it("validates that DDSes in root data stores become visible correctly", async () => {
             const dataObject2 = await createRootDataObject(container1, containerRuntime1, "rootDataStore");
 
             // Create a DDS after data store is locally visible and store its handle.
@@ -316,13 +316,13 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
             await provider.ensureSynchronized();
             const dataObject2C2 = await requestFluidObject<ITestDataObject>(container2, "rootDataStore");
 
-            // Validate that the DDSs are present in the second container.
+            // Validate that the DDSes are present in the second container.
             const map1C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map1"))?.get();
             assert(map1C2 !== undefined, "map1 not found in second container");
             const map2C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map2"))?.get();
             assert(map2C2 !== undefined, "map2 not found in second container");
 
-            // Send ops for all the DDSs created above in both local and remote container and validate that the ops are
+            // Send ops for all the DDSes created above in both local and remote container and validate that the ops are
             // successfully processed.
             map1.set("key1", "value1");
             map1C2.set("key2", "value2");

--- a/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
@@ -77,7 +77,7 @@ async function ensureContainerConnected(container: Container): Promise<void> {
 }
 
 /**
- * These tests validate that new Fluid objects such as data stores and DDSes become visible correctly. For example,
+ * These tests validate that new Fluid objects such as data stores and DDSs become visible correctly. For example,
  * new non-root data stores should not become visible (or reachable from root) until their handles are added to a
  * visible DDS.
  */
@@ -233,7 +233,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
          * Validates that DDSes created in non-root data stores become visible and can send ops when the data store
          * becomes globally visible to all clients.
          */
-         it("validates that DDSes in non-root data stores become visible correctly", async () => {
+         it("validates that DDSs in non-root data stores become visible correctly", async () => {
             const dataObject2 = await createNonRootDataObject(container1, containerRuntime1);
 
             // Create a DDS when data store is not visible and store its handle.
@@ -261,7 +261,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
             const dataObject1C2 = await requestTestObjectWithoutWait(container2, "default");
             const dataObject2C2 = await getAndValidateDataObject(dataObject1C2, "dataObject2", container2);
 
-            // Validate that the DDSes are present in the second container.
+            // Validate that the DDSs are present in the second container.
             const map1C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map1"))?.get();
             assert(map1C2 !== undefined, "map1 not found in second container");
             const map2C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map2"))?.get();
@@ -269,7 +269,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
             const map3C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map3"))?.get();
             assert(map3C2 !== undefined, "map3 not found in second container");
 
-            // Send ops for all the DDSes created above in both local and remote container and validate that the ops are
+            // Send ops for all the DDSs created above in both local and remote container and validate that the ops are
             // successfully processed.
             map1.set("key1", "value1");
             map1C2.set("key2", "value2");
@@ -290,7 +290,7 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
          * Validates that DDSes created in root data stores become visible and can send ops when the data store
          * becomes globally visible to all clients.
          */
-         it("validates that DDSes in root data stores become visible correctly", async () => {
+         it("validates that DDSs in root data stores become visible correctly", async () => {
             const dataObject2 = await createRootDataObject(container1, containerRuntime1, "rootDataStore");
 
             // Create a DDS after data store is locally visible and store its handle.
@@ -316,13 +316,13 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
             await provider.ensureSynchronized();
             const dataObject2C2 = await requestFluidObject<ITestDataObject>(container2, "rootDataStore");
 
-            // Validate that the DDSes are present in the second container.
+            // Validate that the DDSs are present in the second container.
             const map1C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map1"))?.get();
             assert(map1C2 !== undefined, "map1 not found in second container");
             const map2C2 = await (dataObject2C2._root.get<IFluidHandle<SharedMap>>("map2"))?.get();
             assert(map2C2 !== undefined, "map2 not found in second container");
 
-            // Send ops for all the DDSes created above in both local and remote container and validate that the ops are
+            // Send ops for all the DDSs created above in both local and remote container and validate that the ops are
             // successfully processed.
             map1.set("key1", "value1");
             map1C2.set("key2", "value2");

--- a/packages/tools/replay-tool/src/replayFluidFactories.ts
+++ b/packages/tools/replay-tool/src/replayFluidFactories.ts
@@ -96,7 +96,7 @@ const allDdsFactories: IChannelFactory[] = [
 ];
 
 /**
- * Simple data store factory that creates a data store runtime with a list of known DDSs. It does not create a data
+ * Simple data store factory that creates a data store runtime with a list of known DDSes. It does not create a data
  * object since the replay tool doesn't request any data store but only loads the data store runtime to summarize it.
  */
 export class ReplayDataStoreFactory implements IFluidDataStoreFactory, Partial<IFluidDataStoreRegistry> {
@@ -110,7 +110,7 @@ export class ReplayDataStoreFactory implements IFluidDataStoreFactory, Partial<I
 
     /**
      * Return ourselves when asked for child data store entry. The idea is that each data store that is created
-     * has access to and can create from the list of known DDSs.
+     * has access to and can create from the list of known DDSes.
     */
     public async get(name: string): Promise<FluidDataStoreRegistryEntry | undefined> {
         return this;

--- a/packages/tools/replay-tool/src/replayFluidFactories.ts
+++ b/packages/tools/replay-tool/src/replayFluidFactories.ts
@@ -96,7 +96,7 @@ const allDdsFactories: IChannelFactory[] = [
 ];
 
 /**
- * Simple data store factory that creates a data store runtime with a list of known DDSes. It does not create a data
+ * Simple data store factory that creates a data store runtime with a list of known DDSs. It does not create a data
  * object since the replay tool doesn't request any data store but only loads the data store runtime to summarize it.
  */
 export class ReplayDataStoreFactory implements IFluidDataStoreFactory, Partial<IFluidDataStoreRegistry> {
@@ -110,7 +110,7 @@ export class ReplayDataStoreFactory implements IFluidDataStoreFactory, Partial<I
 
     /**
      * Return ourselves when asked for child data store entry. The idea is that each data store that is created
-     * has access to and can create from the list of known DDSes.
+     * has access to and can create from the list of known DDSs.
     */
     public async get(name: string): Promise<FluidDataStoreRegistryEntry | undefined> {
         return this;


### PR DESCRIPTION
## Description

According to various sources, the plural of DDSs is DDSes. This PR changes all occurrences of `DDSs` in the repo to `DDSes`.

## Reviewer Guidance

All the changes here are either in markdown or in comments within a typescript file so there should be no breaking changes.
