### PR TITLE
Update packages depending on older node-gyp

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2408,6 +2408,11 @@
 						"util": "^0.12.0"
 					}
 				},
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+				},
 				"typescript": {
 					"version": "3.9.9",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
@@ -9090,6 +9095,228 @@
 						"signal-exit": "^3.0.2",
 						"typedarray-to-buffer": "^3.1.5"
 					}
+				}
+			}
+		},
+		"@mapbox/node-pre-gyp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
+			"integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+			"requires": {
+				"detect-libc": "^2.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"make-dir": "^3.1.0",
+				"node-fetch": "^2.6.7",
+				"nopt": "^5.0.0",
+				"npmlog": "^5.0.1",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"tar": "^6.1.11"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"requires": {
+						"debug": "4"
+					}
+				},
+				"are-we-there-yet": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+					"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^3.6.0"
+					}
+				},
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"fs-minipass": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"gauge": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+					"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+					"requires": {
+						"aproba": "^1.0.3 || ^2.0.0",
+						"color-support": "^1.1.2",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.1",
+						"object-assign": "^4.1.1",
+						"signal-exit": "^3.0.0",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"wide-align": "^1.1.2"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+					"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"requires": {
+						"semver": "^6.0.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+						}
+					}
+				},
+				"minipass": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+					"integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				},
+				"nopt": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+					"requires": {
+						"abbrev": "1"
+					}
+				},
+				"npmlog": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+					"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+					"requires": {
+						"are-we-there-yet": "^2.0.0",
+						"console-control-strings": "^1.1.0",
+						"gauge": "^3.0.0",
+						"set-blocking": "^2.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+				},
+				"semver": {
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"tar": {
+					"version": "6.1.11",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+					"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -16249,7 +16476,6 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
 			"integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
-			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
 				"depd": "^1.1.2",
@@ -16521,6 +16747,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -16529,12 +16756,14 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -16549,6 +16778,7 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -19111,6 +19341,13 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
 				"pako": "~1.0.5"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+				}
 			}
 		},
 		"browserslist": {
@@ -19450,9 +19687,9 @@
 					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 				},
 				"keyv": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.0.tgz",
-					"integrity": "sha512-C30Un9+63J0CsR7Wka5quXKqYZsT6dcRQ2aOwGcSc3RiQ4HGWpTAHlCA+puNfw2jA/s11EsxA1nCXgZRuRKMQQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.2.tgz",
+					"integrity": "sha512-kn8WmodVBe12lmHpA6W8OY7SNh6wVR+Z+wZESF4iF5FCazaVXGWOtnbnvX0tMQ1bO+/TmOD9LziuYMvrIIs0xw==",
 					"requires": {
 						"compress-brotli": "^1.3.8",
 						"json-buffer": "3.0.1"
@@ -20117,9 +20354,9 @@
 			}
 		},
 		"cli-progress": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.1.tgz",
-			"integrity": "sha512-TTMA2LHrYaZeNMcgZGO10oYqj9hvd03pltNtVbu4ddeyDTHlYV7gWxsFiuvaQlgwMBFCv1TukcjiODWFlb16tQ==",
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
+			"integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
 			"requires": {
 				"string-width": "^4.2.3"
 			},
@@ -23012,9 +23249,9 @@
 			"dev": true
 		},
 		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
 		},
 		"detect-newline": {
 			"version": "3.1.0",
@@ -23563,7 +23800,6 @@
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"iconv-lite": "^0.6.2"
@@ -23573,7 +23809,6 @@
 					"version": "0.6.3",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -23785,8 +24020,7 @@
 		"env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"dev": true
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
 		},
 		"envinfo": {
 			"version": "7.8.1",
@@ -23900,8 +24134,7 @@
 		"err-code": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-			"dev": true
+			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
 		},
 		"errno": {
 			"version": "0.1.8",
@@ -26064,6 +26297,7 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
 			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+			"dev": true,
 			"requires": {
 				"minipass": "^2.6.0"
 			}
@@ -26253,6 +26487,7 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -26267,12 +26502,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -26281,6 +26518,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -26291,6 +26529,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -26684,15 +26923,15 @@
 			}
 		},
 		"good-fences": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/good-fences/-/good-fences-1.1.0.tgz",
-			"integrity": "sha512-mOIQiRVgjiQNoTHJpyWlKqiyvoimbA9DZ1UNjjPntgz5Od9fDAreYf2DeocO4uL6x7uaem4NThGSJMidq0vO1g==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/good-fences/-/good-fences-1.1.1.tgz",
+			"integrity": "sha512-7J1+qLAzj3D9Q/lijFK4pxeXHihYtQzXp4yjtMrhxyiECejsopvVYOjvBVHfNAQnWCuJE0D39Ve5GxK6xLBFdQ==",
 			"requires": {
 				"cli-progress": "^3.9.0",
 				"commander": "^7.2.0",
 				"fdir": "^5.1.0",
 				"minimatch": "^3.0.4",
-				"nodegit": "^0.27.0",
+				"nodegit": "^0.28.0-alpha.18",
 				"picomatch": "^2.3.0",
 				"strip-json-comments": "^3.1.1",
 				"tsconfig-paths": "^3.10.1",
@@ -27777,7 +28016,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
 			}
@@ -27857,6 +28095,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
 			"integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
@@ -28570,8 +28809,7 @@
 		"is-lambda": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
-			"dev": true
+			"integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
 		},
 		"is-lower-case": {
 			"version": "2.0.2",
@@ -28918,6 +29156,11 @@
 				"simple-get": "^4.0.1"
 			},
 			"dependencies": {
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+				},
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -31011,9 +31254,9 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "10.5.23",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.23.tgz",
-			"integrity": "sha512-e3hy//LH8EbRhzqyHJuf3pbehxYcnUZgGUjQKKTukWJ1M5uQTZBgFvItRK5ik8pixpYDAKY6xj527cEa1NQGPg=="
+			"version": "10.5.25",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
+			"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg=="
 		},
 		"jss": {
 			"version": "10.9.0",
@@ -31137,6 +31380,11 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+				},
+				"pako": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -33539,6 +33787,7 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
 			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -33571,7 +33820,6 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.3.tgz",
 			"integrity": "sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.12",
 				"minipass": "^3.1.0",
@@ -33583,7 +33831,6 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -33592,7 +33839,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
 					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-					"dev": true,
 					"requires": {
 						"minipass": "^3.0.0",
 						"yallist": "^4.0.0"
@@ -33601,8 +33847,7 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -33683,7 +33928,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
 			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-			"dev": true,
 			"requires": {
 				"minipass": "^3.0.0"
 			},
@@ -33692,7 +33936,6 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -33700,8 +33943,7 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -33709,6 +33951,7 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
 			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+			"dev": true,
 			"requires": {
 				"minipass": "^2.9.0"
 			}
@@ -34690,31 +34933,10 @@
 				}
 			}
 		},
-		"needle": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-			"integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-			"requires": {
-				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
 		"negotiator": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-			"dev": true
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -35027,40 +35249,6 @@
 				}
 			}
 		},
-		"node-pre-gyp": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
-			"integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"needle": "^2.2.1",
-				"nopt": "^4.0.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0",
-				"tar": "^4"
-			},
-			"dependencies": {
-				"npm-packlist": {
-					"version": "1.4.8",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-					"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1",
-						"npm-normalize-package-bin": "^1.0.1"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
-		},
 		"node-preload": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -35075,17 +35263,17 @@
 			"integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
 		},
 		"nodegit": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/nodegit/-/nodegit-0.27.0.tgz",
-			"integrity": "sha512-E9K4gPjWiA0b3Tx5lfWCzG7Cvodi2idl3V5UD2fZrOrHikIfrN7Fc2kWLtMUqqomyoToYJLeIC8IV7xb1CYRLA==",
+			"version": "0.28.0-alpha.18",
+			"resolved": "https://registry.npmjs.org/nodegit/-/nodegit-0.28.0-alpha.18.tgz",
+			"integrity": "sha512-adLFYT4j/GMYFYcLmqiDMIaedPe7ErnIBLYRo0LZG5LoQpmu8qH10bTUokH76PVe2zioKCX+9/4sZ3ZUIBJbVg==",
 			"requires": {
+				"@mapbox/node-pre-gyp": "^1.0.8",
 				"fs-extra": "^7.0.0",
 				"got": "^10.7.0",
 				"json5": "^2.1.0",
 				"lodash": "^4.17.14",
-				"nan": "^2.14.0",
-				"node-gyp": "^4.0.0",
-				"node-pre-gyp": "^0.13.0",
+				"nan": "^2.15.0",
+				"node-gyp": "^8.4.1",
 				"ramda": "^0.25.0",
 				"tar-fs": "^1.16.3"
 			},
@@ -35103,6 +35291,48 @@
 						"defer-to-connect": "^2.0.0"
 					}
 				},
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"requires": {
+						"debug": "4"
+					}
+				},
+				"are-we-there-yet": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+					"integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^3.6.0"
+					}
+				},
+				"cacache": {
+					"version": "15.3.0",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+					"integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+					"requires": {
+						"@npmcli/fs": "^1.0.0",
+						"@npmcli/move-file": "^1.0.1",
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"glob": "^7.1.4",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^6.0.0",
+						"minipass": "^3.1.1",
+						"minipass-collect": "^1.0.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.2",
+						"mkdirp": "^1.0.3",
+						"p-map": "^4.0.0",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^3.0.2",
+						"ssri": "^8.0.1",
+						"tar": "^6.0.2",
+						"unique-filename": "^1.1.1"
+					}
+				},
 				"cacheable-request": {
 					"version": "7.0.2",
 					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
@@ -35117,6 +35347,11 @@
 						"responselike": "^2.0.0"
 					}
 				},
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+				},
 				"decompress-response": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
@@ -35130,6 +35365,11 @@
 					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
 					"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
 				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
 				"fs-extra": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -35138,6 +35378,29 @@
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
 						"universalify": "^0.1.0"
+					}
+				},
+				"fs-minipass": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"gauge": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+					"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+					"requires": {
+						"aproba": "^1.0.3 || ^2.0.0",
+						"color-support": "^1.1.3",
+						"console-control-strings": "^1.1.0",
+						"has-unicode": "^2.0.1",
+						"signal-exit": "^3.0.7",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"wide-align": "^1.1.5"
 					}
 				},
 				"get-stream": {
@@ -35170,15 +35433,39 @@
 						"type-fest": "^0.10.0"
 					}
 				},
+				"http-proxy-agent": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+					"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+					"requires": {
+						"@tootallnate/once": "1",
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+					"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
 				"json-buffer": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 				},
 				"keyv": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.0.tgz",
-					"integrity": "sha512-C30Un9+63J0CsR7Wka5quXKqYZsT6dcRQ2aOwGcSc3RiQ4HGWpTAHlCA+puNfw2jA/s11EsxA1nCXgZRuRKMQQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.2.tgz",
+					"integrity": "sha512-kn8WmodVBe12lmHpA6W8OY7SNh6wVR+Z+wZESF4iF5FCazaVXGWOtnbnvX0tMQ1bO+/TmOD9LziuYMvrIIs0xw==",
 					"requires": {
 						"compress-brotli": "^1.3.8",
 						"json-buffer": "3.0.1"
@@ -35189,33 +35476,84 @@
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
 					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
 				},
+				"make-fetch-happen": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+					"integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+					"requires": {
+						"agentkeepalive": "^4.1.3",
+						"cacache": "^15.2.0",
+						"http-cache-semantics": "^4.1.0",
+						"http-proxy-agent": "^4.0.1",
+						"https-proxy-agent": "^5.0.0",
+						"is-lambda": "^1.0.1",
+						"lru-cache": "^6.0.0",
+						"minipass": "^3.1.3",
+						"minipass-collect": "^1.0.2",
+						"minipass-fetch": "^1.3.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"negotiator": "^0.6.2",
+						"promise-retry": "^2.0.1",
+						"socks-proxy-agent": "^6.0.0",
+						"ssri": "^8.0.0"
+					}
+				},
 				"mimic-response": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
 					"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
 				},
-				"node-gyp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
-					"integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+				"minipass": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+					"integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
 					"requires": {
-						"glob": "^7.0.3",
-						"graceful-fs": "^4.1.2",
-						"mkdirp": "^0.5.0",
-						"nopt": "2 || 3",
-						"npmlog": "0 || 1 || 2 || 3 || 4",
-						"osenv": "0",
-						"request": "^2.87.0",
-						"rimraf": "2",
-						"semver": "~5.3.0",
-						"tar": "^4.4.8",
-						"which": "1"
+						"yallist": "^4.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"node-gyp": {
+					"version": "8.4.1",
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+					"integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+					"requires": {
+						"env-paths": "^2.2.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.6",
+						"make-fetch-happen": "^9.1.0",
+						"nopt": "^5.0.0",
+						"npmlog": "^6.0.0",
+						"rimraf": "^3.0.2",
+						"semver": "^7.3.5",
+						"tar": "^6.1.2",
+						"which": "^2.0.2"
+					},
+					"dependencies": {
+						"graceful-fs": {
+							"version": "4.2.10",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+							"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+						}
 					}
 				},
 				"nopt": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-					"integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
 					"requires": {
 						"abbrev": "1"
 					}
@@ -35224,6 +35562,17 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
 					"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+				},
+				"npmlog": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+					"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+					"requires": {
+						"are-we-there-yet": "^3.0.0",
+						"console-control-strings": "^1.1.0",
+						"gauge": "^4.0.3",
+						"set-blocking": "^2.0.0"
+					}
 				},
 				"p-cancelable": {
 					"version": "2.1.1",
@@ -35235,6 +35584,16 @@
 					"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
 					"integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
 				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
 				"responselike": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
@@ -35243,10 +35602,112 @@
 						"lowercase-keys": "^2.0.0"
 					}
 				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+				},
 				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw=="
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"signal-exit": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+				},
+				"smart-buffer": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+					"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+				},
+				"socks": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+					"integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+					"requires": {
+						"ip": "^1.1.5",
+						"smart-buffer": "^4.2.0"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+					"integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+					"requires": {
+						"agent-base": "^6.0.2",
+						"debug": "^4.3.3",
+						"socks": "^2.6.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.4",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+							"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+							"requires": {
+								"ms": "2.1.2"
+							}
+						}
+					}
+				},
+				"ssri": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+					"requires": {
+						"minipass": "^3.1.1"
+					}
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"tar": {
+					"version": "6.1.11",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+					"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					}
 				},
 				"to-readable-stream": {
 					"version": "2.1.0",
@@ -35257,6 +35718,27 @@
 					"version": "0.10.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
 					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw=="
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+					"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+					"requires": {
+						"string-width": "^1.0.2 || 2 || 3 || 4"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -35310,6 +35792,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
 			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+			"dev": true,
 			"requires": {
 				"abbrev": "1",
 				"osenv": "^0.1.4"
@@ -35365,6 +35848,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
 			"integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+			"dev": true,
 			"requires": {
 				"npm-normalize-package-bin": "^1.0.1"
 			}
@@ -35397,7 +35881,8 @@
 		"npm-normalize-package-bin": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+			"dev": true
 		},
 		"npm-package-arg": {
 			"version": "8.1.5",
@@ -35845,6 +36330,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -36882,6 +37368,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -37233,9 +37720,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+			"integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
 		},
 		"parallel-transform": {
 			"version": "1.2.0",
@@ -38205,7 +38692,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
 			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-			"dev": true,
 			"requires": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -43751,6 +44237,7 @@
 			"version": "4.4.13",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
 			"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -89,7 +89,7 @@
     "cross-env": "^7.0.2",
     "diff": "^3.5.0",
     "eslint": "~8.6.0",
-    "good-fences": "^1.1.0",
+    "good-fences": "^1.1.1",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "random-js": "^1.0.8",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -514,7 +514,7 @@
         "@fluidframework/server-services-telemetry": "^0.1036.5000",
         "@fluidframework/server-test-utils": "^0.1036.5000",
         "debug": "^4.1.1",
-        "jsrsasign": "^10.5.25",
+        "jsrsasign": "^10.2.0",
         "uuid": "^8.3.1"
       }
     },
@@ -556,7 +556,7 @@
         "crc-32": "1.2.0",
         "debug": "^4.1.1",
         "json-stringify-safe": "^5.0.1",
-        "jsrsasign": "^10.5.25",
+        "jsrsasign": "^10.2.0",
         "jwt-decode": "^3.0.0",
         "querystring": "^0.2.0",
         "sillyname": "^0.1.0",
@@ -1929,16 +1929,34 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
-    "abstract-leveldown": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+    "abstract-level": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+      "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
       "requires": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        }
       }
     },
     "accepts": {
@@ -2356,6 +2374,17 @@
         }
       }
     },
+    "browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -2449,6 +2478,11 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2508,6 +2542,18 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "classic-level": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
+      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "^4.3.0"
       }
     },
     "clean-git-ref": {
@@ -3215,15 +3261,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "deferred-leveldown": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      }
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3426,17 +3463,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "encoding-down": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-      "requires": {
-        "abstract-leveldown": "^6.2.1",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0"
-      }
     },
     "engine.io": {
       "version": "6.2.0",
@@ -5070,11 +5096,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
-    "immediate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5796,13 +5817,12 @@
       "dev": true
     },
     "level": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
-      "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
       "requires": {
-        "level-js": "^5.0.0",
-        "level-packager": "^5.1.0",
-        "leveldown": "^5.4.0"
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
       }
     },
     "level-codec": {
@@ -5813,47 +5833,12 @@
         "buffer": "^5.6.0"
       }
     },
-    "level-concat-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
-    },
     "level-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
       "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "requires": {
         "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "level-js": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
-      "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
-      "requires": {
-        "abstract-leveldown": "~6.2.3",
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.3",
-        "ltgt": "^2.1.2"
-      }
-    },
-    "level-packager": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-      "requires": {
-        "encoding-down": "^6.3.0",
-        "levelup": "^4.3.2"
       }
     },
     "level-post": {
@@ -5931,33 +5916,28 @@
       }
     },
     "level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA=="
+    },
+    "level-transcoder": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
       "requires": {
-        "xtend": "^4.0.2"
-      }
-    },
-    "leveldown": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
-      "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "~4.1.0"
-      }
-    },
-    "levelup": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-      "requires": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "levn": {
@@ -6598,6 +6578,11 @@
         }
       }
     },
+    "module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA=="
+    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -6797,9 +6782,9 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "node-gyp-build": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
     },
     "noms": {
       "version": "0.0.0",
@@ -7414,8 +7399,7 @@
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -7703,6 +7687,14 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
       "requires": {
         "queue-microtask": "^1.2.2"
       }

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -57,7 +57,7 @@
     "express": "^4.16.3",
     "isomorphic-git": "^1.8.2",
     "json-stringify-safe": "^5.0.1",
-    "level": "^6.0.1",
+    "level": "^8.0.0",
     "level-sublevel": "6.6.4",
     "lodash": "^4.17.21",
     "morgan": "^1.8.1",

--- a/server/tinylicious/src/services/levelDb.ts
+++ b/server/tinylicious/src/services/levelDb.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "events";
 import { ICollection, IDb, IDbFactory } from "@fluidframework/server-services-core";
-import level from "level";
+import { Level } from "level";
 import sublevel from "level-sublevel";
 import { Collection, ICollectionProperty } from "./levelDbCollection";
 
@@ -16,7 +16,7 @@ export class LevelDb extends EventEmitter implements IDb {
 
     constructor(private readonly path: string) {
         super();
-        this.db = sublevel(level(this.path, {
+        this.db = sublevel(new Level(this.path, {
             valueEncoding: "json",
         }));
     }


### PR DESCRIPTION
Older versions of node-gyp cause install failures on Mac for Node 16+.  This PR updates external dependencies sufficiently to avoid this problem in the client packages (though we'll need a new published build of `tinylicious` to complete the fix).