### PR TITLE
Modify legacy odsp-driver to properly wok with Fluid storage APIs on Consumer converged stack

### DIFF
--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -96,7 +96,7 @@ export function isSpoUrl(url: string): boolean;
 export const locatorQueryParamName = "nav";
 
 // @public (undocumented)
-export const OdcApiSiteOrigin = "https://api.onedrive.com";
+export const OdcApiSiteOrigin = "https://my.microsoftpersonalcontent.com";
 
 // @public (undocumented)
 export const OdcFileSiteOrigin = "https://1drv.ms";

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -101,6 +101,8 @@
   },
   "typeValidation": {
     "version": "1.2.0",
-    "broken": {}
+    "broken": {
+      "VariableDeclaration_OdcApiSiteOrigin": {"forwardCompat": false, "backCompat": false}
+    }
   }
 }

--- a/packages/drivers/odsp-driver/src/checkUrl.ts
+++ b/packages/drivers/odsp-driver/src/checkUrl.ts
@@ -8,7 +8,7 @@ import { getLocatorFromOdspUrl } from "./odspFluidFileLink";
 
 /**
  * A check that returns DriverPreCheckInfo if the URL format is likely supported by this driver.
- * Note that returning information here is NOT a full guarentee that resolve will ultimately be successsful.
+ * Note that returning information here is NOT a full guarantee that resolve will ultimately be successful.
  * Instead, this should be used as a lightweight check that can filter out easily detectable unsupported URLs
  * before the entire Fluid loading process needs to be kicked off.
  */

--- a/packages/drivers/odsp-driver/src/constants.ts
+++ b/packages/drivers/odsp-driver/src/constants.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export const OdcApiSiteOrigin = "https://api.onedrive.com";
+export const OdcApiSiteOrigin = "https://my.microsoftpersonalcontent.com";
 export const OdcFileSiteOrigin = "https://1drv.ms";

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -86,11 +86,6 @@ async function getFileLinkCore(
 ): Promise<string> {
     const fileItem = await getFileItemLite(getToken, odspUrlParts, logger, identityType === "Consumer");
 
-    // ODC canonical link does not require any additional processing
-    if (identityType === "Consumer") {
-        return fileItem.webUrl;
-    }
-
     // ODSP link requires extra call to return link that is resistant to file being renamed or moved to different folder
     return PerformanceEvent.timedExecAsync(
         logger,

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -18,34 +18,7 @@ describe("getFileLink", () => {
         webUrl: `${siteUrl}/fetchWebUrl`,
     };
 
-    it("should return web url for Consumer user", async () => {
-        const result = await mockFetchOk(
-            async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId1" }, "Consumer", logger),
-            fileItemResponse,
-        );
-        assert.strictEqual(result, fileItemResponse.webUrl, "File link for Consumer user should match webUrl");
-    });
-
-    it("should reject for Consumer user if file web url is missing", async () => {
-        await assert.rejects(mockFetchMultiple(
-            async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId2" }, "Consumer", logger),
-            [
-                async () => okResponse({}, {}),
-                // We retry once on malformed response from server, so need a second response mocked.
-                async () => okResponse({}, {}),
-            ],
-        ), "Should reject for unexpected empty response");
-    });
-
-    it("should reject for Consumer user if file item is not found", async () => {
-        await assert.rejects(mockFetchSingle(async () => {
-                return getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId3" }, "Consumer", logger);
-            },
-            notFound,
-        ), "File link should reject when not found");
-    });
-
-    it("should return share link with existing access for Enterprise user", async () => {
+    it("should return share link with existing access", async () => {
         const result = await mockFetchMultiple(
             async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId4" }, "Enterprise", logger),
             [
@@ -54,10 +27,10 @@ describe("getFileLink", () => {
             ],
         );
         assert.strictEqual(
-            result, "sharelink", "File link for Enterprise user should match url returned from sharing information");
+            result, "sharelink", "File link should match url returned from sharing information");
     });
 
-    it("should reject for Enterprise user if file web dav url is missing", async () => {
+    it("should reject if file web dav url is missing", async () => {
         await assert.rejects(mockFetchMultiple(
             async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId5" }, "Enterprise", logger),
             [
@@ -68,7 +41,7 @@ describe("getFileLink", () => {
         ), "File link should reject for malformed url");
     });
 
-    it("should reject for Enterprise user if file item is not found", async () => {
+    it("should reject if file item is not found", async () => {
         await assert.rejects(mockFetchSingle(async () => {
             return getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId6" }, "Enterprise", logger);
             },

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
 import { getFileLink } from "../getFileLink";
-import { mockFetchOk, mockFetchSingle, mockFetchMultiple, okResponse, notFound } from "./mockFetch";
+import { mockFetchSingle, mockFetchMultiple, okResponse, notFound } from "./mockFetch";
 
 describe("getFileLink", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.ts
@@ -431,6 +431,7 @@ declare function get_old_VariableDeclaration_OdcApiSiteOrigin():
 declare function use_current_VariableDeclaration_OdcApiSiteOrigin(
     use: TypeOnly<typeof current.OdcApiSiteOrigin>);
 use_current_VariableDeclaration_OdcApiSiteOrigin(
+    // @ts-expect-error compatibility expected to be broken
     get_old_VariableDeclaration_OdcApiSiteOrigin());
 
 /*
@@ -443,6 +444,7 @@ declare function get_current_VariableDeclaration_OdcApiSiteOrigin():
 declare function use_old_VariableDeclaration_OdcApiSiteOrigin(
     use: TypeOnly<typeof old.OdcApiSiteOrigin>);
 use_old_VariableDeclaration_OdcApiSiteOrigin(
+    // @ts-expect-error compatibility expected to be broken
     get_current_VariableDeclaration_OdcApiSiteOrigin());
 
 /*


### PR DESCRIPTION
These are non-breaking changes that should only have impact when using odsp-driver with files stored in Converged ODC