### PR TITLE
Remove remaining ICodeLoader Interfaces

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [LocalReference class and method deprecations removed](#LocalReference-class-and-method-deprecations-removed)
 - [Remove TelemetryDataTag.PackageData](#Remove-TelemetryDataTagPackageData)
 - [Deprecate ISummaryRuntimeOptions.disableIsolatedChannels](#Deprecate-ISummaryRuntimeOptionsdisableIsolatedChannels)
+- [Remove ICodeLoader from @fluidframework/container-definitions](#Remove-ICodeLoader-from-@fluidframework/container-definitions)
 
 ### Deprecate ISummaryConfigurationHeuristics.idleTime
 `ISummaryConfigurationHeuristics.idleTime` has been deprecated and will be removed in a future release. See [#10008](https://github.com/microsoft/FluidFramework/issues/10008)
@@ -44,6 +45,9 @@ The following deprecated methods are  now removed from sequence and merge-tree. 
 
 ### Remove TelemetryDataTag.PackageData
 `TelemetryDataTag.PackageData` has been removed. Migrate all usage to `TelemetryDataTag.CodeArtifact` instead.
+
+### Remove ICodeLoader from `@fluidframework/container-definitions`
+`ICodeLoader` in `@fluidframework/container-definitions` was deprecated since 0.40.0 and is now removed. Use `ICodeDetailsLoader` from `@fluidframework/container-loader` instead.
 
 # 1.1.0
 
@@ -215,7 +219,7 @@ Additionally, please note that the `Connecting` state is being renamed to `Catch
 - [Deprecated enableRedeemFallback from HostStoragePolicy in Odsp driver](#Deprecated-enableRedeemFallback-from-HostStoragePolicy-in-Odsp-driver)]
 
 ### Remove ICodeLoader interface
-ICodeLoader interface was deprecated a while ago and will be removed in the next release. Please refer to [replace ICodeLoader with ICodeDetailsLoader interface](#Replace-ICodeLoader-with-ICodeDetailsLoader-interface) for more details.
+`ICodeLoader` in `@fluidframework/container-definitions` was deprecated since 0.40.0 and is now removed. Use `ICodeDetailsLoader` from `@fluidframework/container-loader` instead.
 
 ### IFluidContainer.connect() and IFluidContainer.disconnect() will be made mandatory in future major release
 In major release 1.0, the optional functions `IFluidContainer.connect()` and `IFluidContainer.disconnect()` will be made mandatory functions.
@@ -301,7 +305,7 @@ The `packageInfoSource` argument in `getAbsoluteUrl()` on `@fluidframework/odsp-
 ```
 
 ### Replace ICodeLoader with ICodeDetailsLoader interface
-The interface `ICodeLoader` was deprecated a while ago in previous releases. The alternative for `ICodeLoader` interface is the `ICodeDetailsLoader` interface which can be imported from `@fluidframework/container-definitions`. `ICodeLoader` interface will be removed in the next release.
+`ICodeLoader` in `@fluidframework/container-definitions` was deprecated since 0.40.0 and is now removed. Use `ICodeDetailsLoader` from `@fluidframework/container-loader` instead.
 
 In particular, note the `ILoaderService` and `ILoaderProps` interfaces used with the `Loader` class now only support `ICodeDetailsLoader`. If you were using an `ICodeLoader` with these previously, you'll need to update to an `ICodeDetailsLoader`.
 

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -99,11 +99,6 @@ export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComp
     load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
 
-// @public @deprecated
-export interface ICodeLoader extends Partial<IProvideFluidCodeDetailsComparer> {
-    load(source: IFluidCodeDetails): Promise<IFluidModule>;
-}
-
 // @public
 export interface IConnectionDetails {
     checkpointSequenceNumber: number | undefined;

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -60,9 +60,13 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-   "version": "2.0.0",
+    "version": "2.0.0",
     "broken": {
       "InterfaceDeclaration_IConnectionDetails": {
+        "backCompat": false
+      },
+      "RemovedInterfaceDeclaration_ICodeLoader": {
+        "forwardCompat": false,
         "backCompat": false
       }
     }

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -30,18 +30,6 @@ import {
 } from "./fluidPackage";
 
 /**
- * Code loading interface
- *
- * @deprecated in favor of {@link @fluidframework/container-loader#ICodeDetailsLoader}
- */
-export interface ICodeLoader extends Partial<IProvideFluidCodeDetailsComparer> {
-    /**
-     * Loads the package specified by code details and returns a promise to its entry point exports.
-     */
-    load(source: IFluidCodeDetails): Promise<IFluidModule>;
-}
-
-/**
  * Encapsulates a module entry point with corresponding code details.
  */
 export interface IFluidModuleWithDetails {
@@ -60,14 +48,14 @@ export interface IFluidModuleWithDetails {
  * a package name and package version range.
  */
 export interface ICodeDetailsLoader
- extends Partial<IProvideFluidCodeDetailsComparer> {
- /**
-  * Load the code module (package) that is capable to interact with the document.
-  *
-  * @param source - Code proposal that articulates the current schema the document is written in.
-  * @returns - Code module entry point along with the code details associated with it.
-  */
- load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
+    extends Partial<IProvideFluidCodeDetailsComparer> {
+    /**
+     * Load the code module (package) that is capable to interact with the document.
+     *
+     * @param source - Code proposal that articulates the current schema the document is written in.
+     * @returns - Code module entry point along with the code details associated with it.
+     */
+    load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
 
 /**
@@ -142,11 +130,11 @@ export namespace ConnectionState {
      * The container is disconnected but actively trying to establish a new connection
      * PLEASE NOTE that this numerical value falls out of the order you may expect for this state
      */
-     export type EstablishingConnection = 3;
+    export type EstablishingConnection = 3;
 
-     /**
-     * The container has an inbound connection only, and is catching up to the latest known state from the service.
-     */
+    /**
+    * The container has an inbound connection only, and is catching up to the latest known state from the service.
+    */
     export type CatchingUp = 1;
 
     /**
@@ -158,7 +146,7 @@ export namespace ConnectionState {
     /**
      * The container is fully connected and syncing
      */
-     export type Connected = 2;
+    export type Connected = 2;
 }
 
 /**
@@ -406,44 +394,44 @@ export enum LoaderHeader {
 
 export interface IContainerLoadMode {
     opsBeforeReturn?:
-        /*
-         * No trailing ops are applied before container is returned.
-         * Default value.
-         */
-        | undefined
-        /*
-         * Only cached trailing ops are applied before returning container.
-         * Caching is optional and could be implemented by the driver.
-         * If driver does not implement any kind of local caching strategy, this is same as above.
-         * Driver may cache a lot of ops, so care needs to be exercised (see below).
-         */
-        | "cached"
-        /*
-         * All trailing ops in storage are fetched and applied before container is returned
-         * This mode might have significant impact on boot speed (depends on storage perf characteristics)
-         * Also there might be a lot of trailing ops and applying them might take time, so hosts are
-         * recommended to have some progress UX / cancellation built into loading flow when using this option.
-         */
-        | "all";
+    /*
+     * No trailing ops are applied before container is returned.
+     * Default value.
+     */
+    | undefined
+    /*
+     * Only cached trailing ops are applied before returning container.
+     * Caching is optional and could be implemented by the driver.
+     * If driver does not implement any kind of local caching strategy, this is same as above.
+     * Driver may cache a lot of ops, so care needs to be exercised (see below).
+     */
+    | "cached"
+    /*
+     * All trailing ops in storage are fetched and applied before container is returned
+     * This mode might have significant impact on boot speed (depends on storage perf characteristics)
+     * Also there might be a lot of trailing ops and applying them might take time, so hosts are
+     * recommended to have some progress UX / cancellation built into loading flow when using this option.
+     */
+    | "all";
     deltaConnection?:
-        /*
-         * Connection to delta stream is made only when Container.connect() call is made. Op processing
-         * is paused (when container is returned from Loader.resolve()) until Container.connect() call is made.
-         */
-        | "none"
-        /*
-         * Connection to delta stream is made only when Container.connect() call is made.
-         * Op fetching from storage is performed and ops are applied as they come in.
-         * This is useful option if connection to delta stream is expensive and thus it's beneficial to move it
-         * out from critical boot sequence, but it's beneficial to allow catch up to happen as fast as possible.
-         */
-        | "delayed"
-        /*
-         * Connection to delta stream is made right away.
-         * Ops processing is enabled and ops are flowing through the system.
-         * Default value.
-         */
-        | undefined;
+    /*
+     * Connection to delta stream is made only when Container.connect() call is made. Op processing
+     * is paused (when container is returned from Loader.resolve()) until Container.connect() call is made.
+     */
+    | "none"
+    /*
+     * Connection to delta stream is made only when Container.connect() call is made.
+     * Op fetching from storage is performed and ops are applied as they come in.
+     * This is useful option if connection to delta stream is expensive and thus it's beneficial to move it
+     * out from critical boot sequence, but it's beneficial to allow catch up to happen as fast as possible.
+     */
+    | "delayed"
+    /*
+     * Connection to delta stream is made right away.
+     * Ops processing is enabled and ops are flowing through the system.
+     * Default value.
+     */
+    | undefined;
 }
 
 /**

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -328,26 +328,14 @@ use_old_InterfaceDeclaration_ICodeDetailsLoader(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ICodeLoader": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_ICodeLoader": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_ICodeLoader():
-    TypeOnly<old.ICodeLoader>;
-declare function use_current_InterfaceDeclaration_ICodeLoader(
-    use: TypeOnly<current.ICodeLoader>);
-use_current_InterfaceDeclaration_ICodeLoader(
-    get_old_InterfaceDeclaration_ICodeLoader());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ICodeLoader": {"backCompat": false}
+* "RemovedInterfaceDeclaration_ICodeLoader": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_ICodeLoader():
-    TypeOnly<current.ICodeLoader>;
-declare function use_old_InterfaceDeclaration_ICodeLoader(
-    use: TypeOnly<old.ICodeLoader>);
-use_old_InterfaceDeclaration_ICodeLoader(
-    get_current_InterfaceDeclaration_ICodeLoader());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
# Work Item
The deprecated ICodeLoader Interface should be removed.

## Approach
The interface `ICodeLoader` was deprecated a while ago in previous releases. The alternative for `ICodeLoader` interface is the `ICodeDetailsLoader` interface which can be imported from `@fluidframework/container-definitions`.

## Steps
The alternative for `ICodeLoader` interface is the `ICodeDetailsLoader` interface which can be imported from `@fluidframework/container-definitions`.

## Does this introduce a breaking change?

-   [X] Yes
-   [ ] No

## Other information or known dependencies

[AB#346](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/346)
PR: #9657, #8193
