### PR TITLE
Add a few more verification options to strict API-Extractor config

### DIFF
--- a/common/build/build-common/api-extractor-common-strict.json
+++ b/common/build/build-common/api-extractor-common-strict.json
@@ -15,6 +15,11 @@
                 "logLevel": "error",
                 "addToApiReportFile": false
             },
+            // Prevent cyclic `@inheritDoc` comments
+            "ae-cyclic-inherit-doc": {
+                "logLevel": "error",
+                "addToApiReportFile": false
+            },
             // A documentation comment should contain at most one release tag.
             "ae-extra-release-tag": {
                 "logLevel": "error",
@@ -40,6 +45,11 @@
                 "logLevel": "error",
                 "addToApiReportFile": false
             },
+            // Require packages to include `@packageDocumentation` comment
+            "ae-misplaced-package-tag": {
+                "logLevel": "error",
+                "addToApiReportFile": false
+            },
             // Disabled. We don't require that all exported members have an explicit release tag. While being explicit
             // is preferred and is a best practice, enabling this requires that we have explicit release tags all the
             // way down, which makes it very tough to adopt this config for most of our packages.
@@ -53,6 +63,11 @@
                 "addToApiReportFile": false
             },
             "ae-unresolved-inheritdoc-reference": {
+                "logLevel": "error",
+                "addToApiReportFile": false
+            },
+            // The @link tag needs a TSDoc declaration reference.
+            "ae-unresolved-link": {
                 "logLevel": "error",
                 "addToApiReportFile": false
             }


### PR DESCRIPTION
Specifically:
- [ae-cyclic-inherit-doc](https://api-extractor.com/pages/messages/ae-cyclic-inherit-doc/)
- [ae-misplaced-package-tag](https://api-extractor.com/pages/messages/ae-misplaced-package-tag/)
- [ae-unresolved-link](https://api-extractor.com/pages/messages/ae-unresolved-link/)