### PR TITLE
Added "trackGCState" property to GarbageCollectorLoaded event

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -642,6 +642,7 @@ export class GarbageCollector implements IGarbageCollector {
             sessionExpiry: this.sessionExpiryTimeoutMs,
             inactiveTimeout: this.inactiveTimeoutMs,
             existing: createParams.existing,
+            trackGCState: this.trackGCState,
             ...this.gcOptions,
         });
         if (this.isSummarizerClient) {


### PR DESCRIPTION
This will help filtering document that has this feature enabled. Basically, it makes the following item for analyzing how much GC blobs contribute to summary size in absence of changes easier - https://dev.azure.com/fluidframework/internal/_workitems/edit/977