### PR TITLE
Log unknown service errors in HTTP requests

### DIFF
--- a/server/routerlicious/packages/services-shared/src/http.ts
+++ b/server/routerlicious/packages/services-shared/src/http.ts
@@ -38,6 +38,11 @@ export function validateRequestParams(...paramNames: (string | number)[]): Reque
 }
 
 /**
+ * Default error message sent to API consumer when an unknown error is encountered.
+ */
+export const defaultErrorMessage = "Internal Server Error";
+
+/**
  * Helper function to handle a promise that should be returned to the user.
  * @param resultP - Promise whose resolved value or rejected error will send with appropriate status codes.
  * @param response - Express Response used for writing response body, headers, and status.
@@ -76,7 +81,7 @@ export function handleResponse<T>(
             } else {
                 // Mask unexpected internal errors in outgoing response.
                 Lumberjack.error("Unexpected error when processing HTTP Request", undefined, error);
-                response.status(errorStatus ?? 400).json("Internal Server Error");
+                response.status(errorStatus ?? 400).json(defaultErrorMessage);
             }
         });
 }

--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -70,6 +70,9 @@ export class RestLessServer {
         let definedNewContentType: boolean = false;
         const parseAndSetHeader = (header: string) => {
             const { name, value } = decodeHeader(header);
+            if (!name || value === undefined) {
+                return;
+            }
             if (name.toLowerCase() === "content-type") {
                 definedNewContentType = true;
             }

--- a/server/routerlicious/packages/services-shared/src/test/http.spec.ts
+++ b/server/routerlicious/packages/services-shared/src/test/http.spec.ts
@@ -7,10 +7,10 @@ import assert from "assert";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { Deferred } from "@fluidframework/common-utils";
 import type { Response, Request } from "express";
-import { containsPathTraversal, handleResponse, validateRequestParams } from "../http";
+import { containsPathTraversal, defaultErrorMessage, handleResponse, validateRequestParams } from "../http";
 
 class MockRequest {
-    constructor(public readonly params: { [key: string]: string; }) {}
+    constructor(public readonly params: { [key: string]: string; }) { }
 }
 class MockResponse {
     private _statusCode: number = 200;
@@ -168,28 +168,28 @@ describe("HTTP Utils", () => {
             const responseError = new MockMongoError(11000, "E11000: Duplicate Key");
             await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
             assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
-            assert.strictEqual(mockResponse.responseData, JSON.stringify(responseError.message));
+            assert.strictEqual(mockResponse.responseData, JSON.stringify(defaultErrorMessage));
         });
         it("handles undefined error", async () => {
             const mockResponse = new MockResponse();
             const responseError = undefined;
             await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
             assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
-            assert.strictEqual(mockResponse.responseData, JSON.stringify(undefined));
+            assert.strictEqual(mockResponse.responseData, JSON.stringify(defaultErrorMessage));
         });
         it("handles string error", async () => {
             const mockResponse = new MockResponse();
             const responseError = "Failure occurred";
             await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
             assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
-            assert.strictEqual(mockResponse.responseData, JSON.stringify(responseError));
+            assert.strictEqual(mockResponse.responseData, JSON.stringify(defaultErrorMessage));
         });
         it("handles Error error", async () => {
             const mockResponse = new MockResponse();
             const responseError = new Error("Internal Error");
             await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
             assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
-            assert.strictEqual(mockResponse.responseData, JSON.stringify(responseError.message));
+            assert.strictEqual(mockResponse.responseData, JSON.stringify(defaultErrorMessage));
         });
     });
 });


### PR DESCRIPTION
## Description

We've seen some internal errors bubbled up to client (i.e. "could not call `toLowerCase` on `undefined`"). These types of errors should be masked to the client, because they are of no use to the client. Instead, log the error, which we normally have not done for HTTP request errors, because it is necessary for debugging.

## Reviewer Guidance

- R11s uses `400 Bad Request` as a default for unknown errors. This is obviously wrong and should be `500 Internal Server Error`, but I do not want to break anything in this PR. #9906 exists to track re-aligning auth error codes. I've opened #10968 to track the rest.
- Opened #10969 to track resolution of `undefined` cases not being caught at compilation time.