### PR TITLE
r11s: allow restless to parse large requests

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -49,7 +49,7 @@ export function create(
 
     // initialize RestLess server translation
     const restLessMiddleware: () => express.RequestHandler = () => {
-        const restLessServer = new RestLessServer();
+        const restLessServer = new RestLessServer({ requestSizeLimit: requestSize });
         return (req, res, next) => {
             restLessServer
                 .translate(req, res)

--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -27,11 +27,26 @@ interface IRestLessServerOptions {
     requestSizeLimit: number | string;
 }
 
+const defaultRestLessServerOptions: IRestLessServerOptions = {
+    requestSizeLimit: "1gb",
+};
+
 /**
  * Server for communicating with a "RestLess" client.
  * Translates a "RestLess" HTTP request into a typical RESTful HTTP format
  */
 export class RestLessServer {
+    private readonly options: IRestLessServerOptions;
+
+    constructor(
+        options?: Partial<IRestLessServerOptions>,
+    ) {
+        this.options = {
+            ...defaultRestLessServerOptions,
+            ...options,
+        };
+    }
+
     /**
      * If POST request has content-type application/x-www-urlencoded,
      * translates request from RestLess to standard REST in-place.
@@ -39,7 +54,6 @@ export class RestLessServer {
     public async translate(
         request: IncomingMessageEx,
         response: ServerResponse,
-        options?: Partial<IRestLessServerOptions>,
     ): Promise<IncomingMessageEx> {
         // Ensure it's intended to be RestLess
         if (!RestLessServer.isRestLess(request)) {
@@ -51,7 +65,7 @@ export class RestLessServer {
             await new Promise<void>((resolve, reject) =>
                 urlencoded(
                     {
-                        limit: options?.requestSizeLimit ?? "1gb",
+                        limit: this.options.requestSizeLimit,
                         extended: true,
                         // urlencoded does not recognize content-type: application/x-www-form-urlencoded;restless
                         type: (req) => req.headers["content-type"]?.startsWith("application/x-www-form-urlencoded"),

--- a/server/routerlicious/packages/services-shared/src/restLessServer.ts
+++ b/server/routerlicious/packages/services-shared/src/restLessServer.ts
@@ -17,6 +17,16 @@ export const decodeHeader = (
 
 type IncomingMessageEx = IncomingMessage & { body?: any; };
 
+interface IRestLessServerOptions {
+    /**
+     * Request body size limit in number of bytes or as a string to
+     * be passed to the [bytes](https://www.npmjs.com/package/bytes) library.
+     * Only verified when parsing request body as a stream.
+     * Default: 1gb
+     */
+    requestSizeLimit: number | string;
+}
+
 /**
  * Server for communicating with a "RestLess" client.
  * Translates a "RestLess" HTTP request into a typical RESTful HTTP format
@@ -29,6 +39,7 @@ export class RestLessServer {
     public async translate(
         request: IncomingMessageEx,
         response: ServerResponse,
+        options?: Partial<IRestLessServerOptions>,
     ): Promise<IncomingMessageEx> {
         // Ensure it's intended to be RestLess
         if (!RestLessServer.isRestLess(request)) {
@@ -40,6 +51,7 @@ export class RestLessServer {
             await new Promise<void>((resolve, reject) =>
                 urlencoded(
                     {
+                        limit: options?.requestSizeLimit ?? "1gb",
                         extended: true,
                         // urlencoded does not recognize content-type: application/x-www-form-urlencoded;restless
                         type: (req) => req.headers["content-type"]?.startsWith("application/x-www-form-urlencoded"),


### PR DESCRIPTION
## Description

#10614 replaced Formidable with `urlencoded` from `body-parser`. However, `urlencoded` has a default size limit of 100kb. This can cause RestLess to fail to parse request bodies larger than 100kb.

This PR sets the default limit to "1gb" (matched with the rest of the service APIs) and allows services to change the limit if desired.

