### PR TITLE
Deprecate IContainerRuntime.flush

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -17,23 +17,23 @@ There are a few steps you can take to write a good change note and avoid needing
 # 2.0.0
 
 ## 2.0.0 Upcoming changes
-
- - [Remove `documentId` field from `MockFluidDataStoreContext`](#Remove-documentId-field-from-MockFluidDataStoreContext)
- - [Narrow type of `clientId` field on `MockFluidDataStoreRuntime`](#Narrow-type-of-clientId-field-on-MockFluidDataStoreRuntime)
- - [Remove `ConnectionState.Connecting`](#Remove-ConnectionState.Connecting)
+- [Remove `documentId` field from `MockFluidDataStoreContext`](#Remove-documentId-field-from-MockFluidDataStoreContext)
+- [Narrow type of `clientId` field on `MockFluidDataStoreRuntime`](#Narrow-type-of-clientId-field-on-MockFluidDataStoreRuntime)
+- [Remove `ConnectionState.Connecting`](#Remove-ConnectionState.Connecting)
+- [`IContainerRuntime.flush` is deprecated](#icontainerruntimeflush-is-deprecated)
 
 ### Remove `documentId` field from `MockFluidDataStoreContext`
-
 This field has been deprecated and will be removed in a future breaking change.
 
 ### Narrow type of `clientId` field on `MockFluidDataStoreRuntime`
-
 `clientId` can only ever be of type `string`, so it is superfluous for the type
 to be `string | undefined`.
 
 ### Remove `ConnectionState.Connecting`
-
 `ConnectionState.Connecting` will be removed. Migrate all usage to `ConnectionState.CatchingUp`.
+
+### `IContainerRuntime.flush` is deprecated
+`IContainerRuntime.flush` is deprecated and will be removed in a future release. If a more manual flushing process is needed, move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
 
 # 1.1.0
 

--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -41,6 +41,7 @@ export interface IContainerRuntime extends IProvideContainerRuntime, IProvideFlu
     createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter>;
     // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    // @deprecated
     flush(): void;
     // (undocumented)
     readonly flushMode: FlushMode;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -122,6 +122,8 @@ export interface IContainerRuntime extends
 
     /**
      * Flushes any ops currently being batched to the loader
+     * @deprecated - This will be removed in a later release. If a more manual flushing process is needed,
+     * move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
      */
     flush(): void;
 


### PR DESCRIPTION
# [AB#1059](https://dev.azure.com/fluidframework/internal/_workitems/edit/1059)

For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

## Description

The `IContainerRuntime.flush` method has been deprecated and will be removed in a future release. If a more manual flushing process is needed, move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
