### PR TITLE
Allow only AzureRemoteConnectionConfig or AzureLocalConnectionConfig

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -44,7 +44,7 @@ export class AzureClient {
 
 // @public
 export interface AzureClientProps {
-    readonly connection: AzureConnectionConfig;
+    readonly connection: AzureRemoteConnectionConfig | AzureLocalConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -83,6 +83,10 @@
   },
   "typeValidation": {
     "version": "1.1.0",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_AzureClientProps": {
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -24,7 +24,7 @@ export interface AzureClientProps {
     /**
      * Configuration for establishing a connection with the Azure Fluid Relay.
      */
-    readonly connection: AzureConnectionConfig;
+    readonly connection: AzureRemoteConnectionConfig | AzureLocalConnectionConfig;
     /**
      * Optional. A logger instance to receive diagnostic messages.
      */

--- a/azure/packages/azure-client/src/test/types/validateAzureClientPrevious.ts
+++ b/azure/packages/azure-client/src/test/types/validateAzureClientPrevious.ts
@@ -71,6 +71,7 @@ declare function get_old_InterfaceDeclaration_AzureClientProps():
 declare function use_current_InterfaceDeclaration_AzureClientProps(
     use: TypeOnly<current.AzureClientProps>);
 use_current_InterfaceDeclaration_AzureClientProps(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_AzureClientProps());
 
 /*


### PR DESCRIPTION
# Work item
The connection property in AzureClientProps is typed to the generic AzureConnectionConfig instead of the specific types it will accept. This leads to the remote type not including the required `tenantId`

## Proposal
Connection should be typed to `AzureLocalConnectionConfig | AzureRemoteConnectionConfig` and not the generic.

Valid inputs:

- AzureRemoteConnectionConfig
- AzureLocalConnectionConfig 

Invalid inputs:

- AzureConnectionConfig
