### PR TITLE
fluidBuild: Fix gen-version incremental detection for new internal semver

### DIFF
--- a/build-tools/packages/build-tools/src/bumpVersion/bumpDependencies.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpDependencies.ts
@@ -6,7 +6,7 @@
 import { Context } from "./context";
 import { VersionBag } from "./versionBag";
 import { fatal, prereleaseSatisfies } from "./utils";
-import { MonoRepo, MonoRepoKind } from "../common/monoRepo";
+import { MonoRepo } from "../common/monoRepo";
 import { Package } from "../common/npmPackage";
 import { FluidRepo } from "../common/fluidRepo";
 

--- a/build-tools/packages/build-tools/src/bumpVersion/context.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/context.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import * as path from "path";
 import { VersionBag, ReferenceVersionBag } from "./versionBag";
 import { commonOptions } from "../common/commonOptions";
 import { Timer } from "../common/timer";

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -6,7 +6,7 @@
 import { commonOptions } from "../common/commonOptions";
 import { FluidRepoBuild } from "./fluidRepoBuild";
 import { getResolvedFluidRoot } from "../common/fluidUtils";
-import { logStatus, logError, logVerbose } from "../common/logging";
+import { logStatus, logError } from "../common/logging";
 import { Timer } from "../common/timer";
 import { existsSync } from "../common/utils";
 import { BuildResult } from "./buildGraph";

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -157,12 +157,25 @@ export class CopyfilesTask extends LeafWithDoneFileTask {
 export class GenVerTask extends LeafTask {
     protected addDependentTasks(dependentTasks: LeafTask[]) { }
     protected async checkLeafIsUpToDate() {
+        const file = path.join(this.node.pkg.directory, "src/packageVersion.ts");
         try {
-            const file = path.join(this.node.pkg.directory, "src/packageVersion.ts");
             const content = await readFileAsync(file, "utf8");
-            const match = content.match(/.*\nexport const pkgName = "(.*)";[\n\r]*export const pkgVersion = "([0-9.]+)";.*/m);
-            return (match !== null && this.node.pkg.name === match[1] && this.node.pkg.version === match[2]);
+            const match = content.match(/.*\nexport const pkgName = "(.*)";[\n\r]*export const pkgVersion = "([0-9A-Za-z.+\-]+)";.*/m);
+            if (match === null) {
+                this.logVerboseTrigger("src/packageVersion.ts content not matched");
+                return false;
+            }
+            if (this.node.pkg.name !== match[1]) {
+                this.logVerboseTrigger("package name in src/packageVersion.ts not matched");
+                return false;
+            }
+            if (this.node.pkg.version !== match[2]) {
+                this.logVerboseTrigger("package version in src/packageVersion.ts not matched");
+                return false;
+            }
+            return true;
         } catch {
+            this.logVerboseTrigger(`failed to read src/packageVersion.ts`)
             return false;
         }
     }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -160,7 +160,7 @@ export class GenVerTask extends LeafTask {
         const file = path.join(this.node.pkg.directory, "src/packageVersion.ts");
         try {
             const content = await readFileAsync(file, "utf8");
-            const match = content.match(/.*\nexport const pkgName = "(.*)";[\n\r]*export const pkgVersion = "([0-9A-Za-z.+\-]+)";.*/m);
+            const match = content.match(/.*\nexport const pkgName = "(.*)";[\n\r]*export const pkgVersion = "([0-9A-Za-z.+-]+)";.*/m);
             if (match === null) {
                 this.logVerboseTrigger("src/packageVersion.ts content not matched");
                 return false;


### PR DESCRIPTION
The GenVer task detects if the packageVersion.ts file needs to be regenerated based on a regex match.
The regex match needs to be updated to allow all possible characters that can be in a full semver including prereleases.