### PR TITLE
Add note about Azure CLI in getkeys README

### DIFF
--- a/tools/getkeys/README.md
+++ b/tools/getkeys/README.md
@@ -9,7 +9,7 @@ prague-secrets or WAC Bohemia security group.
 ## How to use this tool
 
 1. Install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli), run `az login` and authenticate
-  with your Microsoft corporate account.
+   with your Microsoft corporate account.
 2. In this folder, run `npm install`, then `npm start`.
 
 You should restart the console/shell after running the script (or for bash/zsh run `source ~/.bashrc` or `source ~/.zshrc`)

--- a/tools/getkeys/README.md
+++ b/tools/getkeys/README.md
@@ -2,6 +2,15 @@
 
 This tool is specifically for Microsoft internal development.
 
-This folder contains a script that will get secret values from the prague keyvault and persist them as environment variables in all future consoles/shells. In order to have access to the prague keyvault you must be a member of the prague-secrets or WAC Bohemia security group.
+This folder contains a script that will get secret values from the prague keyvault and persist them as environment
+variables in all future consoles/shells. In order to have access to the prague keyvault you must be a member of the
+prague-secrets or WAC Bohemia security group.
 
-To run the script, run `npm install`, then `npm start`. The script will then prompt you to use a code to login to your Microsoft account. You should restart the console/shell after running the script, or for bash/zsh run `source ~/.bashrc` or `source ~/.zshrc`.
+It is recommended that you have the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed.
+The tool will first try to use the Azure CLI to retrieve the secrets from Azure Keyavault; if Azure CLI is not instaled,
+it will fall back to an approach using REST calls that might be the cause of some issues we've seen in the past (e.g. not
+retrieving all the existing secrets from the vault).
+
+To run the script, run `npm install`, then `npm start`. The script will then prompt you to use a code to login to your
+Microsoft account. You should restart the console/shell after running the script (or for bash/zsh run `source ~/.bashrc`
+or `source ~/.zshrc`).

--- a/tools/getkeys/README.md
+++ b/tools/getkeys/README.md
@@ -6,11 +6,20 @@ This folder contains a script that will get secret values from the prague keyvau
 variables in all future consoles/shells. In order to have access to the prague keyvault you must be a member of the
 prague-secrets or WAC Bohemia security group.
 
-It is recommended that you have the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed.
-The tool will first try to use the Azure CLI to retrieve the secrets from Azure Keyavault; if Azure CLI is not instaled,
-it will fall back to an approach using REST calls that might be the cause of some issues we've seen in the past (e.g. not
-retrieving all the existing secrets from the vault).
+## How to use this tool
 
-To run the script, run `npm install`, then `npm start`. The script will then prompt you to use a code to login to your
-Microsoft account. You should restart the console/shell after running the script (or for bash/zsh run `source ~/.bashrc`
-or `source ~/.zshrc`).
+1. Install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli), run `az login` and authenticate
+  with your Microsoft corporate account.
+2. In this folder, run `npm install`, then `npm start`.
+
+You should restart the console/shell after running the script (or for bash/zsh run `source ~/.bashrc` or `source ~/.zshrc`)
+for the exported environment variables to become available.
+
+## TO-DO
+
+This tool had a fallback mechanism using REST to access Azure Keyvault if the Azure CLI wasn't installed, but it got
+outdated and had issues (e.g. not retrieving all the existing secrets from the vault). Going forward we want to
+streamline it and make it behave consistently for everyone who runs it; we might remove the (deactivated) REST
+fallback approach, or fix it (start by updating the relevant NPM packages) and remove the AzureCLI flow. [Relevant
+discussion](https://teams.microsoft.com/l/message/19:50292e8934024fc19d6ca2080dd7681e@thread.skype/1657054734667?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9ce27575-2f82-4689-abdb-bcff07e8063b&parentMessageId=1657054734667&teamName=Fluid%20Framework&channelName=Dev&createdTime=1657054734667).
+

--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -116,12 +116,18 @@ async function execAsync(command, options) {
 
 class AzCliKeyVaultClient {
     static async get() {
-        try {
-            await execAsync("az account set --subscription Fluid");
-            return new AzCliKeyVaultClient();
-        } catch (e) {
-            return undefined;
-        }
+
+        await execAsync("az account set --subscription Fluid");
+        return new AzCliKeyVaultClient();
+
+        // Disabling fallback to REST client while we decide how to streamline the getkeys tool
+
+        // try {
+        //     await execAsync("az account set --subscription Fluid");
+        //     return new AzCliKeyVaultClient();
+        // } catch (e) {
+        //     return undefined;
+        // }
     }
 
     async getSecrets(vaultName) {
@@ -153,12 +159,16 @@ class MsRestAzureKeyVaultClinet {
 }
 
 async function getClient() {
-    const primary = await AzCliKeyVaultClient.get();
-    if (primary !== undefined) {
-        console.log("Using Azure CLI");
-        return primary;
-    }
-    return MsRestAzureKeyVaultClinet.get();
+    return await AzCliKeyVaultClient.get();
+
+    // Disabling fallback to REST client while we decide how to streamline the getkeys tool
+
+    // const primary = await AzCliKeyVaultClient.get();
+    // if (primary !== undefined) {
+    //     console.log("Using Azure CLI");
+    //     return primary;
+    // }
+    // return MsRestAzureKeyVaultClinet.get();
 }
 
 (async () => {

--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -201,8 +201,12 @@ async function getClient() {
 })().catch(e => {
     if (e.message.includes("'az' is not recognized as an internal or external command")) {
         console.error(`ERROR: Azure CLI is not installed. Install it and run 'az login' before running this tool.`);
-    } else {
-        console.error(`FATAL ERROR: ${e.stack}`);
+        exit(0);
+    } else if(e.message.includes("The subscription of 'fluid' doesn't exist in cloud 'AzureCloud'.")) {
+        console.error(`ERROR: Could not find the Azure Subscription for Fluid. Did you run 'az login' already?`);
+        exit(0);
     }
+
+    console.error(`FATAL ERROR: ${e.stack}`);
     process.exit(-1);
 });

--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -199,6 +199,10 @@ async function getClient() {
 
     console.warn(`\nFor the new environment to take effect, please restart your terminal.\n`)
 })().catch(e => {
-    console.error(`FATAL ERROR: ${e.stack}`);
+    if (e.message.includes("'az' is not recognized as an internal or external command")) {
+        console.error(`ERROR: Azure CLI is not installed. Install it and run 'az login' before running this tool.`);
+    } else {
+        console.error(`FATAL ERROR: ${e.stack}`);
+    }
     process.exit(-1);
 });


### PR DESCRIPTION
## Description

~Add a recommendation to install Azure CLI before using `getkeys`.~

Disable the REST client flow and make Azure CLI a required dependency for now, while we decide how to move forward with this tool.
