### PR TITLE
[GitRest] Implementing V1 of Summary Delete API

### DIFF
--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -431,7 +431,7 @@
 				"crc-32": "1.2.0",
 				"debug": "^4.1.1",
 				"json-stringify-safe": "^5.0.1",
-				"jsrsasign": "^10.5.25",
+				"jsrsasign": "^10.2.0",
 				"jwt-decode": "^3.0.0",
 				"querystring": "^0.2.0",
 				"sillyname": "^0.1.0",
@@ -456,6 +456,11 @@
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1"
 					}
+				},
+				"jsrsasign": {
+					"version": "10.5.25",
+					"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
+					"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg=="
 				},
 				"uuid": {
 					"version": "8.3.2",
@@ -10275,11 +10280,6 @@
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
 			}
-		},
-		"jsrsasign": {
-			"version": "10.5.20",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.20.tgz",
-			"integrity": "sha512-YHL6y8o6cnRoxwUY0eGpfvwj0pm9o0NToD4KXVp2UJC19oXSR2RgnSdSMplIRRKFovLAJGrAHqdb5MMznnhQDQ=="
 		},
 		"jsx-ast-utils": {
 			"version": "2.4.1",

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -123,7 +123,9 @@ export enum BaseGitRestTelemetryProperties {
     ref = "ref",
     repoName = "repoName",
     repoOwner = "repoOwner",
+    repoPerDocEnabled = "repoPerDocEnabled",
     sha = "sha",
+    softDelete = "softDelete",
     storageName = "storageName",
     summaryType = "summaryType",
 }


### PR DESCRIPTION
## Description

This PR implements the V1 of the DELETE API for summaries in GitRest. The API currently only knows how to "hard" delete summaries - by calling the filesystem's `rm` command recursively. In the future, we will also provide support for "soft delete", like we do in other parts of the service. Another detail is that this implementation is only valid for the "repo-per-doc" model in GitRest; it's not available for when a repo maps to a tenant.

## Does this introduce a breaking change?

No breaking change.

## Any relevant logs or outputs

1. Validated deletion works when running with reference routerlicious implementation and using the local filesystem.
2. Validated deletion also works when using Azure Fluid Relay plus Azure storage.
