### PR TITLE
Support yarn workspaces in build-tools

### DIFF
--- a/build-tools/.gitignore
+++ b/build-tools/.gitignore
@@ -1,0 +1,27 @@
+.cache-loader
+node_modules
+dist
+lib
+nyc
+*.log
+.DS_Store
+
+# TypeScript incremental build cache
+*.tsbuildinfo
+
+# c8 code coverage temporary files
+/coverage/tmp/
+
+# Temporary api-extractor build artifacts
+**/_api-extractor-temp/**
+
+# Bundle analysis artifacts
+bundleAnalysis
+
+# Misc pipeline artifacts
+artifacts
+
+# documentation tool artifact
+tsdoc-metadata.json
+
+packages/**/package-lock.json

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { Package, Packages } from "./npmPackage";
 import * as path from "path";
-import { execWithErrorAsync, rimrafWithErrorAsync, existsSync, readJsonSync } from "./utils";
+import { fatal } from "../bumpVersion/utils";
+import { Package, Packages } from "./npmPackage";
+import { execWithErrorAsync, existsSync, readJsonSync, rimrafWithErrorAsync } from "./utils";
 
 /**
  * Represents the different types of release groups supported by the build tools. Each of these groups should be defined
@@ -33,26 +34,85 @@ function sentenceCase(str: string) {
  * An iterator that returns only the Enum values of MonoRepoKind.
  */
 export function* supportedMonoRepoValues(): IterableIterator<MonoRepoKind> {
-    for(const [, flag] of Object.entries(MonoRepoKind)) {
+    for (const [, flag] of Object.entries(MonoRepoKind)) {
         yield flag;
     }
 }
 
+/**
+ * A monorepo is a collection of packages that are versioned and released together.
+ *
+ * @remarks
+ *
+ * A monorepo is configured using either package.json or lerna.json. The files are checked in the following way:
+ *
+ * - If lerna.json exists, it is checked for a `packages` AND a `version` field.
+ *
+ * - If lerna.json contains BOTH of those fields, then the values in lerna.json will be used. Package.json will not be
+ *   read.
+ *
+ * - If lerna.json contains ONLY the version field, it will be used.
+ *
+ * - Otherwise, if package.json exists, it is checked for a `workspaces` field and a `version` field.
+ *
+ * - If package.json contains a workspaces field, then packages will be loaded based on the globs in that field.
+ *
+ * - If the version was not defined in lerna.json, then the version value in package.json will be used.
+ */
 export class MonoRepo {
     public readonly packages: Package[] = [];
     public readonly version: string;
+
+    /**
+     * Creates a new monorepo.
+     *
+     * @param kind The 'kind' of monorepo this object represents.
+     * @param repoPath The path on the filesystem to the monorepo. This location is expected to have either a
+     * package.json file with a workspaces field, or a lerna.json file with a packages field.
+     * @param ignoredDirs Paths to ignore when loading the monorepo.
+     */
     constructor(public readonly kind: MonoRepoKind, public readonly repoPath: string, ignoredDirs?: string[]) {
+        this.version = "";
         const lernaPath = path.join(repoPath, "lerna.json");
-        if (!existsSync(lernaPath)) {
-            throw new Error(`ERROR: lerna.json not found in ${repoPath}`);
+        const packagePath = path.join(repoPath, "package.json");
+        let versionFromLerna = false;
+
+        if (existsSync(lernaPath)) {
+            const lerna = readJsonSync(lernaPath);
+            if (lerna.version !== undefined) {
+                console.log(`${kind}: Loading version (${lerna.version}) from ${lernaPath}`);
+                this.version = lerna.version;
+                versionFromLerna = true;
+            }
+
+            if (lerna.packages !== undefined) {
+                console.log(`${kind}: Loading packages from ${lernaPath}`);
+                for (const dir of lerna.packages as string[]) {
+                    // TODO: other glob pattern?
+                    const loadDir = dir.endsWith("/**") ? dir.substr(0, dir.length - 3) : dir;
+                    this.packages.push(...Packages.loadDir(path.join(this.repoPath, loadDir), MonoRepoKind[kind], ignoredDirs, this));
+                }
+                return;
+            }
         }
-        const lerna = readJsonSync(lernaPath);
-        for (const dir of lerna.packages as string[]) {
-            // TODO: other glob pattern?
-            const loadDir = dir.endsWith("/**") ? dir.substr(0, dir.length - 3) : dir;
-            this.packages.push(...Packages.loadDir(path.join(this.repoPath, loadDir), MonoRepoKind[kind], ignoredDirs, this));
+
+        if (!existsSync(packagePath)) {
+            throw new Error(`ERROR: package.json not found in ${repoPath}`);
         }
-        this.version = lerna.version;
+        const pkgJson = readJsonSync(packagePath);
+        if (pkgJson.version === undefined && !versionFromLerna) {
+            this.version = pkgJson.version;
+            console.log(`${kind}: Loading version (${pkgJson.version}) from ${packagePath}`);
+        }
+
+        if (pkgJson.workspaces !== undefined) {
+            console.log(`${kind}: Loading packages from ${packagePath}`);
+            for (const dir of pkgJson.workspaces as string[]) {
+                this.packages.push(...Packages.loadGlob(dir, kind, ignoredDirs, this));
+            }
+            return;
+        }
+        fatal(`Couldn't find lerna.json or package.json, or they were missing expected properties.`);
     }
 
     public static isSame(a: MonoRepo | undefined, b: MonoRepo | undefined) {

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -278,6 +278,15 @@ export class Packages {
         return packages;
     }
 
+    /**
+     * Loads all packages found under the specified glob path. Ignores files in node_modules.
+     *
+     * @param globPath The glob path to search for package.json files.
+     * @param group The release group (monorepo) the packages are associated with.
+     * @param ignoredGlobs Glob paths that should be ignored. Note: `**\/node_modules/**` is always ignored.
+     * @param monoRepo A {@link MonoRepo} instance that will be associated with the packages.
+     * @returns An array containing all the packages that were found under the globPath.
+     */
     public static loadGlob(globPath: string, group: MonoRepoKind, ignoredGlobs: string[] | undefined, monoRepo?: MonoRepo,): Package[] {
         const packages: Package[] = [];
 


### PR DESCRIPTION
The build tools make assumptions that release groups (monorepos) are defined in lerna.json. As we consider moving to yarn, the build-tools need to load packages from different locations. This change adds logic into the common build-tools infrastructure to load packages from lerna.json if available, but to fall back to the `workspaces` field in package.json if lerna.json is missing.

The version for the release group will be loaded from lerna.json if present, otherwise the release group root package.json version will be used. This allows us to continue to version packages without using the root package.json to define it. That seems like it will be helpful, but I can't think of a specific use-case.