### PR TITLE
Redact any sharepoint url in fetch error message

### DIFF
--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -123,7 +123,7 @@ export async function fetchHelper(
     }, (error) => {
         const online = isOnline();
         const errorText = `${error}`;
-        const urlRegex = /((http|https):\/\/([\d./a-z-]*))/i;
+        const urlRegex = /((http|https):\/\/(\S*))/i;
         const redactedErrorText = errorText.replace(urlRegex, "REDACTED_URL");
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -124,7 +124,7 @@ export async function fetchHelper(
         const online = isOnline();
         const errorText = `${error}`;
         const spoRegex = /((http|https):\/\/.*\.com)/i;
-        const redactedErrorText = errorText.replace(spoRegex, "REDACTED (url)");
+        const redactedErrorText = errorText.replace(spoRegex, "REDACTED_URL");
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {
             throw new RetryableError(

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -123,7 +123,7 @@ export async function fetchHelper(
     }, (error) => {
         const online = isOnline();
         const errorText = `${error}`;
-        const urlRegex = /((http|https):\/\/([-A-Z0-9.\/]*))/i;
+        const urlRegex = /((http|https):\/\/([\d./a-z-]*))/i;
         const redactedErrorText = errorText.replace(urlRegex, "REDACTED_URL");
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -123,7 +123,7 @@ export async function fetchHelper(
     }, (error) => {
         const online = isOnline();
         const errorText = `${error}`;
-        const urlRegex = /((http|https):\/\/.*\.com)/i;
+        const urlRegex = /((http|https):\/\/([-A-Z0-9.\/]*))/i;
         const redactedErrorText = errorText.replace(urlRegex, "REDACTED_URL");
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -123,7 +123,7 @@ export async function fetchHelper(
     }, (error) => {
         const online = isOnline();
         const errorText = `${error}`;
-        const spoRegex = /((http|https):\/\/.*\.com)/i;
+        const urlRegex = /((http|https):\/\/.*\.com)/i;
         const redactedErrorText = errorText.replace(spoRegex, "REDACTED (url)");
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -13,7 +13,7 @@ import {
     NetworkErrorBasic,
 } from "@fluidframework/driver-utils";
 import { assert, performance } from "@fluidframework/common-utils";
-import { ChildLogger, PerformanceEvent, wrapError } from "@fluidframework/telemetry-utils";
+import { ChildLogger, PerformanceEvent, TelemetryDataTag, wrapError } from "@fluidframework/telemetry-utils";
 import {
     fetchIncorrectResponse,
     throwOdspNetworkError,
@@ -122,9 +122,9 @@ export async function fetchHelper(
         };
     }, (error) => {
         const online = isOnline();
-        let errorText = `${error}`;
-        const spoRegex = /(http.*\.sharepoint(-df)*\.com)/;
-        errorText = errorText.toLowerCase().replace(spoRegex, "REDACTED (sharepoint url)");
+        const errorText = `${error}`;
+        const spoRegex = /((http|https):\/\/.*\.com)/i;
+        const redactedErrorText = errorText.replace(spoRegex, "REDACTED (url)");
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {
             throw new RetryableError(
@@ -144,13 +144,23 @@ export async function fetchHelper(
         if (online === OnlineStatus.Offline) {
             throw new RetryableError(
                 // pre-0.58 error message prefix: Offline
-                `ODSP fetch failure (Offline): ${errorText}`, DriverErrorType.offlineError, { driverVersion });
+                `ODSP fetch failure (Offline): ${redactedErrorText}`,
+                DriverErrorType.offlineError,
+                {
+                    driverVersion,
+                    rawErrorMessage: { value: errorText, tag: TelemetryDataTag.UserData },
+                });
         } else {
             // It is perhaps still possible that this is due to being offline, the error does not reveal enough
             // information to conclude.  Could also be DNS errors, malformed fetch request, CSP violation, etc.
             throw new RetryableError(
                 // pre-0.58 error message prefix: Fetch error
-                `ODSP fetch failure: ${errorText}`, DriverErrorType.fetchFailure, { driverVersion });
+                `ODSP fetch failure: ${redactedErrorText}`,
+                DriverErrorType.fetchFailure,
+                {
+                    driverVersion,
+                    rawErrorMessage: { value: errorText, tag: TelemetryDataTag.UserData },
+                });
         }
     });
 }

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -122,8 +122,9 @@ export async function fetchHelper(
         };
     }, (error) => {
         const online = isOnline();
-        const errorText = `${error}`;
-
+        let errorText = `${error}`;
+        const spoRegex = /(http.*\.sharepoint(-df)*\.com)/;
+        errorText = errorText.toLowerCase().replace(spoRegex, "REDACTED (sharepoint url)");
         // This error is thrown by fetch() when AbortSignal is provided and it gets cancelled
         if (error.name === "AbortError") {
             throw new RetryableError(

--- a/packages/drivers/odsp-driver/src/test/mockFetch.ts
+++ b/packages/drivers/odsp-driver/src/test/mockFetch.ts
@@ -65,3 +65,24 @@ export async function mockFetchOk<T>(
         callback,
         async () => okResponse(headers, response));
 }
+
+export async function mockFetchError<T>(
+    callback: () => Promise<T>,
+    response: Error,
+    type: FetchCallType = "single",
+): Promise<T> {
+    const fetchStub = stub(fetchModule, "default");
+    fetchStub.callsFake(async () => {
+        if (type === "external") {
+            fetchStub.restore();
+        }
+        throw response;
+    });
+    try {
+        return await callback();
+    } finally {
+        if (type !== "internal") {
+            fetchStub.restore();
+        }
+    }
+}

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -14,9 +14,10 @@ import {
 import { NonRetryableError } from "@fluidframework/driver-utils";
 import { OdspError, OdspErrorType } from "@fluidframework/odsp-driver-definitions";
 import { IOdspSocketError } from "../contracts";
-import { getWithRetryForTokenRefresh } from "../odspUtils";
+import { fetchAndParseAsJSONHelper, getWithRetryForTokenRefresh } from "../odspUtils";
 import { errorObjectFromSocketError } from "../odspError";
 import { pkgVersion } from "../packageVersion";
+import { mockFetchError } from "./mockFetch";
 
 describe("Odsp Error", () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -282,5 +283,16 @@ describe("Odsp Error", () => {
         assert.strictEqual(error.errorType, OdspErrorType.locationRedirection, "Error type should be locationRedirection");
         assert.strictEqual(error.redirectLocation, redirectLocation, "Site location should match");
         assert.strictEqual(error.statusCode, 404, "Status code should match");
+    });
+
+    it("Sharepoint url should be redacted in the error", async () => {
+        try {
+            await mockFetchError(
+                async () => fetchAndParseAsJSONHelper("https://microsoft.sharepoint-df.com/siteUrl", {}),
+                new Error("Request to https://6c482541-f706-4168-9e58-8e35a9992f58.sharepoint.com failed"));
+            assert.fail("Fetch should throw an error");
+        } catch (error: any) {
+            assert((error.message as string).includes("REDACTED (sharepoint url)"), "sharepoint url should get redacted");
+        }
     });
 });

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -292,7 +292,18 @@ describe("Odsp Error", () => {
                 new Error("Request to https://6c482541-f706-4168-9e58-8e35a9992f58.sharepoint.com failed"));
             assert.fail("Fetch should throw an error");
         } catch (error: any) {
-            assert((error.message as string).includes("REDACTED (sharepoint url)"), "sharepoint url should get redacted");
+            assert((error.message as string).includes("REDACTED (url)"), "sharepoint url should get redacted");
+        }
+    });
+
+    it("url should be redacted in the error", async () => {
+        try {
+            await mockFetchError(
+                async () => fetchAndParseAsJSONHelper("https://microsoft.sharepoint-df.com/siteUrl", {}),
+                new Error("Request to http://f706-4168-9e58-8e35a9992f58.COM failed"));
+            assert.fail("Fetch should throw an error");
+        } catch (error: any) {
+            assert((error.message as string).includes("REDACTED (url)"), "url should get redacted");
         }
     });
 });

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -292,7 +292,7 @@ describe("Odsp Error", () => {
                 new Error("Request to https://6c482541-f706-4168-9e58-8e35a9992f58.sharepoint.com failed"));
             assert.fail("Fetch should throw an error");
         } catch (error: any) {
-            assert((error.message as string).includes("REDACTED (url)"), "sharepoint url should get redacted");
+            assert((error.message as string).includes("REDACTED_URL"), "sharepoint url should get redacted");
         }
     });
 
@@ -303,7 +303,7 @@ describe("Odsp Error", () => {
                 new Error("Request to http://f706-4168-9e58-8e35a9992f58.COM failed"));
             assert.fail("Fetch should throw an error");
         } catch (error: any) {
-            assert((error.message as string).includes("REDACTED (url)"), "url should get redacted");
+            assert((error.message as string).includes("REDACTED_URL"), "url should get redacted");
         }
     });
 });


### PR DESCRIPTION
## Description
1.) Fetch Error could container the URL to which the network called has failed. So, we need to Redact any SharePoint URL in fetch error message. The URL will get replaced by "REDACTED (sharepoint url)" in the message. Also added a unit test for the same.