### PR TITLE
Add DoesDocumentExists check for stress tests

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -41,7 +41,8 @@ export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(valu
 export type FieldKey = LocalFieldKey | GlobalFieldKey;
 
 // @public
-export type GlobalFieldKey = Opaque<Brand<string, "tree.GlobalFieldKey">>;
+export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKey">> {
+}
 
 // @public
 export interface Invariant<T> extends Contravariant<T>, Covariant<T> {

--- a/packages/dds/tree/src/schema/Schema.ts
+++ b/packages/dds/tree/src/schema/Schema.ts
@@ -45,7 +45,7 @@ export type LocalFieldKey = Brand<string, "tree.LocalFieldKey">;
  * (keeping the two classes of fields separate, name-spacing/escaping,
  * compressing one into numbers and leaving the other strings, etc.)
  */
-export type GlobalFieldKey = Opaque<Brand<string, "tree.GlobalFieldKey">>;
+export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKey">>{}
 
 /**
  * Describes how a particular field functions.

--- a/packages/dds/tree/src/test/util/brand.spec.ts
+++ b/packages/dds/tree/src/test/util/brand.spec.ts
@@ -23,9 +23,9 @@ export type T1 = Brand<number, "1">;
 export type T2 = Brand<number, "2">;
 export type T3 = Brand<{ test: number; }, "2">;
 
-type O1 = Opaque<T1>;
-type O2 = Opaque<T2>;
-type O3 = Opaque<T3>;
+interface O1 extends Opaque<T1>{}
+interface O2 extends Opaque<T2>{}
+interface O3 extends Opaque<T3>{}
 
 type _check =
     | requireTrue<areSafelyAssignable<ExtractFromOpaque<O1>, T1>>

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -50,7 +50,7 @@ export type ChildCollection = FieldKey | RootRange;
  * DetachedRanges are not valid to use as across edits:
  * they are only valid within the edit in which they were created.
  */
-export type DetachedRange = Opaque<Brand<number, "tree.DetachedRange">>;
+export interface DetachedRange extends Opaque<Brand<number, "tree.DetachedRange">> {}
 
 /**
  * TODO: integrate this into Schema. Decide how to persist them (need stable Id?). Maybe allow updating field kinds?.

--- a/packages/dds/tree/src/util/brand.ts
+++ b/packages/dds/tree/src/util/brand.ts
@@ -54,6 +54,12 @@ export abstract class BrandedType<ValueType, Name extends string> {
  * The type can be recovered using {@link extractFromOpaque},
  * however if we assume only code that produces these "opaque" handles does that conversion,
  * they can function like opaque handles.
+ *
+ * Recommenced usage is to use `interface` instead of `type` so tooling (such as tsc and refactoring tools)
+ * uses the type name instead of expanding it:
+ * ```typescript
+ * export interface MyType extends Opaque<Brand<string, "myPackage.MyType">>{}
+ * ```
  */
 export type Opaque<T extends Brand<any, string>> = T extends Brand<
     infer ValueType,

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -78,7 +78,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.3.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -96,7 +96,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.3.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -304,29 +304,36 @@ export class OdspTestDriver implements ITestDriver {
      *  container id is the hashed id generated using driveId and itemId. Container id is not the filename.
      */
     async createContainerUrl(testId: string): Promise<string> {
-        if (!this.testIdToUrl.has(testId)) {
-            const siteUrl = this.config.siteUrl;
-            const driveItem = await getDriveItemByRootFileName(
-                this.config.siteUrl,
-                undefined,
-                `/${this.config.directory}/${testId}.fluid`,
-                {
-                    accessToken: await this.getStorageToken({ siteUrl, refresh: false }),
-                    refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: false }),
-                },
-                false,
-                this.config.driveId);
-
-            this.testIdToUrl.set(
-                testId,
-                this.api.createOdspUrl({
-                    ...driveItem,
-                    siteUrl,
-                    dataStorePath: "/",
-                }));
+        try {
+            if (!this.testIdToUrl.has(testId)) {
+                const url = await this.createContainerUrlNoCache(testId);
+                this.testIdToUrl.set(testId, url);
+            }
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return this.testIdToUrl.get(testId)!;
+        } catch (_) {
+            return "DocWithGivenTestIDDoesNotExist";
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return this.testIdToUrl.get(testId)!;
+    }
+
+    private async createContainerUrlNoCache(testId: string) {
+        const siteUrl = this.config.siteUrl;
+        const driveItem = await getDriveItemByRootFileName(
+            this.config.siteUrl,
+            undefined,
+            `/${this.config.directory}/${testId}.fluid`,
+            {
+                accessToken: await this.getStorageToken({ siteUrl, refresh: false }),
+                refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: false }),
+            },
+            false,
+            this.config.driveId);
+
+        return this.api.createOdspUrl({
+            ...driveItem,
+            siteUrl,
+            dataStorePath: "/",
+        });
     }
 
     createDocumentServiceFactory(): IDocumentServiceFactory {

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -102,10 +102,16 @@ async function orchestratorProcess(
         undefined,
         args.browserAuth);
 
-    // Create a new file if a testId wasn't provided
-    const url = args.testId !== undefined
-        ? await testDriver.createContainerUrl(args.testId)
-        : await initialize(testDriver, seed, profile, args.verbose === true);
+    // If testId is provided, then try to load the file first; And if it doesn't exist, then create the document.
+    let url;
+    if (args.testId !== undefined) {
+        url = await testDriver.createContainerUrl(args.testId);
+    }
+
+    // If file doesn't exists, then create one.
+    if (url === undefined || url === "DocWithGivenTestIDDoesNotExist") {
+        url = await initialize(testDriver, seed, profile, args.verbose === true, args.testId);
+    }
 
     const estRunningTimeMin = Math.floor(2 * profile.totalSendCount / (profile.opRatePerMin * profile.numClients));
     console.log(`Connecting to ${args.testId !== undefined ? "existing" : "new"}`);

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -52,6 +52,8 @@ async function main() {
         .option("-v, --verbose", "Enables verbose logging")
         .option("-b, --browserAuth", "Enables browser auth which may require a user to open a url in a browser.")
         .option("-m, --enableMetrics", "Enable capturing client & ops metrics")
+        .option("-createId", "--createTestId", "Flag indicating whether to create a document corresponding \
+               to the testId passed")
         .parse(process.argv);
 
     const driver: TestDriverTypes = commander.driver;
@@ -65,6 +67,7 @@ async function main() {
     const browserAuth: true | undefined = commander.browserAuth;
     const credFile: string | undefined = commander.credFile;
     const enableMetrics: boolean = commander.enableMetrics ?? false;
+    const createTestId: boolean = commander.createTestId ?? false;
 
     const profile = getProfile(profileArg);
 
@@ -78,7 +81,7 @@ async function main() {
         driver,
         endpoint,
         { ...profile, name: profileArg, testUsers },
-        { testId, debug, verbose, seed, browserAuth, enableMetrics });
+        { testId, debug, verbose, seed, browserAuth, enableMetrics, createTestId });
 }
 
 /**
@@ -89,7 +92,7 @@ async function orchestratorProcess(
     endpoint: DriverEndpoint | undefined,
     profile: ILoadTestConfig & { name: string; testUsers?: ITestUserConfig; },
     args: { testId?: string; debug?: true; verbose?: true; seed?: number; browserAuth?: true;
-        enableMetrics?: boolean; },
+        enableMetrics?: boolean; createTestId?: boolean; },
 ) {
     const seed = args.seed ?? Date.now();
     const seedArg = `0x${seed.toString(16)}`;
@@ -102,14 +105,13 @@ async function orchestratorProcess(
         undefined,
         args.browserAuth);
 
-    // If testId is provided, then try to load the file first; And if it doesn't exist, then create the document.
     let url;
-    if (args.testId !== undefined) {
+    if (args.testId !== undefined && args.createTestId === false) {
+        // If testId is provided and createTestId is false, then load the file;
         url = await testDriver.createContainerUrl(args.testId);
-    }
-
-    // If file doesn't exists, then create one.
-    if (url === undefined || url === "DocWithGivenTestIDDoesNotExist") {
+    } else {
+        // If no testId is provided, (or) if testId is provided but createTestId is not false, then create a file;
+        // In case testId is provided, name of the file to be created is taken as the testId provided
         url = await initialize(testDriver, seed, profile, args.verbose === true, args.testId);
     }
 

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -126,7 +126,8 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
     }
 }
 
-export async function initialize(testDriver: ITestDriver, seed: number, testConfig: ILoadTestConfig, verbose: boolean) {
+export async function initialize(testDriver: ITestDriver, seed: number, testConfig: ILoadTestConfig,
+                                verbose: boolean, testIdn?: string) {
     const randEng = random.engines.mt19937();
     randEng.seed(seed);
     const optionsOverride =
@@ -177,7 +178,8 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
 
     // Currently odsp binary snapshot format only works for special file names. This won't affect any other test
     // since we have a unique dateId as prefix. So we can just add the required suffix.
-    const testId = `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`;
+    const testId = (typeof testIdn !== "undefined") ?
+                    testIdn : `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`;
     const request = testDriver.createCreateNewRequest(testId);
     await container.attach(request);
     assert(container.resolvedUrl !== undefined, "Container missing resolved URL after attach");

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -103,7 +103,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.3.0",
+    "version": "1.2.0",
     "broken": {}
   }
 }


### PR DESCRIPTION
- Add explicit check DoesDocumentExists for stress tests, to check if the document exists.
- Previously, we just assume that the document exists when a testId is supplied to nodeStressTest.ts; This change ensures that we explicitly check if a document corresponding to the testId passed does indeed exist.
- Implemented for odsp driver, raises "not implemented" for other drivers.
- Modify type validation checks to take into account the forward compatibility that will be broken for certain classes and functions because of this change (addition of the doesDocumentExists method to ITestDriver).


EDIT:

- Prior to this change, we just assume that the corresponding document exists when a testId is supplied to nodeStressTest.ts; And when such a document does not actually exist, the stress test would simply error out. Rather, what we want to do now is to check if the corresponding document exists, and in the case that it does not exist, we go ahead and create a document (which is the default behavior when no testId is passed to nodeStressTest.ts) rather than error out and stop the test. The name of the document created is the testId specified.

Also, we previously didn't support the creation of a document with the given name (we just assume a document with the given name exists, and error out if it does not. And, in case no testId is specified we used to create a document with the name set to ${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4).

-  Encode the check into the function itself rather than create a separate method for it.
- Does not break the forward/backwards compatibility anymore.