### PR TITLE
Use interface for named brand types

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -41,7 +41,8 @@ export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(valu
 export type FieldKey = LocalFieldKey | GlobalFieldKey;
 
 // @public
-export type GlobalFieldKey = Opaque<Brand<string, "tree.GlobalFieldKey">>;
+export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKey">> {
+}
 
 // @public
 export interface Invariant<T> extends Contravariant<T>, Covariant<T> {

--- a/packages/dds/tree/src/schema/Schema.ts
+++ b/packages/dds/tree/src/schema/Schema.ts
@@ -45,7 +45,7 @@ export type LocalFieldKey = Brand<string, "tree.LocalFieldKey">;
  * (keeping the two classes of fields separate, name-spacing/escaping,
  * compressing one into numbers and leaving the other strings, etc.)
  */
-export type GlobalFieldKey = Opaque<Brand<string, "tree.GlobalFieldKey">>;
+export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKey">>{}
 
 /**
  * Describes how a particular field functions.

--- a/packages/dds/tree/src/test/util/brand.spec.ts
+++ b/packages/dds/tree/src/test/util/brand.spec.ts
@@ -23,9 +23,9 @@ export type T1 = Brand<number, "1">;
 export type T2 = Brand<number, "2">;
 export type T3 = Brand<{ test: number; }, "2">;
 
-type O1 = Opaque<T1>;
-type O2 = Opaque<T2>;
-type O3 = Opaque<T3>;
+interface O1 extends Opaque<T1>{}
+interface O2 extends Opaque<T2>{}
+interface O3 extends Opaque<T3>{}
 
 type _check =
     | requireTrue<areSafelyAssignable<ExtractFromOpaque<O1>, T1>>

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -50,7 +50,7 @@ export type ChildCollection = FieldKey | RootRange;
  * DetachedRanges are not valid to use as across edits:
  * they are only valid within the edit in which they were created.
  */
-export type DetachedRange = Opaque<Brand<number, "tree.DetachedRange">>;
+export interface DetachedRange extends Opaque<Brand<number, "tree.DetachedRange">> {}
 
 /**
  * TODO: integrate this into Schema. Decide how to persist them (need stable Id?). Maybe allow updating field kinds?.

--- a/packages/dds/tree/src/util/brand.ts
+++ b/packages/dds/tree/src/util/brand.ts
@@ -54,6 +54,12 @@ export abstract class BrandedType<ValueType, Name extends string> {
  * The type can be recovered using {@link extractFromOpaque},
  * however if we assume only code that produces these "opaque" handles does that conversion,
  * they can function like opaque handles.
+ *
+ * Recommenced usage is to use `interface` instead of `type` so tooling (such as tsc and refactoring tools)
+ * uses the type name instead of expanding it:
+ * ```typescript
+ * export interface MyType extends Opaque<Brand<string, "myPackage.MyType">>{}
+ * ```
  */
 export type Opaque<T extends Brand<any, string>> = T extends Brand<
     infer ValueType,


### PR DESCRIPTION
## Description

This prevents VS Codes's intelisense and refactoring tools (and tsc compile errors) from inlining the expanded definitions for Opaque branded types.

This same approach does not build if you do it for non-opaque types (since they can expend a primitive), so they are left as is: it seems like less of a big deal if they end up being transparent anyway.