### PR TITLE
Sweep - Added "deleted" log for objects that are used after they should have been deleted

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -77,7 +77,7 @@ export const trackGCStateKey = "Fluid.GarbageCollection.TrackGCState";
 // Feature gate key to turn GC sweep log off.
 const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 
-// One day in microseconds.
+// One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;
 
 const defaultInactiveTimeoutMs = 7 * oneDayMs; // 7 days
@@ -203,7 +203,7 @@ export type UnreferencedState = typeof UnreferencedState[keyof typeof Unreferenc
 /** The event that is logged when unreferenced node is used after a certain time. */
 interface IUnreferencedEventProps {
     usageType: "Changed" | "Loaded" | "Revived";
-    state: "Inactive" | "Deleted";
+    state: "inactive" | "deleted";
     id: string;
     type: GCNodeType;
     unrefTime: number;
@@ -1257,7 +1257,7 @@ export class GarbageCollector implements IGarbageCollector {
             return;
         }
 
-        const state = nodeStateTracker.state === UnreferencedState.Inactive ? "Inactive" : "Deleted";
+        const state = nodeStateTracker.state === UnreferencedState.Inactive ? "inactive" : "deleted";
         const uniqueEventId = `${state}-${nodeId}-${usageType}`;
         if (this.loggedUnreferencedEvents.has(uniqueEventId)) {
             return;

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -7,6 +7,7 @@
 
 import { strict as assert } from "assert";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
+import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { concatGarbageCollectionStates } from "@fluidframework/garbage-collector";
 import { ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
@@ -31,6 +32,7 @@ import {
     runSessionExpiryKey,
     disableSessionExpiryKey,
     IGarbageCollectorCreateParams,
+    oneDayMs,
 } from "../garbageCollection";
 import { dataStoreAttributesBlobName, IContainerRuntimeMetadata } from "../summaryFormat";
 
@@ -210,27 +212,9 @@ describe("Garbage Collection Tests", () => {
         });
     });
 
-    describe("Inactive events", () => {
-        // Time after which unreferenced nodes becomes inactive.
-        const inactiveTimeoutMs = 500;
-        const revivedEvent = "GarbageCollector:inactiveObject_Revived";
-        const changedEvent = "GarbageCollector:inactiveObject_Changed";
-        const loadedEvent = "GarbageCollector:inactiveObject_Loaded";
-
-        // Validates that no inactive event has been fired.
-        function validateNoInactiveEvents() {
-            assert(
-                !mockLogger.matchAnyEvent([
-                    { eventName: revivedEvent },
-                    { eventName: changedEvent },
-                    { eventName: loadedEvent },
-                ]),
-                "inactive object events should not have been logged",
-            );
-        }
-
-        // Simulates node loaded and changed activity for all the nodes in the graph.
-        async function updateAllNodesAndRunGC(garbageCollector: IGarbageCollector) {
+    describe("errors when unreferenced objects are used after they are inactive / deleted", () => {
+        // Mock node loaded and changed activity for all the nodes in the graph.
+         async function updateAllNodesAndRunGC(garbageCollector: IGarbageCollector) {
             nodes.forEach((nodeId) => {
                 garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
                 garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
@@ -238,17 +222,7 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({});
         }
 
-        // Returns a dummy snapshot tree to be built upon.
-        const getDummySnapshotTree = (): ISnapshotTree => {
-            return {
-                blobs: {},
-                trees: {},
-            };
-        };
-
         beforeEach(async () => {
-            injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
-
             // Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
             defaultGCData.gcNodes["/"] = [nodes[0]];
             defaultGCData.gcNodes[nodes[0]] = [nodes[1]];
@@ -257,323 +231,410 @@ describe("Garbage Collection Tests", () => {
             defaultGCData.gcNodes[nodes[3]] = [nodes[0]];
         });
 
-        it("doesn't generate events for referenced nodes", async () => {
-            const garbageCollector = createGarbageCollector();
-
-            // Run garbage collection on the default GC data where everything is referenced.
-            await garbageCollector.collectGarbage({ runGC: true });
-
-            // Validate that no inactive events are logged yet.
-            await updateAllNodesAndRunGC(garbageCollector);
-            validateNoInactiveEvents();
-
-            // Expire the unreferenced timer (if any).
-            clock.tick(inactiveTimeoutMs + 1);
-
-            // Validate that no inactive events are logged since everything is referenced.
-            await updateAllNodesAndRunGC(garbageCollector);
-            validateNoInactiveEvents();
-        });
-
-        it("generates events when inactive node is changed or revived", async () => {
-            const garbageCollector = createGarbageCollector();
-
-            // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-            defaultGCData.gcNodes[nodes[1]] = [];
-
-            await garbageCollector.collectGarbage({ runGC: true });
-
-            // Validate that no inactive events are logged yet.
-            await updateAllNodesAndRunGC(garbageCollector);
-            validateNoInactiveEvents();
-
-            // Expire the unreferenced timer (if any).
-            clock.tick(inactiveTimeoutMs + 1);
-
-            // Validate that changed and loaded events for node 2 and node 3 are logged since they are inactive.
-            await updateAllNodesAndRunGC(garbageCollector);
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                ]),
-                "inactive events not logged as expected",
-            );
-
-            // Add reference from node 1 to node 3 and validate that revived event is logged.
-            garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
-            await garbageCollector.collectGarbage({});
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg, fromId: nodes[1] },
-                ]),
-                "revived event not logged as expected",
-            );
-        });
-
-        it("generates only revived event when an inactive node is changed and revived", async () => {
-            const garbageCollector = createGarbageCollector();
-
-            // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-            defaultGCData.gcNodes[nodes[1]] = [];
-
-            await garbageCollector.collectGarbage({ runGC: true });
-
-            // Validate that no inactive events are logged yet.
-            await updateAllNodesAndRunGC(garbageCollector);
-            validateNoInactiveEvents();
-
-            // Expire the unreferenced timer (if any).
-            clock.tick(inactiveTimeoutMs + 1);
-
-            // Validate that only revived event is generated for node 2 when it is changed and revived.
-            garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
-            garbageCollector.nodeUpdated(nodes[2], "Loaded", Date.now(), testPkgPath);
-            garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
-            await garbageCollector.collectGarbage({});
-
-            for (const event of mockLogger.events) {
-                assert.notStrictEqual(event.eventName, changedEvent, "Unexpected changed event logged");
-                assert.notStrictEqual(event.eventName, loadedEvent, "Unexpected loaded event logged");
+        const tests = (
+            timeout: number,
+            revivedEventName: string,
+            changedEventName: string,
+            loadedEventName: string,
+            snapshotCacheExpiryMs?: number,
+            deleteEventName?: string,
+        ) => {
+            // Validates that no unexpected event has been fired.
+            function validateNoUnexpectedEvents() {
+                assert(
+                    !mockLogger.matchAnyEvent([
+                        { eventName: revivedEventName },
+                        { eventName: changedEventName },
+                        { eventName: loadedEventName },
+                        { eventName: deleteEventName },
+                    ]),
+                    "unexpected events logged",
+                );
             }
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg, fromId: nodes[1] },
-                ]),
-                "revived event not logged as expected",
-            );
-        });
 
-        it("generates events once per node", async () => {
-            const garbageCollector = createGarbageCollector();
-
-            // Remove node 3's reference from node 2.
-            defaultGCData.gcNodes[nodes[2]] = [];
-
-            await garbageCollector.collectGarbage({ runGC: true });
-
-            // Expire the unreferenced timer (if any).
-            clock.tick(inactiveTimeoutMs + 1);
-
-            // Validate that changed and loaded events are logged for node 3 since it's inactive.
-            await updateAllNodesAndRunGC(garbageCollector);
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                ]),
-                "inactive events not logged as expected",
-            );
-
-            // Validate there are no more inactive events since for each node an event is only logged once.
-            await updateAllNodesAndRunGC(garbageCollector);
-            validateNoInactiveEvents();
-        });
-
-        /**
-         * Here, the base snapshot contains nodes that are inactive. The test validates that we generate inactive events
-         * for these nodes.
-         */
-        it("generates events for nodes that are inactive on load", async () => {
-            // Create GC state where node 3's unreferenced time was > inactiveTimeoutMs ago.
-            // This means this node should become inactive as soon as its data is loaded.
-
-            // Create a snapshot tree to be used as the GC snapshot tree.
-            const gcSnapshotTree = getDummySnapshotTree();
-            const gcBlobId = "root";
-            // Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
-            // is logged by server in real scenarios but we use a static id here for testing.
-            gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
-
-            // Create a base snapshot that contains the GC snapshot tree.
-            const baseSnapshot = getDummySnapshotTree();
-            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-            // Create GC state with node 3 expired. This will be returned when the garbage collector asks
-            // for the GC blob with `gcBlobId`.
-            const gcState: IGarbageCollectionState = { gcNodes: {} };
-            const node3Data: IGarbageCollectionNodeData = {
-                outboundRoutes: [],
-                unreferencedTimestampMs: Date.now() - (inactiveTimeoutMs + 100),
+            // Returns a dummy snapshot tree to be built upon.
+            const getDummySnapshotTree = (): ISnapshotTree => {
+                return {
+                    blobs: {},
+                    trees: {},
+                };
             };
-            gcState.gcNodes[nodes[3]] = node3Data;
 
-            const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([[gcBlobId, gcState]]);
-            const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobMap);
-
-            // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
-            // summary is not loaded until the first time GC is run, so run GC.
-            defaultGCData.gcNodes[nodes[2]] = [];
-            await garbageCollector.collectGarbage({ runGC: true });
-
-            // Validate that changed and loaded events are logged for node 3 since it is inactive.
-            garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
-            garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-            await garbageCollector.collectGarbage({});
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                ]),
-                "inactive events not logged as expected",
-            );
-
-            // Add reference from node 2 to node 3 and validate that we get revived event.
-            garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
-            await garbageCollector.collectGarbage({});
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg, fromId: nodes[2] },
-                ]),
-                "revived event not logged as expected",
-            );
-        });
-
-        /**
-         * Here, the base snapshot contains nodes that are inactive and the GC blob in snapshot is in old format. The
-         * test validates that we generate inactive events for these nodes.
-         */
-        it("generates events for nodes that are inactive on load - old snapshot format", async () => {
-            // Create GC details for node 3's GC blob whose unreferenced time was > inactiveTimeoutMs ago.
-            // This means this node should become inactive as soon as its data is loaded.
-            const node3GCDetails: IGarbageCollectionDetailsBase = {
-                gcData: { gcNodes: { "/": [] } },
-                unrefTimestamp: Date.now() - (inactiveTimeoutMs + 100),
+            const createGCOverride = (
+                baseSnapshot?: ISnapshotTree,
+                gcBlobsMap?: Map<string, IGarbageCollectionState | IGarbageCollectionDetailsBase>,
+            ) => {
+                return createGarbageCollector({ baseSnapshot, snapshotCacheExpiryMs }, gcBlobsMap);
             };
-            const node3Snapshot = getDummySnapshotTree();
-            const gcBlobId = "node3GCDetails";
-            const attributesBlobId = "attributesBlob";
-            node3Snapshot.blobs[gcBlobKey] = gcBlobId;
-            node3Snapshot.blobs[dataStoreAttributesBlobName] = attributesBlobId;
 
-            // Create a base snapshot that contains snapshot tree of node 3.
-            const baseSnapshot = getDummySnapshotTree();
-            baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
+            it("doesn't generate events for referenced nodes", async () => {
+                const garbageCollector = createGCOverride();
 
-            // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
-            const gcBlobMap = new Map([
-                [gcBlobId, node3GCDetails],
-                [attributesBlobId, {}],
-            ]);
-            const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobMap);
+                // Run garbage collection on the default GC data where everything is referenced.
+                await garbageCollector.collectGarbage({});
 
-            // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
-            // summary is not loaded until the first time GC is run, so do that immediately.
-            defaultGCData.gcNodes[nodes[2]] = [];
-            await garbageCollector.collectGarbage({ runGC: true });
+                // Advance the clock just before the timeout and validate no events are generated.
+                clock.tick(timeout - 1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
 
-            // Validate that changed and loaded events are logged for node 3 since it is inactive.
-            garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
-            garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-            await garbageCollector.collectGarbage({});
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                ]),
-                "inactive events not logged as expected",
-            );
+                // Advance the clock to expire the timeout.
+                clock.tick(1);
 
-            // Add reference from node 2 to node 3 and validate that we get revived event.
-            garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
-            await garbageCollector.collectGarbage({});
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: revivedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg, fromId: nodes[2] },
-                ]),
-                "revived event not logged as expected",
+                // Update all nodes again. Validate that no unexpected events are generated since everything is referenced.
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+            });
+
+            it("generates events when nodes that are used after time out", async () => {
+                const garbageCollector = createGCOverride();
+
+                // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+                defaultGCData.gcNodes[nodes[1]] = [];
+
+                await garbageCollector.collectGarbage({});
+
+                // Advance the clock just before the timeout and validate no unexpected events are logged.
+                clock.tick(timeout - 1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+
+                // Expire the timeout and validate that all events for node 2 and node 3 are logged.
+                clock.tick(1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [
+                    { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg },
+                    { eventName: loadedEventName, timeout, id: nodes[2], pkg: eventPkg },
+                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                ];
+                if (deleteEventName) {
+                    expectedEvents.push(
+                        { eventName: deleteEventName, timeout, id: nodes[2] },
+                        { eventName: deleteEventName, timeout, id: nodes[3] },
+                    );
+                }
+                assert(
+                    mockLogger.matchEvents(expectedEvents),
+                    "all events not generated as expected",
+                );
+
+                // Add reference from node 1 to node 3 and validate that we get a revived event.
+                garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
+                await garbageCollector.collectGarbage({});
+                assert(
+                    mockLogger.matchEvents([
+                        { eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[1] },
+                    ]),
+                    "revived event not generated as expected",
+                );
+            });
+
+            it("generates events once per node", async () => {
+                const garbageCollector = createGCOverride();
+
+                // Remove node 3's reference from node 2.
+                defaultGCData.gcNodes[nodes[2]] = [];
+
+                await garbageCollector.collectGarbage({});
+
+                // Advance the clock just before the timeout and validate no unexpected events are logged.
+                clock.tick(timeout - 1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+
+                // Expire the timeout and validate that all events for node 2 and node 3 are logged.
+                clock.tick(1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [
+                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                ];
+                if (deleteEventName) {
+                    expectedEvents.push({ eventName: deleteEventName, timeout, id: nodes[3] });
+                }
+                assert(
+                    mockLogger.matchEvents(expectedEvents),
+                    "all events not generated as expected",
+                );
+
+                // Update all nodes again. There shouldn't be any more events since for each node the event is only once.
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+            });
+
+            /**
+             * Here, the base snapshot contains nodes that have timed out. The test validates that we generate errors
+             * when these nodes are used.
+             */
+            it("generates events for nodes that time out on load", async () => {
+                // Create GC state where node 3's unreferenced time was > timeout ms ago.
+                // This means this node should time out as soon as its data is loaded.
+
+                // Create a snapshot tree to be used as the GC snapshot tree.
+                const gcSnapshotTree = getDummySnapshotTree();
+                const gcBlobId = "root";
+                // Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
+                // is generated by server in real scenarios but we use a static id here for testing.
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
+
+                // Create a base snapshot that contains the GC snapshot tree.
+                const baseSnapshot = getDummySnapshotTree();
+                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+                // Create GC state with node 3 expired. This will be returned when the garbage collector asks
+                // for the GC blob with `gcBlobId`.
+                const gcState: IGarbageCollectionState = { gcNodes: {} };
+                const node3Data: IGarbageCollectionNodeData = {
+                    outboundRoutes: [],
+                    unreferencedTimestampMs: Date.now() - (timeout + 100),
+                };
+                gcState.gcNodes[nodes[3]] = node3Data;
+
+                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([[gcBlobId, gcState]]);
+                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+                // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
+                // summary is not loaded until the first time GC is run, so run GC.
+                defaultGCData.gcNodes[nodes[2]] = [];
+
+                await garbageCollector.collectGarbage({});
+                // Validate that the deleted event is logged when GC runs after load.
+                if (deleteEventName) {
+                    assert(
+                        mockLogger.matchEvents([{ eventName: deleteEventName, timeout, id: nodes[3] }]),
+                        "deleted event not generated as expected",
+                    );
+                }
+
+                // Validate that all events are logged as expected.
+                garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+                await garbageCollector.collectGarbage({});
+                assert(
+                    mockLogger.matchEvents([
+                        { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    ]),
+                    "all events not generated as expected",
+                );
+
+                // Add reference from node 2 to node 3 and validate that revived event is logged.
+                garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+                await garbageCollector.collectGarbage({});
+                assert(
+                    mockLogger.matchEvents([
+                        { eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[2] },
+                    ]),
+                    "revived event not generated as expected",
+                );
+            });
+
+            /**
+             * Here, the base snapshot contains nodes that have timed out and the GC blob in snapshot is in old format. The
+             * test validates that we generate errors when these nodes are used.
+             */
+            it("generates events for nodes that time out on load - old snapshot format", async () => {
+                // Create GC details for node 3's GC blob whose unreferenced time was > timeout ms ago.
+                // This means this node should time out as soon as its data is loaded.
+                const node3GCDetails: IGarbageCollectionDetailsBase = {
+                    gcData: { gcNodes: { "/": [] } },
+                    unrefTimestamp: Date.now() - (timeout + 100),
+                };
+                const node3Snapshot = getDummySnapshotTree();
+                const gcBlobId = "node3GCDetails";
+                const attributesBlobId = "attributesBlob";
+                node3Snapshot.blobs[gcBlobKey] = gcBlobId;
+                node3Snapshot.blobs[dataStoreAttributesBlobName] = attributesBlobId;
+
+                // Create a base snapshot that contains snapshot tree of node 3.
+                const baseSnapshot = getDummySnapshotTree();
+                baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
+
+                // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
+                const gcBlobMap = new Map([
+                    [gcBlobId, node3GCDetails],
+                    [attributesBlobId, {}],
+                ]);
+                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+                // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
+                // summary is not loaded until the first time GC is run, so do that immediately.
+                defaultGCData.gcNodes[nodes[2]] = [];
+                await garbageCollector.collectGarbage({});
+
+                // Validate that the deleted event is logged when GC runs after load.
+                if (deleteEventName) {
+                    assert(
+                        mockLogger.matchEvents([{ eventName: deleteEventName, timeout, id: nodes[3] }]),
+                        "deleted event not generated as expected",
+                    );
+                }
+
+                // Validate that all events are logged as expected.
+                garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+                await garbageCollector.collectGarbage({});
+                assert(
+                    mockLogger.matchEvents([
+                        { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    ]),
+                    "all events not generated as expected",
+                );
+
+                // Add reference from node 2 to node 3 and validate that revived event is logged.
+                garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+                await garbageCollector.collectGarbage({});
+                assert(
+                    mockLogger.matchEvents([
+                        { eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[2] },
+                    ]),
+                    "revived event not generated as expected",
+                );
+            });
+
+            /**
+             * Here, the base snapshot contains nodes that have timed out and the GC data in snapshot is present in multiple
+             * blobs. The test validates that we generate errors when these nodes are used.
+             */
+            it(`generates events for nodes that time out on load - multi blob GC data`, async () => {
+                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
+                const expiredTimestampMs = Date.now() - (timeout + 100);
+
+                // Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
+                // time was > timeout ms ago. These three GC blobs are the added to the GC tree in summary.
+                const blob1Id = "blob1";
+                const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
+                blob1GCState.gcNodes[nodes[1]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+                gcBlobMap.set(blob1Id, blob1GCState);
+
+                const blob2Id = "blob2";
+                const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
+                blob2GCState.gcNodes[nodes[2]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+                gcBlobMap.set(blob2Id, blob2GCState);
+
+                const blob3Id = "blob3";
+                const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
+                blob3GCState.gcNodes[nodes[3]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+                gcBlobMap.set(blob3Id, blob3GCState);
+
+                // Create a GC snapshot tree and add the above three GC blob ids to it.
+                const gcSnapshotTree = getDummySnapshotTree();
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
+
+                // Create a base snapshot that contains the above GC snapshot tree.
+                const baseSnapshot = getDummySnapshotTree();
+                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+                // For the nodes in the GC snapshot blobs, remove their references from the default GC data.
+                defaultGCData.gcNodes[nodes[0]] = [];
+                defaultGCData.gcNodes[nodes[1]] = [];
+                defaultGCData.gcNodes[nodes[2]] = [];
+
+                await garbageCollector.collectGarbage({});
+                 // Validate that the deleted event is logged when GC runs after load.
+                 if (deleteEventName) {
+                    assert(
+                        mockLogger.matchEvents([
+                            { eventName: deleteEventName, timeout, id: nodes[1] },
+                            { eventName: deleteEventName, timeout, id: nodes[2] },
+                            { eventName: deleteEventName, timeout, id: nodes[3] },
+                        ]),
+                        "deleted event not generated as expected",
+                    );
+                }
+
+                // Validate that all events are logged as expected.
+                garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+                await garbageCollector.collectGarbage({});
+                assert(
+                    mockLogger.matchEvents([
+                        { eventName: changedEventName, timeout, id: nodes[1], pkg: eventPkg },
+                        { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg },
+                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    ]),
+                    "all events not generated as expected",
+                );
+            });
+        };
+
+        describe("inactive events", () => {
+            const inactiveTimeoutMs = 500;
+
+            beforeEach(() => {
+                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
+            });
+
+            tests(
+                inactiveTimeoutMs,
+                "GarbageCollector:InactiveObject_Revived",
+                "GarbageCollector:InactiveObject_Changed",
+                "GarbageCollector:InactiveObject_Loaded",
             );
         });
 
-        /**
-         * Here, the base snapshot contains nodes that are inactive and the GC data in snapshot is present in multiple
-         * blobs. The test validates that we generate inactive events for these nodes.
-         */
-        it(`generates events for nodes that are inactive on load - multi blob GC data`, async () => {
-            const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
-            const expiredTimestampMs = Date.now() - (inactiveTimeoutMs + 100);
+        describe("Deleted events", () => {
+            const snapshotCacheExpiryMs = 500;
+            const sweepTimeoutMs = defaultSessionExpiryDurationMs + snapshotCacheExpiryMs + oneDayMs;
 
-            // Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
-            // time was > inactiveTimeoutMs ago. These three GC blobs are the added to the GC tree in summary.
-            const blob1Id = "blob1";
-            const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
-            blob1GCState.gcNodes[nodes[1]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-            gcBlobMap.set(blob1Id, blob1GCState);
+            beforeEach(() => {
+                injectedSettings[runSessionExpiryKey] = "true";
+            });
 
-            const blob2Id = "blob2";
-            const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
-            blob2GCState.gcNodes[nodes[2]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-            gcBlobMap.set(blob2Id, blob2GCState);
-
-            const blob3Id = "blob3";
-            const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
-            blob3GCState.gcNodes[nodes[3]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-            gcBlobMap.set(blob3Id, blob3GCState);
-
-            // Create a GC snapshot tree and add the above three GC blob ids to it.
-            const gcSnapshotTree = getDummySnapshotTree();
-            gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
-            gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
-            gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
-
-            // Create a base snapshot that contains the above GC snapshot tree.
-            const baseSnapshot = getDummySnapshotTree();
-            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-            const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobMap);
-
-            // For the nodes in the GC snapshot blobs, remove their references from the default GC data.
-            defaultGCData.gcNodes[nodes[0]] = [];
-            defaultGCData.gcNodes[nodes[1]] = [];
-            defaultGCData.gcNodes[nodes[2]] = [];
-
-            await garbageCollector.collectGarbage({ runGC: true });
-
-            // Validate that changed and loaded events are logged for inactive nodes.
-            garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
-            garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
-            garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-            await garbageCollector.collectGarbage({});
-            assert(
-                mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[1], pkg: eventPkg },
-                    { eventName: changedEvent, timeout: inactiveTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutMs, id: nodes[3], pkg: eventPkg },
-                ]),
-                "inactive events not logged as expected",
+            tests(
+                sweepTimeoutMs,
+                "GarbageCollector:DeletedObject_Revived",
+                "GarbageCollector:DeletedObject_Changed",
+                "GarbageCollector:DeletedObject_Loaded",
+                snapshotCacheExpiryMs,
+                "GarbageCollector:GCObjectDeleted",
             );
         });
 
-        it("can override inactive timeout via feature flags", async () => {
-            const inactiveTimeoutOverrideMs = 100;
-            const testOverrideInactiveTimeoutMsKey = "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs";
-            injectedSettings[testOverrideInactiveTimeoutMsKey] = inactiveTimeoutOverrideMs;
-            const garbageCollector = createGarbageCollector();
+        it("generates both inactive and swept events when nodes are used after time out", async () => {
+            const inactiveTimeoutMs = 500;
+            const snapshotCacheExpiryMs = 500;
+            const sweepTimeoutMs = defaultSessionExpiryDurationMs + snapshotCacheExpiryMs + oneDayMs;
+            injectedSettings[runSessionExpiryKey] = "true";
+            injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
+
+            const garbageCollector = createGarbageCollector({ snapshotCacheExpiryMs });
 
             // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
             defaultGCData.gcNodes[nodes[1]] = [];
+            await garbageCollector.collectGarbage({});
 
-            await garbageCollector.collectGarbage({ runGC: true });
-
-            // Validate that no inactive events are logged yet.
-            await updateAllNodesAndRunGC(garbageCollector);
-            validateNoInactiveEvents();
-
-            // Advance the clock so that inactive timeout expires.
-            clock.tick(inactiveTimeoutOverrideMs + 1);
-
-            // Validate that changed and loaded events for node 2 and node 3 are logged since they are inactive.
+            // Advance the clock to trigger inactive timeout and validate that we get inactive events.
+            clock.tick(inactiveTimeoutMs + 1);
             await updateAllNodesAndRunGC(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: changedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: changedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEvent, timeout: inactiveTimeoutOverrideMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[3] },
                 ]),
-                "inactive events not logged as expected",
+                "inactive events not generated as expected",
+            );
+
+            // Advance the clock to trigger sweep timeout and validate that we get deleted events.
+            clock.tick(sweepTimeoutMs - inactiveTimeoutMs);
+            await updateAllNodesAndRunGC(garbageCollector);
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: "GarbageCollector:DeletedObject_Changed", timeout: sweepTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:DeletedObject_Loaded", timeout: sweepTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:DeletedObject_Changed", timeout: sweepTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:DeletedObject_Loaded", timeout: sweepTimeoutMs, id: nodes[3] },
+                ]),
+                "deleted events not generated as expected",
             );
         });
     });
@@ -631,7 +692,7 @@ describe("Garbage Collection Tests", () => {
             // Advance the clock by 1 tick so that the unreferenced timestamp is updated in between runs.
             clock.tick(1);
 
-            await garbageCollector.collectGarbage({ runGC: true });
+            await garbageCollector.collectGarbage({});
 
             const summaryTree = garbageCollector.summarize(true, false)?.summary;
             assert(summaryTree !== undefined, "Nothing to summarize after running GC");
@@ -1014,7 +1075,7 @@ describe("Garbage Collection Tests", () => {
         it("No changes to GC between summaries creates a blob handle when no version specified", async () => {
             garbageCollector = createGarbageCollector();
 
-            await garbageCollector.collectGarbage({ runGC: true });
+            await garbageCollector.collectGarbage({});
             const tree1 = garbageCollector.summarize(fullTree, trackState);
 
             checkGCSummaryType(tree1, SummaryType.Tree, "first");
@@ -1024,7 +1085,7 @@ describe("Garbage Collection Tests", () => {
                 parseNothing,
             );
 
-            await garbageCollector.collectGarbage({ runGC: true });
+            await garbageCollector.collectGarbage({});
             const tree2 = garbageCollector.summarize(fullTree, trackState);
 
             checkGCSummaryType(tree2, SummaryType.Handle, "second");

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -574,9 +574,9 @@ describe("Garbage Collection Tests", () => {
 
             tests(
                 inactiveTimeoutMs,
-                "GarbageCollector:InactiveObject_Revived",
-                "GarbageCollector:InactiveObject_Changed",
-                "GarbageCollector:InactiveObject_Loaded",
+                "GarbageCollector:inactiveObject_Revived",
+                "GarbageCollector:inactiveObject_Changed",
+                "GarbageCollector:inactiveObject_Loaded",
             );
         });
 
@@ -590,9 +590,9 @@ describe("Garbage Collection Tests", () => {
 
             tests(
                 sweepTimeoutMs,
-                "GarbageCollector:DeletedObject_Revived",
-                "GarbageCollector:DeletedObject_Changed",
-                "GarbageCollector:DeletedObject_Loaded",
+                "GarbageCollector:deletedObject_Revived",
+                "GarbageCollector:deletedObject_Changed",
+                "GarbageCollector:deletedObject_Loaded",
                 snapshotCacheExpiryMs,
                 "GarbageCollector:GCObjectDeleted",
             );
@@ -616,10 +616,10 @@ describe("Garbage Collection Tests", () => {
             await updateAllNodesAndRunGC(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[3] },
-                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:inactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:inactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:inactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:inactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[3] },
                 ]),
                 "inactive events not generated as expected",
             );
@@ -629,10 +629,10 @@ describe("Garbage Collection Tests", () => {
             await updateAllNodesAndRunGC(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: "GarbageCollector:DeletedObject_Changed", timeout: sweepTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:DeletedObject_Loaded", timeout: sweepTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:DeletedObject_Changed", timeout: sweepTimeoutMs, id: nodes[3] },
-                    { eventName: "GarbageCollector:DeletedObject_Loaded", timeout: sweepTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:deletedObject_Changed", timeout: sweepTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:deletedObject_Loaded", timeout: sweepTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:deletedObject_Changed", timeout: sweepTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:deletedObject_Loaded", timeout: sweepTimeoutMs, id: nodes[3] },
                 ]),
                 "deleted events not generated as expected",
             );

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -138,8 +138,8 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             // Load the data store and validate that we get loadedEvent.
             await summarizerRuntime.resolveHandle({ url });
             await summarize(summarizerRuntime);
-            assert(
-                mockLogger.matchEvents([
+            mockLogger.assertMatch(
+                [
                     {
                         eventName: changedEvent,
                         timeout: inactiveTimeoutMs,
@@ -152,7 +152,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
                         id: url,
                         pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
                     },
-                ]),
+                ],
                 "changed and loaded events not generated as expected",
             );
 
@@ -165,8 +165,8 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             // Revive the inactive data store and validate that we get the revivedEvent event.
             defaultDataStore._root.set("dataStore1", dataObject.handle);
             await summarize(summarizerRuntime);
-            assert(
-                mockLogger.matchEvents([
+            mockLogger.assertMatch(
+                [
                     {
                         eventName: revivedEvent,
                         timeout: inactiveTimeoutMs,
@@ -174,7 +174,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
                         pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
                         fromId: defaultDataStore._root.handle.absolutePath,
                     },
-                ]),
+                ],
                 "revived event not generated as expected",
             );
         });
@@ -216,14 +216,14 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             // Retrieve the blob in the summarizer client now and validate that we get the loadedEvent.
             await summarizerBlobHandle.get();
             await summarize(summarizerRuntime);
-            assert(
-                mockLogger.matchEvents([
+            mockLogger.assertMatch(
+            [
                     {
                         eventName: loadedEvent,
                         timeout: inactiveTimeoutMs,
                         id: summarizerBlobHandle.absolutePath,
                     },
-                ]),
+                ],
                 "updated event not generated as expected for attachment blobs",
             );
 
@@ -231,14 +231,14 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
             defaultDataStore._root.set("blob", blobHandle);
             await provider.ensureSynchronized();
             await summarize(summarizerRuntime);
-            assert(
-                mockLogger.matchEvents([
+            mockLogger.assertMatch(
+                [
                     {
                         eventName: revivedEvent,
                         timeout: inactiveTimeoutMs,
                         id: summarizerBlobHandle.absolutePath,
                     },
-                ]),
+                ],
                 "revived event not generated as expected for attachment blobs",
             );
         });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -21,9 +21,9 @@ import { createSummarizer, summarizeNow, waitForContainerConnection } from "./gc
  * unreferenced for a certain amount of time, using the node results in an error telemetry.
  */
 describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
-    const revivedEvent = "fluid:telemetry:ContainerRuntime:inactiveObject_Revived";
-    const changedEvent = "fluid:telemetry:ContainerRuntime:inactiveObject_Changed";
-    const loadedEvent = "fluid:telemetry:ContainerRuntime:inactiveObject_Loaded";
+    const revivedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Revived";
+    const changedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Changed";
+    const loadedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Loaded";
     const inactiveTimeoutMs = 100;
     const testContainerConfig: ITestContainerConfig = {
         runtimeOptions: {
@@ -144,13 +144,13 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
                         eventName: changedEvent,
                         timeout: inactiveTimeoutMs,
                         id: url,
-                        pkg: { value: TestDataObjectType, tag: TelemetryDataTag.PackageData },
+                        pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
                     },
                     {
                         eventName: loadedEvent,
                         timeout: inactiveTimeoutMs,
                         id: url,
-                        pkg: { value: TestDataObjectType, tag: TelemetryDataTag.PackageData },
+                        pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
                     },
                 ]),
                 "changed and loaded events not generated as expected",
@@ -171,7 +171,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
                         eventName: revivedEvent,
                         timeout: inactiveTimeoutMs,
                         id: url,
-                        pkg: { value: TestDataObjectType, tag: TelemetryDataTag.PackageData },
+                        pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
                         fromId: defaultDataStore._root.handle.absolutePath,
                     },
                 ]),
@@ -252,7 +252,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
          * via the running summarizer's logger.
          */
         itExpects("can generate events for data stores that are not loaded", [
-            { eventName: "fluid:telemetry:Summarizer:Running:inactiveObject_Revived", timeout: inactiveTimeoutMs },
+            { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Revived", timeout: inactiveTimeoutMs },
         ], async () => {
             const waitForSummary = async (summarizer: ISummarizer) => {
                 await provider.ensureSynchronized();


### PR DESCRIPTION
[AB#516](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/516).

This is basically sweep implementation but instead of deleting data stores / attachment blobs, it marks them as "ReadyForSweep". When these objects are used, it logs an deleted object used error.
This is a better version of the inactive object used errors that we have in place. This works with session expiry so when we see this, we can be sure that these objects are not used via in-memory references (undo / redo, cut / paste, etc).

Added another event when objects should be deleted. Basically, when sweep would delete these objects. This takes us very close to sweep implementation where we have to replace this log with deleting the object.