### PR TITLE
Add locationRedirection in DriverErrorType and add Breaking.md note

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -35,6 +35,19 @@ to be `string | undefined`.
 ### `IContainerRuntime.flush` is deprecated
 `IContainerRuntime.flush` is deprecated and will be removed in a future release. If a more manual flushing process is needed, move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
 
+# 1.2.0
+
+## 1.2.0 Upcoming changes
+- [ Added locationRedirection errorType in DriverErrorType enum](#Added-locationRedirection-errorType-in-DriverErrorType-enum)
+- [ Added ILocationRedirectionError error in DriverError type](#Added-ILocationRedirectionError-error-in-DriverError-type)
+
+ ### Added locationRedirection errorType in DriverErrorType enum
+ Added locationRedirection errorType in DriverErrorType enum. This error tells that the location of file on server has changed.
+ This error will not be thrown in 1.x.x version but we are just adding it in the type for now. This will be thrown from 2.x.x onward.
+
+ ### Added ILocationRedirectionError error in DriverError type
+ Added ILocationRedirectionError error in DriverError. This error tells that the location of file on server has changed. In case of Odsp, the domain of file changes on server.
+
 # 1.1.0
 
 ## 1.1.0 Upcoming changes

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -43,7 +43,7 @@ to be `string | undefined`.
 
  ### Added locationRedirection errorType in DriverErrorType enum
  Added locationRedirection errorType in DriverErrorType enum. This error tells that the location of file on server has changed.
- This error will not be thrown in 1.x.x version but we are just adding it in the type for now. This will be thrown from 2.x.x onward.
+ This error will not be thrown in 1.x.x version but we are just adding it in the type for now. This will be thrown from 2.x.x onward. For consumers of errors(in any version due to dynamic driver loading), this needs to be handled as a separate type where an error message banner could be shown etc. Consumers can also choose to not do any action as far as they recognize this error at runtime and not faulter when they receive this error. Ex. if you have a switch statement which does not have this errorType as a case and throw error in default case, then you need to add a case so that it does not throw any error. However this error is not yet emitted from `Fluid Framework`, so in a way it is non breaking.
 
  ### Added ILocationRedirectionError error in DriverError type
  Added ILocationRedirectionError error in DriverError. This error tells that the location of file on server has changed. In case of Odsp, the domain of file changes on server.

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -25,7 +25,7 @@ import { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { IVersion } from '@fluidframework/protocol-definitions';
 
 // @public (undocumented)
-export type DriverError = IThrottlingWarning | IGenericNetworkError | IAuthorizationError | IDriverBasicError;
+export type DriverError = IThrottlingWarning | IGenericNetworkError | IAuthorizationError | ILocationRedirectionError | IDriverBasicError;
 
 // @public
 export enum DriverErrorType {
@@ -37,6 +37,7 @@ export enum DriverErrorType {
     genericError = "genericError",
     genericNetworkError = "genericNetworkError",
     incorrectServerResponse = "incorrectServerResponse",
+    locationRedirection = "locationRedirection",
     offlineError = "offlineError",
     throttlingError = "throttlingError",
     // (undocumented)
@@ -216,6 +217,14 @@ export interface IGenericNetworkError extends IDriverErrorBase {
     readonly errorType: DriverErrorType.genericNetworkError;
     // (undocumented)
     readonly statusCode?: number;
+}
+
+// @public (undocumented)
+export interface ILocationRedirectionError extends IDriverErrorBase {
+    // (undocumented)
+    readonly errorType: DriverErrorType.locationRedirection;
+    // (undocumented)
+    readonly redirectUrl: IResolvedUrl;
 }
 
 // @public (undocumented)

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -57,6 +57,28 @@
   },
   "typeValidation": {
     "version": "1.2.0",
-    "broken": {}
+    "broken": {
+      "TypeAliasDeclaration_DriverError": {
+        "backCompat": false
+      },
+      "EnumDeclaration_DriverErrorType": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IDriverBasicError": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IGenericNetworkError": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IDriverErrorBase": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IThrottlingWarning": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IAuthorizationError": {
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/common/driver-definitions/src/driverError.ts
+++ b/packages/common/driver-definitions/src/driverError.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { IResolvedUrl } from "./urlResolver";
+
 /**
  * Driver Error types
  * Lists types that are likely to be used by all drivers
@@ -75,6 +77,12 @@ export enum DriverErrorType {
       * The document is read-only and delta stream connection is forbidden.
       */
      deltaStreamConnectionForbidden = "deltaStreamConnectionForbidden",
+
+    /**
+     * The location of file/container can change on server. So if the file location moves and we try to access the old
+     * location, then this error is thrown to let the client know about the new location info.
+     */
+    locationRedirection = "locationRedirection",
 }
 
 /**
@@ -110,6 +118,11 @@ export interface IAuthorizationError extends IDriverErrorBase {
     readonly tenantId?: string;
 }
 
+export interface ILocationRedirectionError extends IDriverErrorBase {
+    readonly errorType: DriverErrorType.locationRedirection;
+    readonly redirectUrl: IResolvedUrl;
+}
+
 /**
  * Having this uber interface without types that have their own interfaces
  * allows compiler to differentiate interfaces based on error type
@@ -131,4 +144,5 @@ export type DriverError =
     | IThrottlingWarning
     | IGenericNetworkError
     | IAuthorizationError
+    | ILocationRedirectionError
     | IDriverBasicError;

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.ts
@@ -35,6 +35,7 @@ declare function get_current_TypeAliasDeclaration_DriverError():
 declare function use_old_TypeAliasDeclaration_DriverError(
     use: TypeOnly<old.DriverError>);
 use_old_TypeAliasDeclaration_DriverError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_DriverError());
 
 /*
@@ -59,6 +60,7 @@ declare function get_current_EnumDeclaration_DriverErrorType():
 declare function use_old_EnumDeclaration_DriverErrorType(
     use: TypeOnly<old.DriverErrorType>);
 use_old_EnumDeclaration_DriverErrorType(
+    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_DriverErrorType());
 
 /*
@@ -131,6 +133,7 @@ declare function get_current_InterfaceDeclaration_IAuthorizationError():
 declare function use_old_InterfaceDeclaration_IAuthorizationError(
     use: TypeOnly<old.IAuthorizationError>);
 use_old_InterfaceDeclaration_IAuthorizationError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IAuthorizationError());
 
 /*
@@ -419,6 +422,7 @@ declare function get_current_InterfaceDeclaration_IDriverBasicError():
 declare function use_old_InterfaceDeclaration_IDriverBasicError(
     use: TypeOnly<old.IDriverBasicError>);
 use_old_InterfaceDeclaration_IDriverBasicError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDriverBasicError());
 
 /*
@@ -443,6 +447,7 @@ declare function get_current_InterfaceDeclaration_IDriverErrorBase():
 declare function use_old_InterfaceDeclaration_IDriverErrorBase(
     use: TypeOnly<old.IDriverErrorBase>);
 use_old_InterfaceDeclaration_IDriverErrorBase(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDriverErrorBase());
 
 /*
@@ -515,6 +520,7 @@ declare function get_current_InterfaceDeclaration_IGenericNetworkError():
 declare function use_old_InterfaceDeclaration_IGenericNetworkError(
     use: TypeOnly<old.IGenericNetworkError>);
 use_old_InterfaceDeclaration_IGenericNetworkError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IGenericNetworkError());
 
 /*
@@ -659,6 +665,7 @@ declare function get_current_InterfaceDeclaration_IThrottlingWarning():
 declare function use_old_InterfaceDeclaration_IThrottlingWarning(
     use: TypeOnly<old.IThrottlingWarning>);
 use_old_InterfaceDeclaration_IThrottlingWarning(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IThrottlingWarning());
 
 /*

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -56,6 +56,8 @@
   },
   "typeValidation": {
     "version": "1.2.0",
-    "broken": {}
+    "broken": {
+      "TypeAliasDeclaration_OdspError": { "backCompat": false }
+    }
   }
 }

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.ts
@@ -395,6 +395,7 @@ declare function get_current_TypeAliasDeclaration_OdspError():
 declare function use_old_TypeAliasDeclaration_OdspError(
     use: TypeOnly<old.OdspError>);
 use_old_TypeAliasDeclaration_OdspError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_OdspError());
 
 /*

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -94,6 +94,16 @@
   },
   "typeValidation": {
     "version": "1.2.0",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_ThrottlingError": {
+        "backCompat": false
+      },
+      "ClassDeclaration_AuthorizationError": {
+        "backCompat": false
+      },
+      "ClassDeclaration_GenericNetworkError": {
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.ts
@@ -35,6 +35,7 @@ declare function get_current_ClassDeclaration_AuthorizationError():
 declare function use_old_ClassDeclaration_AuthorizationError(
     use: TypeOnly<old.AuthorizationError>);
 use_old_ClassDeclaration_AuthorizationError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_AuthorizationError());
 
 /*
@@ -419,6 +420,7 @@ declare function get_current_ClassDeclaration_GenericNetworkError():
 declare function use_old_ClassDeclaration_GenericNetworkError(
     use: TypeOnly<old.GenericNetworkError>);
 use_old_ClassDeclaration_GenericNetworkError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_GenericNetworkError());
 
 /*
@@ -1163,6 +1165,7 @@ declare function get_current_ClassDeclaration_ThrottlingError():
 declare function use_old_ClassDeclaration_ThrottlingError(
     use: TypeOnly<old.ThrottlingError>);
 use_old_ClassDeclaration_ThrottlingError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ThrottlingError());
 
 /*


### PR DESCRIPTION
## Description
Add location redirection error in driver error so that it can be used generally by all drivers.
Also add Breaking.md note so that partners know about this change and prepare for future where this error will actually be thrown. We are not throwing this error yet so it will not break partners.