### PR TITLE
Implement info command in build CLI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,8 +16,6 @@
                 "info",
                 "-g",
                 "build-tools",
-                // "-t",
-                // "current"
             ],
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,19 +6,18 @@
     "configurations": [
         {
             "name": "flub",
-            "program": "${workspaceFolder}/tools/build-cli/bin/dev",
+            "program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev",
             "request": "launch",
             "skipFiles": [
                 "<node_internals>/**"
             ],
             "type": "node",
             "args": [
-                "bump",
-                "write",
+                "info",
                 "-g",
-                "client",
-                "-t",
-                "current"
+                "build-tools",
+                // "-t",
+                // "current"
             ],
         },
         {

--- a/build-tools/packages/build-cli/.eslintrc.cjs
+++ b/build-tools/packages/build-cli/.eslintrc.cjs
@@ -15,6 +15,8 @@ module.exports = {
         "prettier",
     ],
     rules: {
+        "@typescript-eslint/no-unused-vars": "warn",
+
         // oclif uses default exports for commands
         "import/no-default-export": "off",
     },

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -7,7 +7,7 @@ maintainable CLI using [oclif](https://oclif.io).
 flub is not built in CI. You need to build it locally.
 
 <!-- toc -->
-* [@fluid-internal/flub](#fluid-internalflub)
+* [@fluid-internal/build-cli](#fluid-internalbuild-cli)
 * [Usage](#usage)
 * [Commands](#commands)
 <!-- tocstop -->
@@ -19,7 +19,7 @@ $ npm install -g @fluid-internal/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version)
-@fluid-internal/build-cli/0.1.0 linux-x64 node-v14.19.3
+@fluid-internal/build-cli/0.3.0 win32-x64 node-v14.19.1
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND
@@ -30,6 +30,7 @@ USAGE
 <!-- commands -->
 * [`flub bump`](#flub-bump)
 * [`flub bump deps`](#flub-bump-deps)
+* [`flub commands`](#flub-commands)
 * [`flub help [COMMAND]`](#flub-help-command)
 * [`flub info`](#flub-info)
 
@@ -39,15 +40,17 @@ Bump versions of packages and dependencies.
 
 ```
 USAGE
-  $ flub bump -t major|minor|patch|current [-r <value>] [-g Azure|Client|Server | ] [-p <value> | ]
+  $ flub bump -t major|minor|patch|current [-r <value>] [-v] [-g client|server|azure|build-tools | ] [-p
+    <value> | ]
 
 FLAGS
   -g, --releaseGroup=<option>  release group
-                               <options: Azure|Client|Server>
+                               <options: client|server|azure|build-tools>
   -p, --package=<value>        package
   -r, --root=<value>           Root directory of the Fluid repo (default: env _FLUID_ROOT_).
   -t, --type=<option>          (required) [default: current] bump type
                                <options: major|minor|patch|current>
+  -v, --verbose                Verbose logging.
 
 DESCRIPTION
   Bump versions of packages and dependencies.
@@ -56,7 +59,7 @@ EXAMPLES
   $ flub bump
 ```
 
-_See code: [dist/commands/bump.ts](https://github.com/microsoft/FluidFramework/blob/v0.1.0/dist/commands/bump.ts)_
+_See code: [dist/commands/bump.ts](https://github.com/microsoft/FluidFramework/blob/v0.3.0/dist/commands/bump.ts)_
 
 ## `flub bump deps`
 
@@ -64,13 +67,14 @@ Bump the dependencies version of specified package or release group
 
 ```
 USAGE
-  $ flub bump deps [-r <value>] [-g Azure|Client|Server | ] [-p <value> | ]
+  $ flub bump deps [-r <value>] [-v] [-g client|server|azure|build-tools | ] [-p <value> | ]
 
 FLAGS
   -g, --releaseGroup=<option>  release group
-                               <options: Azure|Client|Server>
+                               <options: client|server|azure|build-tools>
   -p, --package=<value>        package
   -r, --root=<value>           Root directory of the Fluid repo (default: env _FLUID_ROOT_).
+  -v, --verbose                Verbose logging.
 
 DESCRIPTION
   Bump the dependencies version of specified package or release group
@@ -78,6 +82,38 @@ DESCRIPTION
 EXAMPLES
   $ flub bump deps
 ```
+
+## `flub commands`
+
+list all the commands
+
+```
+USAGE
+  $ flub commands [--json] [-h] [--hidden] [--tree] [--columns <value> | -x] [--sort <value>] [--filter
+    <value>] [--output csv|json|yaml |  | [--csv | --no-truncate]] [--no-header | ]
+
+FLAGS
+  -h, --help         Show CLI help.
+  -x, --extended     show extra columns
+  --columns=<value>  only show provided columns (comma-separated)
+  --csv              output is csv format [alias: --output=csv]
+  --filter=<value>   filter property by partial string matching, ex: name=foo
+  --hidden           show hidden commands
+  --no-header        hide table header from output
+  --no-truncate      do not truncate output to fit screen
+  --output=<option>  output in a more machine friendly format
+                     <options: csv|json|yaml>
+  --sort=<value>     property to sort by (prepend '-' for descending)
+  --tree             show tree of commands
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  list all the commands
+```
+
+_See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/v2.2.0/src/commands/commands.ts)_
 
 ## `flub help [COMMAND]`
 
@@ -101,20 +137,24 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.1
 
 ## `flub info`
 
-Get info about the repo, release groups, and packages
+Get info about the repo, release groups, and packages.
 
 ```
 USAGE
-  $ flub info [-r <value>]
+  $ flub info [-r <value>] [-v] [-g client|server|azure|build-tools | ] [-p]
 
 FLAGS
-  -r, --root=<value>  Root directory of the Fluid repo (default: env _FLUID_ROOT_).
+  -g, --releaseGroup=<option>  release group
+                               <options: client|server|azure|build-tools>
+  -p, --[no-]private           Include private packages (default true).
+  -r, --root=<value>           Root directory of the Fluid repo (default: env _FLUID_ROOT_).
+  -v, --verbose                Verbose logging.
 
 DESCRIPTION
-  Get info about the repo, release groups, and packages
+  Get info about the repo, release groups, and packages.
 ```
 
-_See code: [dist/commands/info.ts](https://github.com/microsoft/FluidFramework/blob/v0.1.0/dist/commands/info.ts)_
+_See code: [dist/commands/info.ts](https://github.com/microsoft/FluidFramework/blob/v0.3.0/dist/commands/info.ts)_
 <!-- commandsstop -->
 
 ## Trademark

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -48,11 +48,13 @@
   "dependencies": {
     "@fluidframework/build-tools": "^0.3.0",
     "@oclif/core": "^1.9.5",
+    "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.1",
     "@oclif/plugin-plugins": "^2.0.1",
     "@oclif/test": "^2",
-    "semver": "^7.3.7"
+    "semver": "^7.3.7",
+    "table": "^6.8.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
@@ -86,10 +88,15 @@
   },
   "oclif": {
     "bin": "flub",
-    "dirname": "tools/build-cli",
+    "dirname": "flub",
     "commands": "./dist/commands",
+    "additionalHelpFlags": [
+      "-h"
+    ],
     "plugins": [
-      "@oclif/plugin-help"
+      "@oclif/plugin-commands",
+      "@oclif/plugin-help",
+      "@oclif/plugin-not-found"
     ],
     "topicSeparator": " ",
     "topics": {}

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -33,7 +33,6 @@ export abstract class BaseCommand extends Command {
             this._context = new Context(gitRepo, "github.com/microsoft/FluidFramework", branch);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this._context;
     }
 }

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -39,7 +39,12 @@ export abstract class BaseCommand extends Command {
             this.log(`Repo: ${resolvedRoot}`);
             this.log(`Branch: ${branch}`);
 
-            this._context = new Context(gitRepo, "github.com/microsoft/FluidFramework", branch, logVerbose);
+            this._context = new Context(
+                gitRepo,
+                "github.com/microsoft/FluidFramework",
+                branch,
+                logVerbose,
+            );
         }
 
         return this._context;

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -3,13 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import {
-    Context,
-    createReleaseBump,
-    getResolvedFluidRoot,
-    GitRepo,
-} from "@fluidframework/build-tools";
-import { Command } from "@oclif/core";
+import { Context, getResolvedFluidRoot, GitRepo } from "@fluidframework/build-tools";
+import { Command, Flags } from "@oclif/core";
 import { rootPathFlag } from "./flags";
 
 /**
@@ -19,18 +14,32 @@ import { rootPathFlag } from "./flags";
 export abstract class BaseCommand extends Command {
     static flags = {
         root: rootPathFlag(),
+        verbose: Flags.boolean({
+            char: "v",
+            description: "Verbose logging.",
+            required: false,
+        }),
     };
 
     private _context: Context | undefined;
 
-    async getContext(): Promise<Context> {
+    /**
+     * The repo {@link Context}. The context is retrieved and cached the first time this method is called. Subsequent
+     * calls will return the cached context.
+     *
+     * @param logVerbose - Set to true to enable logging.
+     * @returns The repo {@link Context}.
+     */
+    async getContext(logVerbose = false): Promise<Context> {
         if (this._context === undefined) {
             const resolvedRoot = await getResolvedFluidRoot();
-            this.log(`Repo: ${resolvedRoot}`);
             const gitRepo = new GitRepo(resolvedRoot);
             const branch = await gitRepo.getCurrentBranchName();
+
+            this.log(`Repo: ${resolvedRoot}`);
             this.log(`Branch: ${branch}`);
-            this._context = new Context(gitRepo, "github.com/microsoft/FluidFramework", branch);
+
+            this._context = new Context(gitRepo, "github.com/microsoft/FluidFramework", branch, logVerbose);
         }
 
         return this._context;

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
+import {
+    Context,
+    createReleaseBump,
+    getResolvedFluidRoot,
+    GitRepo,
+} from "@fluidframework/build-tools";
 import { Command } from "@oclif/core";
 import { rootPathFlag } from "./flags";
 
@@ -14,4 +20,20 @@ export abstract class BaseCommand extends Command {
     static flags = {
         root: rootPathFlag(),
     };
+
+    private _context: Context | undefined;
+
+    async getContext(): Promise<Context> {
+        if (this._context === undefined) {
+            const resolvedRoot = await getResolvedFluidRoot();
+            this.log(`Repo: ${resolvedRoot}`);
+            const gitRepo = new GitRepo(resolvedRoot);
+            const branch = await gitRepo.getCurrentBranchName();
+            this.log(`Branch: ${branch}`);
+            this._context = new Context(gitRepo, "github.com/microsoft/FluidFramework", branch);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return this._context;
+    }
 }

--- a/build-tools/packages/build-cli/src/commands/info.ts
+++ b/build-tools/packages/build-cli/src/commands/info.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { isMonoRepoKind, MonoRepoKind } from "@fluidframework/build-tools";
+import { isMonoRepoKind, MonoRepoKind, Package } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 import { table } from "table";
 import { BaseCommand } from "../base";
@@ -21,11 +21,11 @@ export default class InfoCommand extends BaseCommand {
             required: false,
         }),
         private: Flags.boolean({
+            allowNo: true,
             char: "p",
             default: true,
-            required: false,
             description: "Include private packages (default true).",
-            allowNo: true,
+            required: false,
         }),
     };
 
@@ -34,14 +34,14 @@ export default class InfoCommand extends BaseCommand {
     async run(): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { args, flags } = await this.parse(InfoCommand);
-        const context = await this.getContext();
-        let packages = [...context.fullPackageMap.values()];
+        const context = await this.getContext(flags.verbose);
+        let packages =
+            flags.releaseGroup !== undefined && isMonoRepoKind(flags.releaseGroup)
+                ? context.packagesForReleaseGroup(flags.releaseGroup)
+                : [...context.fullPackageMap.values()];
 
-        if (flags.releaseGroup !== undefined && isMonoRepoKind(flags.releaseGroup)) {
-            packages = context.packagesForReleaseGroup(flags.releaseGroup);
-        }
-
-        if(!flags.private) {
+        // Filter out private packages
+        if (!flags.private) {
             packages = packages.filter((p) => !p.packageJson.private);
         }
 

--- a/build-tools/packages/build-cli/src/commands/info.ts
+++ b/build-tools/packages/build-cli/src/commands/info.ts
@@ -13,18 +13,19 @@ import { releaseGroupFlag } from "../flags";
  * The root `info` command.
  */
 export default class InfoCommand extends BaseCommand {
-    static description = "Get info about the repo, release groups, and packages";
+    static description = "Get info about the repo, release groups, and packages.";
 
     static flags = {
         ...super.flags,
         releaseGroup: releaseGroupFlag({
             required: false,
         }),
-        all: Flags.boolean({
-            char: "a",
-            default: false,
-            description: "Get info about all release groups.",
-            exclusive: ["g"],
+        private: Flags.boolean({
+            char: "p",
+            default: true,
+            required: false,
+            description: "Include private packages (default true).",
+            allowNo: true,
         }),
     };
 
@@ -38,6 +39,10 @@ export default class InfoCommand extends BaseCommand {
 
         if (flags.releaseGroup !== undefined && isMonoRepoKind(flags.releaseGroup)) {
             packages = context.packagesForReleaseGroup(flags.releaseGroup);
+        }
+
+        if(!flags.private) {
+            packages = packages.filter((p) => !p.packageJson.private);
         }
 
         const data: (string | MonoRepoKind | undefined)[][] = [

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { supportedMonoRepoValues } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 
 /**
@@ -21,8 +22,8 @@ export const rootPathFlag = Flags.build({
 export const releaseGroupFlag = Flags.build({
     char: "g",
     description: "release group",
-    options: ["Azure", "Client", "Server"], // releaseGroupOptions,
-    parse: async (str: string, _: never) => str.charAt(0).toUpperCase() + str.slice(1),
+    options: [...supportedMonoRepoValues()], // releaseGroupOptions,
+    parse: async (str: string, _: never) => str.toLowerCase(),
     // Can't be used with individual packages.
     exclusive: ["p"],
 });

--- a/build-tools/packages/build-cli/tsconfig.json
+++ b/build-tools/packages/build-cli/tsconfig.json
@@ -1,8 +1,5 @@
 {
-    "exclude": [
-        "dist",
-        "node_modules"
-    ],
+    "exclude": ["dist", "node_modules"],
     "compilerOptions": {
         "declaration": true,
         "importHelpers": true,
@@ -13,7 +10,7 @@
         "target": "es2019",
         "types": ["node"],
         "esModuleInterop": true,
-        "incremental": true,
+        "incremental": false,
         "pretty": true,
     },
     "parserOptions": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "author": "Microsoft and contributors",
-  "main": "dist/fluidBuild/fluidBuild.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "fluid-build": "bin/fluid-build",

--- a/build-tools/packages/build-tools/src/bumpVersion/context.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/context.ts
@@ -31,6 +31,9 @@ export function isVersionBumpTypeExtended(type: VersionChangeType | string): typ
     return type === "major" || type === "minor" || type === "patch" || type === "current";
 }
 
+/**
+ * Context provides access to data about the Fluid repo, and exposes methods to interrogate the repo state.
+ */
 export class Context {
     public readonly repo: FluidRepo;
     public readonly fullPackageMap: Map<string, Package>;
@@ -43,12 +46,13 @@ export class Context {
     constructor(
         public readonly gitRepo: GitRepo,
         public readonly originRemotePartialUrl: string,
-        public readonly originalBranchName: string
+        public readonly originalBranchName: string,
+        logVerbose = false,
     ) {
         this.timer = new Timer(commonOptions.timer);
 
         // Load the package
-        this.repo = new FluidRepo(this.gitRepo.resolvedRoot, false);
+        this.repo = new FluidRepo(this.gitRepo.resolvedRoot, false, logVerbose);
         this.timer.time("Package scan completed");
 
         this.fullPackageMap = this.repo.createPackageMap();

--- a/build-tools/packages/build-tools/src/bumpVersion/utils.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/utils.ts
@@ -114,9 +114,9 @@ export type VersionScheme = "semver" | "internal" | "virtualPatch";
 /**
  * Adjusts the provided version according to the bump type and version scheme. Returns the adjusted version.
  *
- * @param version The input version.
- * @param bumpType The type of bump,
- * @param scheme The version scheme to use.
+ * @param version - The input version.
+ * @param bumpType - The type of bump.
+ * @param scheme - The version scheme to use.
  * @returns An adjusted version as a semver.SemVer.
  */
 export function adjustVersion(

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -49,7 +49,7 @@ export class FluidRepo {
         return this.monoRepos.get(MonoRepoKind.Azure);
     }
 
-    constructor(public readonly resolvedRoot: string, services: boolean) {
+    constructor(public readonly resolvedRoot: string, services: boolean, logVerbose = false) {
         const packageManifest = getPackageManifest(resolvedRoot);
 
         // Expand to full IFluidRepoPackage and full path
@@ -72,7 +72,7 @@ export class FluidRepo {
             const item = normalizeEntry(packageManifest.repoPackages[group]);
             if (isMonoRepoKind(group)) {
                 const { directory, ignoredDirs } = item as IFluidRepoPackage;
-                const monorepo = new MonoRepo(group, directory, ignoredDirs);
+                const monorepo = new MonoRepo(group, directory, ignoredDirs, logVerbose);
                 this.monoRepos.set(group, monorepo);
                 loadedPackages.push(...monorepo.packages);
             } else if (group !== "services" || services) {

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -69,7 +69,11 @@ export class MonoRepo {
      * package.json file with a workspaces field, or a lerna.json file with a packages field.
      * @param ignoredDirs Paths to ignore when loading the monorepo.
      */
-    constructor(public readonly kind: MonoRepoKind, public readonly repoPath: string, ignoredDirs?: string[]) {
+    constructor(
+        public readonly kind: MonoRepoKind,
+        public readonly repoPath: string,
+        ignoredDirs?: string[],
+        logVerbose = false) {
         this.version = "";
         const lernaPath = path.join(repoPath, "lerna.json");
         const packagePath = path.join(repoPath, "package.json");
@@ -78,13 +82,17 @@ export class MonoRepo {
         if (existsSync(lernaPath)) {
             const lerna = readJsonSync(lernaPath);
             if (lerna.version !== undefined) {
-                console.log(`${kind}: Loading version (${lerna.version}) from ${lernaPath}`);
+                if (logVerbose) {
+                    console.log(`${kind}: Loading version (${lerna.version}) from ${lernaPath}`);
+                }
                 this.version = lerna.version;
                 versionFromLerna = true;
             }
 
             if (lerna.packages !== undefined) {
-                console.log(`${kind}: Loading packages from ${lernaPath}`);
+                if (logVerbose) {
+                    console.log(`${kind}: Loading packages from ${lernaPath}`);
+                }
                 for (const dir of lerna.packages as string[]) {
                     // TODO: other glob pattern?
                     const loadDir = dir.endsWith("/**") ? dir.substr(0, dir.length - 3) : dir;
@@ -100,11 +108,15 @@ export class MonoRepo {
         const pkgJson = readJsonSync(packagePath);
         if (pkgJson.version === undefined && !versionFromLerna) {
             this.version = pkgJson.version;
-            console.log(`${kind}: Loading version (${pkgJson.version}) from ${packagePath}`);
+            if (logVerbose) {
+                console.log(`${kind}: Loading version (${pkgJson.version}) from ${packagePath}`);
+            }
         }
 
         if (pkgJson.workspaces !== undefined) {
-            console.log(`${kind}: Loading packages from ${packagePath}`);
+            if (logVerbose) {
+                console.log(`${kind}: Loading packages from ${packagePath}`);
+            }
             for (const dir of pkgJson.workspaces as string[]) {
                 this.packages.push(...Packages.loadGlob(dir, kind, ignoredDirs, this));
             }

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -3,8 +3,23 @@
  * Licensed under the MIT License.
  */
 
+export { cleanPrereleaseDependencies } from "./bumpVersion/bumpDependencies";
+export {
+    bumpRepo, setReleaseGroupVersion
+} from "./bumpVersion/bumpVersion";
+export {
+    Context, VersionBumpType, VersionBumpTypeExtended
+} from "./bumpVersion/context";
+export { createReleaseBump } from "./bumpVersion/createReleaseBump";
+export { GitRepo } from "./bumpVersion/gitRepo";
+export { adjustVersion } from "./bumpVersion/utils";
+export { VersionBag } from "./bumpVersion/versionBag";
+export { getResolvedFluidRoot } from "./common/fluidUtils";
 export {
     isMonoRepoKind,
     MonoRepoKind,
     supportedMonoRepoValues
 } from "./common/monoRepo";
+export {
+    Package
+} from "./common/npmPackage";

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -5,7 +5,7 @@
 
 export { cleanPrereleaseDependencies } from "./bumpVersion/bumpDependencies";
 export {
-    bumpRepo, setReleaseGroupVersion
+    bumpRepo
 } from "./bumpVersion/bumpVersion";
 export {
     Context, VersionBumpType, VersionBumpTypeExtended


### PR DESCRIPTION
This change primarily implements the `info` command, which displays a table of packages and their version, optionally filtered by release group and private status.

The change required some minor changes to the build-tools lib, most notably to add exports so they can be called from the CLI package.