### PR TITLE
Implement basics for Tree's Object Forest

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -91,7 +91,11 @@ export type TreeSchemaIdentifier = Brand<string, "tree.TreeSchemaIdentifier">;
 export type TreeType = TreeSchemaIdentifier;
 
 // @public
-export type Value = undefined | Serializable;
+export interface TreeValue extends Serializable {
+}
+
+// @public
+export type Value = undefined | TreeValue;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/dds/tree/src/feature-libraries/defaultRebaser.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultRebaser.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Value } from "../forest";
-import { AnchorSet, UpPath } from "../tree";
+import { AnchorSet, UpPath, Value } from "../tree";
 import { ChangeRebaser } from "../rebase";
 import { Contravariant, Covariant, Invariant } from "../util";
 

--- a/packages/dds/tree/src/forest/cursor.ts
+++ b/packages/dds/tree/src/forest/cursor.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Serializable } from "@fluidframework/datastore-definitions";
-import { FieldKey, TreeType } from "../tree";
+import { FieldKey, TreeType, Value } from "../tree";
 
 export const enum TreeNavigationResult {
     /** Attempt to navigate cursor to a key or index that is outside the client's view. */
@@ -16,16 +15,6 @@ export const enum TreeNavigationResult {
     /** ITreeReader successfully navigated to the desired node. */
     Ok = 1,
 }
-
-/**
- * Value stored on a node.
- *
- * TODO: `Serializable` is not really the right type to use here,
- * since may types (including functions) are "Serializable" (according to the type) despite not being serializable.
- *
- * Use this type instead of directly using Serializable for both clarity and so the above TODO can be addressed.
- */
-export type Value = undefined | Serializable;
 
 /**
  * A stateful low-level interface for reading tree data.

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -79,6 +79,10 @@ export interface TreeLocation {
     readonly index: number;
 }
 
+export function isFieldLocation(range: FieldLocation | DetachedRange): range is FieldLocation {
+    return typeof range === "object";
+}
+
 /**
  * Wrapper around DetachedRange that can be detected at runtime.
  */

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -4,8 +4,8 @@
  */
 
 import { StoredSchemaRepository } from "../schema";
-import { AnchorSet, FieldKey, DetachedRange } from "../tree";
-import { Value, ITreeCursor } from "./cursor";
+import { AnchorSet, FieldKey, DetachedRange, Value } from "../tree";
+import { ITreeCursor } from "./cursor";
 import { IForestSubscription, NodeId } from "./forest";
 
 /**

--- a/packages/dds/tree/src/forest/index.ts
+++ b/packages/dds/tree/src/forest/index.ts
@@ -6,7 +6,6 @@
 export {
     ITreeCursor,
     TreeNavigationResult,
-    Value,
 } from "./cursor";
 export * from "./forest";
 export { IEditableForest, FieldLocation, TreeLocation, isFieldLocation } from "./editableForest";

--- a/packages/dds/tree/src/forest/index.ts
+++ b/packages/dds/tree/src/forest/index.ts
@@ -9,4 +9,4 @@ export {
     Value,
 } from "./cursor";
 export * from "./forest";
-export { IEditableForest, FieldLocation, TreeLocation } from "./editableForest";
+export { IEditableForest, FieldLocation, TreeLocation, isFieldLocation } from "./editableForest";

--- a/packages/dds/tree/src/forest/snapshot.ts
+++ b/packages/dds/tree/src/forest/snapshot.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKey, ChildLocation } from "../tree";
-import { Value, ITreeCursor } from "./cursor";
+import { FieldKey, ChildLocation, Value } from "../tree";
+import { ITreeCursor } from "./cursor";
 
 /**
  * Copy on write and immutable views for forests.

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-export { EmptyKey, FieldKey, TreeType } from "./tree";
+export { EmptyKey, FieldKey, TreeType, Value, TreeValue } from "./tree";
 
-export { ITreeCursor, TreeNavigationResult, Value } from "./forest";
+export { ITreeCursor, TreeNavigationResult } from "./forest";
 export { LocalFieldKey, GlobalFieldKey, TreeSchemaIdentifier } from "./schema";
 
 export {

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -24,33 +24,44 @@ import { json as jsonSchema, jsonTypes } from "./schema/examples/JsonDomainSchem
 import { JsonCursor, extract } from "./forest/jsonCursor";
 
 describe("object-forest", () => {
-    it("basic usage", () => {
-        const forest = new ObjectForest();
-        const schema = forest.schema;
+    // Use Json Cursor to insert and extract some Json data
+   describe("insert and extract json", () => {
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        const testCases: [string, {} | number][] = [
+            ["primitive", 5],
+            ["array", [1, 2, 3]],
+            ["object", { blah: "test" }],
+            ["nested objects", { blah: { foo: 5 }, baz: [{}, {}] }],
+        ];
+        for (const [name, data] of testCases) {
+            it(name, () => {
+                const forest = new ObjectForest();
+                const schema = forest.schema;
 
-        for (const t of jsonSchema) {
-            assert(schema.tryUpdateTreeSchema(t.name, t));
+                for (const t of jsonSchema) {
+                    assert(schema.tryUpdateTreeSchema(t.name, t));
+                }
+
+                const rootField = fieldSchema(FieldKind.Optional, [...jsonTypes]);
+                assert(schema.tryUpdateFieldSchema(rootFieldKey, rootField));
+
+                // Check schema is actually valid. If we forgot to add some required types this would fail.
+                assert(!isNeverField(schema, rootField));
+
+                const insertCursor = new JsonCursor(data);
+                const clone = extract(insertCursor);
+                assert.deepEqual(clone, data);
+                const newRange = forest.add([insertCursor]);
+                const dst = { index: 0, range: forest.rootField };
+                forest.attachRangeOfChildren(dst, newRange);
+
+                const reader = forest.allocateCursor();
+                assert(forest.tryGet(forest.root, reader) === TreeNavigationResult.Ok);
+
+                // copy data from reader into json object and compare to data.
+                const copy = extract(reader);
+                assert.deepEqual(copy, data);
+            });
         }
-
-        const rootField = fieldSchema(FieldKind.Optional, [...jsonTypes]);
-        assert(schema.tryUpdateFieldSchema(rootFieldKey, rootField));
-
-        // Check schema is actually valid. If we forgot to add some required types this would fail.
-        assert(!isNeverField(schema, rootField));
-
-        const dataToInsert = { blah: "test" };
-        const insertCursor = new JsonCursor(dataToInsert);
-        const clone = extract(insertCursor);
-        assert.deepEqual(clone, dataToInsert);
-        const newRange = forest.add([insertCursor]);
-        const dst = { index: 0, range: forest.rootField };
-        forest.attachRangeOfChildren(dst, newRange);
-
-        const reader = forest.allocateCursor();
-        assert(forest.tryGet(forest.root, reader) === TreeNavigationResult.Ok);
-
-        // copy data from reader into json object and compare to dataToInsert.
-        const copy = extract(reader);
-        assert.deepEqual(copy, dataToInsert);
     });
 });

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+// Allow importing from this specific file which is being tested:
+/* eslint-disable-next-line import/no-internal-modules */
+import { ObjectForest } from "../feature-libraries/object-forest";
+
+import {
+    fieldSchema, rootFieldKey,
+    isNeverField, FieldKind,
+} from "../schema";
+import { TreeNavigationResult } from "../forest";
+
+// Allow importing specific example files:
+/* eslint-disable-next-line import/no-internal-modules */
+import { json as jsonSchema, jsonTypes } from "./schema/examples/JsonDomainSchema";
+
+// TODO: move JsonCursor to test utilities or non test code.
+/* eslint-disable-next-line import/no-internal-modules */
+import { JsonCursor, extract } from "./forest/jsonCursor";
+
+describe("object-forest", () => {
+    it("basic usage", () => {
+        const forest = new ObjectForest();
+        const schema = forest.schema;
+
+        for (const t of jsonSchema) {
+            assert(schema.tryUpdateTreeSchema(t.name, t));
+        }
+
+        const rootField = fieldSchema(FieldKind.Optional, [...jsonTypes]);
+        assert(schema.tryUpdateFieldSchema(rootFieldKey, rootField));
+
+        // Check schema is actually valid. If we forgot to add some required types this would fail.
+        assert(!isNeverField(schema, rootField));
+
+        const dataToInsert = { blah: "test" };
+        const insertCursor = new JsonCursor(dataToInsert);
+        const clone = extract(insertCursor);
+        assert.deepEqual(clone, dataToInsert);
+        const newRange = forest.add([insertCursor]);
+        const dst = { index: 0, range: forest.rootField };
+        forest.attachRangeOfChildren(dst, newRange);
+
+        const reader = forest.allocateCursor();
+        assert(forest.tryGet(forest.root, reader) === TreeNavigationResult.Ok);
+
+        // copy data from reader into json object and compare to dataToInsert.
+        const copy = extract(reader);
+        assert.deepEqual(copy, dataToInsert);
+    });
+});

--- a/packages/dds/tree/src/test/schema/examples/JsonDomainSchema.ts
+++ b/packages/dds/tree/src/test/schema/examples/JsonDomainSchema.ts
@@ -26,9 +26,9 @@ import {
 
 export const typeSchema: Map<TreeSchemaIdentifier, TreeSchema> = new Map();
 
-const jsonTypes: Set<TreeSchemaIdentifier> = new Set();
+export const jsonTypes: Set<TreeSchemaIdentifier> = new Set();
 
-const json: NamedTreeSchema[] = [];
+export const json: NamedTreeSchema[] = [];
 
 export const jsonObject: NamedTreeSchema = {
     name: "Json.Object" as TreeSchemaIdentifier,

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -3,7 +3,15 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { Brand } from "../util";
+import {
+    ChildLocation,
+    DetachedRange,
+    ChildCollection,
+    RootRange,
+    FieldKey,
+ } from "../tree";
 import { UpPath } from "./pathTree";
 
 /**
@@ -18,8 +26,9 @@ import { UpPath } from "./pathTree";
  */
 
 export class AnchorSet {
+    public readonly paths = new PathCollection();
+    public readonly anchorsToPath: Map<Anchor, PathShared> = new Map();
     public constructor() {
-        throw Error("Not implemented"); // TODO
     }
 
     /**
@@ -28,7 +37,9 @@ export class AnchorSet {
      * (not ideal for anchors for places or ranges instead of nodes).
      */
     public locate(anchor: Anchor): UpPath | undefined {
-        throw Error("Not implemented"); // TODO
+        // TODO: this should error for anchors that do not exist,
+        // and return undefined only if anchor does exist, but points nowhere in current revision.
+        return this.anchorsToPath.get(anchor);
     }
 
     public forget(anchor: Anchor): void {
@@ -40,5 +51,72 @@ export class AnchorSet {
      */
     public track(path: UpPath): Anchor {
         throw Error("Not implemented"); // TODO
+    }
+}
+
+/**
+ * This file contains some work in progress code to implement a prefix tree style collection of paths,
+ * designed to support collections of cursors and anchors,
+ * allowing for optimize rebase and storage of batches of paths.
+ *
+ * This is currently unused as object forest is focused on correctness not performance.
+ */
+
+/**
+ * Base type for nodes in a path tree.
+ */
+ export class PathShared<TParent extends ChildCollection = ChildCollection> implements UpPath {
+    // PathNode arrays are kept sorted by index for efficient search.
+    protected readonly children: Map<TParent, PathNode[]> = new Map();
+    // public constructor() {}
+
+    public detach(start: number, length: number, destination: DetachedRange): void {
+        // TODO: implement.
+    }
+
+    public insert(start: number, paths: PathNode, length: number) {
+        assert(paths.parent instanceof PathCollection, 0x333 /* PathShared.splice can only insert detached ranges */);
+        // TODO: implement.
+    }
+
+    parent(): UpPath | DetachedRange {
+        throw new Error("Method not implemented.");
+    }
+    parentField(): FieldKey {
+        throw new Error("Method not implemented.");
+    }
+    parentIndex(): number {
+        throw new Error("Method not implemented.");
+    }
+}
+
+class PathNode extends PathShared<FieldKey> {
+    public constructor(public parentPath: PathShared<FieldKey>, location: ChildLocation) {
+        super();
+    }
+}
+
+/**
+ * Tree of anchors.
+ * Updated on changes to forest.
+ * Contains parent pointers.
+ *
+ * Each anchor is equivalent to a path through the tree.
+ * This tree structure stores a collection of these paths, but deduplicating the common prefixes of the tree
+ * prefix-tree style.
+ *
+ * These anchors are used instead of just holding onto the node objects so that the parent path is available:
+ * these store parents, but regular object forest nodes do not.
+ *
+ * Thus this can be thought of as a sparse copy of the subset of trees which are used as anchors
+ * (and thus need parent paths).
+ */
+class PathCollection extends PathShared<RootRange> {
+    public constructor() {
+        super();
+    }
+
+    public delete(range: DetachedRange): void {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -11,6 +11,8 @@ export {
     DetachedRange,
     ChildCollection,
     RootRange,
+    Value,
+    TreeValue,
 } from "./types";
 
 export * from "./pathTree";

--- a/packages/dds/tree/src/tree/pathTree.ts
+++ b/packages/dds/tree/src/tree/pathTree.ts
@@ -3,12 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/common-utils";
 import {
-    ChildLocation,
     DetachedRange,
-    ChildCollection,
-    RootRange,
     FieldKey,
  } from "../tree";
 
@@ -22,62 +18,4 @@ export interface UpPath {
     parent(): UpPath | DetachedRange;
     parentField(): FieldKey; // TODO: Type information, including when in DetachedRange.
     parentIndex(): number; // TODO: field index branded type?
-}
-
-/**
- * This file contains some work in progress code to implement a prefix tree style collection of paths,
- * designed to support collections of cursors and anchors,
- * allowing for optimize rebase and storage of batches of paths.
- *
- * This is currently unused as object forest is focused on correctness not performance.
- */
-
-/**
- * Base type for nodes in a path tree.
- * TODO: implement UpPath/
- */
-export class PathShared<TParent extends ChildCollection = ChildCollection> {
-    // PathNode arrays are kept sorted by index for efficient search.
-    protected readonly children: Map<TParent, PathNode[]> = new Map();
-    // public constructor() {}
-
-    public detach(start: number, length: number, destination: DetachedRange): void {
-        // TODO: implement.
-    }
-
-    public insert(start: number, paths: PathNode, length: number) {
-        assert(paths.parent instanceof PathCollection, 0x333 /* PathShared.splice can only insert detached ranges */);
-        // TODO: implement.
-    }
-}
-
-class PathNode extends PathShared<FieldKey> {
-    public constructor(public parent: PathShared<FieldKey>, location: ChildLocation) {
-        super();
-    }
-}
-
-/**
- * Tree of anchors.
- * Updated on changes to forest.
- * Contains parent pointers.
- *
- * Each anchor is equivalent to a path through the tree.
- * This tree structure stores a collection of these paths, but deduplicating the common prefixes of the tree
- * prefix-tree style.
- *
- * These anchors are used instead of just holding onto the node objects so that the parent path is available:
- * these store parents, but regular object forest nodes do not.
- *
- * Thus this can be thought of as a sparse copy of the subset of trees which are used as anchors
- * (and thus need parent paths).
- */
-class PathCollection extends PathShared<RootRange> {
-    public constructor() {
-        super();
-    }
-
-    public delete(range: DetachedRange): void {
-        throw new Error("Method not implemented.");
-    }
 }

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { Serializable } from "@fluidframework/datastore-definitions";
 import { GlobalFieldKey, LocalFieldKey, TreeSchemaIdentifier } from "../schema";
 import { Brand, Opaque } from "../util";
 
@@ -63,3 +64,20 @@ export interface FieldKind {
     readonly minimumChildren: number;
     readonly maximumChildren: number;
 }
+
+/**
+ * Value that may be stored on a node.
+ *
+ * TODO: `Serializable` is not really the right type to use here,
+ * since many types (including functions) are "Serializable" (according to the type) despite not being serializable.
+ *
+ * Use this type instead of directly using Serializable for both clarity and so the above TODO can be addressed.
+ *
+ * This is a named interface instead of a Type alias so tooling (ex: refactors) will not replace it with `any`.
+ */
+export interface TreeValue extends Serializable {}
+
+ /**
+  * Value stored on a node.
+  */
+export type Value = undefined | TreeValue;


### PR DESCRIPTION
## Description

Adds basic editing and reading support to object-forest, along with minimal tests.

Also moves and adds a named interface for Value so it works better and makes more sense.