### PR TITLE
docs: Add links and fix links

### DIFF
--- a/docs/content/docs/updates/v1.0.0.md
+++ b/docs/content/docs/updates/v1.0.0.md
@@ -9,8 +9,8 @@ summary: |
 ## Patch Updates
 
 ### Update 1.0.1:
-- Add the missing [ConnectionState](https://fluidframework.com/docs/apis/container-loader#connectionstate-Enum) export to `fluid-framework`
-- Fix [AzureClient](https://fluidframework.com/docs/apis/azure-client/azureclient) issue where the second user could not connect in `local` mode
+- Add the missing [ConnectionState]({{< relref "container-loader.md#connectionstate-Enum" >}}) export to `fluid-framework`
+- Fix [AzureClient]({{< relref "azureclient.md" >}}) issue where the second user could not connect in `local` mode
 
 ## Breaking changes
 
@@ -95,8 +95,8 @@ const connection = {
 
 We've added two new methods to AzureClient that will enable developers to recover data from corrupted containers. The Fluid Framework automatically generates and saves snapshots of the operation stream that we use to load the latest container. `getContainerVersions` will allow developers to access previous versions of the container. `copyContainer` allows developers to generate a new detached container from another container.
 
-[`getContainerVersions(id, options)`](https://fluidframework.com/docs/apis/azure-client/azureclient/#getcontainerversions-Method)
-[copyContainer(id, containerSchema)](https://fluidframework.com/docs/apis/azure-client/azureclient/#copycontainer-Method)
+[`getContainerVersions(id, options)`]({{< relref "azureclient.md#getcontainerversions-Method" >}})
+[copyContainer(id, containerSchema)]({{< relref "azureclient.md#copycontainer-Method" >}})
 
 In an situation where a container will fail to load these two methods can be used together to load a document from a previous state in time.
 

--- a/docs/content/docs/updates/v1.0.0.md
+++ b/docs/content/docs/updates/v1.0.0.md
@@ -9,8 +9,8 @@ summary: |
 ## Patch Updates
 
 ### Update 1.0.1:
-- Add the missing `ConnectionState` export to `fluid-framework`
-- Fix AzureClient issue where the second user could not connect in `local` mode
+- Add the missing [ConnectionState](https://fluidframework.com/docs/apis/container-loader#connectionstate-Enum) export to `fluid-framework`
+- Fix [AzureClient](https://fluidframework.com/docs/apis/azure-client/azureclient) issue where the second user could not connect in `local` mode
 
 ## Breaking changes
 
@@ -69,9 +69,9 @@ The AzureClient connection config has been changed to have a single endpoint ins
 
 If your using the Public Preview of Azure Fluid Relay, use the following region dependent url as your new single endpoint url:
 
-- West US 2 ->  https://us.fluidrelay.azure.com
-- West Europe -> https://eu.fluidrelay.azure.com
-- Southeast Asia -> https://global.fluidrelay.azure.com
+- West US 2 ->  `https://us.fluidrelay.azure.com`
+- West Europe -> `https://eu.fluidrelay.azure.com`
+- Southeast Asia -> `https://global.fluidrelay.azure.com`
 
 ```js
 // Previous Syntax
@@ -95,8 +95,8 @@ const connection = {
 
 We've added two new methods to AzureClient that will enable developers to recover data from corrupted containers. The Fluid Framework automatically generates and saves snapshots of the operation stream that we use to load the latest container. `getContainerVersions` will allow developers to access previous versions of the container. `copyContainer` allows developers to generate a new detached container from another container.
 
-[`getContainerVersions(id, options)`](https://fluidframework.com/docs/apis/azure-client/azureclient/#azure-client-azureclient-getcontainerversions-Method)
-[copyContainer(id, containerSchema)](https://fluidframework.com/docs/apis/azure-client/azureclient/#azure-client-azureclient-copycontainer-Method)
+[`getContainerVersions(id, options)`](https://fluidframework.com/docs/apis/azure-client/azureclient/#getcontainerversions-Method)
+[copyContainer(id, containerSchema)](https://fluidframework.com/docs/apis/azure-client/azureclient/#copycontainer-Method)
 
 In an situation where a container will fail to load these two methods can be used together to load a document from a previous state in time.
 


### PR DESCRIPTION
Also escape endpoint URLs, since it's not useful for readers to click-through, and they are currently causing the link checker to fail in PRs.