### PR TITLE
Remove Redunent SummaryNack Log

### DIFF
--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -393,8 +393,6 @@ export class SummaryGenerator {
 
                 // pre-0.58 error message prefix: summaryNack
                 const error = new LoggingError(`Received summaryNack: ${message}`, { retryAfterSeconds });
-                logger.sendErrorEvent(
-                    { eventName: "SummaryNack", ...summarizeTelemetryProps, retryAfterSeconds }, error);
 
                 assert(getRetryDelaySecondsFromError(error) === retryAfterSeconds, 0x25f /* "retryAfterSeconds" */);
                 // This will only set resultsBuilder.receivedSummaryAckOrNack, as other promises are already set.


### PR DESCRIPTION
## Description
Every time we receive a summary nack there are three log entries generated

Data_eventName
--
fluid:telemetry:Summarizer:Running:SummaryNack
fluid:telemetry:Summarizer:summarizingError
fluid:telemetry:Summarizer:Running:Summarize_cancel

The SummaryNack is clearly redundant. It less clear if there cases where Summarize_cancel and summarizingError are not redundant in the non-nack case. so leaving both of those in place

