### PR TITLE
Update comments and error message

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -727,8 +727,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                             // Likely to be an issue with Fluid Services. Content does not match previous client
                             // knowledge about this file. If the file is overwritten for any reason, this error can be
                             // hit. One example is that some clients could be submitting ops to two different service
-                            // instances that record different values for the same sequence number and submit it to the
-                            // same file.
+                            // instances such that the same sequence number is reused for two different ops.
                             // pre-0.58 error message: twoMessagesWithSameSeqNumAndDifferentPayload
                             "Found two messages with the same sequenceNumber but different payloads. Likely to be a "
                             + "service issue",

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -724,8 +724,13 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                         // This looks like a data corruption but the culprit has been found instead
                         // to be the file being overwritten in storage.  See PR #5882.
                         const error = new NonRetryableError(
+                            // Likely to be an issue with Fluid Services. Content does not match previous client
+                            // knowledge about this file. One example is that some clients could be submitting ops to
+                            // two different services that record different values for the same sequence number and
+                            // submit it to the same file.
                             // pre-0.58 error message: twoMessagesWithSameSeqNumAndDifferentPayload
-                            "Found two messages with the same sequenceNumber but different payloads",
+                            "Found two messages with the same sequenceNumber but different payloads. Likely to be a "
+                            + "service issue",
                             DriverErrorType.fileOverwrittenInStorage,
                             {
                                 clientId: this.connectionManager.clientId,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -721,9 +721,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                     const message1 = this.comparableMessagePayload(this.previouslyProcessedMessage);
                     const message2 = this.comparableMessagePayload(message);
                     if (message1 !== message2) {
-                        // This looks like a data corruption but the culprit has been found instead
-                        // to be the file being overwritten in storage.  See PR #5882.
                         const error = new NonRetryableError(
+                            // This looks like a data corruption but the culprit was that the file was overwritten
+                            // in storage.  See PR #5882.
                             // Likely to be an issue with Fluid Services. Content does not match previous client
                             // knowledge about this file. If the file is overwritten for any reason, this error can be
                             // hit. One example is that some clients could be submitting ops to two different service

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -725,9 +725,10 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                         // to be the file being overwritten in storage.  See PR #5882.
                         const error = new NonRetryableError(
                             // Likely to be an issue with Fluid Services. Content does not match previous client
-                            // knowledge about this file. One example is that some clients could be submitting ops to
-                            // two different services that record different values for the same sequence number and
-                            // submit it to the same file.
+                            // knowledge about this file. If the file is overwritten for any reason, this error can be
+                            // hit. One example is that some clients could be submitting ops to two different service
+                            // instances that record different values for the same sequence number and submit it to the
+                            // same file.
                             // pre-0.58 error message: twoMessagesWithSameSeqNumAndDifferentPayload
                             "Found two messages with the same sequenceNumber but different payloads. Likely to be a "
                             + "service issue",


### PR DESCRIPTION
[AB#1113](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1113)

Our stress tests caught this issue in which from FF perspective the file was overwritten (content does not match previous client knowledge about this file). From POV of some clients, the tail of the file is overwritten with different content.

Update the documentation and error message so that it is easier for users of FluidFramework to determine the source of the error.