### PR TITLE
Add schema to forest

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -31,17 +31,24 @@ export interface Covariant<T> {
 // @public
 export const EmptyKey: FieldKey;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFromOpaque" needs to be exported by the entry point index.d.ts
-//
+// @public
+export type ExtractFromOpaque<TOpaque extends BrandedType<any, string>> = TOpaque extends BrandedType<infer ValueType, infer Name> ? isAny<ValueType> extends true ? unknown : Brand<ValueType, Name> : never;
+
 // @public
 export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(value: TOpaque): ExtractFromOpaque<TOpaque>;
 
 // @public (undocumented)
-export type FieldKey = Brand<number | string, "FieldKey">;
+export type FieldKey = LocalFieldKey | GlobalFieldKey;
+
+// @public
+export type GlobalFieldKey = Opaque<Brand<string, "tree.GlobalFieldKey">>;
 
 // @public
 export interface Invariant<T> extends Contravariant<T>, Covariant<T> {
 }
+
+// @public
+export type isAny<T> = boolean extends (T extends {} ? true : false) ? true : false;
 
 // @public
 export interface ITreeCursor {
@@ -60,6 +67,9 @@ export interface ITreeCursor {
 }
 
 // @public
+export type LocalFieldKey = Brand<string, "tree.LocalFieldKey">;
+
+// @public
 export interface MakeNominal {
 }
 
@@ -73,8 +83,11 @@ export const enum TreeNavigationResult {
     Pending = 0
 }
 
+// @public
+export type TreeSchemaIdentifier = Brand<string, "tree.TreeSchemaIdentifier">;
+
 // @public (undocumented)
-export type TreeType = Brand<number | string, "TreeType">;
+export type TreeType = TreeSchemaIdentifier;
 
 // @public
 export type Value = undefined | Serializable;

--- a/packages/dds/tree/src/dependency-tracking/simpleObservingDependent.ts
+++ b/packages/dds/tree/src/dependency-tracking/simpleObservingDependent.ts
@@ -10,41 +10,42 @@ import { ObservingDependent } from "./incrementalObservation";
 /**
  * A basic {@link ObservingDependent} implementation.
  */
-export abstract class SimpleObservingDependent implements ObservingDependent {
-	private _dependees: Dependee[] = [];
+export class SimpleObservingDependent implements ObservingDependent {
+    private _dependees: Dependee[] = [];
 
-	public constructor(public readonly computationName = "SimpleObservingDependent") {}
+    public constructor(
+        public readonly markInvalid: (token?: InvalidationToken) => void,
+        public readonly computationName = "SimpleObservingDependent",
+    ) {}
 
-	public listDependees(): readonly Dependee[] {
-		return this._dependees;
-	}
+    public listDependees(): readonly Dependee[] {
+        return this._dependees;
+    }
 
-	public abstract markInvalid(token?: InvalidationToken): void;
+    public registerDependee(dependee: Dependee): void {
+        this._dependees.push(dependee);
+    }
 
-	public registerDependee(dependee: Dependee): void {
-		this._dependees.push(dependee);
-	}
-
-	/**
-	 * Unregister from dependees as a dependent. Necessary as part of disposal and markInvalid.
-	 */
-	public unregisterDependees(): void {
-		assert(this._dependees !== null,
+    /**
+     * Unregister from dependees as a dependent. Necessary as part of disposal and markInvalid.
+     */
+    public unregisterDependees(): void {
+        assert(this._dependees !== null,
             0x309 /* Cannot unregister dependees on a disposed SimpleObservingDependent. */);
-		for (const dependee of this._dependees) {
-			// remove references to this from each dependee
-			dependee.removeDependent(this);
-		}
-		// remove references of each dependee
-		this._dependees.length = 0;
-	}
+        for (const dependee of this._dependees) {
+            // remove references to this from each dependee
+            dependee.removeDependent(this);
+        }
+        // remove references of each dependee
+        this._dependees.length = 0;
+    }
 
-	/**
-	 * Disconnect from all other proxies and clear. This object is not usable after dispose.
-	 */
-	public dispose(): void {
-		// Null out fields to make this object error if used after disposed
-		this.unregisterDependees();
-		this._dependees = null as any;
-	}
+    /**
+     * Disconnect from all other proxies and clear. This object is not usable after dispose.
+     */
+    public dispose(): void {
+        // Null out fields to make this object error if used after disposed
+        this.unregisterDependees();
+        this._dependees = null as any;
+    }
 }

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { StoredSchemaRepository } from "../schema";
 import { FieldKey, DetachedRange } from "../tree";
 import { Value, ITreeCursor } from "./cursor";
 import { IForestSubscription, NodeId } from "./forest";
@@ -17,6 +18,10 @@ import { IForestSubscription, NodeId } from "./forest";
  * TODO: improve these APIs, addressing the above.
  */
 export interface IEditableForest extends IForestSubscription {
+
+    // Overrides field from IForestSubscription adding editing support.
+    readonly schema: StoredSchemaRepository;
+
     /**
      * Adds the supplied nodes to the forest.
      * @param nodes - the sequence of nodes to add to the forest.

--- a/packages/dds/tree/src/forest/forest.ts
+++ b/packages/dds/tree/src/forest/forest.ts
@@ -4,6 +4,7 @@
  */
 
 import { Dependee, ObservingDependent } from "../dependency-tracking";
+import { SchemaRepository } from "../schema";
 import { ITreeCursor, TreeNavigationResult } from "./cursor";
 
 /**
@@ -31,6 +32,14 @@ export interface IForestSubscription extends Dependee {
     // but then accessing it would reduce the ability to mutate in place as an optimization.
     // Maybe add an explicit getter with a perf disclaimer? For now just expose subset of functionality:
     // current(): IForestSnapshot;
+
+    /**
+     * Schema used within this forest.
+     * All data must conform to these schema.
+     *
+     * The root's schema is tracked under {@link rootFieldKey}.
+     */
+    readonly schema: SchemaRepository & Dependee;
 
     /**
      * Allocates a cursor in the "cleared" state.

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -6,6 +6,7 @@
 export { EmptyKey, FieldKey, TreeType } from "./tree";
 
 export { ITreeCursor, TreeNavigationResult, Value } from "./forest";
+export { LocalFieldKey, GlobalFieldKey, TreeSchemaIdentifier } from "./schema";
 
 export {
     Brand,
@@ -16,4 +17,6 @@ export {
     Invariant,
     Contravariant,
     Covariant,
+    ExtractFromOpaque,
+    isAny,
 } from "./util";

--- a/packages/dds/tree/src/schema/Builders.ts
+++ b/packages/dds/tree/src/schema/Builders.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { brandOpaque } from "../util";
 import {
     FieldSchema, GlobalFieldKey, LocalFieldKey, FieldKind, TreeSchema, TreeSchemaIdentifier, ValueSchema,
 } from "./Schema";
@@ -35,7 +36,7 @@ export const itemsKey = "items" as LocalFieldKey;
  * TODO: if we do want to standardize on a single value for this,
  * it likely should be namespaced or a UUID to avoid risk of collisions.
  */
-export const rootFieldKey = "rootFieldKey" as GlobalFieldKey;
+export const rootFieldKey = brandOpaque<GlobalFieldKey>("rootFieldKey");
 
 /**
  * Default field which only permits emptiness.

--- a/packages/dds/tree/src/schema/Schema.ts
+++ b/packages/dds/tree/src/schema/Schema.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { Brand, Opaque } from "../util";
+
 /**
  * Example internal schema representation types.
  */
@@ -20,24 +22,18 @@
  * 2. Persist the whole schema.
  * Use the identifier to associate it with schema when loading to check that the schema match.
  */
-export type SchemaIdentifier = string & {
-    readonly SchemaIdentifier: "3965006b-66d0-41d6-bb04-bd6873b528b4";
-};
+export type SchemaIdentifier = GlobalFieldKey | TreeSchemaIdentifier;
 
 /**
  * SchemaIdentifier for a Tree.
  * Also known as "Definition"
  */
-export type TreeSchemaIdentifier = SchemaIdentifier & {
-    readonly TreeSchemaIdentifier: "ffc4b4b6-a4d8-4479-9636-fe6c6a1a4a7f";
-};
+export type TreeSchemaIdentifier = Brand<string, "tree.TreeSchemaIdentifier">;
 
 /**
- * Key / Name / Label for a field which is scoped to a specific TreeSchema.
+ * Key (aka Name or Label) for a field which is scoped to a specific TreeSchema.
  */
-export type LocalFieldKey = string & {
-    readonly TreeSchemaIdentifier: "1108736b-ebb5-4924-9a25-d4dbabd83fc5";
-};
+export type LocalFieldKey = Brand<string, "tree.LocalFieldKey">;
 
 /**
  * SchemaIdentifier for a Field "global field",
@@ -49,9 +45,7 @@ export type LocalFieldKey = string & {
  * (keeping the two classes of fields separate, name-spacing/escaping,
  * compressing one into numbers and leaving the other strings, etc.)
  */
-export type GlobalFieldKey = SchemaIdentifier & {
-    readonly TreeSchemaIdentifier: "7cc802f9-3360-4176-bbbf-cab23320d80b";
-};
+export type GlobalFieldKey = Opaque<Brand<string, "tree.GlobalFieldKey">>;
 
 /**
  * Describes how a particular field functions.

--- a/packages/dds/tree/src/schema/fence.json
+++ b/packages/dds/tree/src/schema/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": [ "schema" ],
     "exports": [ "index"],
-    "imports": ["util"]
+    "imports": ["util","dependency-tracking"]
 }

--- a/packages/dds/tree/src/schema/index.ts
+++ b/packages/dds/tree/src/schema/index.ts
@@ -5,7 +5,7 @@
 
 export {
     FieldSchema, FieldKind, ValueSchema, GlobalFieldKey, TreeSchema,
-    TreeSchemaIdentifier, LocalFieldKey, NamedTreeSchema,
+    TreeSchemaIdentifier, LocalFieldKey, NamedTreeSchema, SchemaRepository,
 } from "./Schema";
 export { anyField, anyTree, neverField, neverTree } from "./SpecialSchema";
 export { StoredSchemaRepository } from "./StoredSchemaRepository";

--- a/packages/dds/tree/src/test/dependency-tracking/disposingDependee.spec.ts
+++ b/packages/dds/tree/src/test/dependency-tracking/disposingDependee.spec.ts
@@ -18,9 +18,9 @@ import {
 
 class MockDependent extends SimpleObservingDependent {
 	public readonly tokens: (InvalidationToken | undefined)[] = [];
-    public markInvalid(token?: InvalidationToken | undefined): void {
-        this.tokens.push(token);
-    }
+	public constructor(name: string = "MockDependent") {
+		super((token) => this.tokens.push(token), name);
+	}
 }
 
 describe("DisposingDependee", () => {

--- a/packages/dds/tree/src/test/forest/jsonCursor.ts
+++ b/packages/dds/tree/src/test/forest/jsonCursor.ts
@@ -14,15 +14,11 @@ import {
     Value,
 } from "../../..";
 
-/** NodeTypes used by the JsonCursor. */
-export const enum JsonType {
-    Null = 0,
-    Boolean = 1,
-    Number = 2,
-    String = 3,
-    Array = 4,
-    Object = 5,
-}
+import {
+    jsonArray, jsonBoolean, jsonNull, jsonNumber, jsonObject, jsonString,
+// TODO: organize this in a more valid way
+// eslint-disable-next-line import/no-internal-modules
+} from "../schema/examples/JsonDomainSchema";
 
 /**
  * An ITreeCursor implementation used to read a Jsonable tree for testing and benchmarking.
@@ -89,7 +85,7 @@ export class JsonCursor<T> implements ITreeCursor {
         if (key === EmptyKey && Array.isArray(parentNode)) {
             childNode = parentNode[index];
         } else if (index === 0) {
-            childNode = (parentNode as any)[key];
+            childNode = (parentNode as any)[key as string];
         } else {
             return TreeNavigationResult.NotFound;
         }
@@ -132,18 +128,18 @@ export class JsonCursor<T> implements ITreeCursor {
 
         switch (type) {
             case "number":
-                return JsonType.Number as TreeType;
+                return jsonNumber.name;
             case "string":
-                return JsonType.String as TreeType;
+                return jsonString.name;
             case "boolean":
-                return JsonType.Boolean as TreeType;
+                return jsonBoolean.name;
             default:
                 if (node === null) {
-                    return JsonType.Null as TreeType;
+                    return jsonNull.name;
                 } else if (Array.isArray(node)) {
-                    return JsonType.Array as TreeType;
+                    return jsonArray.name;
                 } else {
-                    return JsonType.Object as TreeType;
+                    return jsonObject.name;
                 }
         }
     }
@@ -169,7 +165,7 @@ export class JsonCursor<T> implements ITreeCursor {
             return node.length;
         }
 
-        return (node as any)[key] === undefined
+        return (node as any)[key as string] === undefined
             ? 0     // A field with an undefined value has 0 length
             : 1;    // All other fields have a length of 1
     }

--- a/packages/dds/tree/src/test/schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/schema/comparison.spec.ts
@@ -21,6 +21,7 @@ import {
 	ValueSchema,
 	emptyField, emptyMap, emptySet, fieldSchema, anyField, anyTree, neverField, neverTree, StoredSchemaRepository,
 } from "../../schema";
+import { brandOpaque } from "../../util";
 
 describe("Schema Comparison", () => {
 	const neverTree2: TreeSchema = {
@@ -96,10 +97,10 @@ describe("Schema Comparison", () => {
 			value: ValueSchema.Nothing,
 		}));
 		assert(isNeverTree(repo, neverTree2));
-		repo.tryUpdateFieldSchema("never" as GlobalFieldKey, neverField);
+		repo.tryUpdateFieldSchema(brandOpaque<GlobalFieldKey>("never"), neverField);
 		assert(isNeverTree(repo, {
 			localFields: emptyMap,
-			globalFields: new Set(["never" as GlobalFieldKey]),
+			globalFields: new Set([brandOpaque<GlobalFieldKey>("never")]),
 			extraLocalFields: emptyField,
 			extraGlobalFields: true,
 			value: ValueSchema.Serializable,

--- a/packages/dds/tree/src/test/schema/examples/JsonDomainSchema.ts
+++ b/packages/dds/tree/src/test/schema/examples/JsonDomainSchema.ts
@@ -30,7 +30,7 @@ const jsonTypes: Set<TreeSchemaIdentifier> = new Set();
 
 const json: NamedTreeSchema[] = [];
 
-const jsonObject: NamedTreeSchema = {
+export const jsonObject: NamedTreeSchema = {
     name: "Json.Object" as TreeSchemaIdentifier,
     localFields: emptyMap,
     globalFields: emptySet,
@@ -39,7 +39,7 @@ const jsonObject: NamedTreeSchema = {
     value: ValueSchema.Nothing,
 };
 
-const jsonArray: NamedTreeSchema = {
+export const jsonArray: NamedTreeSchema = {
     name: "Json.Array" as TreeSchemaIdentifier,
     globalFields: emptySet,
     extraLocalFields: emptyField,
@@ -53,7 +53,7 @@ const jsonArray: NamedTreeSchema = {
     value: ValueSchema.Nothing,
 };
 
-const jsonNumber: NamedTreeSchema = {
+export const jsonNumber: NamedTreeSchema = {
     name: "Json.Number" as TreeSchemaIdentifier,
     localFields: emptyMap,
     globalFields: emptySet,
@@ -62,7 +62,7 @@ const jsonNumber: NamedTreeSchema = {
     value: ValueSchema.Number,
 };
 
-const jsonString: NamedTreeSchema = {
+export const jsonString: NamedTreeSchema = {
     name: "Json.String" as TreeSchemaIdentifier,
     localFields: emptyMap,
     globalFields: emptySet,
@@ -71,7 +71,7 @@ const jsonString: NamedTreeSchema = {
     value: ValueSchema.String,
 };
 
-const jsonNull: NamedTreeSchema = {
+export const jsonNull: NamedTreeSchema = {
     name: "Json.Null" as TreeSchemaIdentifier,
     localFields: emptyMap,
     globalFields: emptySet,
@@ -80,7 +80,7 @@ const jsonNull: NamedTreeSchema = {
     value: ValueSchema.Nothing,
 };
 
-const jsonBoolean: NamedTreeSchema = {
+export const jsonBoolean: NamedTreeSchema = {
     name: "Json.Boolean" as TreeSchemaIdentifier,
     localFields: emptyMap,
     globalFields: emptySet,

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -3,10 +3,11 @@
  * Licensed under the MIT License.
  */
 
+import { GlobalFieldKey, LocalFieldKey, TreeSchemaIdentifier } from "../schema";
 import { Brand, Opaque } from "../util";
 
-export type FieldKey = Brand<number | string, "FieldKey">;
-export type TreeType = Brand<number | string, "TreeType">;
+export type FieldKey = LocalFieldKey | GlobalFieldKey;
+export type TreeType = TreeSchemaIdentifier;
 
 /**
  * The empty key ("") is used for unnamed relationships, such as the indexer


### PR DESCRIPTION
Add schema to forest and replace indent with spaces.
Unify identifier types across forest tree and schema.