### PR TITLE
1.1: Run typetests:prepare on client packages

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1657,7 +1657,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -2279,25 +2279,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.1.0.tgz",
-			"integrity": "sha512-RWxNNM7B6AF3JbCgrzH8L+W7HjiUYqDj2lYtgLFFeFFU9hkDUmp1fbZnjxiCrvtXZCwC3FqhRgNN9LaN1d5j1Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.0.tgz",
+			"integrity": "sha512-Yey7dJlnAj8CUZr0aYh34WEtmeHjJiQUtn/OwYrg5PasRFMrYTM0vaM8XRYEUZMDdI0JpiOgpgsAK/iNpkGuCg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-loader": "^1.1.0",
-				"@fluidframework/container-runtime": "^1.1.0",
-				"@fluidframework/container-runtime-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/map": "^1.1.0",
-				"@fluidframework/request-handler": "^1.1.0",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/synthesize": "^1.1.0",
-				"@fluidframework/view-interfaces": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-loader": "^1.2.0",
+				"@fluidframework/container-runtime": "^1.2.0",
+				"@fluidframework/container-runtime-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/map": "^1.2.0",
+				"@fluidframework/request-handler": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/synthesize": "^1.2.0",
+				"@fluidframework/view-interfaces": "^1.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -2416,17 +2416,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.1.0.tgz",
-			"integrity": "sha512-MBReNvBGNAHGHVu9kbtFxxYhtLDeG98jm21ubfGMO1aM+8i/k9Z62AymKKGp9uI7mwyKQnsrS6Wkhr87/M5wxg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.0.tgz",
+			"integrity": "sha512-zkrzssBwx3/1bgl0ZlhxLSRJP40MlflhL5OmuHO4AT/qU69csrvk5TSilROCpAzl+kU1Qu3yhEynH1uqp0ectA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0"
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0"
 			}
 		},
 		"@fluidframework/cell-previous": {
@@ -2469,13 +2469,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.1.0.tgz",
-			"integrity": "sha512-SINUvqZdEkUY1RnpYEJ1uWRb0DCJfNWVny2pkmPaVYY8dg8I85+iX90+bTPEF3RXXSaa4Cdhj09h9cBHwp/fxA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.0.tgz",
+			"integrity": "sha512-Zx/L15OCB3LB26yvrFpNDKsIdd8p0Z1qK5/wSyB3uvLnyZ7wHjr3BJDqtTk89U9ORRn3202hOqFYe8L6GeLzGA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
@@ -2491,20 +2491,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.1.0.tgz",
-			"integrity": "sha512-NVPyrf0ncEURTvxOCdYE2PRzhwA3J+OYXrjr4MK6jnbdf+sp64u2oAm8ous1lvn7VmTFUt5udF0F/RLyvj/WKg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.0.tgz",
+			"integrity": "sha512-/PSbKypP+5233kkQ5daq/XLQ4uBNJIpIS25MnfQ2DNkRKR3DqP0YBUm7IfySf7ub1gLWCk9sMGelBwhQR7dL9g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-utils": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2533,40 +2533,40 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.1.0.tgz",
-			"integrity": "sha512-rAxOnFNfeYXUsNebMHNu1F1OGYHZb4gy/rUr9svZA7lkviaZSW5o+PVV49G4RKXRdocidL+IkoRUvEgX7PT7Ng==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.0.tgz",
+			"integrity": "sha512-/4TnxjrfzllfMD8PbaqGg4XdBQ0yg2bUxmx5N5FzWQxzyy0KwjDBV3uvBa3antmpcF3V1HzFBhzGJ4dnlwZcSw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-runtime-definitions": "^1.1.0",
-				"@fluidframework/container-utils": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
-				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-runtime-definitions": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/garbage-collector": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.1.0.tgz",
-			"integrity": "sha512-flCKCjLWnJ7xijNTWdt8mlW60nTVo0MwaxByyhTSVijkO9uXbwOzPdwcKZHzAsrCmCC1EuNDB0kyvyKFP2cV9Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.0.tgz",
+			"integrity": "sha512-XQQt3z/c1N0IOboC0dBAY1IlVhXl7VVdW9GWVAFA0APEug8QXMAJ3wC958+uVe05+eEcip8EBYL+k5X3yWLsQw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
 				"@types/node": "^14.18.0"
 			}
 		},
@@ -2609,15 +2609,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.1.0.tgz",
-			"integrity": "sha512-Z3fDlytTQL4Y5eeWTQhYHZG+wOPd7QCdbwi9zM6nc7OvSBkdCwY5HGsck/sgYvRwcBIdLIVoZ+DctVplKVboBw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.0.tgz",
+			"integrity": "sha512-D/kbhfESuyeqXM5YmEAOHO0U/Kns1Lt4xWYlxUrfGnZY+rjSbXgkel2MndkqengVewwQQNuEoK2Kh9n1yRRItQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.1.0"
+				"@fluidframework/telemetry-utils": "^1.2.0"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
@@ -2633,9 +2633,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.1.0.tgz",
-			"integrity": "sha512-lwZTJwF67dQJjw7VHVeqJyLukarD/apxYOBcVDHMFFFA5yvkHMOTfN6rAOrjQ6TmJ3uwzamZxRm3+3wUU2rBVA=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.0.tgz",
+			"integrity": "sha512-jYzIO9idQSRNe2DJ08VzWie4cVUe59o8sl6A7r17mcRqUymVxgbeSdBY4NvmCb3gwW8Rm20P8OJr4/uXNgAI1Q=="
 		},
 		"@fluidframework/core-interfaces-previous": {
 			"version": "npm:@fluidframework/core-interfaces@1.1.0",
@@ -2643,17 +2643,17 @@
 			"integrity": "sha512-lwZTJwF67dQJjw7VHVeqJyLukarD/apxYOBcVDHMFFFA5yvkHMOTfN6rAOrjQ6TmJ3uwzamZxRm3+3wUU2rBVA=="
 		},
 		"@fluidframework/counter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.1.0.tgz",
-			"integrity": "sha512-zv9Yd4wXjdMjHV1CZL29iOSJvkJAMf5B5xXVX9Ayvql3yvdXodtIpGSrLzvV9v0Nb8crolbTeiF6JvdYjqc5xQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.0.tgz",
+			"integrity": "sha512-3vQRI7KjclnP4ejPKSPzQ0CDxurqAGRSQxUvMXHk1veQS/03y/vbL/c0M0Jspu30lAeCwPVR/akLG7CxDdOu+A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0"
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0"
 			}
 		},
 		"@fluidframework/counter-previous": {
@@ -2689,39 +2689,39 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.1.0.tgz",
-			"integrity": "sha512-9c/b7neSKrmLo8Hzf9yDR6AtiI6zY+sn6pJyur6+uiG4X9cG5K4KONoP2oW9nMEwI1ZuFlPaKQf22y8ABhTX5w==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.0.tgz",
+			"integrity": "sha512-dx/xgdfERQJvEhuEhPlS9s0+kZPKUPTDPFHRXkm92Uv3q/5c2+pBqDUogfXcEwk52Kg6vnNZxef5CaMtmXsL9A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-utils": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
-				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/garbage-collector": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.1.0.tgz",
-			"integrity": "sha512-QtDJP1B2/krmvtDfds3hEV5fpIHJgtP5bqxW/OdhP342jmsiLe7bottSoGTBRaz2sFrhtVO49cfI3Wnv1c9Mfw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.0.tgz",
+			"integrity": "sha512-x/HqRiYdDVtRUahAvQtExVZDJni8H7W2k7EYUTy2xOnDXT5paYAif0nVlqDHGHy/yHShhV0e4J5opX6EOsYl9Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
 				"@types/node": "^14.18.0"
 			}
 		},
@@ -2788,16 +2788,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.1.0.tgz",
-			"integrity": "sha512-K93DVQg+ILGrvY3UwdGGiTm0oqL4mjHhYTpl8nnf7ELSqAM2lLPHs3CwvFVphoUJjY62n3UgDVKn6SENxvCJKA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.0.tgz",
+			"integrity": "sha512-L5ab7RNe8VPFu2WdCKt2dJN/K/j+QNd/cyx8EB5bGjSxgOgumitHh230Y4lrNkyCDs8AzqNli0ZszLeh27vlHA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.1.0"
+				"@fluidframework/telemetry-utils": "^1.2.0"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
@@ -2814,12 +2814,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.1.0.tgz",
-			"integrity": "sha512-NzvFeDy8Rzi2fXED6NWTdm+RIfUF0mkoEmj1oZkHhWyoNrAhXviS4k03J8Pib+A3LZqVufVclrFQhcrSVQiobA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.0.tgz",
+			"integrity": "sha512-lwvM7G9Qa62E541DA1mKruMvu2QGEDzqBYEWzuqIDgAfa2ham2IlW0hZU43vCFqkcQJZ/1W+oZ7VhStPiovCqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
@@ -2834,18 +2834,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.1.0.tgz",
-			"integrity": "sha512-M3T1sfopSc0+lBSMGmlJlW3KS0DalT/LSmHd3/lChKS0KVBJSHXWmwPw6zqJiorH6A26bZIoBG2/SbpPRdte2w==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.0.tgz",
+			"integrity": "sha512-y5N5a2F3oEqd6o6+Xp1jxsKVzgZoOGCNASzgY7R5lf6XckETk9gIhmRKvQcd0h1Tmw2jSIMUmrnT5/kaOHSEkg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			}
@@ -2911,22 +2911,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.1.0.tgz",
-			"integrity": "sha512-QAKkDGPy7wQv2wo6jHO8RSd4EGoiQt6UwpC0CBjH1G8sC9DELiTAqP1D0aATyh9OEr3tv2224FseCg0jwYqkow==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.0.tgz",
+			"integrity": "sha512-sp79UNflkejT7nLTc7Iv2m0hCsfSfQY4OTKXcMMdvOFK0PJfBxCqFnS/ReccywI4bjW7ARbVhA4M6K9owd1nvA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.1.0",
+				"@fluidframework/aqueduct": "^1.2.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-loader": "^1.1.0",
-				"@fluidframework/container-runtime-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-loader": "^1.2.0",
+				"@fluidframework/container-runtime-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.1.0",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0"
+				"@fluidframework/request-handler": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
@@ -2949,13 +2949,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.1.0.tgz",
-			"integrity": "sha512-NXyzumWwpANyPeOZUaEF+U31RjYINXjgCUUpVZJOZ6GV+15dTaqXrjg9Cc3j39u0lP3xnCk1wZYGVOxssaKqxw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.0.tgz",
+			"integrity": "sha512-+06VAzl07md9aiX9Rq7/+a4QPMpJD+pHLM3+3LCa+yWqczfZqHR8xyzTAQt29j0zP14lY2Qe8mI2UX/B9PwTWw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.1.0"
+				"@fluidframework/runtime-definitions": "^1.2.0"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
@@ -2989,17 +2989,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.1.0.tgz",
-			"integrity": "sha512-n60rnzmZUs+DG6U3FQYzdT7hE6vtvq/Z6qZiZu7vmisvT9qaDXKTCQhkiFRTdPNXJIU/Zh9OYJQqlGyvfz7Yrg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.0.tgz",
+			"integrity": "sha512-/q56V3WANjE8IItJMDBsacHLC2q954ngMCuhagsNi4V4apRnTmryW2p0SC7ZNISuoM4eNagrhKJkYRBzhVWRkg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3019,24 +3019,31 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.1.0.tgz",
-			"integrity": "sha512-08rEMv254BqJD75f5XLZ5zYVyZ8E5t7n9DOOzoWgBg3lfvoRc303Fng3H19g/fODHz5s//ZUlfq9LxrUKYVzJQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.0.tgz",
+			"integrity": "sha512-CIrIMcO4SKB6h9tqUvKpYBRmbYHTuMkML1Dau+3SuYrfwQFVQG2TuC75HW5hoZCcI5Wt/J1xK36A1ouYkL8ESQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-base": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-base": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/routerlicious-driver": "^1.2.0",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
 				"@fluidframework/server-test-utils": "^0.1036.5000",
-				"jsrsasign": "^10.2.0",
+				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"jsrsasign": {
+					"version": "10.5.25",
+					"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
+					"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg=="
+				}
 			}
 		},
 		"@fluidframework/local-driver-previous": {
@@ -3061,20 +3068,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.1.0.tgz",
-			"integrity": "sha512-Uwi/nYcgNlA2oTR5J9Q/LXwi7fSphxWIPgvUUgO99iRl6/1PNfqFmDMSMSxtCzBTDmXIMkTyikWkaM1xWGc3/A==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.0.tgz",
+			"integrity": "sha512-lbOdtoG/aCAe5a4URywSG/8ThFIb15FbvrTgDxMBNjfkDpuWDvkx60pQfAYwXJ2UXAO2lUMv6FoS4zfgP19FOg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/container-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
@@ -3097,21 +3104,21 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.1.0.tgz",
-			"integrity": "sha512-J7wOhr3Ph1djvR0XRQmUwM2/29uf1sCerBvnhgmhSu3Yy1+QsaURjFvuOthyI1KKZElgfcQ0bwc/6wgUHTfihA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.0.tgz",
+			"integrity": "sha512-8Nju7EkLknDeO9S+9eE6+wUVhDssQSVKVkmGfQERv/8lmfsGDnv5vdBFIN7FwRA8xkCQE71J50yuaisqhNHk3Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/merge-tree": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/merge-tree": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			}
@@ -3137,21 +3144,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.1.0.tgz",
-			"integrity": "sha512-HRnDdlQmqPSFWgGRaZ/IA3R49Hp0lC8ZeIn+fprb1MD2uJ7/WbE484mYd0ZV/VnpPHHy/reKdC4wFTNorqjnOg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.0.tgz",
+			"integrity": "sha512-QHe1LM0gxcCTFZWtgRS8cRcMsbITXY0V9npBvjp8vYGq4BCnxKf0TnflVWYOK8Jy8/Nh0j6SVX8wCVxQXdTzxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-utils": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0"
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
@@ -3173,12 +3180,12 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.1.0.tgz",
-			"integrity": "sha512-6WIj7FNZE2WniFdAUvPE469KQcFYUJdbjP1h3Ma4Zong63TeQBbzN/HUM7N8p/3tJijdXLvRoFxRGzBFzDgMZA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.0.tgz",
+			"integrity": "sha512-ChtEnou4SeO8NsSKaVjIfkQsZ+0yVMAjjj7BDg7lgBQqFJUgmilz8pl/+2Sf1uAV5AUUq4sto9a9QqdT6AAGAQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.1.0",
+				"@fluidframework/test-driver-definitions": "^1.2.0",
 				"mocha": "^10.0.0"
 			}
 		},
@@ -3193,16 +3200,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.1.0.tgz",
-			"integrity": "sha512-oM5ukWlkf95zfnXPfEAz2wHMVWg2r5qC0lQuaNECG4jOJ3CBPwiVXLQ7xHI83gDY5Uxkwuqoq261L3ANX9WoGQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.0.tgz",
+			"integrity": "sha512-qgnS0bV5vKgV6deW0LAqrPLFvTNlHwl4Z2gOtug8dDrs+7aSYv9IYyPDtB1I+nf7zWfbZx/+EBE779TvjAvlng==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
-				"@fluidframework/odsp-driver-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/odsp-driver-definitions": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
@@ -3221,22 +3228,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.1.0.tgz",
-			"integrity": "sha512-A6BkhAOZSu8judvhrNLCI/3iLzV46jbjAuBnVQSRIPuoOkEjMFgsFPdU59bVIhnm6yO/hTf6TV36xdZHdR7fNw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.0.tgz",
+			"integrity": "sha512-hCd0UDxNI3ZL0SAzozHrxXp0wKQwGURIExLEr0+jhTc8gg1gPAVsBKP62DXV+lqdutKpfvgA8gSEr7wsbGG4jQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-base": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-base": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.1.0",
-				"@fluidframework/odsp-driver-definitions": "^1.1.0",
+				"@fluidframework/odsp-doclib-utils": "^1.2.0",
+				"@fluidframework/odsp-driver-definitions": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -3244,11 +3251,11 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.1.0.tgz",
-			"integrity": "sha512-CVUXIPN1OGMUz6rLTxPubVSCGCi4pbRXWWkHCSWIbK1NrHIhOOkbVjuOUkbdMGZtp18qrZ4GB1IKcxF1elcApg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.0.tgz",
+			"integrity": "sha512-v2A4QGNlyZOp9+tom7hQBTT01mjji1tcPjbE3uQBil7rxASdniLjF1O925haHOjxYFJDzNGDxkNMAHFLuUu+lw==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.1.0"
+				"@fluidframework/driver-definitions": "^1.2.0"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
@@ -3283,14 +3290,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.1.0.tgz",
-			"integrity": "sha512-GjfgNGxJOySAY6wRTbM49KDcKDPb7QvNjtoCFB+1DXTfh3AmPhvtPsQIfVAca9dP2WFjFClN6soPsU/ZRYX40w==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.0.tgz",
+			"integrity": "sha512-clO0gNsPRXk2hsnX1LoO2EJUbPY5Un32bMkmAHkBznlVkikpYgZyos04lhEgvNLvrNjL8ykcXGecr55jFb8obQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/odsp-driver": "^1.1.0",
-				"@fluidframework/odsp-driver-definitions": "^1.1.0"
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/odsp-driver": "^1.2.0",
+				"@fluidframework/odsp-driver-definitions": "^1.2.0"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
@@ -3305,17 +3312,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.1.0.tgz",
-			"integrity": "sha512-4t9BgJhcvbZiKah+Y2jZQNHqLxLo7ZZI31CpGozHahk9qnN7ixwZGufCOcOg9c/X2B/HB/I81vml3jo+ITS9yQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.0.tgz",
+			"integrity": "sha512-zozWQkrAz7OmCaNjwnic7rjNbwSGOg19zTFrun0HCMTnmy3VpbrDJ5Hz+U9h+BgBym02WUFm8UTOz+YdtowQag==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3354,17 +3361,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.1.0.tgz",
-			"integrity": "sha512-SvP9Ouk/Dt46LI8ySh1FbL4i1k4IUJlJxoN1re2+DVbMko2UJRuaSsVv2dRVWHwPl5ynLlFUQd1cir5UDXElcw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.0.tgz",
+			"integrity": "sha512-I9q8q5+8qA/xkX82YIMmw6gCrSJ2JvywbOqlNocboIvNKRz+sRYPHSOMMubjkqGyE1Cm1tfk6rvFPy3SvrWRzQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0"
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0"
 			}
 		},
 		"@fluidframework/register-collection-previous": {
@@ -3382,16 +3389,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.1.0.tgz",
-			"integrity": "sha512-+PvOw5TWKdyWmIyvhjbl94JkAskIJqRuLu5hH/tnsJYxmM2B6HL7fyS0qH9b6yd+shEnIx3hzmY2+bI3/eA5mg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.0.tgz",
+			"integrity": "sha512-JrYriu5ZwOtcfdzw36nvJxxvjn9R6spkP22k6zhqzW1ozdAnNpq4wtAbd8CKiqVjFZZviyYD7QoLt2bf8dZ/dQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.1.0"
+				"@fluidframework/telemetry-utils": "^1.2.0"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
@@ -3408,15 +3415,15 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.1.0.tgz",
-			"integrity": "sha512-u6bP8w2GDXkIZnSe8ZBnkSh1pkT98HXyeuRrodkah9/Wu1HogS0asxfcDrbcrrPZS8luvooXusfjReYCBHFhNQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.0.tgz",
+			"integrity": "sha512-IrcWa+6be8mhaRZmLjrMBtgCgyhCCNH+4xQ0ez7rk+HQkJ++fS4JJCCYrf5ZPLllfRcDIlFM2/5VrS07F+0c+Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0"
+				"@fluidframework/container-runtime-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
@@ -3432,20 +3439,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.1.0.tgz",
-			"integrity": "sha512-dF9fSfNk+q+vqNGN7L7jdqG0GjBVGQBTxX2/IOqWfwsd6lEZr7daWte/hytrNHcNSxCYEP2OuYtthICbPfM4AA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.0.tgz",
+			"integrity": "sha512-eK/hhdSzjTt3KaPERejZoIznKrOE0OEsMN/stI5I6cMwspL5etOp8c4NjTbSY9N9mAhuk11JFxCcxIiA6SNc7g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/driver-base": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -3501,15 +3508,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.1.0.tgz",
-			"integrity": "sha512-Wn/mOCN7Jt4PWbh5IikKpUCuoBdy3N4CAOi9jB3J1KjqAqRisa1kjl6c2ExYmY/H1Q8GrzvuHP8boVkgbsNLvw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.0.tgz",
+			"integrity": "sha512-uYyF4wowCvN/vhvkEwGiEY4Ldu53IxYiJ5fKY+V/Kd1OfW0Nhuw41CoOji22tZFuZyQwWXJJy9cW2ahvHcs+yQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			}
@@ -3529,21 +3536,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.1.0.tgz",
-			"integrity": "sha512-bpUcWTl7HirLr1h6KVpI5cTWDc7cX4p1R4//J+3SaCw2znGBCC1K6kwUYraYy5+1N15NWfr4nu2hx2D3sIVPgQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.0.tgz",
+			"integrity": "sha512-9ChM6j76mWiEXaMBcAP1EgiPcvaqewvyIk3Xg8LjH853ykIlX7R4iLBUgN5g/SKfVFgkpyjnD6WumWTplr6npQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-runtime-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/garbage-collector": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-runtime-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/garbage-collector": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0"
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0"
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
@@ -3565,21 +3572,21 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.1.0.tgz",
-			"integrity": "sha512-qRkySflYdL3IBaEKT7Dq5css/o9D4gcSIjc+6HLyArnupgvqbCDg1KYkQwa6nbOSZ0GesdfO8Nd8tdLPHoSang==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.0.tgz",
+			"integrity": "sha512-3vbc+38xHPASsa74lkobAe1LhIjwrrYiubswz7MrxLz4yoiiXE/fTIYiV9l3gJMKVSxNAaOuyfekRKNWG6tlPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/merge-tree": "^1.1.0",
+				"@fluidframework/container-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/merge-tree": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/shared-object-base": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4206,22 +4213,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.1.0.tgz",
-			"integrity": "sha512-DkiTKIK0HH/lGKQQgjJo/NFD47s41MbWkO+OTt7gKLORimawjpHtaVy9mRf8VdV4QPYs3z+DzZxuFXc7OpcwLw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.0.tgz",
+			"integrity": "sha512-Bm+8TniHWWI3se0pDFBQ/+4uowznKyKf+tfdbn46CLMUKl3evSJz7oHqWnaPM7Lmcycr0Yp5dhHSwIKd5M/8vA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-runtime": "^1.1.0",
-				"@fluidframework/container-utils": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-runtime": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4260,9 +4267,9 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.1.0.tgz",
-			"integrity": "sha512-G052+fcd3cs/SMbgUbAqzwWIIP3y0ZNqQ5PmMk4ed3RMTNmJpCNeF8ZHDvZpcekp4ZWn9XhUd9OmPkLbH8l5Hw=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.0.tgz",
+			"integrity": "sha512-3EmzbkWBPYloAhqCCFxJIwIWSxBIQ7lVmnP++Od1kxTa4UmpNBv0q7cwinV+yxXrZmWBAKnnHmoTk6IyboNCLA=="
 		},
 		"@fluidframework/synthesize-previous": {
 			"version": "npm:@fluidframework/synthesize@1.1.0",
@@ -4270,9 +4277,9 @@
 			"integrity": "sha512-G052+fcd3cs/SMbgUbAqzwWIIP3y0ZNqQ5PmMk4ed3RMTNmJpCNeF8ZHDvZpcekp4ZWn9XhUd9OmPkLbH8l5Hw=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.1.0.tgz",
-			"integrity": "sha512-YMCsD/RwhFF1pRuUkf5BHiKzebQWZMMSBlaIbsXV9sTBIdukDLx29isWkU0uvIS8/46RSyc6hoBSGH0eUv8YIA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.0.tgz",
+			"integrity": "sha512-nTKgh1+6pVpR9ptjx9c34xcsVx+ByAHDEz3bYYpH/I/W6T4o66pgvrb9NeJQ1ob6EGxU/FvRm254Lrqmkb/58g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -4304,13 +4311,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.1.0.tgz",
-			"integrity": "sha512-m1R1Q1wSUBlGImQZ4jxnYNifaIruv0QArR5Dnp0aRXFCbz/bSVibR8NBpqT3GG+kn3GiUzhYk29RgUi8llTzSA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.0.tgz",
+			"integrity": "sha512-rwqr9xwceXbCgJ6Q3ftb2xu7ggrxP6u0uvT2vTw35pTQWCF2X2zqTh6qYXrtfq4HF30gHTHQHIESP75+BR4U6A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			}
@@ -4328,27 +4335,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.1.0.tgz",
-			"integrity": "sha512-J+UuqFS2O/jhwcGhF2xO/28yREJmWJf/laFDiQTAoKVXJi7i5t+HDZGxVbrHFsmoJCi+MXU60FC9zJ9aTWMRQA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.0.tgz",
+			"integrity": "sha512-yPlSLmbj+yLioeTZA9qf3iqQH3c5pF2tZ9WgTKLj0Ar0SM8PljQHzoFkACV4lz+sGLtEckxv/hR9auSa7XyNsg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
-				"@fluidframework/local-driver": "^1.1.0",
-				"@fluidframework/odsp-doclib-utils": "^1.1.0",
-				"@fluidframework/odsp-driver": "^1.1.0",
-				"@fluidframework/odsp-driver-definitions": "^1.1.0",
-				"@fluidframework/odsp-urlresolver": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/local-driver": "^1.2.0",
+				"@fluidframework/odsp-doclib-utils": "^1.2.0",
+				"@fluidframework/odsp-driver": "^1.2.0",
+				"@fluidframework/odsp-driver-definitions": "^1.2.0",
+				"@fluidframework/odsp-urlresolver": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/routerlicious-driver": "^1.2.0",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.1.0",
-				"@fluidframework/test-pairwise-generator": "^1.1.0",
-				"@fluidframework/test-runtime-utils": "^1.1.0",
-				"@fluidframework/tinylicious-driver": "^1.1.0",
-				"@fluidframework/tool-utils": "^1.1.0",
+				"@fluidframework/test-driver-definitions": "^1.2.0",
+				"@fluidframework/test-pairwise-generator": "^1.2.0",
+				"@fluidframework/test-runtime-utils": "^1.2.0",
+				"@fluidframework/tinylicious-driver": "^1.2.0",
+				"@fluidframework/tool-utils": "^1.2.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -4394,9 +4401,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.1.0.tgz",
-			"integrity": "sha512-GnkRw43klkKLyso+xQCgNIp3t1FrMDw6T2mUy+rIGkt3WtxZr6iBOjROU6DbCPkxYfuGk6o0+z9IFR7eYhHRIg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.0.tgz",
+			"integrity": "sha512-IAmbUsFNhmjeh0EyeLEPxC9Jmt1Obr7OaEHAQfbUQ24WTph9lsHoqpESmNhcGu5XtY2dxnuf5nonJH03qhAihw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
@@ -4412,25 +4419,32 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.1.0.tgz",
-			"integrity": "sha512-iIDOrASdZ/sCKNIq/8yfC56otRS9X4w5WVyz4pGu6+EDiAW3XmOn6FLW3wsRXM6GABSa8+FSDkZSNDG+SjZHsA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.0.tgz",
+			"integrity": "sha512-TMurPhAy40N8O52x236p4HRWiKAr1MiBFK/keVysDB10o4P/fXMmT3V72yZC/uN8uUCfuwRurdfKKN8T9lR+cA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.1.0",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
+				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
 				"axios": "^0.26.0",
-				"jsrsasign": "^10.2.0",
+				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"jsrsasign": {
+					"version": "10.5.25",
+					"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
+					"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg=="
+				}
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
@@ -4462,32 +4476,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.1.0.tgz",
-			"integrity": "sha512-UGs2dUPrHySWHdJ9CCt2nV3Yrg2cMpgBf5I9rPCGDsDL1YB+VAREKCyTy3oCVOVJKLkJuTWS8eeG+T38FgvvcA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.0.tgz",
+			"integrity": "sha512-63cVTPhbvWRbJMo1tBRNonSOm7X/A4BcJCFsoxXtfwFPGsDMVX0MjNmb69PTfKIzdHs9bMm8MMBLXAjRG7rzcQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.1.0",
+				"@fluidframework/aqueduct": "^1.2.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/container-loader": "^1.1.0",
-				"@fluidframework/container-runtime": "^1.1.0",
-				"@fluidframework/container-runtime-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/datastore": "^1.1.0",
-				"@fluidframework/datastore-definitions": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
-				"@fluidframework/local-driver": "^1.1.0",
-				"@fluidframework/map": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-loader": "^1.2.0",
+				"@fluidframework/container-runtime": "^1.2.0",
+				"@fluidframework/container-runtime-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/datastore": "^1.2.0",
+				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/local-driver": "^1.2.0",
+				"@fluidframework/map": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.1.0",
-				"@fluidframework/routerlicious-driver": "^1.1.0",
-				"@fluidframework/runtime-definitions": "^1.1.0",
-				"@fluidframework/runtime-utils": "^1.1.0",
-				"@fluidframework/telemetry-utils": "^1.1.0",
-				"@fluidframework/test-driver-definitions": "^1.1.0",
-				"@fluidframework/test-runtime-utils": "^1.1.0",
+				"@fluidframework/request-handler": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/test-driver-definitions": "^1.2.0",
+				"@fluidframework/test-runtime-utils": "^1.2.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
@@ -4578,18 +4592,25 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.1.0.tgz",
-			"integrity": "sha512-9nF1F9oBbXRin8d2IQme5K4JL/5SrZ3XxncoQVR1ExemUMyVu6GpUI/fhF6y1oY3rcQOVAI9rY1WObZqXOifzA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.0.tgz",
+			"integrity": "sha512-yjEMHQzRYSEOP3FmNig1yGhqSekWgOjJ361UDrwToHieB+LrpIGfYHtctuoIQs/6fZ6C8Pht1+xgdTSpIt4NtQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/driver-definitions": "^1.1.0",
-				"@fluidframework/driver-utils": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/driver-utils": "^1.2.0",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.1.0",
+				"@fluidframework/routerlicious-driver": "^1.2.0",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"jsrsasign": "^10.2.0",
+				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"jsrsasign": {
+					"version": "10.5.25",
+					"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
+					"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg=="
+				}
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
@@ -4608,12 +4629,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.1.0.tgz",
-			"integrity": "sha512-NWewWIDJ3yKfdX1L7HrtkiSfUkMAdzoy6ZJVbUc3o5SIiF8jagFZVdd33gwsRTLpnzoemPBLo1/stPtnwsOhjg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.0.tgz",
+			"integrity": "sha512-aP6AGBWwHWpWgq8SEKtHeYJmvFmMyw8bDs2lji+2lTG7taNxZivNTYWcz4L/Z1tTjBAWGpFvbBj2kOVy6TelYA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.1.0",
+				"@fluidframework/odsp-doclib-utils": "^1.2.0",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -4638,14 +4659,14 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@0.59.4001",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.4001.tgz",
-			"integrity": "sha512-aPAnNPvdVXdVRVAoCmP3lfrG3hZDpgfO0hyjVEpRP9UQOXNZwl4cxyCfvIMSW2XIdVcjCKh0qtTkhqa3EsrNtw==",
+			"version": "npm:@fluidframework/undo-redo@0.59.4002",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-0.59.4002.tgz",
+			"integrity": "sha512-3KMmAK9D8uRTLOVYpTYRokT2hdVQDXoDO8d4xCZ+Qs7DGxQkqSwiuy4S+1PqGGz/uo641rEBsjNCEZoK27z6sg==",
 			"requires": {
-				"@fluidframework/map": "^0.59.4001",
-				"@fluidframework/matrix": "^0.59.4001",
-				"@fluidframework/merge-tree": "^0.59.4001",
-				"@fluidframework/sequence": "^0.59.4001"
+				"@fluidframework/map": "^0.59.4002",
+				"@fluidframework/matrix": "^0.59.4002",
+				"@fluidframework/merge-tree": "^0.59.4002",
+				"@fluidframework/sequence": "^0.59.4002"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
@@ -4660,53 +4681,53 @@
 					}
 				},
 				"@fluidframework/container-runtime": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.4001.tgz",
-					"integrity": "sha512-K92Vc50UYQF/uY1HtSvPRxQIYu8mpdWK4pxcusdKu+i4wYbWR/iXTl5DvEPmfi2kKMQFg2ReJyaRGcCsGtpodQ==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.59.4002.tgz",
+					"integrity": "sha512-Zz2f7hR3lUd1lBR2imQF9OOvXqykO5/gYG//9qAcKIuvOs8O5WmbC95+Ab6cvInu9YgmXUOp3kxwU0IMiShJYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime-definitions": "^0.59.4001",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-runtime-definitions": "^0.59.4002",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore": "^0.59.4001",
+						"@fluidframework/datastore": "^0.59.4002",
 						"@fluidframework/driver-definitions": "^0.46.2000",
-						"@fluidframework/driver-utils": "^0.59.4001",
-						"@fluidframework/garbage-collector": "^0.59.4001",
+						"@fluidframework/driver-utils": "^0.59.4002",
+						"@fluidframework/garbage-collector": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"double-ended-queue": "^2.1.0-0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.4001.tgz",
-					"integrity": "sha512-ql78Rt8KRQt3sAFfHD1/rMCk/gr0NaP7PzmGObXKmYIr5ySdEelVOWyqTCM2t8GKJMkW9L+LV1oiiyORJnaHZw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.59.4002.tgz",
+					"integrity": "sha512-+6ObkheY8Ogw5rPdCXsSPXDnyQwZf5yopVkCQZfBMJ4XnDlymdvNVfOVYTZFoBohlY6cnu+nsEL1mx5W7Qq6Kw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/driver-definitions": "^0.46.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
 						"@types/node": "^14.18.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.4001.tgz",
-					"integrity": "sha512-b5r1kQntAjG6j/VfEI3AJF99cglmiAeh7LRAlV1LfCWzhpXfx2LabZ/t0bHj4ZakvMKL6WdiDPu0M1WdZKtxug==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.59.4002.tgz",
+					"integrity": "sha512-jt80eaxsOOBrhHe+XeCwyZxCutdzt3Kqv/aaVgfVl5+J11CUPF3d6lerltX6cy3UfCv7MbX2kfoGJdyAnyyiVg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/telemetry-utils": "^0.59.4001"
+						"@fluidframework/telemetry-utils": "^0.59.4002"
 					}
 				},
 				"@fluidframework/core-interfaces": {
@@ -4715,39 +4736,39 @@
 					"integrity": "sha512-RU7BxVQUaleOz+415dig6m3cE7tDAtFJP1IRlfOj83meKoQyMclRyXIKQpE5HD0EhI1BLRtl/nc4YsZDa9AHbA=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.4001.tgz",
-					"integrity": "sha512-UR8reBhmDtN1NfRim13jY8WzEUphh3ns+YJHxLmixFWR8/+VGxfz5ml1IQRPjq+0dExQrHAwohUHuyrxfBSFTg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.59.4002.tgz",
+					"integrity": "sha512-miZ7fH8/A5Bcj5hG2VNyaBz7d6LqniMs1gsXqwAWFDD1J6ac1pYYM7Q9Ha5aBQf9tLJm4sMD10z8Ij+dUOSOOA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
 						"@fluidframework/driver-definitions": "^0.46.2000",
-						"@fluidframework/driver-utils": "^0.59.4001",
-						"@fluidframework/garbage-collector": "^0.59.4001",
+						"@fluidframework/driver-utils": "^0.59.4002",
+						"@fluidframework/garbage-collector": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"lodash": "^4.17.21",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.4001.tgz",
-					"integrity": "sha512-q7bYVzyDjvlaxjx82QXPcKJCwWnJNFtOBbZH7MOL3/VvLqsB3IhaGE28RbTouFZXZDgkbnRnP/H3yWRzDfxYCg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.59.4002.tgz",
+					"integrity": "sha512-stilyyhpZYSbHqbp8I2CwC5C4dW02w1miWp34FQdxy0yFro2yXyVCEfEPeTCRbAUE6UPd/muPSrwJ9pPxK5aWw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
 						"@types/node": "^14.18.0"
 					}
 				},
@@ -4762,9 +4783,9 @@
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.4001.tgz",
-					"integrity": "sha512-1Y1CVYYMKerKdsFkEL9SRzNFGX81PoAukPVPG/yhP/bDAzztcO6YEp8Fg7eVMfGVVE9pPqSx5HKqpbMcuu+ffw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.59.4002.tgz",
+					"integrity": "sha512-NsuamiiDWlCW1QioSU3DNkzO6LxYC3FR1jvfVDScXmv9xO41dUlaqB09tdF4RHGiRj4zd4G32fLuwYoX7T2c+w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -4773,80 +4794,80 @@
 						"@fluidframework/gitresources": "^0.1036.4000",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"axios": "^0.26.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.4001.tgz",
-					"integrity": "sha512-Owy1mTnIAmQHfbSfMF41katFA+B3iJrUS+81TnXwOpJWjDqnYEkdeF3ohY2Iv2xZqoTaLT8DCtoxyuAS1vm0ZQ==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.59.4002.tgz",
+					"integrity": "sha512-0aZFcjicvUuPW5XNACqo9rZ0d92uBwlzvnRkSfepHHW2ZY/nKqmbYs87LO1wIG2fP7x8URhtdDCtwobXO0HE+Q==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/runtime-definitions": "^0.59.4001"
+						"@fluidframework/runtime-definitions": "^0.59.4002"
 					}
 				},
 				"@fluidframework/map": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.4001.tgz",
-					"integrity": "sha512-qyT7HOGOQcGD221N9kCSdghlOtpYuUPJYmBL8Izqa9iGvSzIRKxF4/3mgqWwsTJqrR9HjAZGTlJCRQyMcNkrYw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.59.4002.tgz",
+					"integrity": "sha512-U+5uoKwL5O/4GtVBeXMeOi05qCAPJ4Pgx0gJKVmRsxyZvm8ZXSwOg7zj7glef5z1VLs24L5wrIRG2U+oIZzsaw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/driver-utils": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/driver-utils": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
 						"path-browserify": "^1.0.1"
 					}
 				},
 				"@fluidframework/matrix": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.4001.tgz",
-					"integrity": "sha512-4kdi0YGBYjtRZYOxtXKbrkBVHoWe2ojuOofa4v2FZyz7lBccPKD/ODoNgddildWrjw+tndClHcLe+1l4Lrx0zA==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.59.4002.tgz",
+					"integrity": "sha512-DemcOc2Mb7x0sfEjTs6LxftOvWdR65gybb8afWSr6cIfxSsSIqtPIxsAxEOVVy6rO+ZJz2F6mEfWmr5SmxcgYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/merge-tree": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/merge-tree": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"@tiny-calc/nano": "0.0.0-alpha.5",
 						"tslib": "^1.10.0"
 					}
 				},
 				"@fluidframework/merge-tree": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.4001.tgz",
-					"integrity": "sha512-sEQg6Phj1O3y0c4ngbpdrWWoiVjbsI4DcTCLHkd57fCqmOrCYCglpWLhn+qF7OmQieqjR5HQ966/asnsHXiZEw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.59.4002.tgz",
+					"integrity": "sha512-R/PyxBNlE53Q254r2z++zUh9CCu5EvmpMB/S1YvmlZsdYs0aOgSfkHN9jLGTsa9dYn5CJYGxyjZFIhq0UYbTrA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001"
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.4001.tgz",
-					"integrity": "sha512-CP0fNsgOUfQwXfUy9mttueg9aGOxMU+gXZNBTzRe48VNui5laHPFROWLrOj658FoY5GmDJCEW67J7mWKxrY7Tg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.59.4002.tgz",
+					"integrity": "sha512-Iq9dZ3ez9NUfWLSBeAhaKlGGDQn1om8g9+FCzj23WxOvzITLSMpHdXf5KXmcBXi2EZFe5vWM0z00VHOrNIdJrA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -4858,65 +4879,65 @@
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.4001.tgz",
-					"integrity": "sha512-OFbwZm3Op1isE5jkAupiyJmJ5F2pxnmJn7/zc5bhGl0sqVKs0/zhhe8q1XdmpIrEVlBhZkeLPmzT/AMD8Hr0+Q==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.59.4002.tgz",
+					"integrity": "sha512-whJfMTZpSPxn56aKDX8WhrluwvQEW/4//VgbVS4VXAzSOfn5uKuMJ1W3XePGjAxn31y/09G3f2YvP4CrqRcUJA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime-definitions": "^0.59.4001",
+						"@fluidframework/container-runtime-definitions": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/garbage-collector": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/garbage-collector": "^0.59.4002",
 						"@fluidframework/protocol-base": "^0.1036.4000",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001"
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002"
 					}
 				},
 				"@fluidframework/sequence": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.4001.tgz",
-					"integrity": "sha512-pNS5pGYJgY6FkBIhN90sOfovgTQ6pMzt1NOWc54mLCVnRnSi/CUgbME/b2n4Sr4mK0mxGR/iBLbJhTBBpXizjw==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.59.4002.tgz",
+					"integrity": "sha512-biFXkwn1A6yh/NMA1YhWRBf1IvfeXQfPzWTBACXoxdbLE0VBcj0xHwElBqJnLx48qpgnLtSrMd6+TgHN+WBO6w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
-						"@fluidframework/merge-tree": "^0.59.4001",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
+						"@fluidframework/merge-tree": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/shared-object-base": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/shared-object-base": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.4001.tgz",
-					"integrity": "sha512-p0tpIzmK+RInyjS8rW+UqjH+hX9bJG2vTrNXXLOF40DUp9DypFOP/Dbd1dE0r6AvltwqKO09gQhhafyXkzjoTQ==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.59.4002.tgz",
+					"integrity": "sha512-mDf/WcJFzkIVqF5DfhYeGFnU7hGb3rr30QJugd9wScSCF+uEIaHxQnzYr8jxFDtNwJkOD9IZV5wQ6Fgf9ZBWJw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
 						"@fluidframework/container-definitions": "^0.48.2000",
-						"@fluidframework/container-runtime": "^0.59.4001",
-						"@fluidframework/container-utils": "^0.59.4001",
+						"@fluidframework/container-runtime": "^0.59.4002",
+						"@fluidframework/container-utils": "^0.59.4002",
 						"@fluidframework/core-interfaces": "^0.43.1000",
-						"@fluidframework/datastore": "^0.59.4001",
-						"@fluidframework/datastore-definitions": "^0.59.4001",
+						"@fluidframework/datastore": "^0.59.4002",
+						"@fluidframework/datastore-definitions": "^0.59.4002",
 						"@fluidframework/protocol-definitions": "^0.1028.2000",
-						"@fluidframework/runtime-definitions": "^0.59.4001",
-						"@fluidframework/runtime-utils": "^0.59.4001",
-						"@fluidframework/telemetry-utils": "^0.59.4001",
+						"@fluidframework/runtime-definitions": "^0.59.4002",
+						"@fluidframework/runtime-utils": "^0.59.4002",
+						"@fluidframework/telemetry-utils": "^0.59.4002",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.59.4001",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.4001.tgz",
-					"integrity": "sha512-Zmu1dDcVhOhsISapBGQVuz8k2H7fCatjaWU2ia6gBPIildxbjzHyYGCyTJMHsbMK7h77FH3XSxbGoVYCBJ/QXg==",
+					"version": "0.59.4002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.59.4002.tgz",
+					"integrity": "sha512-lTs9zptGduRFH6rpDDsrMKwZ0tAkQNe/qpcnyxdVxknZyKD8yhh4zvSwyISbI2zHbgVyde9b/3Rw4rgy598pGA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -4928,12 +4949,12 @@
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.1.0.tgz",
-			"integrity": "sha512-OQuW/cAgZvrPKAbQEoU1A3hkpFDTSmsTUnO9SKx95fJctd/ZhomBaH/SMzyTzQqpx4NUtz6kjo6i/k/+Dc/c+g==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.0.tgz",
+			"integrity": "sha512-iLpnZpgeGVvJBSyUoBfS2mC6kj1AnqqcFH8kq0MgmbDLW6xGFIHofl640l6AIhmCXWUEfbYPLpiE/WN7d9uEVQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.1.0",
-				"@fluidframework/view-interfaces": "^1.1.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/view-interfaces": "^1.2.0",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
@@ -4950,11 +4971,11 @@
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.1.0.tgz",
-			"integrity": "sha512-K3AoXG0EuRoUnmXMtoAm1hgo91/kkl/p1LbveUQr9iNuWMrk87zDuJjate0dtL2REZ+GWuWSgN2dcKZOtHXyZw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.0.tgz",
+			"integrity": "sha512-L1ftL7WPlBWnx9CQYXUTtEuJmtGYdwl1eTFtqwKteoFgxSEoctHZWPcWilffNJL8dNujffbG/FoOk9It+T4YBw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.1.0"
+				"@fluidframework/core-interfaces": "^1.2.0"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
@@ -4966,12 +4987,12 @@
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.1.0.tgz",
-			"integrity": "sha512-KAjD/zEcvq/vmWvohUmeQwHJjGVshC5RemjFtjgWqTcTAUHdau1Go6JC20aoBfL3njfACmdLPSBEJOMMgzCb2Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.0.tgz",
+			"integrity": "sha512-egCQ+WWs46HBtoXMxuO6+ljvJfsuGxBpB4X57MVtz5m4G+t0vrBbjOTMDbQTDK5Cp/9Rcxlh9E8qmHkfTu8Pbw==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.1.0",
-				"@fluidframework/core-interfaces": "^1.1.0",
+				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
@@ -17675,7 +17696,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
 		"auto-bind": {
@@ -19144,7 +19165,7 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
 			"dev": true
 		},
 		"buffer": {
@@ -19185,7 +19206,7 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"buffer-fill": {
 			"version": "1.0.0",
@@ -24017,7 +24038,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
 		},
 		"es6-promise": {
 			"version": "4.2.8",
@@ -24027,7 +24048,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -24959,7 +24980,7 @@
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -26031,7 +26052,7 @@
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
 		},
 		"fs-extra": {
 			"version": "9.1.0",
@@ -26371,7 +26392,7 @@
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-			"integrity": "sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==",
+			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -27700,7 +27721,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -27785,7 +27806,7 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
+			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
 			"dev": true
 		},
 		"hyperlinker": {
@@ -27874,7 +27895,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"immutable": {
 			"version": "3.7.6",
@@ -28225,7 +28246,7 @@
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
+			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
 		},
 		"internal-slot": {
 			"version": "1.0.3",
@@ -28498,7 +28519,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -28604,7 +28625,7 @@
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
+			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -31670,7 +31691,7 @@
 		"li": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-			"integrity": "sha512-z34TU6GlMram52Tss5mt1m//ifRIpKH5Dqm7yUVOdHI+BQCs9qGPHFaCUTIzsWX7edN30aa2WrPwR7IO10FHaw==",
+			"integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
 			"dev": true
 		},
 		"libnpmaccess": {
@@ -32353,7 +32374,7 @@
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
 			"dev": true
 		},
 		"lodash.flatten": {
@@ -32379,7 +32400,7 @@
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -32389,7 +32410,7 @@
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
@@ -32404,7 +32425,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -32415,23 +32436,23 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
 		},
 		"lodash.isobject": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-			"integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
 			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -32441,19 +32462,19 @@
 		"lodash.keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-			"integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==",
+			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
 			"dev": true
 		},
 		"lodash.mapvalues": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-			"integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+			"integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
 			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -32464,12 +32485,12 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
 		},
 		"lodash.snakecase": {
 			"version": "4.1.1",
@@ -32479,7 +32500,7 @@
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"lodash.template": {
@@ -32504,7 +32525,7 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -34475,7 +34496,7 @@
 		"msgpack-lite": {
 			"version": "0.1.26",
 			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+			"integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
 			"requires": {
 				"event-lite": "^0.1.1",
 				"ieee754": "^1.1.8",
@@ -34486,7 +34507,7 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
 		},
@@ -34803,7 +34824,7 @@
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-			"integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
+			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
 			"dev": true
 		},
 		"node-dir": {
@@ -36906,7 +36927,7 @@
 		"override-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-			"integrity": "sha512-eoJ9YWxFcXbrn2U8FKT6RV+/Kj7fiGAB1VvHzbYKt8xM5ZuKZgCGvnHzDxmreEjcBH28ejg5MiOH4iyY1mQnkg==",
+			"integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
 			"dev": true
 		},
 		"p-all": {
@@ -37391,7 +37412,7 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parse-path": {
 			"version": "4.0.3",
@@ -37647,7 +37668,7 @@
 		"pinpoint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-			"integrity": "sha512-+04FTD9x7Cls2rihLlo57QDCcHoLBGn5Dk51SwtFBWkUWLxZaBXyNVpCw1S+atvE7GmnFjeaRZ0WLq3UYuqAdg==",
+			"integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
 			"dev": true
 		},
 		"pirates": {
@@ -43150,7 +43171,7 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
 					"dev": true
 				},
 				"supports-color": {

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@^1.0.0",
+    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -60,7 +60,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@^1.0.0",
+    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -53,7 +53,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@^1.0.0",
+    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -72,7 +72,7 @@
     "@fluid-internal/test-dds-utils": "^1.1.1",
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/cell-previous": "npm:@fluidframework/cell@^1.0.0",
+    "@fluidframework/cell-previous": "npm:@fluidframework/cell@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/counter-previous": "npm:@fluidframework/counter@^1.0.0",
+    "@fluidframework/counter-previous": "npm:@fluidframework/counter@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
@@ -87,7 +87,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/ink-previous": "npm:@fluidframework/ink@^1.0.0",
+    "@fluidframework/ink-previous": "npm:@fluidframework/ink@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
@@ -90,7 +90,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/map-previous": "npm:@fluidframework/map@^1.0.0",
+    "@fluidframework/map-previous": "npm:@fluidframework/map@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
@@ -95,7 +95,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@^1.0.0",
+    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
@@ -101,7 +101,7 @@
     "uuid": "^8.3.1"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@^1.0.0",
+    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
@@ -98,7 +98,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": { }
+    "version": "1.1.1",
+    "broken": {}
   }
 }

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@^1.0.0",
+    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -92,7 +92,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@^1.0.0",
+    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/gitresources": "^0.1036.5000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@^1.0.0",
+    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@1.1.0",
     "@fluidframework/server-services-client": "^0.1036.5000",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
@@ -105,7 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": { }
+    "version": "1.1.1",
+    "broken": {}
   }
 }

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@^1.0.0",
+    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -100,7 +100,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@^1.0.0",
+    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/shared-object-base": "^1.1.1"
   },
   "devDependencies": {
-    "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@^1.0.0",
+    "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@1.1.0",
     "@fluid-internal/test-dds-utils": "^1.1.1",
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
@@ -95,7 +95,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@^1.0.0",
+    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,7 +58,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
-    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@^1.0.0",
+    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@^1.0.0",
+    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -61,7 +61,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@^1.0.0",
+    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/odsp-driver-definitions": "^1.1.1"
   },
   "devDependencies": {
-    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@^1.0.0",
+    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@1.1.0",
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
@@ -60,7 +60,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@^1.0.0",
+    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -61,7 +61,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@^1.0.0",
+    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -56,6 +56,8 @@
   },
   "typeValidation": {
     "version": "1.1.1",
-    "broken": {}
+    "broken": {
+      "TypeAliasDeclaration_OdspError": {"forwardCompat": false}
+    }
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@^1.0.0",
+    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@1.1.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -55,7 +55,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.ts
@@ -383,6 +383,7 @@ declare function get_old_TypeAliasDeclaration_OdspError():
 declare function use_current_TypeAliasDeclaration_OdspError(
     use: TypeOnly<current.OdspError>);
 use_current_TypeAliasDeclaration_OdspError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_OdspError());
 
 /*

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@^1.0.0",
+    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -100,7 +100,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@^1.0.0",
+    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "concurrently": "^6.2.0",
@@ -59,7 +59,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@^1.0.0",
+    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -61,7 +61,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@^1.0.0",
+    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -102,7 +102,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
-    "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@^1.0.0",
+    "@fluidframework/routerlicious-host-previous": "npm:@fluidframework/routerlicious-host@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@^1.0.0",
+    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nconf": "^0.10.0",
@@ -63,7 +63,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@^1.0.0",
+    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^9.1.1",
@@ -59,7 +59,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -64,7 +64,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@^1.0.0",
+    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@1.1.0",
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@rushstack/eslint-config": "^2.5.1",
@@ -89,7 +89,7 @@
     }
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -81,7 +81,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@^1.0.0",
+    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@1.1.0",
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
@@ -102,7 +102,7 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
-    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@^1.0.0",
+    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
@@ -91,7 +91,7 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@^1.0.0",
+    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -52,13 +52,13 @@
     "copyfiles": "^2.1.0",
     "cross-env": "^7.0.2",
     "eslint": "~8.6.0",
-    "fluid-framework-previous": "npm:fluid-framework@^1.0.0",
+    "fluid-framework-previous": "npm:fluid-framework@1.1.0",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": { }
+    "version": "1.1.1",
+    "broken": {}
   }
 }

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -59,6 +59,16 @@
   },
   "typeValidation": {
     "version": "1.1.1",
-    "broken": {}
+    "broken": {
+      "RemovedInterfaceDeclaration_IDirectoryClearOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedInterfaceDeclaration_IDirectoryCreateSubDirectoryOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedInterfaceDeclaration_IDirectoryDeleteOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedInterfaceDeclaration_IDirectoryDeleteSubDirectoryOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedTypeAliasDeclaration_IDirectoryKeyOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedInterfaceDeclaration_IDirectorySetOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedTypeAliasDeclaration_IDirectoryStorageOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedTypeAliasDeclaration_IDirectorySubDirectoryOperation": {"backCompat": false, "forwardCompat": false},
+      "RemovedInterfaceDeclaration_ILocalValue": {"backCompat": false, "forwardCompat": false}
+    }
   }
 }

--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
@@ -280,6 +280,30 @@ use_old_InterfaceDeclaration_IDirectory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryClearOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryClearOperation": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryCreateSubDirectoryOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryCreateSubDirectoryOperation": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IDirectoryDataObject": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IDirectoryDataObject():
@@ -304,6 +328,30 @@ use_old_InterfaceDeclaration_IDirectoryDataObject(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryDeleteOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryDeleteOperation": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryDeleteSubDirectoryOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectoryDeleteSubDirectoryOperation": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IDirectoryEvents": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IDirectoryEvents():
@@ -324,6 +372,18 @@ declare function use_old_InterfaceDeclaration_IDirectoryEvents(
     use: TypeOnly<old.IDirectoryEvents>);
 use_old_InterfaceDeclaration_IDirectoryEvents(
     get_current_InterfaceDeclaration_IDirectoryEvents());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_IDirectoryKeyOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_IDirectoryKeyOperation": {"backCompat": false}
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -372,6 +432,42 @@ declare function use_old_TypeAliasDeclaration_IDirectoryOperation(
     use: TypeOnly<old.IDirectoryOperation>);
 use_old_TypeAliasDeclaration_IDirectoryOperation(
     get_current_TypeAliasDeclaration_IDirectoryOperation());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectorySetOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IDirectorySetOperation": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_IDirectoryStorageOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_IDirectoryStorageOperation": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_IDirectorySubDirectoryOperation": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_IDirectorySubDirectoryOperation": {"backCompat": false}
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -516,6 +612,18 @@ declare function use_old_InterfaceDeclaration_IJSONRunSegment(
     use: TypeOnly<old.IJSONRunSegment<any>>);
 use_old_InterfaceDeclaration_IJSONRunSegment(
     get_current_InterfaceDeclaration_IJSONRunSegment());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_ILocalValue": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_ILocalValue": {"backCompat": false}
+*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@^1.0.0",
+    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
@@ -66,7 +66,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@^1.0.0",
+    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@1.1.0",
     "@fluidframework/test-runtime-utils": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -91,7 +91,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/datastore": "^1.1.1",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@^1.0.0",
+    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -85,7 +85,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@^1.0.0",
+    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -56,7 +56,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/aqueduct": "^1.1.1",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@^1.0.0",
+    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -74,7 +74,7 @@
     "fluid-framework": "^1.0.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@^1.0.0",
+    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
@@ -52,7 +52,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@^1.0.0",
+    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
@@ -49,7 +49,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@^1.0.0",
+    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-loader-utils": "^1.1.1",
@@ -102,7 +102,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@^1.0.0",
+    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
@@ -86,7 +86,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -94,6 +94,10 @@
   },
   "typeValidation": {
     "version": "1.1.1",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_AuthorizationError": {"forwardCompat": false},
+      "ClassDeclaration_GenericNetworkError": {"forwardCompat": false},
+      "ClassDeclaration_ThrottlingError": {"forwardCompat": false}
+    }
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@^1.0.0",
+    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/runtime-utils": "^1.1.1",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.ts
@@ -23,6 +23,7 @@ declare function get_old_ClassDeclaration_AuthorizationError():
 declare function use_current_ClassDeclaration_AuthorizationError(
     use: TypeOnly<current.AuthorizationError>);
 use_current_ClassDeclaration_AuthorizationError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_AuthorizationError());
 
 /*
@@ -407,6 +408,7 @@ declare function get_old_ClassDeclaration_GenericNetworkError():
 declare function use_current_ClassDeclaration_GenericNetworkError(
     use: TypeOnly<current.GenericNetworkError>);
 use_current_ClassDeclaration_GenericNetworkError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_GenericNetworkError());
 
 /*
@@ -1151,6 +1153,7 @@ declare function get_old_ClassDeclaration_ThrottlingError():
 declare function use_current_ClassDeclaration_ThrottlingError(
     use: TypeOnly<current.ThrottlingError>);
 use_current_ClassDeclaration_ThrottlingError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ThrottlingError());
 
 /*

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@^1.0.0",
+    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",
@@ -47,7 +47,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
-    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@^1.0.0",
+    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/isomorphic-fetch": "^0.0.35",
@@ -54,7 +54,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
-    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@^1.0.0",
+    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -54,7 +54,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@^1.0.0",
+    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
@@ -105,7 +105,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
-    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@^1.0.0",
+    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -54,7 +54,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
-    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@^1.0.0",
+    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@1.1.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@fluidframework/test-runtime-utils": "^1.1.1",
@@ -101,7 +101,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@^1.0.0",
+    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@1.1.0",
     "@fluidframework/mocha-test-setup": "^1.1.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -88,7 +88,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@^1.0.0",
+    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -55,7 +55,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": { }
+    "version": "1.1.1",
+    "broken": {}
   }
 }

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@^1.0.0",
+    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -95,7 +95,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@^1.0.0",
+    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -96,7 +96,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": { }
+    "version": "1.1.1",
+    "broken": {}
   }
 }

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@^1.0.0",
+    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -75,7 +75,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@^1.0.0",
+    "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -78,7 +78,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -81,7 +81,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@^1.0.0",
+    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -96,7 +96,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@^1.0.0",
+    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",
@@ -70,7 +70,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@^1.0.0",
+    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -103,7 +103,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": { }
+    "version": "1.1.1",
+    "broken": {}
   }
 }

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
-    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@^1.0.0",
+    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nock": "^9.3.0",
@@ -104,7 +104,7 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -92,7 +92,7 @@
     "webpack-dev-server": "~4.6.0"
   },
   "devDependencies": {
-    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@^1.0.0",
+    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@1.1.0",
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
@@ -117,7 +117,7 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@^1.0.0",
+    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@1.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node-fetch": "^2.5.10",
@@ -86,7 +86,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@^1.0.0",
+    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -93,12 +93,7 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "1.1.0",
-    "broken": {
-      "RemovedFunctionDeclaration_originatedAsExternalError": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
-    }
+    "version": "1.1.1",
+    "broken": {}
   }
 }

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.2.74327",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
     "@fluidframework/mocha-test-setup": "^1.1.1",
-    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@^1.0.0",
+    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -93,7 +93,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "broken": {}
   }
 }


### PR DESCRIPTION
This updates typetests to have correct dependency specifiers. Builds on #11080

Some warnings were suppressed due to transitively incorrect installed dependencies in the previous package versions.