### PR TITLE
Cleanup how defaults are handled in benchmark runner

### DIFF
--- a/tools/benchmark/src/Runner.ts
+++ b/tools/benchmark/src/Runner.ts
@@ -37,19 +37,16 @@ import { BenchmarkData } from "./Reporter";
  * @public
  */
 export function benchmark(args: BenchmarkArguments): Test {
-    const defaults: Required<BenchmarkOptions> = {
-        maxBenchmarkDurationSeconds: 5,
-        minSampleCount: 5,
-        minSampleDurationSeconds: 0,
-        type: BenchmarkType.Measurement,
-        only: false,
-        before: () => {},
-        after: () => {},
+    const options: Required<BenchmarkOptions> = {
+        maxBenchmarkDurationSeconds: args.maxBenchmarkDurationSeconds ?? 5,
+        minSampleCount: args.minSampleCount ?? 5,
+        minSampleDurationSeconds: args.minSampleDurationSeconds ?? 0,
+        type: args.type ?? BenchmarkType.Measurement,
+        only: args.only ?? false,
+        before: args.before ?? (() => {}),
+        after: args.after ?? (() => {}),
     };
-    const options: Required<BenchmarkOptions> = Object.assign(defaults, args);
     const { isAsync, benchmarkFn: argsBenchmarkFn } = validateBenchmarkArguments(args);
-    const beforeBenchmark = options.before ?? options.before;
-    const afterBenchmark = options.after ?? options.after;
     const typeTag = BenchmarkType[options.type];
     const qualifiedTitle = `${performanceTestSuiteTag} @${typeTag} ${args.title}`;
 
@@ -105,7 +102,7 @@ export function benchmark(args: BenchmarkArguments): Test {
 
         // Create and run a benchmark if we are in perfMode, else run the passed in function normally
         if (isInPerformanceTestingMode) {
-            await beforeBenchmark?.();
+            await options.before();
 
             const benchmarkOptions: Benchmark.Options = {
                 maxTime: options.maxBenchmarkDurationSeconds,
@@ -143,7 +140,7 @@ export function benchmark(args: BenchmarkArguments): Test {
 
                     test.emit("benchmark end", stats);
 
-                    await afterBenchmark?.();
+                    await options.after();
                     resolve();
                 });
                 benchmarkInstance.run();
@@ -151,9 +148,9 @@ export function benchmark(args: BenchmarkArguments): Test {
             return;
         }
 
-        await beforeBenchmark?.();
+        await options.before();
         await argsBenchmarkFn();
-        await afterBenchmark?.();
+        await options.after();
         await Promise.resolve();
     });
     return test;


### PR DESCRIPTION
Fix up handling of defaults in benchmark runner.
There was redundant handling of undefined options, and the first approach, using object.assign would mishandle explicitly undefined fields (it just handled missing fields).

Now all undefined/unspecified options are handled in a uniform way which treats undefined values and unspecified values the same.

Tested by running tests and perf tests in the benchmark package as well as those in experimental/tree via npm link.