### PR TITLE
Allow Transient References on Removed Segments

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2549,8 +2549,9 @@ export class MergeTree {
         client: Client,
     ): LocalReferencePosition {
         if (isRemoved(segment)) {
-            if (!refTypeIncludesFlag(refType, ReferenceType.SlideOnRemove)) {
-                throw new UsageError("Can only create SlideOnRemove local reference position on a removed segment");
+            if (!refTypeIncludesFlag(refType, ReferenceType.SlideOnRemove | ReferenceType.Transient)) {
+                throw new UsageError(
+                    "Can only create SlideOnRemove or Transient local reference position on a removed segment");
             }
         }
         const localRefs = segment.localRefs ?? new LocalReferenceCollection(segment);


### PR DESCRIPTION
## Description
There is a small bug where we block transient references on removed segments. this should be allowed for cases like undo-redo