### PR TITLE
Squash merging prs using MerlinBot

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,1922 +1,1897 @@
 {
-  "version": "1.0",
-  "tasks": [
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "id": "r7GVxnL0t",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              1,
-              4,
-              7,
-              10,
-              13,
-              16,
-              19,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              1,
-              4,
-              7,
-              10,
-              13,
-              16,
-              19,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              1,
-              4,
-              7,
-              10,
-              13,
-              16,
-              19,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              1,
-              4,
-              7,
-              10,
-              13,
-              16,
-              19,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              1,
-              4,
-              7,
-              10,
-              13,
-              16,
-              19,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              1,
-              4,
-              7,
-              10,
-              13,
-              16,
-              19,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              1,
-              4,
-              7,
-              10,
-              13,
-              16,
-              19,
-              22
-            ],
-            "timezoneOffset": -7
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "completelyNoLabels",
-            "parameters": {}
-          },
-          {
-            "name": "isIssue",
-            "parameters": {}
-          }
-        ],
-        "taskName": "Add \"triage\" to issues with no label",
-        "actions": [
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "triage"
+    "version": "1.0",
+    "tasks": [
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                1,
+                4,
+                7,
+                10,
+                13,
+                16,
+                19,
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                1,
+                4,
+                7,
+                10,
+                13,
+                16,
+                19,
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                1,
+                4,
+                7,
+                10,
+                13,
+                16,
+                19,
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                1,
+                4,
+                7,
+                10,
+                13,
+                16,
+                19,
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                1,
+                4,
+                7,
+                10,
+                13,
+                16,
+                19,
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                1,
+                4,
+                7,
+                10,
+                13,
+                16,
+                19,
+                22
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                1,
+                4,
+                7,
+                10,
+                13,
+                16,
+                19,
+                22
+              ],
+              "timezoneOffset": -7
             }
-          }
-        ]
-      },
-      "disabled": true
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "pOLj5BYPD",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "isAction",
-              "parameters": {
-                "action": "opened"
-              }
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isPartOfProject",
-                  "parameters": {}
-                }
-              ]
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isInMilestone",
-                  "parameters": {}
-                }
-              ]
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isAssignedToSomeone",
-                  "parameters": {}
-                }
-              ]
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isLabeled",
-                  "parameters": {}
-                }
-              ]
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "actions": [
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "triage"
-            }
-          }
-        ],
-        "taskName": "Add 'triage' unassigned scheduled work."
-      },
-      "disabled": false
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "f6ha861-_",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
+          ],
+          "searchTerms": [
             {
               "name": "isOpen",
               "parameters": {}
             },
             {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isPartOfProject",
-                  "parameters": {}
-                }
-              ]
+              "name": "completelyNoLabels",
+              "parameters": {}
             },
             {
-              "name": "hasLabel",
+              "name": "isIssue",
+              "parameters": {}
+            }
+          ],
+          "taskName": "Add \"triage\" to issues with no label",
+          "actions": [
+            {
+              "name": "addLabel",
               "parameters": {
-                "label": "bug"
+                "label": "triage"
               }
             }
           ]
         },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Put bugs into 'Bugs' project",
-        "actions": [
-          {
-            "name": "addToProject",
-            "parameters": {
-              "projectName": "Bugs",
-              "columnName": "Needs triage"
-            }
+        "disabled": true
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "opened"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isPartOfProject",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAssignedToSomeone",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isLabeled",
+                    "parameters": {}
+                  }
+                ]
+              }
+            ]
           },
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "triage"
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "triage"
+              }
             }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "izG7jFkvP",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
+          ],
+          "taskName": "Add 'triage' unassigned scheduled work."
+        },
+        "disabled": false
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isPartOfProject",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "bug"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Put bugs into 'Bugs' project",
+          "actions": [
             {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "isInProjectColumn",
+              "name": "addToProject",
               "parameters": {
                 "projectName": "Bugs",
                 "columnName": "Needs triage"
               }
+            },
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "triage"
+              }
             }
           ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Add 'triage' to bugs in Needs triage project",
-        "actions": [
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "triage"
-            }
-          }
-        ],
-        "dangerZone": {
-          "respondToBotActions": true,
-          "acceptRespondToBotActions": true
         }
       },
-      "disabled": true
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.0",
-      "config": {
-        "taskName": "Close issues marked as \"not an issue\"",
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "resolution: not an issue"
-            }
-          },
-          {
-            "name": "isIssue",
-            "parameters": {}
-          },
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 1
-            }
-          }
-        ],
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "This issue has been marked as being beyond the support scope of Fluid Frameworks's issue board. It will now be closed automatically for house-keeping purposes. "
-            }
-          },
-          {
-            "name": "closeIssue",
-            "parameters": {}
-          }
-        ]
-      },
-      "id": "dL-FvUaIz"
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              0,
-              6,
-              12,
-              18
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Bugs",
+                  "columnName": "Needs triage"
+                }
+              }
             ]
           },
-          {
-            "weekDay": 1,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "resolution: by design"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 3
-            }
-          }
-        ],
-        "taskName": "Close issues marked as by design",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "Because this issue is marked as \"by design\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
-            }
-          },
-          {
-            "name": "closeIssue",
-            "parameters": {}
-          }
-        ]
-      },
-      "id": "QxEcWj2mkx"
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              2,
-              5,
-              8,
-              11,
-              14,
-              17,
-              20,
-              23
-            ],
-            "timezoneOffset": -8
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "resolution: won't fix"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 3
-            }
-          }
-        ],
-        "taskName": "Close issues and PRs marked as won't fix",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "Because this issue is marked as \"won't fix\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
-            }
-          },
-          {
-            "name": "closeIssue",
-            "parameters": {}
-          }
-        ]
-      },
-      "id": "q_VIe1nWhU"
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "EmailCleanser",
-      "subCapability": "EmailCleanser",
-      "version": "1.0",
-      "config": {
-        "taskName": "Cleanse emails"
-      },
-      "id": "7Jjq5HF5oG"
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "AutoMerge",
-      "subCapability": "AutoMerge",
-      "version": "1.0",
-      "config": {
-        "taskName": "Automatically merge pull requests",
-        "label": "automerge",
-        "silentMode": false,
-        "minMinutesOpen": 480,
-        "mergeType": "squash",
-        "deleteBranches": true,
-        "allowAutoMergeInstructionsWithoutLabel": true,
-        "enforceDMPAsStatus": true,
-        "removeLabelOnPush": true,
-        "usePrDescriptionAsCommitMessage": true,
-        "requireAllStatuses": false
-      },
-      "id": "-5oLtB6T9Z",
-      "disabled": true
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "nir-Swuam",
-      "config": {
-        "conditions": {
-          "operator": "or",
-          "operands": [
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Add 'triage' to bugs in Needs triage project",
+          "actions": [
             {
-              "name": "labelAdded",
+              "name": "addLabel",
+              "parameters": {
+                "label": "triage"
+              }
+            }
+          ],
+          "dangerZone": {
+            "respondToBotActions": true,
+            "acceptRespondToBotActions": true
+          }
+        },
+        "disabled": true
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.0",
+        "config": {
+          "taskName": "Close issues marked as \"not an issue\"",
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "hasLabel",
               "parameters": {
                 "label": "resolution: not an issue"
               }
             },
             {
-              "name": "labelAdded",
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "noActivitySince",
               "parameters": {
-                "label": "resolution: won't fix"
+                "days": 1
+              }
+            }
+          ],
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "This issue has been marked as being beyond the support scope of Fluid Frameworks's issue board. It will now be closed automatically for house-keeping purposes. "
               }
             },
             {
-              "name": "labelAdded",
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
               "parameters": {
                 "label": "resolution: by design"
               }
             },
             {
-              "name": "labelAdded",
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 3
+              }
+            }
+          ],
+          "taskName": "Close issues marked as by design",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "Because this issue is marked as \"by design\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+              }
+            },
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                2,
+                5,
+                8,
+                11,
+                14,
+                17,
+                20,
+                23
+              ],
+              "timezoneOffset": -8
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "resolution: won't fix"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 3
+              }
+            }
+          ],
+          "taskName": "Close issues and PRs marked as won't fix",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "Because this issue is marked as \"won't fix\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+              }
+            },
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "EmailCleanser",
+        "subCapability": "EmailCleanser",
+        "version": "1.0",
+        "config": {
+          "taskName": "Cleanse emails"
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "AutoMerge",
+        "subCapability": "AutoMerge",
+        "version": "1.0",
+        "config": {
+          "taskName": "Automatically squash-merge pull requests in next",
+          "label": "msftbot: merge-next",
+          "silentMode": false,
+          "minMinutesOpen": 480,
+          "mergeType": "squash",
+          "deleteBranches": true,
+          "allowAutoMergeInstructionsWithoutLabel": true,
+          "enforceDMPAsStatus": true,
+          "removeLabelOnPush": true,
+          "usePrDescriptionAsCommitMessage": true,
+          "requireAllStatuses": false,
+          "conditionalMergeTypes": []
+        },
+        "disabled": false
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "resolution: not an issue"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "resolution: won't fix"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "resolution: by design"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "resolution: duplicate"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "resolution: can't repro"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Remove triage label when specific actions are taken",
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "triage"
+              }
+            }
+          ]
+        },
+        "disabled": true
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "resolution: can't repro"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 3
+              }
+            }
+          ],
+          "taskName": "Close issues marked can't repro",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "Because this issue is marked as \"can't repro\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+              }
+            },
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ],
+              "timezoneOffset": -8
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "needs: more information"
+              }
+            },
+            {
+              "name": "noLabel",
+              "parameters": {
+                "label": "status: no recent activity"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 2
+              }
+            }
+          ],
+          "taskName": "Add no recent activity label to \"needs more information\" issues",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "This issue has been automatically marked as stale because it has marked as requiring more information but has not had any activity for **2 days**. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
+              }
+            },
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "taskName": "Close 'no recent activity' issues after 8 days",
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                3,
+                6,
+                9,
+                12,
+                15,
+                18,
+                21
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                3,
+                6,
+                9,
+                12,
+                15,
+                18,
+                21
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                3,
+                6,
+                9,
+                12,
+                15,
+                18,
+                21
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                3,
+                6,
+                9,
+                12,
+                15,
+                18,
+                21
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                3,
+                6,
+                9,
+                12,
+                15,
+                18,
+                21
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                3,
+                6,
+                9,
+                12,
+                15,
+                18,
+                21
+              ],
+              "timezoneOffset": -8
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                3,
+                6,
+                9,
+                12,
+                15,
+                18,
+                21
+              ],
+              "timezoneOffset": -8
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "status: no recent activity"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 8
+              }
+            }
+          ],
+          "actions": [
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "taskName": "Remove no recent activity label from issues when issue is updated",
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "closed"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "status: no recent activity"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "status: no recent activity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "status: no recent activity"
+              }
+            }
+          ],
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "taskName": "Remove no recent activity label from issues when issue is commented on",
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "status: no recent activity"
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "status: no recent activity"
+              }
+            }
+          ],
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "question"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "resolution: not an issue"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Comment after \"question\" tag added",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "The Fluid Framework issue queue is meant to capture bug reports and feature requests. \nIt is best to ask questions in the \"Discussions\" section of the FluidFramework GitHub repo so that the entire community can contribute and learn from the question."
+              }
+            },
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "resolution: not an issue"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
               "parameters": {
                 "label": "resolution: duplicate"
               }
             },
             {
-              "name": "labelAdded",
+              "name": "noActivitySince",
               "parameters": {
-                "label": "resolution: can't repro"
+                "days": 3
               }
             }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Remove triage label when specific actions are taken",
-        "actions": [
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "triage"
-            }
-          }
-        ]
-      },
-      "disabled": true
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "resolution: can't repro"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 3
-            }
-          }
-        ],
-        "taskName": "Close issues marked can't repro",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "Because this issue is marked as \"can't repro\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
-            }
-          },
-          {
-            "name": "closeIssue",
-            "parameters": {}
-          }
-        ]
-      },
-      "id": "n_C97f95U"
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ],
-            "timezoneOffset": -8
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "isIssue",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "needs: more information"
-            }
-          },
-          {
-            "name": "noLabel",
-            "parameters": {
-              "label": "status: no recent activity"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 2
-            }
-          }
-        ],
-        "taskName": "Add no recent activity label to \"needs more information\" issues",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "This issue has been automatically marked as stale because it has marked as requiring more information but has not had any activity for **2 days**. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "Status: No Recent Activity"
-            }
-          }
-        ]
-      },
-      "id": "aOj9L_2xS"
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "config": {
-        "taskName": "Close 'no recent activity' issues after 8 days",
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
-            ],
-            "timezoneOffset": -8
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
-            ],
-            "timezoneOffset": -8
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isIssue",
-            "parameters": {}
-          },
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "status: no recent activity"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 8
-            }
-          }
-        ],
-        "actions": [
-          {
-            "name": "closeIssue",
-            "parameters": {}
-          }
-        ]
-      },
-      "id": "bk0BGfnIDJ"
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "config": {
-        "taskName": "Remove no recent activity label from issues when issue is updated",
-        "conditions": {
-          "operator": "and",
-          "operands": [
+          ],
+          "taskName": "Close issues marked duplicate",
+          "actions": [
             {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isAction",
-                  "parameters": {
-                    "action": "closed"
-                  }
-                }
-              ]
-            },
-            {
-              "name": "hasLabel",
+              "name": "addReply",
               "parameters": {
-                "label": "status: no recent activity"
+                "comment": "Because this issue is marked as \"duplicate\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
               }
             },
             {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "labelAdded",
-                  "parameters": {
-                    "label": "status: no recent activity"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "actions": [
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "status: no recent activity"
-            }
-          }
-        ],
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ]
-      },
-      "id": "UEDdPHqilQ"
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssueCommentResponder",
-      "version": "1.0",
-      "config": {
-        "taskName": "Remove no recent activity label from issues when issue is commented on",
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "status: no recent activity"
-              }
-            }
-          ]
-        },
-        "actions": [
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "status: no recent activity"
-            }
-          }
-        ],
-        "eventType": "issue",
-        "eventNames": [
-          "issue_comment"
-        ]
-      },
-      "id": "k-TqMCCcHy"
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "WDB1_lN-p",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "labelAdded",
-              "parameters": {
-                "label": "question"
-              }
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "hasLabel",
-                  "parameters": {
-                    "label": "resolution: not an issue"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Comment after \"question\" tag added",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "The Fluid Framework issue queue is meant to capture bug reports and feature requests. \nIt is best to ask questions in the \"Discussions\" section of the FluidFramework GitHub repo so that the entire community can contribute and learn from the question."
-            }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "resolution: not an issue"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "id": "bF75sfkK1",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "resolution: duplicate"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 3
-            }
-          }
-        ],
-        "taskName": "Close issues marked duplicate",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "Because this issue is marked as \"duplicate\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
-            }
-          },
-          {
-            "name": "closeIssue",
-            "parameters": {}
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "W-UNUGWM3",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "isOpen",
+              "name": "closeIssue",
               "parameters": {}
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isPartOfProject",
-                  "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isPartOfProject",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "spec-required"
                 }
-              ]
-            },
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Put 'spec-required' into \"Solution Design\" project",
+          "actions": [
             {
-              "name": "hasLabel",
+              "name": "addToProject",
               "parameters": {
-                "label": "spec-required"
+                "projectName": "Solution Design",
+                "columnName": "Design Triage"
               }
             }
           ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Put 'spec-required' into \"Solution Design\" project",
-        "actions": [
-          {
-            "name": "addToProject",
-            "parameters": {
-              "projectName": "Solution Design",
-              "columnName": "Design Triage"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "PullRequestResponder",
-      "version": "1.0",
-      "id": "GLXse_rmRajdIwrjVnftc",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "prModifiesFiles",
-              "parameters": {
-                "pathFilters": [
-                  "/server/**"
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "PullRequestResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "prModifiesFiles",
+                "parameters": {
+                  "pathFilters": [
+                    "/server/**"
+                  ]
+                }
+              },
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "reopened"
+                    }
+                  },
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "synchronize"
+                    }
+                  }
                 ]
               }
-            },
-            {
-              "operator": "or",
-              "operands": [
-                {
-                  "name": "isAction",
-                  "parameters": {
-                    "action": "opened"
-                  }
-                },
-                {
-                  "name": "isAction",
-                  "parameters": {
-                    "action": "reopened"
-                  }
-                },
-                {
-                  "name": "isAction",
-                  "parameters": {
-                    "action": "synchronize"
-                  }
-                }
-              ]
-            }
-          ]
+            ]
+          },
+          "eventType": "pull_request",
+          "eventNames": [
+            "pull_request",
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Label PRs \"area: server\""
         },
-        "eventType": "pull_request",
-        "eventNames": [
-          "pull_request",
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Label PRs \"area: server\""
+        "disabled": true
       },
-      "disabled": true
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "id": "dORjBMeuOzXNENEUrW0K3",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              8,
-              20
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              8,
-              20
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              8,
-              20
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              8,
-              20
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              8,
-              20
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              8,
-              20
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              8,
-              20
-            ],
-            "timezoneOffset": -7
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 180
-            }
-          },
-          {
-            "name": "noLabel",
-            "parameters": {
-              "label": "epic"
-            }
-          },
-          {
-            "name": "notPartOfMilestone",
-            "parameters": {
-              "milestone": "Future"
-            }
-          },
-          {
-            "name": "notPartOfMilestone",
-            "parameters": {
-              "milestone": "Next"
-            }
-          }
-        ],
-        "taskName": "Mark old issues as stale",
-        "actions": [
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "status: stale"
-            }
-          },
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "This issue has been automatically marked as stale because it has had no activity for 180 days. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "id": "QgeHB_DzYjPfnfZG4xlMu",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              0,
-              6,
-              12,
-              18
-            ]
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isOpen",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "status: stale"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 8
-            }
-          }
-        ],
-        "taskName": "Close stale issues after 8 days ",
-        "actions": [
-          {
-            "name": "closeIssue",
-            "parameters": {}
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "FP71VFkeyEGlzaNeRlN_e",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
             {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isAction",
-                  "parameters": {
-                    "action": "closed"
-                  }
-                }
-              ]
+              "weekDay": 0,
+              "hours": [
+                8,
+                20
+              ],
+              "timezoneOffset": -7
             },
             {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "status: stale"
-              }
+              "weekDay": 1,
+              "hours": [
+                8,
+                20
+              ],
+              "timezoneOffset": -7
             },
             {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "labelAdded",
-                  "parameters": {
-                    "action": "labeled",
-                    "label": "status: stale"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Remove stale label from issues when issue is updated",
-        "actions": [
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "status: stale"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssueCommentResponder",
-      "version": "1.0",
-      "id": "3OqrilqP0BlLclukn2Y9b",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "status: stale"
-              }
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issue_comment"
-        ],
-        "taskName": "Remove stale label from issues when issue is commented on",
-        "actions": [
-          {
-            "name": "removeLabel",
-            "parameters": {
-              "label": "status: stale"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "rKYnUjCMSKOiNV9wki_Ot",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "activitySenderHasAssociation",
-              "parameters": {
-                "permissions": "write",
-                "association": "NONE"
-              }
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "actions": [
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "community-contribution"
-            }
-          }
-        ],
-        "taskName": "Label issues from outside the team"
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "CUkI8ICSmu_LW4EWuCcww",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "api deprecation"
-              }
+              "weekDay": 2,
+              "hours": [
+                8,
+                20
+              ],
+              "timezoneOffset": -7
             },
             {
-              "name": "isAssignedToSomeone",
-              "parameters": {}
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Auto assign author to API Deprecation Issues",
-        "actions": [
-          {
-            "name": "assignToUser",
-            "parameters": {
-              "comment": "${issueAuthor}",
-              "user": "${issueAuthor}"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "id": "e6uT6Y_DKJLV8TTp8lZvY",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "api deprecation"
-              }
+              "weekDay": 3,
+              "hours": [
+                8,
+                20
+              ],
+              "timezoneOffset": -7
             },
             {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isAssignedToSomeone",
-                  "parameters": {}
-                }
-              ]
+              "weekDay": 4,
+              "hours": [
+                8,
+                20
+              ],
+              "timezoneOffset": -7
             },
+            {
+              "weekDay": 5,
+              "hours": [
+                8,
+                20
+              ],
+              "timezoneOffset": -7
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                8,
+                20
+              ],
+              "timezoneOffset": -7
+            }
+          ],
+          "searchTerms": [
             {
               "name": "isOpen",
               "parameters": {}
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 180
+              }
+            },
+            {
+              "name": "noLabel",
+              "parameters": {
+                "label": "epic"
+              }
+            },
+            {
+              "name": "notPartOfMilestone",
+              "parameters": {
+                "milestone": "Future"
+              }
+            },
+            {
+              "name": "notPartOfMilestone",
+              "parameters": {
+                "milestone": "Next"
+              }
+            }
+          ],
+          "taskName": "Mark old issues as stale",
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "status: stale"
+              }
+            },
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "This issue has been automatically marked as stale because it has had no activity for 180 days. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
+              }
             }
           ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Add 'triage' to unassigned API Deprecation issues",
-        "actions": [
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "triage"
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
             }
-          }
-        ]
+          ],
+          "searchTerms": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "status: stale"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 8
+              }
+            }
+          ],
+          "taskName": "Close stale issues after 8 days ",
+          "actions": [
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "closed"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "status: stale"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "action": "labeled",
+                      "label": "status: stale"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Remove stale label from issues when issue is updated",
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "status: stale"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "status: stale"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ],
+          "taskName": "Remove stale label from issues when issue is commented on",
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "status: stale"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "activitySenderHasAssociation",
+                "parameters": {
+                  "permissions": "write",
+                  "association": "NONE"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "community-contribution"
+              }
+            }
+          ],
+          "taskName": "Label issues from outside the team"
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "api deprecation"
+                }
+              },
+              {
+                "name": "isAssignedToSomeone",
+                "parameters": {}
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Auto assign author to API Deprecation Issues",
+          "actions": [
+            {
+              "name": "assignToUser",
+              "parameters": {
+                "comment": "${issueAuthor}",
+                "user": "${issueAuthor}"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "api deprecation"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAssignedToSomeone",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Add 'triage' to unassigned API Deprecation issues",
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "triage"
+              }
+            }
+          ]
+        }
       }
-    }
-  ],
-  "userGroups": []
-}
+    ],
+    "userGroups": []
+  }

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,1668 +1,1710 @@
 {
-    "version": "1.0",
-    "tasks": [
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                1,
-                4,
-                7,
-                10,
-                13,
-                16,
-                19,
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                1,
-                4,
-                7,
-                10,
-                13,
-                16,
-                19,
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                1,
-                4,
-                7,
-                10,
-                13,
-                16,
-                19,
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                1,
-                4,
-                7,
-                10,
-                13,
-                16,
-                19,
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                1,
-                4,
-                7,
-                10,
-                13,
-                16,
-                19,
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                1,
-                4,
-                7,
-                10,
-                13,
-                16,
-                19,
-                22
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                1,
-                4,
-                7,
-                10,
-                13,
-                16,
-                19,
-                22
-              ],
-              "timezoneOffset": -7
+  "version": "1.0",
+  "tasks": [
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "completelyNoLabels",
+            "parameters": {}
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          }
+        ],
+        "taskName": "Add \"triage\" to issues with no label",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "triage"
             }
-          ],
-          "searchTerms": [
+          }
+        ]
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isPartOfProject",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isInMilestone",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAssignedToSomeone",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isLabeled",
+                  "parameters": {}
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "triage"
+            }
+          }
+        ],
+        "taskName": "Add 'triage' unassigned scheduled work."
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
             {
               "name": "isOpen",
               "parameters": {}
             },
             {
-              "name": "completelyNoLabels",
-              "parameters": {}
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isPartOfProject",
+                  "parameters": {}
+                }
+              ]
             },
             {
-              "name": "isIssue",
-              "parameters": {}
-            }
-          ],
-          "taskName": "Add \"triage\" to issues with no label",
-          "actions": [
-            {
-              "name": "addLabel",
+              "name": "hasLabel",
               "parameters": {
-                "label": "triage"
+                "label": "bug"
               }
             }
           ]
         },
-        "disabled": true
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "isAction",
-                "parameters": {
-                  "action": "opened"
-                }
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isPartOfProject",
-                    "parameters": {}
-                  }
-                ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isInMilestone",
-                    "parameters": {}
-                  }
-                ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isAssignedToSomeone",
-                    "parameters": {}
-                  }
-                ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isLabeled",
-                    "parameters": {}
-                  }
-                ]
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "actions": [
-            {
-              "name": "addLabel",
-              "parameters": {
-                "label": "triage"
-              }
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Put bugs into 'Bugs' project",
+        "actions": [
+          {
+            "name": "addToProject",
+            "parameters": {
+              "projectName": "Bugs",
+              "columnName": "Needs triage"
             }
-          ],
-          "taskName": "Add 'triage' unassigned scheduled work."
-        },
-        "disabled": false
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "isOpen",
-                "parameters": {}
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isPartOfProject",
-                    "parameters": {}
-                  }
-                ]
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "bug"
-                }
-              }
-            ]
           },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Put bugs into 'Bugs' project",
-          "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "triage"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
             {
-              "name": "addToProject",
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "isInProjectColumn",
               "parameters": {
                 "projectName": "Bugs",
                 "columnName": "Needs triage"
               }
-            },
-            {
-              "name": "removeLabel",
-              "parameters": {
-                "label": "triage"
-              }
             }
           ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Add 'triage' to bugs in Needs triage project",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "triage"
+            }
+          }
+        ],
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
         }
       },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "isOpen",
-                "parameters": {}
-              },
-              {
-                "name": "isInProjectColumn",
-                "parameters": {
-                  "projectName": "Bugs",
-                  "columnName": "Needs triage"
-                }
-              }
+      "disabled": true
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.0",
+      "config": {
+        "taskName": "Close issues marked as \"not an issue\"",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "resolution: not an issue"
+            }
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 1
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue has been marked as being beyond the support scope of Fluid Frameworks's issue board. It will now be closed automatically for house-keeping purposes. "
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              6,
+              12,
+              18
             ]
           },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Add 'triage' to bugs in Needs triage project",
-          "actions": [
-            {
-              "name": "addLabel",
-              "parameters": {
-                "label": "triage"
-              }
-            }
-          ],
-          "dangerZone": {
-            "respondToBotActions": true,
-            "acceptRespondToBotActions": true
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
           }
-        },
-        "disabled": true
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.0",
-        "config": {
-          "taskName": "Close issues marked as \"not an issue\"",
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "resolution: by design"
             }
-          ],
-          "searchTerms": [
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 3
+            }
+          }
+        ],
+        "taskName": "Close issues marked as by design",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Because this issue is marked as \"by design\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "resolution: won't fix"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 3
+            }
+          }
+        ],
+        "taskName": "Close issues and PRs marked as won't fix",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Because this issue is marked as \"won't fix\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "EmailCleanser",
+      "subCapability": "EmailCleanser",
+      "version": "1.0",
+      "config": {
+        "taskName": "Cleanse emails"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "AutoMerge",
+      "subCapability": "AutoMerge",
+      "version": "1.0",
+      "config": {
+        "taskName": "Automatically squash-merge pull requests in next",
+        "label": "msftbot: merge-next",
+        "silentMode": false,
+        "minMinutesOpen": 480,
+        "mergeType": "squash",
+        "deleteBranches": true,
+        "allowAutoMergeInstructionsWithoutLabel": true,
+        "enforceDMPAsStatus": true,
+        "removeLabelOnPush": true,
+        "usePrDescriptionAsCommitMessage": true,
+        "requireAllStatuses": false,
+        "conditionalMergeTypes": []
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "or",
+          "operands": [
             {
-              "name": "hasLabel",
+              "name": "labelAdded",
               "parameters": {
                 "label": "resolution: not an issue"
               }
             },
             {
-              "name": "isIssue",
-              "parameters": {}
-            },
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "noActivitySince",
-              "parameters": {
-                "days": 1
-              }
-            }
-          ],
-          "actions": [
-            {
-              "name": "addReply",
-              "parameters": {
-                "comment": "This issue has been marked as being beyond the support scope of Fluid Frameworks's issue board. It will now be closed automatically for house-keeping purposes. "
-              }
-            },
-            {
-              "name": "closeIssue",
-              "parameters": {}
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            }
-          ],
-          "searchTerms": [
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "resolution: by design"
-              }
-            },
-            {
-              "name": "noActivitySince",
-              "parameters": {
-                "days": 3
-              }
-            }
-          ],
-          "taskName": "Close issues marked as by design",
-          "actions": [
-            {
-              "name": "addReply",
-              "parameters": {
-                "comment": "Because this issue is marked as \"by design\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
-              }
-            },
-            {
-              "name": "closeIssue",
-              "parameters": {}
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                2,
-                5,
-                8,
-                11,
-                14,
-                17,
-                20,
-                23
-              ],
-              "timezoneOffset": -8
-            }
-          ],
-          "searchTerms": [
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "hasLabel",
+              "name": "labelAdded",
               "parameters": {
                 "label": "resolution: won't fix"
               }
             },
             {
-              "name": "noActivitySince",
+              "name": "labelAdded",
               "parameters": {
-                "days": 3
-              }
-            }
-          ],
-          "taskName": "Close issues and PRs marked as won't fix",
-          "actions": [
-            {
-              "name": "addReply",
-              "parameters": {
-                "comment": "Because this issue is marked as \"won't fix\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+                "label": "resolution: by design"
               }
             },
             {
-              "name": "closeIssue",
-              "parameters": {}
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "EmailCleanser",
-        "subCapability": "EmailCleanser",
-        "version": "1.0",
-        "config": {
-          "taskName": "Cleanse emails"
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "AutoMerge",
-        "subCapability": "AutoMerge",
-        "version": "1.0",
-        "config": {
-          "taskName": "Automatically squash-merge pull requests in next",
-          "label": "msftbot: merge-next",
-          "silentMode": false,
-          "minMinutesOpen": 480,
-          "mergeType": "squash",
-          "deleteBranches": true,
-          "allowAutoMergeInstructionsWithoutLabel": true,
-          "enforceDMPAsStatus": true,
-          "removeLabelOnPush": true,
-          "usePrDescriptionAsCommitMessage": true,
-          "requireAllStatuses": false,
-          "conditionalMergeTypes": []
-        },
-        "disabled": false
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "or",
-            "operands": [
-              {
-                "name": "labelAdded",
-                "parameters": {
-                  "label": "resolution: not an issue"
-                }
-              },
-              {
-                "name": "labelAdded",
-                "parameters": {
-                  "label": "resolution: won't fix"
-                }
-              },
-              {
-                "name": "labelAdded",
-                "parameters": {
-                  "label": "resolution: by design"
-                }
-              },
-              {
-                "name": "labelAdded",
-                "parameters": {
-                  "label": "resolution: duplicate"
-                }
-              },
-              {
-                "name": "labelAdded",
-                "parameters": {
-                  "label": "resolution: can't repro"
-                }
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Remove triage label when specific actions are taken",
-          "actions": [
-            {
-              "name": "removeLabel",
-              "parameters": {
-                "label": "triage"
-              }
-            }
-          ]
-        },
-        "disabled": true
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            }
-          ],
-          "searchTerms": [
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "resolution: can't repro"
-              }
-            },
-            {
-              "name": "noActivitySince",
-              "parameters": {
-                "days": 3
-              }
-            }
-          ],
-          "taskName": "Close issues marked can't repro",
-          "actions": [
-            {
-              "name": "addReply",
-              "parameters": {
-                "comment": "Because this issue is marked as \"can't repro\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
-              }
-            },
-            {
-              "name": "closeIssue",
-              "parameters": {}
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ],
-              "timezoneOffset": -8
-            }
-          ],
-          "searchTerms": [
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "isIssue",
-              "parameters": {}
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "needs: more information"
-              }
-            },
-            {
-              "name": "noLabel",
-              "parameters": {
-                "label": "status: no recent activity"
-              }
-            },
-            {
-              "name": "noActivitySince",
-              "parameters": {
-                "days": 2
-              }
-            }
-          ],
-          "taskName": "Add no recent activity label to \"needs more information\" issues",
-          "actions": [
-            {
-              "name": "addReply",
-              "parameters": {
-                "comment": "This issue has been automatically marked as stale because it has marked as requiring more information but has not had any activity for **2 days**. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
-              }
-            },
-            {
-              "name": "addLabel",
-              "parameters": {
-                "label": "Status: No Recent Activity"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "taskName": "Close 'no recent activity' issues after 8 days",
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                0,
-                3,
-                6,
-                9,
-                12,
-                15,
-                18,
-                21
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                0,
-                3,
-                6,
-                9,
-                12,
-                15,
-                18,
-                21
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                0,
-                3,
-                6,
-                9,
-                12,
-                15,
-                18,
-                21
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                0,
-                3,
-                6,
-                9,
-                12,
-                15,
-                18,
-                21
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                0,
-                3,
-                6,
-                9,
-                12,
-                15,
-                18,
-                21
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                0,
-                3,
-                6,
-                9,
-                12,
-                15,
-                18,
-                21
-              ],
-              "timezoneOffset": -8
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                0,
-                3,
-                6,
-                9,
-                12,
-                15,
-                18,
-                21
-              ],
-              "timezoneOffset": -8
-            }
-          ],
-          "searchTerms": [
-            {
-              "name": "isIssue",
-              "parameters": {}
-            },
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "status: no recent activity"
-              }
-            },
-            {
-              "name": "noActivitySince",
-              "parameters": {
-                "days": 8
-              }
-            }
-          ],
-          "actions": [
-            {
-              "name": "closeIssue",
-              "parameters": {}
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "taskName": "Remove no recent activity label from issues when issue is updated",
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isAction",
-                    "parameters": {
-                      "action": "closed"
-                    }
-                  }
-                ]
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "status: no recent activity"
-                }
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "labelAdded",
-                    "parameters": {
-                      "label": "status: no recent activity"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "actions": [
-            {
-              "name": "removeLabel",
-              "parameters": {
-                "label": "status: no recent activity"
-              }
-            }
-          ],
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssueCommentResponder",
-        "version": "1.0",
-        "config": {
-          "taskName": "Remove no recent activity label from issues when issue is commented on",
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "status: no recent activity"
-                }
-              }
-            ]
-          },
-          "actions": [
-            {
-              "name": "removeLabel",
-              "parameters": {
-                "label": "status: no recent activity"
-              }
-            }
-          ],
-          "eventType": "issue",
-          "eventNames": [
-            "issue_comment"
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "labelAdded",
-                "parameters": {
-                  "label": "question"
-                }
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "hasLabel",
-                    "parameters": {
-                      "label": "resolution: not an issue"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Comment after \"question\" tag added",
-          "actions": [
-            {
-              "name": "addReply",
-              "parameters": {
-                "comment": "The Fluid Framework issue queue is meant to capture bug reports and feature requests. \nIt is best to ask questions in the \"Discussions\" section of the FluidFramework GitHub repo so that the entire community can contribute and learn from the question."
-              }
-            },
-            {
-              "name": "addLabel",
-              "parameters": {
-                "label": "resolution: not an issue"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            }
-          ],
-          "searchTerms": [
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "hasLabel",
+              "name": "labelAdded",
               "parameters": {
                 "label": "resolution: duplicate"
               }
             },
             {
-              "name": "noActivitySince",
+              "name": "labelAdded",
               "parameters": {
-                "days": 3
-              }
-            }
-          ],
-          "taskName": "Close issues marked duplicate",
-          "actions": [
-            {
-              "name": "addReply",
-              "parameters": {
-                "comment": "Because this issue is marked as \"duplicate\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
-              }
-            },
-            {
-              "name": "closeIssue",
-              "parameters": {}
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "isOpen",
-                "parameters": {}
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isPartOfProject",
-                    "parameters": {}
-                  }
-                ]
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "spec-required"
-                }
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Put 'spec-required' into \"Solution Design\" project",
-          "actions": [
-            {
-              "name": "addToProject",
-              "parameters": {
-                "projectName": "Solution Design",
-                "columnName": "Design Triage"
+                "label": "resolution: can't repro"
               }
             }
           ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "PullRequestResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "prModifiesFiles",
-                "parameters": {
-                  "pathFilters": [
-                    "/server/**"
-                  ]
-                }
-              },
-              {
-                "operator": "or",
-                "operands": [
-                  {
-                    "name": "isAction",
-                    "parameters": {
-                      "action": "opened"
-                    }
-                  },
-                  {
-                    "name": "isAction",
-                    "parameters": {
-                      "action": "reopened"
-                    }
-                  },
-                  {
-                    "name": "isAction",
-                    "parameters": {
-                      "action": "synchronize"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "eventType": "pull_request",
-          "eventNames": [
-            "pull_request",
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Label PRs \"area: server\""
         },
-        "disabled": true
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remove triage label when specific actions are taken",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "triage"
+            }
+          }
+        ]
       },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
-            {
-              "weekDay": 0,
-              "hours": [
-                8,
-                20
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 1,
-              "hours": [
-                8,
-                20
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                8,
-                20
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                8,
-                20
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                8,
-                20
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                8,
-                20
-              ],
-              "timezoneOffset": -7
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                8,
-                20
-              ],
-              "timezoneOffset": -7
+      "disabled": true
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "resolution: can't repro"
             }
-          ],
-          "searchTerms": [
-            {
-              "name": "isOpen",
-              "parameters": {}
-            },
-            {
-              "name": "noActivitySince",
-              "parameters": {
-                "days": 180
-              }
-            },
-            {
-              "name": "noLabel",
-              "parameters": {
-                "label": "epic"
-              }
-            },
-            {
-              "name": "notPartOfMilestone",
-              "parameters": {
-                "milestone": "Future"
-              }
-            },
-            {
-              "name": "notPartOfMilestone",
-              "parameters": {
-                "milestone": "Next"
-              }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 3
             }
-          ],
-          "taskName": "Mark old issues as stale",
-          "actions": [
+          }
+        ],
+        "taskName": "Close issues marked can't repro",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Because this issue is marked as \"can't repro\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs: more information"
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "status: no recent activity"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 2
+            }
+          }
+        ],
+        "taskName": "Add no recent activity label to \"needs more information\" issues",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue has been automatically marked as stale because it has marked as requiring more information but has not had any activity for **2 days**. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Close 'no recent activity' issues after 8 days",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "status: no recent activity"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 8
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label from issues when issue is updated",
+        "conditions": {
+          "operator": "and",
+          "operands": [
             {
-              "name": "addLabel",
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
               "parameters": {
-                "label": "status: stale"
+                "label": "status: no recent activity"
               }
             },
             {
-              "name": "addReply",
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "status: no recent activity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "status: no recent activity"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label from issues when issue is commented on",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
               "parameters": {
-                "comment": "This issue has been automatically marked as stale because it has had no activity for 180 days. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
+                "label": "status: no recent activity"
               }
             }
           ]
-        }
-      },
-      {
-        "taskType": "scheduled",
-        "capabilityId": "ScheduledSearch",
-        "subCapability": "ScheduledSearch",
-        "version": "1.1",
-        "config": {
-          "frequency": [
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "status: no recent activity"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
             {
-              "weekDay": 0,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
+              "name": "labelAdded",
+              "parameters": {
+                "label": "question"
+              }
             },
             {
-              "weekDay": 1,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 2,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 3,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 4,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 5,
-              "hours": [
-                0,
-                6,
-                12,
-                18
-              ]
-            },
-            {
-              "weekDay": 6,
-              "hours": [
-                0,
-                6,
-                12,
-                18
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": "resolution: not an issue"
+                  }
+                }
               ]
             }
-          ],
-          "searchTerms": [
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Comment after \"question\" tag added",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "The Fluid Framework issue queue is meant to capture bug reports and feature requests. \nIt is best to ask questions in the \"Discussions\" section of the FluidFramework GitHub repo so that the entire community can contribute and learn from the question."
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "resolution: not an issue"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "resolution: duplicate"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 3
+            }
+          }
+        ],
+        "taskName": "Close issues marked duplicate",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Because this issue is marked as \"duplicate\" and has not had activity for over 3 days, we're automatically closing it for house-keeping purposes. "
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
             {
               "name": "isOpen",
               "parameters": {}
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isPartOfProject",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "spec-required"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Put 'spec-required' into \"Solution Design\" project",
+        "actions": [
+          {
+            "name": "addToProject",
+            "parameters": {
+              "projectName": "Solution Design",
+              "columnName": "Design Triage"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "prModifiesFiles",
+              "parameters": {
+                "pathFilters": [
+                  "/server/**"
+                ]
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "reopened"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "synchronize"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Label PRs \"area: server\""
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              8,
+              20
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              8,
+              20
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              8,
+              20
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              8,
+              20
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              8,
+              20
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              8,
+              20
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              8,
+              20
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 180
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "epic"
+            }
+          },
+          {
+            "name": "notPartOfMilestone",
+            "parameters": {
+              "milestone": "Future"
+            }
+          },
+          {
+            "name": "notPartOfMilestone",
+            "parameters": {
+              "milestone": "Next"
+            }
+          }
+        ],
+        "taskName": "Mark old issues as stale",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "status: stale"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue has been automatically marked as stale because it has had no activity for 180 days. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ]
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "status: stale"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 8
+            }
+          }
+        ],
+        "taskName": "Close stale issues after 8 days ",
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
             },
             {
               "name": "hasLabel",
@@ -1671,227 +1713,185 @@
               }
             },
             {
-              "name": "noActivitySince",
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "action": "labeled",
+                    "label": "status: stale"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remove stale label from issues when issue is updated",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "status: stale"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
               "parameters": {
-                "days": 8
+                "label": "status: stale"
               }
             }
-          ],
-          "taskName": "Close stale issues after 8 days ",
-          "actions": [
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Remove stale label from issues when issue is commented on",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "status: stale"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
             {
-              "name": "closeIssue",
+              "name": "activitySenderHasAssociation",
+              "parameters": {
+                "permissions": "write",
+                "association": "NONE"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "community-contribution"
+            }
+          }
+        ],
+        "taskName": "Label issues from outside the team"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "api deprecation"
+              }
+            },
+            {
+              "name": "isAssignedToSomeone",
               "parameters": {}
             }
           ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isAction",
-                    "parameters": {
-                      "action": "closed"
-                    }
-                  }
-                ]
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "status: stale"
-                }
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "labelAdded",
-                    "parameters": {
-                      "action": "labeled",
-                      "label": "status: stale"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Remove stale label from issues when issue is updated",
-          "actions": [
-            {
-              "name": "removeLabel",
-              "parameters": {
-                "label": "status: stale"
-              }
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Auto assign author to API Deprecation Issues",
+        "actions": [
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "comment": "${issueAuthor}",
+              "user": "${issueAuthor}"
             }
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssueCommentResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "status: stale"
-                }
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issue_comment"
-          ],
-          "taskName": "Remove stale label from issues when issue is commented on",
-          "actions": [
-            {
-              "name": "removeLabel",
-              "parameters": {
-                "label": "status: stale"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "activitySenderHasAssociation",
-                "parameters": {
-                  "permissions": "write",
-                  "association": "NONE"
-                }
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "actions": [
-            {
-              "name": "addLabel",
-              "parameters": {
-                "label": "community-contribution"
-              }
-            }
-          ],
-          "taskName": "Label issues from outside the team"
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "api deprecation"
-                }
-              },
-              {
-                "name": "isAssignedToSomeone",
-                "parameters": {}
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Auto assign author to API Deprecation Issues",
-          "actions": [
-            {
-              "name": "assignToUser",
-              "parameters": {
-                "comment": "${issueAuthor}",
-                "user": "${issueAuthor}"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "taskType": "trigger",
-        "capabilityId": "IssueResponder",
-        "subCapability": "IssuesOnlyResponder",
-        "version": "1.0",
-        "config": {
-          "conditions": {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "api deprecation"
-                }
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "isAssignedToSomeone",
-                    "parameters": {}
-                  }
-                ]
-              },
-              {
-                "name": "isOpen",
-                "parameters": {}
-              }
-            ]
-          },
-          "eventType": "issue",
-          "eventNames": [
-            "issues",
-            "project_card"
-          ],
-          "taskName": "Add 'triage' to unassigned API Deprecation issues",
-          "actions": [
-            {
-              "name": "addLabel",
-              "parameters": {
-                "label": "triage"
-              }
-            }
-          ]
-        }
+          }
+        ]
       }
-    ],
-    "userGroups": []
-  }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "api deprecation"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAssignedToSomeone",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Add 'triage' to unassigned API Deprecation issues",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "triage"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "userGroups": []
+}


### PR DESCRIPTION
MerlinBot can be used to squash-merge PRs going to the next branch. Once the PR is approved and CI checks have passed, the assignee would have to add `msftbot: merge-next` label on the PR for it to get squash-merge to next branch.

Task name: Automatically squash-merge pull requests in next