### PR TITLE
Fix SharedTree fuzz move validation

### DIFF
--- a/experimental/dds/tree/src/test/fuzz/Generators.ts
+++ b/experimental/dds/tree/src/test/fuzz/Generators.ts
@@ -288,11 +288,8 @@ const makeEditGenerator = (passedConfig: EditGenerationConfig): AsyncGenerator<O
 			const forbiddenDescendantId =
 				destination.referenceTrait?.parent ?? destination.referenceSibling ?? fail('Invalid place');
 
-			const unadjustedStartIndex: number = view.findIndexWithinTrait(start);
-			const unadjustedEndIndex: number = view.findIndexWithinTrait(end);
-			const startIndex = unadjustedStartIndex + (start.side === Side.After ? 1 : 0);
-			const endIndex = unadjustedEndIndex + (end.side === Side.After ? 1 : 0);
-
+			const startIndex = view.findIndexWithinTrait(start);
+			const endIndex = view.findIndexWithinTrait(end);
 			const idsInSource = new Set(view.getTrait(start.trait).slice(startIndex, endIndex));
 			for (
 				let current: NodeId | undefined = forbiddenDescendantId;


### PR DESCRIPTION
SharedTree fuzz tests generate "move" operations, but guard against moving a node in the tree such that it becomes its own descendant. Part of the check includes adjusting the indices of the nodes being moved, but this actually over-corrects them since they are already adjusted by the helper method being used. This can allow fuzz move operations to unintentionally create cycles in the tree.