### PR TITLE
Update content-length from body in RestLess

### DIFF
--- a/server/routerlicious/packages/services-shared/src/redisSocketIoAdapter.ts
+++ b/server/routerlicious/packages/services-shared/src/redisSocketIoAdapter.ts
@@ -216,7 +216,7 @@ export class RedisSocketIoAdapter extends Adapter {
         if (!this.isDefaultNamespaceAndDisable) {
             const rooms = this.sids.get(socketId);
             if (rooms) {
-                const unsubscribeRooms = [];
+                const unsubscribeRooms: string[] = [];
 
                 for (const roomId of rooms) {
                     const shouldUnsubscribe = this.removeFromRoom(socketId, roomId);
@@ -423,6 +423,9 @@ export class RedisSocketIoAdapter extends Adapter {
      * It will publish a message over the pub connection and wait until it receives it
      */
     private async runRoomHealthCheck(room: string) {
+        if (!RedisSocketIoAdapter.options.healthChecks) {
+            return;
+        }
         const healthCheckId = uuid.v4();
 
         const startTime = Date.now();

--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -102,7 +102,7 @@ export class RestLessServer {
         } else {
             request.body = bodyField;
         }
-        request.headers["content-length"] = request.body ? request.body.length : undefined;
+        request.headers["content-length"] = request.body ? `${(request.body as string).length}` : undefined;
     }
 
     private parseRequestBody(request: IncomingMessageEx): void {

--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -16,6 +16,7 @@ export const decodeHeader = (
 };
 
 type IncomingMessageEx = IncomingMessage & { body?: any; };
+type RequestField = undefined | string | string[];
 
 /**
  * Server for communicating with a "RestLess" client.
@@ -57,16 +58,19 @@ export class RestLessServer {
 
     private translateRequestFields(request: IncomingMessageEx, fields: Record<string, any>): void {
         // Parse and override HTTP Method
-        const methodOverrideField = fields[
+        const methodOverrideField: RequestField = fields[
             RestLessFieldNames.Method
-        ] as string[] | string;
+        ];
+        if (!methodOverrideField) {
+            throw new NetworkError(400, "Invalid RestLess Method Property");
+        }
         if (methodOverrideField instanceof Array) {
             request.method = methodOverrideField[0];
         } else {
             request.method = methodOverrideField;
         }
         // Parse and add HTTP Headers
-        const headerField: string | string[] = fields[RestLessFieldNames.Header];
+        const headerField: RequestField = fields[RestLessFieldNames.Header];
         let definedNewContentType: boolean = false;
         const parseAndSetHeader = (header: string) => {
             const { name, value } = decodeHeader(header);
@@ -90,7 +94,7 @@ export class RestLessServer {
             request.headers["content-type"] = "application/json";
         }
         // Parse and replace request body
-        const bodyField: string[] | string = fields[RestLessFieldNames.Body];
+        const bodyField: RequestField = fields[RestLessFieldNames.Body];
         // Tell body-parser middleware not to parse the body
         (request as any)._body = true;
         if (bodyField instanceof Array) {
@@ -98,6 +102,7 @@ export class RestLessServer {
         } else {
             request.body = bodyField;
         }
+        request.headers["content-length"] = request.body ? request.body.length : undefined;
     }
 
     private parseRequestBody(request: IncomingMessageEx): void {
@@ -105,13 +110,13 @@ export class RestLessServer {
             // TODO: not as robust as body-parser middleware,
             // but body-parser only compatible with request streams, and req stream is exhausted by now
             const contentType = request.headers["content-type"]?.toLowerCase();
-            if (contentType.includes("application/json")) {
+            if (contentType?.includes("application/json")) {
                 try {
                     request.body = JSON.parse(request.body);
                 } catch (e) {
                     throw new NetworkError(400, "Failed to parse json body");
                 }
-            } else if (contentType.includes("application/x-www-form-urlencoded")) {
+            } else if (contentType?.includes("application/x-www-form-urlencoded")) {
                 try {
                     request.body = qs.parse(request.body);
                 } catch (e) {

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -99,7 +99,7 @@ export function create(
         Lumberjack.error("Error with Redis sub connection", undefined, err);
     });
 
-    let adapter: (nsp: Namespace) => Adapter | undefined;
+    let adapter: (nsp: Namespace) => Adapter;
     if (socketIoAdapterConfig?.enableCustomSocketIoAdapter) {
         const socketIoRedisOptions: redisSocketIoAdapter.ISocketIoRedisOptions =
         {

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -52,7 +52,7 @@ export interface IHttpServerConfig {
      * A value of 0 will disable the timeout behavior on incoming connections.
      * Default: 0 (disabled)
      */
-     connectionTimeoutMs?: number;
+    connectionTimeoutMs: number;
 }
 
 const defaultHttpServerConfig: IHttpServerConfig = {
@@ -60,7 +60,7 @@ const defaultHttpServerConfig: IHttpServerConfig = {
 };
 const createAndConfigureHttpServer = (
     requestListener: RequestListener,
-    httpServerConfig: IHttpServerConfig | undefined,
+    httpServerConfig: Partial<IHttpServerConfig> | undefined,
 ): http.Server => {
     const server = http.createServer(requestListener);
     server.timeout = httpServerConfig?.connectionTimeoutMs ?? defaultHttpServerConfig.connectionTimeoutMs;
@@ -99,6 +99,6 @@ export class BasicWebServerFactory implements core.IWebServerFactory {
         const server = createAndConfigureHttpServer(requestListener, this.httpServerConfig);
         const httpServer = new HttpServer(server);
 
-        return new WebServer(httpServer, null);
+        return new WebServer(httpServer, (null as unknown) as core.IWebSocketServer);
     }
 }

--- a/server/routerlicious/packages/services-shared/tsconfig.json
+++ b/server/routerlicious/packages/services-shared/tsconfig.json
@@ -4,7 +4,6 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true


### PR DESCRIPTION
## Description

RestLess requests are sent with a body that includes additional headers. However, the translated body will always be smaller or nonexistent, so to correctly log the request size, we must update content-length.

### Related Work

- Logging content length PR: #10982
- Strict undefined issue: #9500 