### PR TITLE
Fix component governance in build tools pipeline

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/FluidFramework.git",
-    "directory": "azure"
+    "directory": "build-tools"
   },
   "license": "MIT",
   "author": "Microsoft and contributors",
@@ -85,6 +85,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
+    "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@microsoft/api-documenter": "^7.17.9",
     "@microsoft/api-extractor": "^7.22.2",

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -85,7 +85,6 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@microsoft/api-documenter": "^7.17.9",
     "@microsoft/api-extractor": "^7.22.2",

--- a/build-tools/packages/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
+++ b/build-tools/packages/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
@@ -228,13 +228,12 @@ async function main() {
     const repo = new FluidRepo(resolvedRoot, false);
     timer.time("Package scan completed");
 
-    if (kind === MonoRepoKind.Client) {
-        await generateMonoRepoInstallPackageJson(repo.clientMonoRepo);
-    } else if (kind === MonoRepoKind.Server && repo.serverMonoRepo) {
-        await generateMonoRepoInstallPackageJson(repo.serverMonoRepo);
-    } else if (kind === MonoRepoKind.Azure && repo.azureMonoRepo) {
-        await generateMonoRepoInstallPackageJson(repo.azureMonoRepo);
+    const releaseGroup = repo.monoRepos.get(kind);
+    if(releaseGroup === undefined) {
+        throw new Error(`release group couldn't be found.`);
     }
+
+    await generateMonoRepoInstallPackageJson(releaseGroup);
 }
 
 main().catch(error => {

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -83,7 +83,7 @@ extends:
         customCommand: 'ci'
         customRegistry: 'useNpmrc'
         workingDir: '$(Build.SourcesDirectory)/build-tools'
-    # Build the build-tools locally so it can be used to generate the monorepo package.json
+    # Build the build-tools locally so it can be used to generate the monorepo package.jsonnode
     - task: Npm@1
       displayName: 'npm run build:compile'
       inputs:

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -82,11 +82,13 @@ extends:
         command: 'custom'
         customCommand: 'ci --ignore-scripts'
         customRegistry: 'useNpmrc'
+        workingDir: '$(Build.SourcesDirectory)/build-tools'
     - task: Npm@1
       displayName: 'npm run build:compile'
       inputs:
         command: 'custom'
         customCommand: 'run build:compile'
+        workingDir: '$(Build.SourcesDirectory)/build-tools'
     - task: Bash@3
       displayName: 'Generate Mono repo package json'
       inputs:

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -94,7 +94,6 @@ extends:
       displayName: 'Generate Mono repo package json'
       inputs:
         targetType: 'inline'
-        workingDir: '$(Build.SourcesDirectory)/build-tools'
         script: |
           # Generate the package/package lock for the lerna project so we would scan it.
           cd build-tools

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -97,6 +97,7 @@ extends:
         workingDir: '$(Build.SourcesDirectory)/build-tools'
         script: |
           # Generate the package/package lock for the lerna project so we would scan it.
+          cd build-tools
           node packages/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --build-tools
           cp repo-package.json packages/package.json
           cp repo-package-lock.json packages/package-lock.json

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -83,7 +83,7 @@ extends:
         customCommand: 'ci'
         customRegistry: 'useNpmrc'
         workingDir: '$(Build.SourcesDirectory)/build-tools'
-    # Build the build-tools locally so it can be used to generate the monorepo package.jsonnode
+    # Build the build-tools locally so it can be used to generate the monorepo package.json
     - task: Npm@1
       displayName: 'npm run build:compile'
       inputs:

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -91,7 +91,7 @@ extends:
       displayName: 'Generate Mono repo package json'
       inputs:
         targetType: 'inline'
-        workingDir: ${{ parameters.buildDirectory }}
+        workingDir: '$(Build.SourcesDirectory)/build-tools'
         script: |
           # Generate the package/package lock for the lerna project so we would scan it.
           node packages/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --build-tools

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -82,12 +82,18 @@ extends:
         command: 'custom'
         customCommand: 'ci --ignore-scripts'
         customRegistry: 'useNpmrc'
+    - task: Npm@1
+      displayName: 'npm run build:compile'
+      inputs:
+        command: 'custom'
+        customCommand: 'run build:compile'
     - task: Bash@3
       displayName: 'Generate Mono repo package json'
       inputs:
         targetType: 'inline'
+        workingDir: ${{ parameters.buildDirectory }}
         script: |
           # Generate the package/package lock for the lerna project so we would scan it.
-          node node_modules/@fluidframework/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --build-tools
-          cp build-tools/repo-package.json build-tools/packages/package.json
-          cp build-tools/repo-package-lock.json build-tools/packages/package-lock.json
+          node packages/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --build-tools
+          cp repo-package.json packages/package.json
+          cp repo-package-lock.json packages/package-lock.json

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -80,9 +80,10 @@ extends:
       displayName: npm ci
       inputs:
         command: 'custom'
-        customCommand: 'ci --ignore-scripts'
+        customCommand: 'ci'
         customRegistry: 'useNpmrc'
         workingDir: '$(Build.SourcesDirectory)/build-tools'
+    # Build the build-tools locally so it can be used to generate the monorepo package.json
     - task: Npm@1
       displayName: 'npm run build:compile'
       inputs:


### PR DESCRIPTION
The CG step of the build pipeline was failing because I didn't properly update the tool that generates monorepo package.jsons.