### PR TITLE
Deprecate ISummaryAuthor and ISummaryCommitter

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -24,7 +24,7 @@ There are a few steps you can take to write a good change note and avoid needing
  See [#9660](https://github.com/microsoft/FluidFramework/issues/9660). The API is vulnerable to name conflicts, which lead to invalid documents. As a replacement, create a regular datastore using the `IContainerRuntimeBase.createDataStore` function, then alias the datastore by using the `IDataStore.trySetAlias` function and specify a string value to serve as the alias to which the datastore needs to be bound. If successful, "Success" will be returned, and a call to `getRootDataStore` with the alias as parameter will return the same datastore.
 
  ### ISummaryAuthor and ISummaryCommitter are deprecated
-  See [#10456](https://github.com/microsoft/FluidFramework/issues/10456). `ISummaryAuthor` and`ISummaryCommitter` have never been used so they are being deprecated.
+  See [#10456](https://github.com/microsoft/FluidFramework/issues/10456). `ISummaryAuthor` and `ISummaryCommitter`are deprecated and will be removed in a future release.
 
 # 1.0.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -24,7 +24,8 @@ There are a few steps you can take to write a good change note and avoid needing
  See [#9660](https://github.com/microsoft/FluidFramework/issues/9660). The API is vulnerable to name conflicts, which lead to invalid documents. As a replacement, create a regular datastore using the `IContainerRuntimeBase.createDataStore` function, then alias the datastore by using the `IDataStore.trySetAlias` function and specify a string value to serve as the alias to which the datastore needs to be bound. If successful, "Success" will be returned, and a call to `getRootDataStore` with the alias as parameter will return the same datastore.
 
  ### ISummaryAuthor and ISummaryCommitter are deprecated
-  See [#10456](https://github.com/microsoft/FluidFramework/issues/10456). `ISummaryAuthor` and `ISummaryCommitter`are deprecated and will be removed in a future release.
+  See [#10456](https://github.com/microsoft/FluidFramework/issues/10456). `ISummaryAuthor` and `ISummaryCommitter`
+  are deprecated and will be removed in a future release.
 
 # 1.0.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,9 +18,13 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 1.1.0 Upcoming changes
 - [IContainerRuntime.createRootDataStore is deprecated](#icontainerruntimecreaterootdatastore-is-deprecated)
+- [ ISummaryAuthor and ISummaryCommitter are deprecated](#isummaryauthor-and-isummarycommitter-are-deprecated)
 
  ### IContainerRuntime.createRootDataStore is deprecated
  See [#9660](https://github.com/microsoft/FluidFramework/issues/9660). The API is vulnerable to name conflicts, which lead to invalid documents. As a replacement, create a regular datastore using the `IContainerRuntimeBase.createDataStore` function, then alias the datastore by using the `IDataStore.trySetAlias` function and specify a string value to serve as the alias to which the datastore needs to be bound. If successful, "Success" will be returned, and a call to `getRootDataStore` with the alias as parameter will return the same datastore.
+
+ ### ISummaryAuthor and ISummaryCommitter are deprecated
+  See [#10456](https://github.com/microsoft/FluidFramework/issues/10456). `ISummaryAuthor` and`ISummaryCommitter` have never been used so we are depracating them.
 
 # 1.0.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -24,7 +24,7 @@ There are a few steps you can take to write a good change note and avoid needing
  See [#9660](https://github.com/microsoft/FluidFramework/issues/9660). The API is vulnerable to name conflicts, which lead to invalid documents. As a replacement, create a regular datastore using the `IContainerRuntimeBase.createDataStore` function, then alias the datastore by using the `IDataStore.trySetAlias` function and specify a string value to serve as the alias to which the datastore needs to be bound. If successful, "Success" will be returned, and a call to `getRootDataStore` with the alias as parameter will return the same datastore.
 
  ### ISummaryAuthor and ISummaryCommitter are deprecated
-  See [#10456](https://github.com/microsoft/FluidFramework/issues/10456). `ISummaryAuthor` and`ISummaryCommitter` have never been used so we are depracating them.
+  See [#10456](https://github.com/microsoft/FluidFramework/issues/10456). `ISummaryAuthor` and`ISummaryCommitter` have never been used so they are being deprecated.
 
 # 1.0.0
 

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -416,7 +416,7 @@ export interface ISummaryAttachment {
     type: SummaryType.Attachment;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface ISummaryAuthor {
     // (undocumented)
     date: string;
@@ -434,7 +434,7 @@ export interface ISummaryBlob {
     type: SummaryType.Blob;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface ISummaryCommitter {
     // (undocumented)
     date: string;

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -7,6 +7,10 @@ export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISumm
 
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
+/**
+ * @deprecated - ISummaryAuthor has never been used anywhere and is unlikely to be used in the
+ * future so it is being depracated.
+ */
 export interface ISummaryAuthor {
     name: string;
     email: string;
@@ -14,6 +18,10 @@ export interface ISummaryAuthor {
     date: string;
 }
 
+/**
+ * @deprecated - ISummaryCommitter has never been used anywhere and is unlikely to be used in the
+ * future so it is being depracated.
+ */
 export interface ISummaryCommitter {
     name: string;
     email: string;

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -8,7 +8,7 @@ export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISumm
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
 /**
- * @deprecated - ISummaryAuthor has never been used anywhere and is unlikely to be used in the
+ * @deprecated ISummaryAuthor has never been used anywhere and is unlikely to be used in the
  * future so it is being depracated.
  */
 export interface ISummaryAuthor {
@@ -19,7 +19,7 @@ export interface ISummaryAuthor {
 }
 
 /**
- * @deprecated - ISummaryCommitter has never been used anywhere and is unlikely to be used in the
+ * @deprecated ISummaryCommitter has never been used anywhere and is unlikely to be used in the
  * future so it is being depracated.
  */
 export interface ISummaryCommitter {

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -8,8 +8,7 @@ export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISumm
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
 /**
- * @deprecated ISummaryAuthor has never been used anywhere and is unlikely to be used in the
- * future so it is being depracated.
+ * @deprecated ISummaryAuthor is deprecated and will be removed in a future release.
  */
 export interface ISummaryAuthor {
     name: string;
@@ -19,8 +18,7 @@ export interface ISummaryAuthor {
 }
 
 /**
- * @deprecated ISummaryCommitter has never been used anywhere and is unlikely to be used in the
- * future so it is being depracated.
+ * @deprecated ISummaryCommitter is deprecated and will be removed in a future release.
  */
 export interface ISummaryCommitter {
     name: string;


### PR DESCRIPTION
## Description

Deprecate ISummaryAuthor and ISummaryCommitter as they have never been used. See https://github.com/microsoft/FluidFramework/issues/10456 for more details.

## Does this introduce a breaking change?

Yes, technically, public interfaces are being deprecated but since they have never been used in practicality it _should_ not affect users.
