### PR TITLE
Add better support for release groups in build-tools

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,19 @@
             ],
         },
         {
+            "name": "fluid-bump-version",
+            "program": "${workspaceFolder}/build-tools/packages/build-tools/dist/bumpVersion/bumpVersionCli.js",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node",
+            "args": [
+                "-d",
+                "@fluidframework/common-utils@^0.33.1000",
+            ],
+        },
+        {
             "name": "layer-check",
             "program": "${workspaceFolder}/build-tools/packages/build-tools/dist/layerCheck/layerCheck.js",
             "request": "launch",

--- a/build-tools/lerna-package-lock.json
+++ b/build-tools/lerna-package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@fluid-tools/build-tools",
+	"name": "root",
 	"version": "0.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -3497,6 +3497,15 @@
 			"resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
 			"integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
 		},
+		"@oclif/plugin-commands": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@oclif/plugin-commands/-/plugin-commands-2.2.0.tgz",
+			"integrity": "sha512-l/iQ+LFd02VXUISY7YcIH9NLPlTaqiqtTK640dorTPag0pJHCH9q0HqiK8apBUhLW7ZfF6c/+wkINJQgz5sgdw==",
+			"requires": {
+				"@oclif/core": "^1.2.0",
+				"lodash": "^4.17.11"
+			}
+		},
 		"@oclif/plugin-help": {
 			"version": "5.1.12",
 			"resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.1.12.tgz",
@@ -4795,6 +4804,11 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+		},
+		"astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
 		},
 		"async": {
 			"version": "3.2.4",
@@ -9591,6 +9605,11 @@
 				"lodash._reinterpolate": "^3.0.0"
 			}
 		},
+		"lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -12404,6 +12423,39 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
 		},
+		"slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				}
+			}
+		},
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -12800,6 +12852,36 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+		},
+		"table": {
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+			"requires": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.11.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+					"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+				}
+			}
 		},
 		"taketalk": {
 			"version": "1.0.0",

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluid-tools/build-tools",
+  "name": "root",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluid-tools/build-tools",
+  "name": "root",
   "version": "0.0.1",
   "private": true,
   "homepage": "https://fluidframework.com",

--- a/build-tools/packages/build-tools/src/bumpVersion/bumpDependencies.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpDependencies.ts
@@ -23,7 +23,7 @@ import { FluidRepo } from "../common/fluidRepo";
 export async function bumpDependencies(context: Context, commitMessage: string, bumpDepPackages: Map<string, string | undefined>, updateLock: boolean, commit: boolean = false, release: boolean = false) {
     const suffix = release ? "" : "-0";
     const bumpPackages = context.repo.packages.packages.map(pkg => {
-        const matchName = pkg.monoRepo ? MonoRepoKind[pkg.monoRepo.kind] : pkg.name;
+        const matchName = pkg.monoRepo ? pkg.monoRepo.kind : pkg.name;
         const matched = bumpDepPackages.has(matchName);
         // Only add the suffix if it is not user specified
         const version = bumpDepPackages.get(matchName) ?? `${pkg.version}${suffix}`;

--- a/build-tools/packages/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpVersion.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { Context, isVersionBumpType, VersionChangeType } from "./context";
 import { getRepoStateChange, VersionBag } from "./versionBag";
-import { fatal, exec } from "./utils";
+import { fatal, exec, adjustVersion, VersionScheme } from "./utils";
 import { isMonoRepoKind, MonoRepo, MonoRepoKind } from "../common/monoRepo";
 import { Package } from "../common/npmPackage";
 import { getPackageShortName } from "./releaseVersion";
@@ -72,57 +72,6 @@ export async function bumpVersion(context: Context, bump: string[], version: Ver
     }
 }
 
-
-/**
- * Translate a VersionChangeType for the virtual patch scenario where we overload a beta version number
- * to include all of major, minor, and patch.  Actual semver type is not translated
- * "major" maps to "minor" with "patch" = 1000 (<N + 1>.0.0 -> 0.<N + 1>.1000)
- * "minor" maps to "patch" * 1000 (x.<N + 1>.0 -> 0.x.<N + 1>000)
- * "patch" is unchanged (but remember the final patch number holds "minor" * 1000 + the incrementing "patch")
- */
-function translateVirtualVersion(
-    versionBump: VersionChangeType,
-    versionString: string,
-    virtualPatch: boolean,
-): VersionChangeType {
-    if (!virtualPatch) {
-        return versionBump;
-    }
-
-    // Virtual patch can only be used for a major/minor/patch bump and not a specific version
-    if (!isVersionBumpType(versionBump)) {
-        fatal("Can only use virtual patches when doing major/minor/patch bumps");
-    }
-
-    const virtualVersion = semver.parse(versionString);
-    if (!virtualVersion) {
-        fatal("unable to deconstruct package version for virtual patch");
-    }
-    if (virtualVersion.major !== 0) {
-        fatal("Can only use virtual patches with major version 0");
-    }
-
-    switch (versionBump) {
-        case "major": {
-            virtualVersion.minor += 1;
-            // the "minor" component starts at 1000 to work around issues padding to
-            // 4 digits using 0s with semvers
-            virtualVersion.patch = 1000;
-            break;
-        }
-        case "minor": {
-            virtualVersion.patch += 1000;
-            break;
-        }
-        case "patch": {
-            virtualVersion.patch += 1;
-            break;
-        }
-    }
-
-    virtualVersion.format(); // semver must be reformated after edits
-    return virtualVersion;
-}
 /**
  * Bump version of packages in the repo
  *
@@ -140,24 +89,27 @@ export async function bumpRepo(
         return exec(`npx lerna version ${repoVersionBump} --no-push --no-git-tag-version -y && npm run build:genver`, monoRepo.repoPath, "bump mono repo");
     }
 
+    const scheme: VersionScheme = virtualPatch ? "virtualPatch" : "semver";
     const vPatchLogString = virtualPatch ? " using virtual patches" : "";
 
     for (const monoRepo of monoReposNeedBump) {
-        console.log(`  Bumping ${monoRepo} version${vPatchLogString}`);
+        console.log(`  Bumping ${monoRepo}${vPatchLogString}...`);
         // Translate the versionBump into the appropriate change for virtual patch versioning
-        const translatedVersionBump = translateVirtualVersion(versionBump, versionBag.get(monoRepo), virtualPatch);
+        const ver = getVersion(monoRepo);
+        assert(ver, "ver is missing");
+        const adjVer = await adjustVersion(ver, versionBump, scheme);
         const toBump = context.repo.monoRepos.get(monoRepo);
         assert(toBump !== undefined, `No monorepo with name '${toBump}'`);
         if (toBump !== undefined) {
-            await bumpLegacyDependencies(context, translatedVersionBump);
-            await bumpMonoRepo(translatedVersionBump, toBump);
+            await bumpLegacyDependencies(context, adjVer);
+            await bumpMonoRepo(adjVer, toBump);
         }
     }
 
     for (const pkg of packageNeedBump) {
-        console.log(`  Bumping ${pkg.name}${vPatchLogString}`);
+        console.log(`  Bumping ${pkg.name}${vPatchLogString}...`);
         // Translate the versionBump into the appropriate change for virtual patch versioning
-        const translatedVersionBump = translateVirtualVersion(versionBump, versionBag.get(pkg.name), virtualPatch);
+        const translatedVersionBump = await adjustVersion(getVersion(pkg.name), versionBump, scheme);
         let cmd = `npm version ${translatedVersionBump}`;
         if (pkg.getScript("build:genver")) {
             cmd += " && npm run build:genver";
@@ -169,6 +121,9 @@ export async function bumpRepo(
     return context.collectVersions(true);
 }
 
+/**
+ * Note: this function does nothing if called with versionBump !== "patch".
+ */
 async function bumpLegacyDependencies(context: Context, versionBump: VersionChangeType) {
     if (versionBump !== "patch") {
         // Assumes that we want N/N-1 testing

--- a/build-tools/packages/build-tools/src/bumpVersion/bumpVersionCli.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpVersionCli.ts
@@ -116,13 +116,7 @@ function parseOptions(argv: string[]) {
             const dep = split[0];
             const version = split[1];
 
-            if (dep.toLowerCase() === MonoRepoKind[MonoRepoKind.Client].toLowerCase()) {
-                paramBumpDepPackages.set(MonoRepoKind[MonoRepoKind.Client], version);
-            } else if (dep.toLowerCase() === MonoRepoKind[MonoRepoKind.Server].toLowerCase()) {
-                paramBumpDepPackages.set(MonoRepoKind[MonoRepoKind.Server], version);
-            } else {
-                paramBumpDepPackages.set(dep, version);
-            }
+            paramBumpDepPackages.set(dep, version);
             continue;
         }
 
@@ -296,7 +290,7 @@ async function main() {
 
         switch (command) {
             case "releaseBump":
-                await createReleaseBump(context, paramReleaseVersion, paramVirtualPatch);
+                await createReleaseBump(MonoRepoKind.Client, context, paramReleaseVersion, paramVirtualPatch);
                 break;
             case "dep":
                 console.log("Bumping dependencies");

--- a/build-tools/packages/build-tools/src/bumpVersion/bumpVersionCli.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpVersionCli.ts
@@ -290,7 +290,7 @@ async function main() {
 
         switch (command) {
             case "releaseBump":
-                await createReleaseBump(MonoRepoKind.Client, context, paramReleaseVersion, paramVirtualPatch);
+                await createReleaseBump(context, paramReleaseVersion, paramVirtualPatch);
                 break;
             case "dep":
                 console.log("Bumping dependencies");

--- a/build-tools/packages/build-tools/src/bumpVersion/context.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/context.ts
@@ -186,6 +186,12 @@ export class Context {
         }
     }
 
+    /**
+     * Returns the packages that belong to the specified release group.
+     *
+     * @param releaseGroup The release group to filter by
+     * @returns An array of packages that belong to the release group
+     */
     public packagesForReleaseGroup(releaseGroup: MonoRepoKind) {
         let packages: Package[] = [...this.fullPackageMap.values()];
         packages = packages.filter(pkg => pkg.monoRepo?.kind === releaseGroup);

--- a/build-tools/packages/build-tools/src/bumpVersion/context.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/context.ts
@@ -189,7 +189,7 @@ export class Context {
     /**
      * Returns the packages that belong to the specified release group.
      *
-     * @param releaseGroup The release group to filter by
+     * @param releaseGroup - The release group to filter by
      * @returns An array of packages that belong to the release group
      */
     public packagesForReleaseGroup(releaseGroup: MonoRepoKind) {

--- a/build-tools/packages/build-tools/src/bumpVersion/context.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/context.ts
@@ -19,9 +19,16 @@ import { fatal, prereleaseSatisfies } from "./utils";
 import * as semver from "semver";
 
 export type VersionBumpType = "major" | "minor" | "patch";
+export type VersionBumpTypeExtended = VersionBumpType | "current";
 export type VersionChangeType = VersionBumpType | semver.SemVer;
+export type VersionChangeTypeExtended = VersionBumpTypeExtended | semver.SemVer;
+
 export function isVersionBumpType(type: VersionChangeType | string): type is VersionBumpType {
     return type === "major" || type === "minor" || type === "patch";
+}
+
+export function isVersionBumpTypeExtended(type: VersionChangeType | string): type is VersionBumpTypeExtended {
+    return type === "major" || type === "minor" || type === "patch" || type === "current";
 }
 
 export class Context {
@@ -177,5 +184,11 @@ export class Context {
         for (const tag of this.newTags) {
             await this.gitRepo.deleteTag(tag);
         }
+    }
+
+    public packagesForReleaseGroup(releaseGroup: MonoRepoKind) {
+        let packages: Package[] = [...this.fullPackageMap.values()];
+        packages = packages.filter(pkg => pkg.monoRepo?.kind === releaseGroup);
+        return packages;
     }
 }

--- a/build-tools/packages/build-tools/src/bumpVersion/releaseVersion.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/releaseVersion.ts
@@ -124,8 +124,8 @@ async function releasePackages(context: Context, packages: Package[], updateLock
 }
 
 async function releaseMonoRepo(context: Context, monoRepo: MonoRepo, updateLock: boolean, virtualPatch: boolean) {
-    const kind = MonoRepoKind[monoRepo.kind];
-    const kindLowerCase = MonoRepoKind[monoRepo.kind].toLowerCase();
+    const kind = monoRepo.kind;
+    const kindLowerCase = monoRepo.kind.toLowerCase();
     const tagName = `${kindLowerCase}_v${monoRepo.version}`;
     await context.gitRepo.fetchTags();
     if ((await context.gitRepo.getTags(tagName)).trim() !== tagName) {

--- a/build-tools/packages/build-tools/src/bumpVersion/showVersions.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/showVersions.ts
@@ -6,7 +6,7 @@
 import { Context } from "./context";
 import { ReferenceVersionBag } from "./versionBag";
 import { fatal } from "./utils";
-import { MonoRepo, MonoRepoKind } from "../common/monoRepo";
+import { isMonoRepoKind, MonoRepo, MonoRepoKind } from "../common/monoRepo";
 import { Package } from "../common/npmPackage";
 import * as semver from "semver";
 import { strict as assert } from "assert";
@@ -23,11 +23,11 @@ export async function showVersions(context: Context, name: string, publishedVers
         };
         const depVersions = new ReferenceVersionBag(context.repo.resolvedRoot, context.fullPackageMap, context.collectVersions());
         let pkg: Package | undefined;
-        if (name === MonoRepoKind[MonoRepoKind.Client]) {
-            await processMonoRepo(context.repo.clientMonoRepo);
-        } else if (name === MonoRepoKind[MonoRepoKind.Server]) {
-            assert(context.repo.serverMonoRepo, "Attempted show server versions on a Fluid repo with no server directory");
-            await processMonoRepo(context.repo.serverMonoRepo!);
+        if (isMonoRepoKind(name)) {
+            if (name === MonoRepoKind.Server) {
+                assert(context.repo.serverMonoRepo, "Attempted show server versions on a Fluid repo with no server directory");
+            }
+            await processMonoRepo(context.repo.monoRepos.get(name)!);
         } else {
             pkg = context.fullPackageMap.get(name);
             if (!pkg) {

--- a/build-tools/packages/build-tools/src/bumpVersion/utils.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/utils.ts
@@ -50,7 +50,7 @@ export function prereleaseSatisfies(packageVersion: string, range: string) {
 }
 
 /**
- * Translate a VersionChangeType for the virtual patch scenario where we overload a beta version number
+ * Translate a {@link VersionChangeType} for the virtual patch scenario where we overload a beta version number
  * to include all of major, minor, and patch.  Actual semver type is not translated
  * "major" maps to "minor" with "patch" = 1000 (<N + 1>.0.0 -> 0.<N + 1>.1000)
  * "minor" maps to "patch" * 1000 (x.<N + 1>.0 -> 0.x.<N + 1>000)

--- a/build-tools/packages/build-tools/src/bumpVersion/utils.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/utils.ts
@@ -112,16 +112,17 @@ function translateVirtualVersion(
 export type VersionScheme = "semver" | "internal" | "virtualPatch";
 
 /**
+ * Adjusts the provided version according to the bump type and version scheme. Returns the adjusted version.
  *
  * @param version The input version.
  * @param bumpType The type of bump,
  * @param scheme The version scheme to use.
  * @returns An adjusted version as a semver.SemVer.
  */
-export const adjustVersion = async (
+export function adjustVersion(
     version: string | semver.SemVer | undefined,
     bumpType: VersionChangeTypeExtended,
-    scheme: VersionScheme): Promise<semver.SemVer> => {
+    scheme: VersionScheme): semver.SemVer {
     const sv = semver.parse(version);
     assert(sv !== null, `Not a valid semver: ${version}`);
     switch (scheme) {

--- a/build-tools/packages/build-tools/src/bumpVersion/utils.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/utils.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "assert";
 import { execAsync } from "../common/utils";
 import * as semver from "semver";
+import { isVersionBumpType, VersionBumpType, VersionChangeType, VersionChangeTypeExtended } from "./context";
 
 export function fatal(error: string): never {
     const e = new Error(error);
@@ -45,4 +47,112 @@ export async function execNoError(cmd: string, dir: string, pipeStdIn?: string) 
 export function prereleaseSatisfies(packageVersion: string, range: string) {
     // Pretend that the current package is latest prerelease (zzz) and see if the version still satisfies.
     return semver.satisfies(`${packageVersion}-zzz`, range)
+}
+
+/**
+ * Translate a VersionChangeType for the virtual patch scenario where we overload a beta version number
+ * to include all of major, minor, and patch.  Actual semver type is not translated
+ * "major" maps to "minor" with "patch" = 1000 (<N + 1>.0.0 -> 0.<N + 1>.1000)
+ * "minor" maps to "patch" * 1000 (x.<N + 1>.0 -> 0.x.<N + 1>000)
+ * "patch" is unchanged (but remember the final patch number holds "minor" * 1000 + the incrementing "patch")
+ */
+function translateVirtualVersion(
+    versionBump: VersionChangeType,
+    versionString: string,
+    virtualPatch: boolean,
+): semver.SemVer | VersionBumpType {
+    if (!virtualPatch) {
+        return versionBump;
+    }
+
+    // Virtual patch can only be used for a major/minor/patch bump and not a specific version
+    if (!isVersionBumpType(versionBump)) {
+        fatal("Can only use virtual patches when doing major/minor/patch bumps");
+    }
+
+    const virtualVersion = semver.parse(versionString);
+    if (!virtualVersion) {
+        fatal("unable to deconstruct package version for virtual patch");
+    }
+    if (virtualVersion.major !== 0) {
+        fatal("Can only use virtual patches with major version 0");
+    }
+
+    switch (versionBump) {
+        case "major": {
+            virtualVersion.minor += 1;
+            // the "minor" component starts at 1000 to work around issues padding to
+            // 4 digits using 0s with semvers
+            virtualVersion.patch = 1000;
+            break;
+        }
+        case "minor": {
+            virtualVersion.patch += 1000;
+            break;
+        }
+        case "patch": {
+            virtualVersion.patch += 1;
+            break;
+        }
+    }
+
+    virtualVersion.format(); // semver must be reformated after edits
+    return virtualVersion;
+}
+
+/**
+ * A type defining the version schemes that can be used for packages.
+ *
+ * "semver" is the standard semver scheme.
+ *
+ * "internal" is the 2.0.0-internal.1.0.0 scheme.
+ *
+ * "virtualPatch" is the 0.36.1002 scheme.
+ */
+export type VersionScheme = "semver" | "internal" | "virtualPatch";
+
+/**
+ *
+ * @param version The input version.
+ * @param bumpType The type of bump,
+ * @param scheme The version scheme to use.
+ * @returns An adjusted version as a semver.SemVer.
+ */
+export const adjustVersion = async (
+    version: string | semver.SemVer | undefined,
+    bumpType: VersionChangeTypeExtended,
+    scheme: VersionScheme): Promise<semver.SemVer> => {
+    const sv = semver.parse(version);
+    assert(sv !== null, `Not a valid semver: ${version}`);
+    switch (scheme) {
+        case "semver": {
+            switch (bumpType) {
+                case "current":
+                    return sv;
+                case "major":
+                case "minor":
+                case "patch":
+                    return sv?.inc(bumpType) ?? null;
+                default:
+                    // If the bump type is an explicit version, just use it.
+                    return bumpType;
+            }
+        }
+        case "internal": {
+            fatal("Not yet implemented");
+            break;
+        }
+        case "virtualPatch": {
+            if (isVersionBumpType(bumpType)) {
+                const translatedVersion = translateVirtualVersion(bumpType, sv.version, true);
+                if (!isVersionBumpType(translatedVersion)) {
+                    return translatedVersion;
+                } else {
+                    fatal(`Applying virtual patch failed. The version returned was: ${translatedVersion}`);
+                }
+            } else {
+                fatal("Can only use virtual patches when doing major/minor/patch bumps");
+            }
+        }
+    }
 }

--- a/build-tools/packages/build-tools/src/bumpVersion/versionBag.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/versionBag.ts
@@ -5,7 +5,7 @@
 
 import { Package } from "../common/npmPackage";
 import { fatal, exec, execNoError } from "./utils";
-import { MonoRepo, MonoRepoKind } from "../common/monoRepo";
+import { MonoRepo } from "../common/monoRepo";
 import * as semver from "semver";
 
 export class VersionBag {
@@ -42,8 +42,12 @@ export class VersionBag {
         return Object.entries(this.versionData)[Symbol.iterator]();
     }
 
-    protected static getEntryName(pkg: Package) {
-        return pkg.monoRepo ? MonoRepoKind[pkg.monoRepo.kind] : pkg.name;
+    protected static getEntryName(pkg: Package): string {
+        if (pkg.monoRepo !== undefined) {
+            return pkg.monoRepo.kind;
+        } else {
+            return pkg.name;
+        }
     }
 }
 

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -5,7 +5,7 @@
 
 import * as path from "path";
 import { Package, Packages } from "./npmPackage";
-import { MonoRepo, MonoRepoKind } from "./monoRepo";
+import { isMonoRepoKind, MonoRepo, MonoRepoKind } from "./monoRepo";
 import { getPackageManifest } from "./fluidUtils";
 import { ExecAsyncResult } from "./utils";
 
@@ -70,20 +70,10 @@ export class FluidRepo {
         const loadedPackages: Package[] = [];
         for (const group in packageManifest.repoPackages) {
             const item = normalizeEntry(packageManifest.repoPackages[group]);
-            if (group === "client") {
+            if (isMonoRepoKind(group)) {
                 const { directory, ignoredDirs } = item as IFluidRepoPackage;
-                const monorepo = new MonoRepo(MonoRepoKind.Client, directory, ignoredDirs);
-                this.monoRepos.set(MonoRepoKind.Client, monorepo);
-                loadedPackages.push(...monorepo.packages);
-            } else if (group === "server") {
-                const { directory, ignoredDirs } = item as IFluidRepoPackage;
-                const monorepo = new MonoRepo(MonoRepoKind.Server, directory, ignoredDirs);
-                this.monoRepos.set(MonoRepoKind.Server, monorepo);
-                loadedPackages.push(...monorepo.packages);
-            } else if (group === "azure") {
-                const { directory, ignoredDirs } = item as IFluidRepoPackage;
-                const monorepo = new MonoRepo(MonoRepoKind.Azure, directory, ignoredDirs);
-                this.monoRepos.set(MonoRepoKind.Azure, monorepo);
+                const monorepo = new MonoRepo(group, directory, ignoredDirs);
+                this.monoRepos.set(group, monorepo);
                 loadedPackages.push(...monorepo.packages);
             } else if (group !== "services" || services) {
                 if (Array.isArray(item)) {

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -12,28 +12,26 @@ import { execWithErrorAsync, rimrafWithErrorAsync, existsSync, readJsonSync } fr
  * in the fluid-build section of the root package.json.
  */
 export enum MonoRepoKind {
-    Client = "Client",
-    Server = "Server",
-    Azure = "Azure",
-    BuildTools = "BuildTools",
+    Client = "client",
+    Server = "server",
+    Azure = "azure",
+    BuildTools = "build-tools",
 }
 
 /**
  * A type guard used to determine if a string is a MonoRepoKind.
  */
-export function isMonoRepoKind(str: unknown): str is MonoRepoKind {
-    return typeof str === "string" && sentenceCase(str) in MonoRepoKind;
-}
-
-function sentenceCase(str: string) {
-    return str.charAt(0).toUpperCase() + str.slice(1);
+export function isMonoRepoKind(str: string): str is MonoRepoKind {
+    const list = Object.values<string>(MonoRepoKind);
+    const isMonoRepoValue = list.includes(str);
+    return isMonoRepoValue;
 }
 
 /**
  * An iterator that returns only the Enum values of MonoRepoKind.
  */
 export function* supportedMonoRepoValues(): IterableIterator<MonoRepoKind> {
-    for(const [, flag] of Object.entries(MonoRepoKind)) {
+    for (const [, flag] of Object.entries(MonoRepoKind)) {
         yield flag;
     }
 }
@@ -50,7 +48,7 @@ export class MonoRepo {
         for (const dir of lerna.packages as string[]) {
             // TODO: other glob pattern?
             const loadDir = dir.endsWith("/**") ? dir.substr(0, dir.length - 3) : dir;
-            this.packages.push(...Packages.loadDir(path.join(this.repoPath, loadDir), MonoRepoKind[kind], ignoredDirs, this));
+            this.packages.push(...Packages.loadDir(path.join(this.repoPath, loadDir), kind, ignoredDirs, this));
         }
         this.version = lerna.version;
     }
@@ -64,7 +62,7 @@ export class MonoRepo {
     }
 
     public async install() {
-        console.log(`${MonoRepoKind[this.kind]}: Installing - npm i`);
+        console.log(`${this.kind}: Installing - npm i`);
         const installScript = "npm i";
         return execWithErrorAsync(installScript, { cwd: this.repoPath }, this.repoPath);
     }

--- a/build-tools/packages/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
+++ b/build-tools/packages/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
@@ -124,7 +124,7 @@ async function generateMonoRepoPackageLockJson(monoRepo: MonoRepo, repoPackageJs
     const markTopLevelNonDev = (dep: string, ref: string, topRef: string) => {
         const item = repoPackageLockJson.dependencies[dep];
         if (!item) {
-            throw new Error(`Missing ${dep} in lock file referenced by ${ref} from ${topRef} in ${MonoRepoKind[monoRepo.kind].toLowerCase()}`);
+            throw new Error(`Missing ${dep} in lock file referenced by ${ref} from ${topRef} in ${monoRepo.kind.toLowerCase()}`);
         }
         if (commonOptions.verbose) {
             console.log(`NonDev Ref: ${topRef}..${ref} => ${dep}`);
@@ -141,8 +141,8 @@ async function generateMonoRepoPackageLockJson(monoRepo: MonoRepo, repoPackageJs
         markTopLevelNonDev(dep, "<root>", "<root>");
     }
 
-    console.log(`${MonoRepoKind[monoRepo.kind]}: ${format(totalDevCount)}/${format(totalCount)} locked devDependencies`);
-    console.log(`${MonoRepoKind[monoRepo.kind]}: ${format(topLevelDevCount)}/${format(topLevelTotalCount)} top level locked devDependencies`);
+    console.log(`${monoRepo.kind}: ${format(totalDevCount)}/${format(totalCount)} locked devDependencies`);
+    console.log(`${monoRepo.kind}: ${format(topLevelDevCount)}/${format(topLevelTotalCount)} top level locked devDependencies`);
     return writeFileAsync(path.join(monoRepo.repoPath, "repo-package-lock.json"), JSON.stringify(repoPackageLockJson, undefined, 2));
 }
 
@@ -193,7 +193,7 @@ function processDevDependencies(repoPackageJson: PackageJson, packageJson: Packa
 async function generateMonoRepoInstallPackageJson(monoRepo: MonoRepo) {
     const packageMap = new Map<string, Package>(monoRepo.packages.map(pkg => [pkg.name, pkg]));
     const repoPackageJson: PackageJson = {
-        name: `@fluid-internal/${MonoRepoKind[monoRepo.kind].toLowerCase()}`,
+        name: `@fluid-internal/${monoRepo.kind.toLowerCase()}`,
         version: monoRepo.version,
         private: true,
         dependencies: {},
@@ -215,7 +215,7 @@ async function generateMonoRepoInstallPackageJson(monoRepo: MonoRepo) {
     processDevDependencies(repoPackageJson, rootPackageJson, packageMap);
 
     await writeFileAsync(path.join(monoRepo.repoPath, "repo-package.json"), JSON.stringify(repoPackageJson, undefined, 2));
-    console.log(`${MonoRepoKind[monoRepo.kind]}: ${format(devDepCount)}/${format(depCount + devDepCount)} devDependencies`);
+    console.log(`${monoRepo.kind}: ${format(devDepCount)}/${format(depCount + devDepCount)} devDependencies`);
     return generateMonoRepoPackageLockJson(monoRepo, repoPackageJson);
 }
 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
       "common-utils": "common/lib/common-utils",
       "protocol-def": "common/lib/protocol-definitions",
       "azure": "azure",
+      "build-tools": "build-tools",
       "server": "server/routerlicious",
       "client": {
         "directory": "",


### PR DESCRIPTION
- Updates several MonoRepoKind uses that were incorrect.
- Formalizes the version schemes into a string union type with the three supported schemes.
- Condenses the existing version translation function into a new adjustVersions function that can support the new schemes.
- Adds a new bump type, "current" that can be used to bump a monorepo to its expected (current) version as defined in lerna.json. This can be useful to clean up versions when merging changes from between branches.

## Reviewer guide

The first three commits in this PR can be reviewed individually. It may be helpful to look at the changes in that way so the number of changes isn't overwhelming.