### PR TITLE
docs: Add missing package-level summary comments for website

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -555,6 +555,4 @@ export type ReadOnlyInfo = {
     readonly storageOnly: boolean;
 };
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -143,6 +143,4 @@ export type SharedObjectClass<T extends IFluidLoadable> = {
     readonly getFactory: () => IChannelFactory;
 } & LoadableObjectCtor<T>;
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/api-report/map.api.md
+++ b/api-report/map.api.md
@@ -53,6 +53,19 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
 }
 
 // @public
+export interface IDirectoryClearOperation {
+    path: string;
+    type: "clear";
+}
+
+// @public
+export interface IDirectoryCreateSubDirectoryOperation {
+    path: string;
+    subdirName: string;
+    type: "createSubDirectory";
+}
+
+// @public
 export interface IDirectoryDataObject {
     // (undocumented)
     storage?: {
@@ -62,6 +75,20 @@ export interface IDirectoryDataObject {
     subdirectories?: {
         [subdirName: string]: IDirectoryDataObject;
     };
+}
+
+// @public
+export interface IDirectoryDeleteOperation {
+    key: string;
+    path: string;
+    type: "delete";
+}
+
+// @public
+export interface IDirectoryDeleteSubDirectoryOperation {
+    path: string;
+    subdirName: string;
+    type: "deleteSubDirectory";
 }
 
 // @public
@@ -76,6 +103,9 @@ export interface IDirectoryEvents extends IEvent {
     (event: "disposed", listener: (target: IEventThisPlaceHolder) => void): any;
 }
 
+// @public
+export type IDirectoryKeyOperation = IDirectorySetOperation | IDirectoryDeleteOperation;
+
 // @public (undocumented)
 export interface IDirectoryNewStorageFormat {
     // (undocumented)
@@ -84,15 +114,33 @@ export interface IDirectoryNewStorageFormat {
     content: IDirectoryDataObject;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IDirectoryStorageOperation" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "IDirectorySubDirectoryOperation" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDirectoryOperation;
 
 // @public
+export interface IDirectorySetOperation {
+    key: string;
+    path: string;
+    type: "set";
+    value: ISerializableValue;
+}
+
+// @public
+export type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
+
+// @public
+export type IDirectorySubDirectoryOperation = IDirectoryCreateSubDirectoryOperation | IDirectoryDeleteSubDirectoryOperation;
+
+// @public
 export interface IDirectoryValueChanged extends IValueChanged {
     path: string;
+}
+
+// @public
+export interface ILocalValue {
+    makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle): ISerializedValue;
+    readonly type: string;
+    readonly value: any;
 }
 
 // @public
@@ -151,7 +199,6 @@ export interface IValueChanged {
 export class LocalValueMaker {
     constructor(serializer: IFluidSerializer);
     fromInMemory(value: any): ILocalValue;
-    // Warning: (ae-forgotten-export) The symbol "ILocalValue" needs to be exported by the entry point index.d.ts
     fromSerializable(serializable: ISerializableValue): ILocalValue;
 }
 

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -785,6 +785,4 @@ export class SubSequence<T> extends BaseSegment {
     static readonly typeString: string;
 }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -4,8 +4,7 @@
  */
 
 /**
- * This package contains the interfaces and types concerning the {@link ILoader | Loader} and loading the
- * {@link IContainer | Container}.
+ * This package contains the interfaces and types concerning the `Loader` and loading the `Container`.
  *
  * @packageDocumentation
  */

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -2,6 +2,13 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/**
+ * This package contains the interfaces and types concerning the {@link Loader} and loading the {@link Container}.
+ *
+ * @packageDocumentation
+ */
+
 export * from "./audience";
 export * from "./browserPackage";
 export * from "./deltas";

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -4,7 +4,8 @@
  */
 
 /**
- * This package contains the interfaces and types concerning the {@link Loader} and loading the {@link Container}.
+ * This package contains the interfaces and types concerning the {@link ILoader | Loader} and loading the
+ * {@link IContainer | Container}.
  *
  * @packageDocumentation
  */

--- a/packages/dds/map/api-extractor.json
+++ b/packages/dds/map/api-extractor.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluidframework/build-common/api-extractor-common-report.json",
+  "extends": "@fluidframework/build-common/api-extractor-common-strict.json"
 }

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -72,7 +72,7 @@ interface IDirectoryMessageHandler {
 /**
  * Operation indicating a value should be set for a key.
  */
-interface IDirectorySetOperation {
+export interface IDirectorySetOperation {
     /**
      * String identifier of the operation type.
      */
@@ -97,7 +97,7 @@ interface IDirectorySetOperation {
 /**
  * Operation indicating a key should be deleted from the directory.
  */
-interface IDirectoryDeleteOperation {
+export interface IDirectoryDeleteOperation {
     /**
      * String identifier of the operation type.
      */
@@ -117,12 +117,12 @@ interface IDirectoryDeleteOperation {
 /**
  * An operation on a specific key within a directory
  */
-type IDirectoryKeyOperation = IDirectorySetOperation | IDirectoryDeleteOperation;
+export type IDirectoryKeyOperation = IDirectorySetOperation | IDirectoryDeleteOperation;
 
 /**
  * Operation indicating the directory should be cleared.
  */
-interface IDirectoryClearOperation {
+export interface IDirectoryClearOperation {
     /**
      * String identifier of the operation type.
      */
@@ -137,12 +137,12 @@ interface IDirectoryClearOperation {
 /**
  * An operation on one or more of the keys within a directory
  */
-type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
+export type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
 
 /**
  * Operation indicating a subdirectory should be created.
  */
-interface IDirectoryCreateSubDirectoryOperation {
+export interface IDirectoryCreateSubDirectoryOperation {
     /**
      * String identifier of the operation type.
      */
@@ -162,7 +162,7 @@ interface IDirectoryCreateSubDirectoryOperation {
 /**
  * Operation indicating a subdirectory should be deleted.
  */
-interface IDirectoryDeleteSubDirectoryOperation {
+export interface IDirectoryDeleteSubDirectoryOperation {
     /**
      * String identifier of the operation type.
      */
@@ -182,7 +182,8 @@ interface IDirectoryDeleteSubDirectoryOperation {
 /**
  * An operation on the subdirectories within a directory
  */
-type IDirectorySubDirectoryOperation = IDirectoryCreateSubDirectoryOperation | IDirectoryDeleteSubDirectoryOperation;
+export type IDirectorySubDirectoryOperation = IDirectoryCreateSubDirectoryOperation
+    | IDirectoryDeleteSubDirectoryOperation;
 
 /**
  * Any operation on a directory

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -6,10 +6,10 @@
 /**
  * The `map` package provides interfaces and implementing classes for map-like distributed data structures.
  *
- * @remarks
- * The following distributed data structures are defined in this package:
+ * @remarks The following distributed data structures are defined in this package:
  *
  * - {@link @fluidframework/map#SharedMap}
+ *
  * - {@link @fluidframework/map#SharedDirectory}
  *
  * @packageDocumentation

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -18,4 +18,4 @@
 export * from "./interfaces";
 export * from "./map";
 export * from "./directory";
-export { LocalValueMaker } from "./localValues";
+export { LocalValueMaker, ILocalValue } from "./localValues";

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -8,9 +8,9 @@
  *
  * @remarks The following distributed data structures are defined in this package:
  *
- * - {@link @fluidframework/map#SharedMap}
+ * - {@link SharedMap}
  *
- * - {@link @fluidframework/map#SharedDirectory}
+ * - {@link SharedDirectory}
  *
  * @packageDocumentation
  */

--- a/packages/dds/sequence/api-extractor.json
+++ b/packages/dds/sequence/api-extractor.json
@@ -1,12 +1,4 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluidframework/build-common/api-extractor-common-report.json",
-  "messages": {
-    "extractorMessageReporting": {
-      "ae-internal-missing-underscore": {
-        "logLevel": "none",
-        "addToApiReportFile": false
-      }
-    }
-  }
+  "extends": "@fluidframework/build-common/api-extractor-common-strict.json"
 }

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -3,6 +3,18 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Supports distributed data structures which are list-like.
+ *
+ * This package's main export is {@link SharedSequence}, a DDS for storing and simultaneously editing a sequence of
+ * text.
+ *
+ * @remarks Note that SharedString is a sequence DDS but it has additional specialized features and behaviors for
+ * working with text.
+ *
+ * @packageDocumentation
+ */
+
 export {
     DeserializeCallback,
     IIntervalCollectionEvent,

--- a/packages/framework/fluid-framework/api-extractor.json
+++ b/packages/framework/fluid-framework/api-extractor.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluidframework/build-common/api-extractor-common-report.json"
+  "extends": "@fluidframework/build-common/api-extractor-common-strict.json"
 }

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -5,8 +5,8 @@
 
 /**
  * The **fluid-framework** package bundles a collection of Fluid Framework client packages for easy use when paired with
- * a corresponding service client package (for example, \@fluidframework/azure-client or
- * \@fluidframework/tinylicious-client).
+ * a corresponding service client package (for example, `\@fluidframework/azure-client` or
+ * `\@fluidframework/tinylicious-client`).
  *
  * @packageDocumentation
  */

--- a/packages/framework/fluid-static/README.md
+++ b/packages/framework/fluid-static/README.md
@@ -2,8 +2,6 @@
 
 The `fluid-static` package provides a simple and powerful way to consume collaborative Fluid data.
 
-This package is marked as experimental and currently under development. The API surface is currently under going drastic braking changes with no guarantees on compatibility.
-
 ## Using fluid-static
 
 The `fluid-static` package contains a container with a pre-created default data object with the ability to create and store additional objects. This is abstracted behind a developer-friendly `FluidContainer` interface that provides configurations for defining the container's initial object and supported dynamic object types, as well as callbacks for creating and fetching DDSes and data objects.

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Provides a simple and powerful way to consume collaborative Fluid data.
+ *
+ * @packageDocumentation
+ */
+
 export * from "./fluidContainer";
 export * from "./rootDataObject";
 export * from "./serviceAudience";


### PR DESCRIPTION
Also...
- Remove obsolete comment from package README
- Update core framework packages to use strict api-extractor config variant
  - Required adding missing API members to `fluidframework/map`'s exports (all are types already directly referenced by existing exports - this change simply makes the API surface more accurate, and the docs more complete).
- Fix list formatting in `@fluidframework/map` package docs