### PR TITLE
Ensure stack is always logged for sendErrorEvent

### DIFF
--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -148,7 +148,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         error?: any) {
         const newEvent = { ...event };
         if (error !== undefined) {
-            TelemetryLogger.prepareErrorObject(newEvent, error, true);
+            TelemetryLogger.prepareErrorObject(newEvent, error, true /* fetchStack */);
         }
 
         // Will include Nan & Infinity, but probably we do not care

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -148,7 +148,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         error?: any) {
         const newEvent = { ...event };
         if (error !== undefined) {
-            TelemetryLogger.prepareErrorObject(newEvent, error, false);
+            TelemetryLogger.prepareErrorObject(newEvent, error, true);
         }
 
         // Will include Nan & Infinity, but probably we do not care
@@ -166,13 +166,12 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param error - optional error object to log
      */
     public sendErrorEvent(event: ITelemetryErrorEvent, error?: any) {
+        // ensure the error field has some value even if no error object is given (will generate stack too)
+        const errorForLogging = error ?? event.eventName;
         this.sendTelemetryEventCore({
-            // ensure the error field has some value,
-            // this can and will be overridden by event, or error
-            error: event.eventName,
             ...event,
             category: "error",
-        }, error);
+        }, errorForLogging);
     }
 
     /**

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -167,7 +167,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      */
     public sendErrorEvent(event: ITelemetryErrorEvent, error?: any) {
         // ensure the error field has some value even if no error object is given (will generate stack too)
-        const errorForLogging = error ?? event.eventName;
+        const errorForLogging = error ?? event.error ?? event.eventName;
         this.sendTelemetryEventCore({
             ...event,
             category: "error",

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -56,9 +56,17 @@ describe("Error Logging", () => {
             const error = new Error("boom");
             error.name = "MyErrorName";
             TelemetryLogger.prepareErrorObject(event, error, false);
-            assert(event.error === "boom");
+            assert.equal(event.error, "boom", "event.error should contain the error message");
+            assert.equal(event.message, undefined, "event.message should be undefined for plain Error object");
             assert((event.stack as string).includes("MyErrorName"));
             assert(!(event.stack as string).includes("boom"));
+        });
+        it("LoggingError: message added to event twice", () => {
+            const event = freshEvent();
+            const error = new LoggingError("boom");
+            TelemetryLogger.prepareErrorObject(event, error, false);
+            assert.equal(event.error, "boom", "event.error should contain the error message");
+            assert.equal(event.message, "boom", "event.message should contain the error message");
         });
         it("containsPII (legacy) is ignored", () => {
             // Previously, setting containsPII = true on an error obj would (attempt to) redact its message

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -32,7 +32,8 @@ propertyCases.push(...errorCases);
 propertyCases.push(undefined);
 
 describe("TelemetryLogger", () => {
-    describe("Properties", () => {
+    //* ONLY
+    describe.only("Properties", () => {
         it("send", () => {
             for (const props of propertyCases) {
                 const logger = new TestTelemetryLogger("namespace", props);
@@ -42,12 +43,11 @@ describe("TelemetryLogger", () => {
                 assert.strictEqual(event.category, "anything");
                 assert.strictEqual(event.eventName, "namespace:whatever");
                 const eventKeys = Object.keys(event);
-                const propsKeys = Object.keys(props?.all ?? {});
-                // +2 for category and event name
-                assert.strictEqual(
-                    eventKeys.length,
-                    propsKeys.length + 2,
-                    `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
+                const expectedKeys = [...Object.keys(props?.all ?? {}), "category", "eventName"];
+                assert.deepStrictEqual(
+                    eventKeys.sort(),
+                    expectedKeys.sort(),
+                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -72,11 +72,11 @@ describe("TelemetryLogger", () => {
                             `${k} value does not match.
                             actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
                 });
-                // +3 for category, event name and stack
-                assert.strictEqual(
-                    eventKeys.length,
-                    propsKeys.length + 3,
-                    `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
+                const expectedKeys = [...propsKeys, "category", "eventName"];
+                assert.deepStrictEqual(
+                    eventKeys.sort(),
+                    expectedKeys.sort(),
+                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -101,40 +101,11 @@ describe("TelemetryLogger", () => {
                             `${k} value does not match.
                             actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
                 });
-                // +3 for category, event name and stack
-                assert.strictEqual(
-                    eventKeys.length,
-                    propsKeys.length + 3,
-                    `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
-            }
-        });
-
-        it("sendErrorEvent with error object", () => {
-            for (const props of propertyCases) {
-                const logger = new TestTelemetryLogger("namespace", props);
-                logger.sendErrorEvent({ eventName: "whatever" }, new Error("bad"));
-                assert.strictEqual(logger.events.length, 1);
-                const event = logger.events[0];
-                assert.strictEqual(event.category, "error");
-                assert.strictEqual(event.eventName, "namespace:whatever");
-                const eventKeys = Object.keys(event);
-                // should include error props too
-                const expected = { error: "bad", ... props?.all, ... props?.error };
-                const propsKeys = Object.keys(expected);
-                propsKeys.forEach(
-                    (k) => {
-                        const e = typeof expected[k] === "function" ? expected[k]() : expected[k];
-                        assert.strictEqual(
-                            event[k],
-                            e,
-                            `${k} value does not match.
-                            actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
-                });
-                // +3 for category, event name and stack
-                assert.strictEqual(
-                    eventKeys.length,
-                    propsKeys.length + 3,
-                    `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
+                const expectedKeys = [...propsKeys, "category", "eventName"];
+                assert.deepStrictEqual(
+                    eventKeys.sort(),
+                    expectedKeys.sort(),
+                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -164,11 +135,11 @@ describe("TelemetryLogger", () => {
                         `${k} value does not match.
                          actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
                 });
-                // +4 for category, event name, message and stack
-                assert.strictEqual(
-                    eventKeys.length,
-                    propsKeys.length + 4,
-                    `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
+                const expectedKeys = [...propsKeys, "category", "eventName", "errorType", "stack"];
+                assert.deepStrictEqual(
+                    eventKeys.sort(),
+                    expectedKeys.sort(),
+                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -182,11 +153,11 @@ describe("TelemetryLogger", () => {
                 assert.strictEqual(event.eventName, "namespace:whatever");
                 const eventKeys = Object.keys(event);
                 const propsKeys = Object.keys(props?.all ?? {});
-                // +2 for category and event name
-                assert.strictEqual(
-                    eventKeys.length,
-                    propsKeys.length + 2,
-                    `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
+                const expectedKeys = [...propsKeys, "category", "eventName"];
+                assert.deepStrictEqual(
+                    eventKeys.sort(),
+                    expectedKeys.sort(),
+                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
     });

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -67,15 +67,15 @@ describe("TelemetryLogger", () => {
                     (k) => {
                         const e = typeof expected[k] === "function" ? expected[k]() : expected[k];
                         assert.strictEqual(
-                        event[k],
-                        e,
-                        `${k} value does not match.
-                         actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
+                            event[k],
+                            e,
+                            `${k} value does not match.
+                            actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
                 });
-                // +2 for category and event name
+                // +3 for category, event name and stack
                 assert.strictEqual(
                     eventKeys.length,
-                    propsKeys.length + 2,
+                    propsKeys.length + 3,
                     `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
@@ -96,15 +96,44 @@ describe("TelemetryLogger", () => {
                     (k) => {
                         const e = typeof expected[k] === "function" ? expected[k]() : expected[k];
                         assert.strictEqual(
-                        event[k],
-                        e,
-                        `${k} value does not match.
-                         actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
+                            event[k],
+                            e,
+                            `${k} value does not match.
+                            actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
                 });
-                // +2 for category and event name
+                // +3 for category, event name and stack
                 assert.strictEqual(
                     eventKeys.length,
-                    propsKeys.length + 2,
+                    propsKeys.length + 3,
+                    `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
+            }
+        });
+
+        it("sendErrorEvent with error object", () => {
+            for (const props of propertyCases) {
+                const logger = new TestTelemetryLogger("namespace", props);
+                logger.sendErrorEvent({ eventName: "whatever" }, new Error("bad"));
+                assert.strictEqual(logger.events.length, 1);
+                const event = logger.events[0];
+                assert.strictEqual(event.category, "error");
+                assert.strictEqual(event.eventName, "namespace:whatever");
+                const eventKeys = Object.keys(event);
+                // should include error props too
+                const expected = { error: "bad", ... props?.all, ... props?.error };
+                const propsKeys = Object.keys(expected);
+                propsKeys.forEach(
+                    (k) => {
+                        const e = typeof expected[k] === "function" ? expected[k]() : expected[k];
+                        assert.strictEqual(
+                            event[k],
+                            e,
+                            `${k} value does not match.
+                            actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
+                });
+                // +3 for category, event name and stack
+                assert.strictEqual(
+                    eventKeys.length,
+                    propsKeys.length + 3,
                     `actual:\n${JSON.stringify(event)}\nexpected:${props ? JSON.stringify(props) : "undefined"}`);
             }
         });

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -32,8 +32,7 @@ propertyCases.push(...errorCases);
 propertyCases.push(undefined);
 
 describe("TelemetryLogger", () => {
-    //* ONLY
-    describe.only("Properties", () => {
+    describe("Properties", () => {
         it("send", () => {
             for (const props of propertyCases) {
                 const logger = new TestTelemetryLogger("namespace", props);

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -47,7 +47,7 @@ describe("TelemetryLogger", () => {
                 assert.deepStrictEqual(
                     eventKeys.sort(),
                     expectedKeys.sort(),
-                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
+                    `event:\n${JSON.stringify(event)}\nprops:\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -59,6 +59,7 @@ describe("TelemetryLogger", () => {
                 const event = logger.events[0];
                 assert.strictEqual(event.category, "error");
                 assert.strictEqual(event.eventName, "namespace:whatever");
+                assert.strictEqual(event.errorType, undefined);
                 const eventKeys = Object.keys(event);
                 // should include error props too
                 const expected = { error: "whatever", ... props?.all, ... props?.error };
@@ -72,11 +73,11 @@ describe("TelemetryLogger", () => {
                             `${k} value does not match.
                             actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
                 });
-                const expectedKeys = [...propsKeys, "category", "eventName"];
+                const expectedKeys = [...propsKeys, "category", "eventName", "errorType", "stack"];
                 assert.deepStrictEqual(
                     eventKeys.sort(),
                     expectedKeys.sort(),
-                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
+                    `event:\n${JSON.stringify(event)}\nprops:\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -88,6 +89,7 @@ describe("TelemetryLogger", () => {
                 const event = logger.events[0];
                 assert.strictEqual(event.category, "error");
                 assert.strictEqual(event.eventName, "namespace:whatever");
+                assert.strictEqual(event.errorType, undefined);
                 const eventKeys = Object.keys(event);
                 // should include error props too
                 const expected = { error: "bad", ... props?.all, ... props?.error };
@@ -101,11 +103,11 @@ describe("TelemetryLogger", () => {
                             `${k} value does not match.
                             actual: ${JSON.stringify(event[k])} expected: ${JSON.stringify(e)}`);
                 });
-                const expectedKeys = [...propsKeys, "category", "eventName"];
+                const expectedKeys = [...propsKeys, "category", "eventName", "errorType", "stack"];
                 assert.deepStrictEqual(
                     eventKeys.sort(),
                     expectedKeys.sort(),
-                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
+                    `event:\n${JSON.stringify(event)}\nprops:\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -118,6 +120,7 @@ describe("TelemetryLogger", () => {
                 const event = logger.events[0];
                 assert.strictEqual(event.category, "error");
                 assert.strictEqual(event.eventName, "namespace:whatever");
+                assert.strictEqual(event.errorType, undefined);
                 const eventKeys = Object.keys(event);
                 // should include error props too
                 const expected = {
@@ -139,7 +142,7 @@ describe("TelemetryLogger", () => {
                 assert.deepStrictEqual(
                     eventKeys.sort(),
                     expectedKeys.sort(),
-                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
+                    `event:\n${JSON.stringify(event)}\nprops:\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
 
@@ -157,7 +160,7 @@ describe("TelemetryLogger", () => {
                 assert.deepStrictEqual(
                     eventKeys.sort(),
                     expectedKeys.sort(),
-                    `event:\n${JSON.stringify(event)}\nprops\n${props ? JSON.stringify(props) : "undefined"}`);
+                    `event:\n${JSON.stringify(event)}\nprops:\n${props ? JSON.stringify(props) : "undefined"}`);
             }
         });
     });


### PR DESCRIPTION
## Description

During a recent investigation, our partners were struggling to identify where a particular function was called which was resulting in an error log (but no thrown error).  Having callstack of that error logging event would probably have given some insight.

This PR updates `sendErrorEvent` to always pass a value for `error`, which will ensure we go through `prepareErrorObject` which generates a stack if it's missing.
