### PR TITLE
lerna lock changes after 'npm ci'

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2408,6 +2408,11 @@
 						"util": "^0.12.0"
 					}
 				},
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+				},
 				"typescript": {
 					"version": "3.9.9",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
@@ -19111,6 +19116,13 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
 				"pako": "~1.0.5"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+				}
 			}
 		},
 		"browserslist": {
@@ -28918,6 +28930,11 @@
 				"simple-get": "^4.0.1"
 			},
 			"dependencies": {
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+				},
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -31011,9 +31028,9 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "10.5.23",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.23.tgz",
-			"integrity": "sha512-e3hy//LH8EbRhzqyHJuf3pbehxYcnUZgGUjQKKTukWJ1M5uQTZBgFvItRK5ik8pixpYDAKY6xj527cEa1NQGPg=="
+			"version": "10.5.25",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
+			"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg=="
 		},
 		"jss": {
 			"version": "10.9.0",
@@ -31137,6 +31154,11 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+				},
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -37233,9 +37255,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+			"integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
 		},
 		"parallel-transform": {
 			"version": "1.2.0",


### PR DESCRIPTION
I was surprised to see any lock file changes when I ran `npm ci` from the root... but here they are.  Should this be merged?