### PR TITLE
FRS test pipeline fixes

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -58,7 +58,6 @@
     "@fluidframework/routerlicious-driver": "^1.0.1",
     "@fluidframework/runtime-utils": "^1.0.1",
     "@fluidframework/server-services-client": "^0.1037.1000-0",
-    "start-server-and-test": "^1.11.7",
     "axios": "^0.26.0",
     "uuid": "^8.3.1"
   },
@@ -81,6 +80,7 @@
     "mocha": "^10.0.0",
     "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
+    "start-server-and-test": "^1.11.7",
     "typescript": "~4.5.5"
   },
   "peerDependencies": {

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -58,6 +58,7 @@
     "@fluidframework/routerlicious-driver": "^1.0.1",
     "@fluidframework/runtime-utils": "^1.0.1",
     "@fluidframework/server-services-client": "^0.1037.1000-0",
+    "start-server-and-test": "^1.11.7",
     "axios": "^0.26.0",
     "uuid": "^8.3.1"
   },
@@ -80,7 +81,6 @@
     "mocha": "^10.0.0",
     "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
-    "start-server-and-test": "^1.11.7",
     "typescript": "~4.5.5"
   },
   "peerDependencies": {

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -44,6 +44,10 @@ parameters:
   type: string
   default: null
 
+- name: downloadAzureTestArtifacts
+  type: boolean
+  default: false
+
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -70,6 +74,12 @@ jobs:
       - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')) }}:
         - name: feed
           value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+      - ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
+        - name: artifactPipeline
+          value: Build - azure
+      - ${{ else }}:
+        - name: artifactPipeline
+          value: Build - client packages
 
       steps:
       # Setup
@@ -112,7 +122,7 @@ jobs:
         inputs:
           source: specific
           project: internal
-          pipeline: Build - client packages
+          pipeline: ${{ variables.artifactPipeline }}
           preferTriggeringPipeline: true
           allowPartiallySucceededBuilds: true
           runVersion: latestFromBranch
@@ -189,7 +199,7 @@ jobs:
           inputs:
             source: specific
             project: internal
-            pipeline: Build - client packages
+            pipeline: ${{ variables.artifactPipeline }}
             preferTriggeringPipeline: true
             allowPartiallySucceededBuilds: true
             runVersion: latestFromBranch

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -13,7 +13,7 @@ trigger:
     - release/*
   paths:
     include:
-    - packages/framework/azure-client
+    - azure/packages/azure-client
     - packages/framework/loader/container-loader
     - packages/framework/fluid-static
     - packages/drivers/routerlicious-driver
@@ -25,8 +25,10 @@ pr: none
 
 resources:
   pipelines:
-  - pipeline: client   # Name of the pipeline resource
+  - pipeline: client
     source: Build - client packages
+  - pipeline: azure
+    source: Build - azure
     trigger:
       branches:
         include:
@@ -40,9 +42,9 @@ variables:
   value: $(Pipeline.Workspace)/test
 
 stages:
-  # Run Azure FRS Tests
+  # Run Azure Client FRS Tests
   - stage:
-    displayName: e2e - azure
+    displayName: e2e - azure client with frs
     dependsOn: []
     jobs:
     - template: templates/include-test-real-service.yml
@@ -53,7 +55,24 @@ stages:
         testCommand: test:realsvc:azure
         testFileTarName: azure-client
         extraDependencies: "cross-env mocha @fluidframework/test-client-utils"
+        downloadAzureTestArtifacts: true
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)
           azure__fluid__relay__service__function__url: $(azure-fluid-relay-service-function-url)
+
+  - stage:
+    displayName: e2e - azure client with azure local service
+    dependsOn: []
+    jobs:
+    - template: templates/include-test-real-service.yml
+      parameters:
+        poolBuild: Small
+        testPackage: "@fluidframework/azure-client"
+        testWorkspace: ${{ variables.testWorkspace }}
+        testCommand: test:realsvc:tinylicious
+        testFileTarName: azure-client
+        extraDependencies: "cross-env mocha @fluidframework/test-client-utils"
+        downloadAzureTestArtifacts: true
+        env:
+          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -72,7 +72,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:tinylicious
         testFileTarName: azure-client
-        extraDependencies: "cross-env mocha @fluidframework/test-client-utils"
+        extraDependencies: "cross-env mocha start-server-and-test @fluidframework/test-client-utils"
         downloadAzureTestArtifacts: true
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
Tickets:
https://dev.azure.com/fluidframework/internal/_workitems/edit/1139 (FRS)
https://dev.azure.com/fluidframework/internal/_workitems/edit/927 (Azure Local Service)

FRS / Azure Local Service runs:
https://dev.azure.com/fluidframework/internal/_build/results?buildId=79057&view=results

Note: Validated that e2e/stress pipelines are not broken.

Follow up item: Rename pipeline to better reflect its serving two stages: frs and local azure service. 