### PR TITLE
Disable npm task autodetection in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,10 @@
     "typescript.format.placeOpenBraceOnNewLineForControlBlocks": false,
     "typescript.tsdk": "node_modules/typescript/lib",
 
-    // Autodetecting TSC tasks on a repo this size makes 'Tasks: Run Build Task' unusably slow.
+    // Autodetecting tasks on a repo this size makes 'Tasks: Run Build Task' unusably slow.
     // (See https://github.com/Microsoft/vscode/issues/34387)
     "typescript.tsc.autoDetect": "off",
+    "npm.autoDetect": "off",
 
     "files.associations": {
         "tools/pipelines/*.yml": "azure-pipelines"


### PR DESCRIPTION
## Description

Disable auto-detection of npm tasks in VSCode, for the same reason that it is disabled for TSC tasks. In my not-very-scientific tests with this, `Ctrl-Shift-B` (i.e. `Tasks: Run Build Task`) went from taking 1min+ to even start the build command, to being instantaneous. After the first time it seems to cache the tasks so subsequent executions trigger quickly, until the window is reloaded and then it goes back to a slow first execution.

