### PR TITLE
Handle the closed events for dirty containers

### DIFF
--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -195,7 +195,10 @@ export class LoaderContainerTracker implements IOpProcessingController {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 debugWait(`Waiting container to be saved ${dirtyContainers.map((c) => this.containers.get(c)!.index)}`);
                 waitingSequenceNumberSynchronized = false;
-                await Promise.all(dirtyContainers.map(async (c) => new Promise((resolve) => c.once("saved", resolve))));
+                await Promise.all(dirtyContainers.map(async (c) => Promise.race(
+                    [new Promise((resolve) => c.once("saved", resolve)),
+                    new Promise((resolve) => c.once("closed", resolve))],
+                )));
             }
 
             // yield a turn to allow side effect of the ops we just processed execute before we check again

--- a/packages/test/test-utils/tsconfig.json
+++ b/packages/test/test-utils/tsconfig.json
@@ -6,8 +6,7 @@
     "compilerOptions": {
         "rootDir": "./src",
         "outDir": "./dist",
-        "composite": true,
-        "lib": ["es2021"]
+        "composite": true
     },
     "include": [
         "src/**/*"

--- a/packages/test/test-utils/tsconfig.json
+++ b/packages/test/test-utils/tsconfig.json
@@ -6,7 +6,8 @@
     "compilerOptions": {
         "rootDir": "./src",
         "outDir": "./dist",
-        "composite": true
+        "composite": true,
+        "lib": ["es2021"]
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
 ## Description

> The related ticket: https://dev.azure.com/fluidframework/internal/_workitems/edit/745/
> The related github issue: https://github.com/microsoft/FluidFramework/issues/9148
> The issue is when emitting the `save `events among all dirty containers, some containers may be already closed. It never operate the save action and will lead to the timeout result.  

## Does this introduce a breaking change?

> No

