### PR TITLE
Boot perf telemetry: add coverage to better understand where we spend time

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -286,8 +286,10 @@ export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, ID
     peek(): T | undefined;
     resume(): void;
     toArray(): T[];
-    // (undocumented)
-    waitTillProcessingDone(): Promise<void>;
+    waitTillProcessingDone(): Promise<{
+        count: number;
+        duration: number;
+    }>;
 }
 
 // @public

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -359,7 +359,7 @@ export class RateLimiter {
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
 
 // @public
-export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal, reason?: string): IStream<ISequencedDocumentMessage[]>;
+export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal, scenarioName?: string): IStream<ISequencedDocumentMessage[]>;
 
 // @public (undocumented)
 export class RetryableError<T extends string> extends NetworkErrorBasic<T> {

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -358,8 +358,8 @@ export class RateLimiter {
 // @public
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
 
-// @public (undocumented)
-export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal, fetchReason?: string): IStream<ISequencedDocumentMessage[]>;
+// @public
+export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal, reason?: string): IStream<ISequencedDocumentMessage[]>;
 
 // @public (undocumented)
 export class RetryableError<T extends string> extends NetworkErrorBasic<T> {

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -253,7 +253,10 @@ export class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
     // (undocumented)
     toArray(): T[];
     // (undocumented)
-    waitTillProcessingDone(): Promise<void>;
+    waitTillProcessingDone(): Promise<{
+        count: number;
+        duration: number;
+    }>;
 }
 
 // @public

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -182,7 +182,11 @@ export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, ID
      */
     toArray(): T[];
 
-    waitTillProcessingDone(): Promise<void>;
+    /**
+     * returns number of ops processed and time it took to process these ops.
+     * Zeros if queue did not process anything (had no messages, was paused or had hit an error before)
+     */
+    waitTillProcessingDone(): Promise<{ count: number; duration: number; }>;
 }
 
 export type ReadOnlyInfo = {

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -35,13 +35,14 @@ export class OdspDeltaStorageService {
      * @param from - inclusive
      * @param to - exclusive
      * @param telemetryProps - properties to add when issuing telemetry events
+     * @param reason - reason for fetching ops
      * @returns ops retrieved & info if result was partial (i.e. more is available)
      */
      public async get(
         from: number,
         to: number,
         telemetryProps: ITelemetryProperties,
-        fetchReason?: string,
+        reason?: string,
     ): Promise<IDeltasFetchResult> {
         return getWithRetryForTokenRefresh(async (options) => {
             // Note - this call ends up in getSocketStorageDiscovery() and can refresh token
@@ -78,7 +79,7 @@ export class OdspDeltaStorageService {
                 },
                 "ops",
                 true,
-                fetchReason,
+                reason,
             );
             clearTimeout(timer);
             const deltaStorageResponse = response.content;
@@ -99,6 +100,7 @@ export class OdspDeltaStorageService {
                 from,
                 to,
                 ...telemetryProps,
+                reason,
             });
 
             // It is assumed that server always returns all the ops that it has in the range that was requested.

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -35,14 +35,14 @@ export class OdspDeltaStorageService {
      * @param from - inclusive
      * @param to - exclusive
      * @param telemetryProps - properties to add when issuing telemetry events
-     * @param reason - reason for fetching ops
+     * @param scenarioName - reason for fetching ops
      * @returns ops retrieved & info if result was partial (i.e. more is available)
      */
      public async get(
         from: number,
         to: number,
         telemetryProps: ITelemetryProperties,
-        reason?: string,
+        scenarioName?: string,
     ): Promise<IDeltasFetchResult> {
         return getWithRetryForTokenRefresh(async (options) => {
             // Note - this call ends up in getSocketStorageDiscovery() and can refresh token
@@ -79,7 +79,7 @@ export class OdspDeltaStorageService {
                 },
                 "ops",
                 true,
-                reason,
+                scenarioName,
             );
             clearTimeout(timer);
             const deltaStorageResponse = response.content;
@@ -100,7 +100,7 @@ export class OdspDeltaStorageService {
                 from,
                 to,
                 ...telemetryProps,
-                reason,
+                reason: scenarioName,
             });
 
             // It is assumed that server always returns all the ops that it has in the range that was requested.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -234,11 +234,15 @@ const getCodeProposal =
  * @param eventName - event name
  * @param action - functor to call and measure
  */
-async function ReportIfTooLong(logger: ITelemetryLogger, eventName: string, action: () => Promise<void>) {
+async function ReportIfTooLong(
+    logger: ITelemetryLogger,
+    eventName: string,
+    action: () => Promise<ITelemetryProperties>,
+) {
     const event = PerformanceEvent.start(logger, { eventName });
-    await action();
+    const props = await action();
     if (event.duration > 1000) {
-        event.end();
+        event.end(props);
     }
 }
 
@@ -1200,7 +1204,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 await ReportIfTooLong(
                     this.mc.logger,
                     "WaitOps",
-                    async () => opsBeforeReturnP);
+                    async () => { await opsBeforeReturnP; return {}; });
                 await ReportIfTooLong(
                     this.mc.logger,
                     "WaitOpProcessing",

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -228,6 +228,12 @@ const getCodeProposal =
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     (quorum: IQuorumProposals) => quorum.get("code") ?? quorum.get("code2");
 
+/**
+ * Helper function to report to telemetry cases where operation takes longer than expected (1s)
+ * @param logger - logger to use
+ * @param eventName - event name
+ * @param action - functor to call and measure
+ */
 async function ReportIfTooLong(logger: ITelemetryLogger, eventName: string, action: () => Promise<void>) {
     const event = PerformanceEvent.start(logger, { eventName });
     await action();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -7,7 +7,7 @@
 import merge from "lodash/merge";
 import { v4 as uuid } from "uuid";
 import {
-    IDisposable, ITelemetryProperties,
+    IDisposable, ITelemetryLogger, ITelemetryProperties,
 } from "@fluidframework/common-definitions";
 import { assert, performance, unreachableCase } from "@fluidframework/common-utils";
 import {
@@ -227,6 +227,14 @@ export async function waitContainerToCatchUp(container: IContainer) {
 const getCodeProposal =
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     (quorum: IQuorumProposals) => quorum.get("code") ?? quorum.get("code2");
+
+async function ReportIfTooLong(logger: ITelemetryLogger, eventName: string, action: () => Promise<void>) {
+    const event = PerformanceEvent.start(logger, { eventName });
+    await action();
+    if (event.duration > 1000) {
+        event.end();
+    }
+}
 
 /**
  * State saved by a container at close time, to be used to load a new instance
@@ -566,6 +574,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     containerAttachState: () => this._attachState,
                     containerLifecycleState: () => this._lifecycleState,
                     containerConnectionState: () => ConnectionState[this.connectionState],
+                    serializedContainer: config.serializedContainerState !== undefined,
                 },
                 // we need to be judicious with our logging here to avoid generating too much data
                 // all data logged here should be broadly applicable, and not specific to a
@@ -578,6 +587,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     containerLoadedFromVersionId: () => this.loadedFromVersion?.id,
                     containerLoadedFromVersionDate: () => this.loadedFromVersion?.date,
                     // message information to associate errors with the specific execution state
+                    // dmLastMsqSeqNumber: if present, same as dmLastProcessedSeqNumber
                     dmLastMsqSeqNumber: () => this.deltaManager?.lastMessage?.sequenceNumber,
                     dmLastMsqSeqTimestamp: () => this.deltaManager?.lastMessage?.timestamp,
                     dmLastMsqSeqClientId: () => this.deltaManager?.lastMessage?.clientId,
@@ -1175,17 +1185,20 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             pendingLocalState?.pendingRuntimeState,
         );
 
-        // Internal context is fully loaded at this point
-        this.setLoaded();
-
         // We might have hit some failure that did not manifest itself in exception in this flow,
         // do not start op processing in such case - static version of Container.load() will handle it correctly.
         if (!this.closed) {
             if (opsBeforeReturnP !== undefined) {
                 this._deltaManager.inbound.resume();
 
-                await opsBeforeReturnP;
-                await this._deltaManager.inbound.waitTillProcessingDone();
+                await ReportIfTooLong(
+                    this.mc.logger,
+                    "WaitOps",
+                    async () => opsBeforeReturnP);
+                await ReportIfTooLong(
+                    this.mc.logger,
+                    "WaitOpProcessing",
+                    async () => this._deltaManager.inbound.waitTillProcessingDone());
 
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 this._deltaManager.inbound.pause();
@@ -1215,9 +1228,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             throw new Error("Container was closed while load()");
         }
 
+        // Internal context is fully loaded at this point
+        this.setLoaded();
+
         return {
             sequenceNumber: attributes.sequenceNumber,
             version: versionId,
+            dmLastProcessedSeqNumber: this._deltaManager.lastSequenceNumber,
+            dmLastKnownSeqNumber: this._deltaManager.lastKnownSeqNumber,
         };
     }
 

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -157,6 +157,6 @@ export class DeltaQueue<T>
         if (this.q.length === 0) {
             this.emit("idle", count, duration);
         }
-        return {count, duration };
+        return { count, duration };
     }
 }

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -356,7 +356,7 @@ export class Queue<T> implements IStream<T> {
  * If false, returning less ops would mean we reached end of file.
  * @param logger - logger object to use to log progress & errors
  * @param signal - cancelation signal
- * @param reason - reason for fetching ops
+ * @param scenarioName - reason for fetching ops
  * @returns - an object with resulting ops and cancellation / partial result flags
  */
 async function getSingleOpBatch(
@@ -365,7 +365,7 @@ async function getSingleOpBatch(
     strongTo: boolean,
     logger: ITelemetryLogger,
     signal?: AbortSignal,
-    reason?: string):
+    scenarioName?: string):
         Promise<{ partial: boolean; cancel: boolean; payload: ISequencedDocumentMessage[]; }> {
     let lastSuccessTime: number | undefined;
 
@@ -429,7 +429,7 @@ async function getSingleOpBatch(
                     retry,
                     duration: performance.now() - startTime,
                     retryAfter,
-                    reason,
+                    reason: scenarioName,
                 },
                 error);
 
@@ -458,7 +458,7 @@ async function getSingleOpBatch(
  * @param payloadSize - Payload size
  * @param logger - Logger to log progress and errors
  * @param signal - Cancelation signal
- * @param reason - Reason for fetching ops
+ * @param scenarioName - Reason for fetching ops
  * @returns - Messages fetched
  */
 export function requestOps(
@@ -469,7 +469,7 @@ export function requestOps(
     payloadSize: number,
     logger: ITelemetryLogger,
     signal?: AbortSignal,
-    reason?: string,
+    scenarioName?: string,
 ): IStream<ISequencedDocumentMessage[]> {
     let requests = 0;
     let lastFetch: number | undefined;
@@ -484,7 +484,7 @@ export function requestOps(
     const telemetryEvent = PerformanceEvent.start(logger, {
         eventName: "GetDeltas",
         ...propsTotal,
-        reason,
+        reason: scenarioName,
     });
 
     const manager = new ParallelRequests<ISequencedDocumentMessage>(
@@ -500,7 +500,7 @@ export function requestOps(
                 strongTo,
                 logger,
                 signal,
-                reason,
+                scenarioName,
             );
         },
         (deltas: ISequencedDocumentMessage[]) => {

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -354,6 +354,9 @@ export class Queue<T> implements IStream<T> {
  * @param telemetryEvent - telemetry event used to track consecutive batch of requests
  * @param strongTo - tells if ops in range from...to have to be there and have to be retrieved.
  * If false, returning less ops would mean we reached end of file.
+ * @param logger - logger object to use to log progress & errors
+ * @param signal - cancelation signal
+ * @param reason - reason for fetching ops
  * @returns - an object with resulting ops and cancellation / partial result flags
  */
 async function getSingleOpBatch(
@@ -362,7 +365,7 @@ async function getSingleOpBatch(
     strongTo: boolean,
     logger: ITelemetryLogger,
     signal?: AbortSignal,
-    fetchReason?: string):
+    reason?: string):
         Promise<{ partial: boolean; cancel: boolean; payload: ISequencedDocumentMessage[]; }> {
     let lastSuccessTime: number | undefined;
 
@@ -426,7 +429,7 @@ async function getSingleOpBatch(
                     retry,
                     duration: performance.now() - startTime,
                     retryAfter,
-                    fetchReason,
+                    reason,
                 },
                 error);
 
@@ -446,6 +449,18 @@ async function getSingleOpBatch(
     return nothing;
 }
 
+/**
+ * Request ops from storage
+ * @param get - Getter callback to get individual batches
+ * @param concurrency - Number of concurrent requests to make
+ * @param fromTotal - starting sequence number to fetch (inclusive)
+ * @param toTotal - max (exclusive) sequence number to fetch
+ * @param payloadSize - Payload size
+ * @param logger - Logger to log progress and errors
+ * @param signal - Cancelation signal
+ * @param reason - Reason for fetching ops
+ * @returns - Messages fetched
+ */
 export function requestOps(
     get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>,
     concurrency: number,
@@ -454,7 +469,7 @@ export function requestOps(
     payloadSize: number,
     logger: ITelemetryLogger,
     signal?: AbortSignal,
-    fetchReason?: string,
+    reason?: string,
 ): IStream<ISequencedDocumentMessage[]> {
     let requests = 0;
     let lastFetch: number | undefined;
@@ -469,7 +484,7 @@ export function requestOps(
     const telemetryEvent = PerformanceEvent.start(logger, {
         eventName: "GetDeltas",
         ...propsTotal,
-        fetchReason,
+        reason,
     });
 
     const manager = new ParallelRequests<ISequencedDocumentMessage>(
@@ -485,7 +500,7 @@ export function requestOps(
                 strongTo,
                 logger,
                 signal,
-                fetchReason,
+                reason,
             );
         },
         (deltas: ISequencedDocumentMessage[]) => {

--- a/packages/runtime/test-runtime-utils/src/mockDeltas.ts
+++ b/packages/runtime/test-runtime-utils/src/mockDeltas.ts
@@ -81,8 +81,8 @@ export class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
 
     public dispose() { }
 
-    public async waitTillProcessingDone() {
-        assert(false, "NYI");
+    public async waitTillProcessingDone(): Promise<{ count: number; duration: number; }> {
+        throw new Error("NYI");
     }
 
     constructor() {


### PR DESCRIPTION
When looking at numbers in aggregate (for all sessions in telemetry for 1st party scenarios), individual steps we report do not add up to total time we spend loading container. Looking at specific sessions, couple things pop up:
1. We would benefit from more info, including adding measurements for op processing times
2. There are a lot of sessions where container waits quite substantial time at the end of the process, without any visible activity. Instrumenting last two steps of the process should help provide us some clarity
3. We do not clearly report why we are doing op fetches, and if these are cached or non-cached requests
4. Cached requests are not performed at boot- they all result in "ExtraStorageCall" due to a bug.
5. (minor) `reason` is a property that is rather standard across code base, it helps to use same name (vs. fetchReason) for easier dev experience.
6. Move where we call setLoaded() to better attribute activity happening as part of boot.

While this change only addresses # 4 above, it attempts to add extra telemetry for problematic areas, and some extra telemetry around snapshot processing to better understand where we spend time.

More info can be found in https://dev.azure.com/fluidframework/internal/_workitems/edit/1135