### PR TITLE
docs: Misc. API documentation improvements in `common/lib` packages

### DIFF
--- a/common/lib/common-definitions/api-report/common-definitions.api.md
+++ b/common/lib/common-definitions/api-report/common-definitions.api.md
@@ -7,11 +7,9 @@
 // @public
 export type ExtendEventProvider<TBaseEvent extends IEvent, TBase extends IEventProvider<TBaseEvent>, TEvent extends TBaseEvent> = Omit<Omit<Omit<TBase, "on">, "once">, "off"> & IEventProvider<TBaseEvent> & IEventProvider<TEvent>;
 
-// @public (undocumented)
+// @public
 export interface IDisposable {
-    // (undocumented)
     dispose(error?: Error): void;
-    // (undocumented)
     readonly disposed: boolean;
 }
 
@@ -29,20 +27,17 @@ export interface IEvent {
 
 // @public (undocumented)
 export interface IEventProvider<TEvent extends IEvent> {
-    // (undocumented)
     readonly off: IEventTransformer<this, TEvent>;
-    // (undocumented)
     readonly on: IEventTransformer<this, TEvent>;
-    // (undocumented)
     readonly once: IEventTransformer<this, TEvent>;
 }
 
-// @public (undocumented)
+// @public
 export type IEventThisPlaceHolder = {
     thisPlaceHolder: "thisPlaceHolder";
 };
 
-// @public (undocumented)
+// @public
 export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
     (event: infer E0, listener: (...args: infer A0) => void): any;
     (event: infer E1, listener: (...args: infer A1) => void): any;
@@ -250,26 +245,24 @@ export interface ITelemetryPerformanceEvent extends ITelemetryGenericEvent {
     duration?: number;
 }
 
-// @public (undocumented)
+// @public
 export interface ITelemetryProperties {
     // (undocumented)
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
 }
 
-// @public (undocumented)
+// @public
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any[] ? {
     [K in keyof L]: L[K] extends IEventThisPlaceHolder ? TThis : L[K];
 } : L;
 
-// @public (undocumented)
+// @public
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 
-// @public (undocumented)
+// @public
 export type TelemetryEventPropertyType = string | number | boolean | undefined;
 
-// @public (undocumented)
+// @public
 export type TransformedEvent<TThis, E, A extends any[]> = (event: E, listener: (...args: ReplaceIEventThisPlaceHolder<A, TThis>) => void) => TThis;
-
-// (No @packageDocumentation comment for this package)
 
 ```

--- a/common/lib/common-definitions/src/disposable.ts
+++ b/common/lib/common-definitions/src/disposable.ts
@@ -3,7 +3,20 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Base interface for objects that require lifetime management via explicit disposal.
+ */
 export interface IDisposable {
+    /**
+     * Whether or not the object has been disposed.
+     * If true, the object should be considered invalid, and its other state should be disregarded.
+     */
     readonly disposed: boolean;
+
+    /**
+     * Dispose of the object and its resources.
+     * @param error - Optional error indicating the reason for the disposal, if the object was
+     * disposed as the result of an error.
+     */
     dispose(error?: Error): void;
 }

--- a/common/lib/common-definitions/src/events.ts
+++ b/common/lib/common-definitions/src/events.ts
@@ -15,13 +15,24 @@ export interface IErrorEvent extends IEvent {
 }
 
 export interface IEventProvider<TEvent extends IEvent> {
+    /**
+     * Registers a callback to be invoked when the corresponding event is triggered.
+     */
     readonly on: IEventTransformer<this, TEvent>;
+
+    /**
+     * Registers a callback to be invoked the first time the corresponding event is triggered.
+     */
     readonly once: IEventTransformer<this, TEvent>;
+
+    /**
+     * Removes the corresponding event if it has been registered.
+     */
     readonly off: IEventTransformer<this, TEvent>;
 }
 
 /**
- * Allow an interface to extend an interfaces that already extends an IEventProvider
+ * Allows an interface to extend interfaces that already extend an {@link IEventProvider}.
  *
  * @example
  * ``` typescript
@@ -49,7 +60,7 @@ export type ExtendEventProvider<
         Omit<Omit<Omit<TBase, "on">, "once">, "off"> & IEventProvider<TBaseEvent> & IEventProvider<TEvent>;
 
 // These types handle replacing IEventThisPlaceHolder with this, so we can
-// support polymorphic this. For instance if an event wanted to be:
+// support polymorphic `this`. For instance if an event wanted to be:
 // (event: "some-event", listener:(target: this)=>void)
 //
 // it should be written as
@@ -58,25 +69,34 @@ export type ExtendEventProvider<
 // and IEventThisPlaceHolder will be replaced with this.
 // This is all consumers of these types need to know.
 
-// This is the place holder type that should be used instead of this in events
+/**
+ * The placeholder type that should be used instead of `this` in events.
+ */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type IEventThisPlaceHolder = { thisPlaceHolder: "thisPlaceHolder"; };
 
-// This does the type replacement by changing types of IEventThisPlaceHolder to TThis
+/**
+ * Does the type replacement by changing types of {@link IEventThisPlaceHolder} to `TThis`
+ */
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> =
     L extends any[] ? { [K in keyof L]: L[K] extends IEventThisPlaceHolder ? TThis : L[K] } : L;
 
-// this transforms the event overload by replacing IEventThisPlaceHolder with TThis in the event listener arguments
-// and having the overload return TTHis as well
+/**
+ * Transforms the event overload by replacing {@link IEventThisPlaceHolder} with `TThis` in the event listener
+ * arguments and having the overload return `TTHis` as well
+ */
 export type TransformedEvent<TThis, E, A extends any[]> =
     (event: E, listener: (...args: ReplaceIEventThisPlaceHolder<A, TThis>) => void) => TThis;
 
-// This type is a conditional type for transforming all the overloads provides in TEvent.
-// Due to limitations of the typescript typing system, we need to handle each number of overload individually.
-// It currently supports the max of 15 event overloads which is more than we use anywhere.
-// At more than 15 overloads we start to hit TS2589. If we need to move beyond 15 we should evaluate
-// using a mapped type pattern like {"event":(listenerArgs)=>void}
-//
+/**
+ * This type is a conditional type for transforming all the overloads provided in `TEvent`.
+ *
+ * @remarks
+ * Due to limitations of the TypeScript typing system, we need to handle each number of overload individually.
+ * It currently supports the max of 15 event overloads which is more than we use anywhere.
+ * At more than 15 overloads we start to hit {@link https://github.com/microsoft/TypeScript/issues/37209 | TS2589}.
+ * If we need to move beyond 15 we should evaluate using a mapped type pattern like `{"event":(listenerArgs)=>void}`
+ */
 export type IEventTransformer<TThis, TEvent extends IEvent> =
     TEvent extends
     {

--- a/common/lib/common-definitions/src/events.ts
+++ b/common/lib/common-definitions/src/events.ts
@@ -21,7 +21,7 @@ export interface IEventProvider<TEvent extends IEvent> {
     readonly on: IEventTransformer<this, TEvent>;
 
     /**
-     * Registers a callback to be invoked the first time the corresponding event is triggered.
+     * Registers a callback to be invoked the first time (after registration) the corresponding event is triggered.
      */
     readonly once: IEventTransformer<this, TEvent>;
 

--- a/common/lib/common-definitions/src/index.ts
+++ b/common/lib/common-definitions/src/index.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * This package contains common interfaces and definitions used by the Fluid Framework.
+ *
+ * @packageDocumentation
+ */
+
 export type {
     IDisposable,
 } from "./disposable";

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -3,12 +3,18 @@
  * Licensed under the MIT License.
  */
 
-// Examples of known categories, however category can be any string for extensibility
+/**
+ * Examples of known categories, however category can be any string for extensibility.
+ */
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 
-// Logging entire objects is considered extremely dangerous from a telemetry point of view because people
-// can easily add fields to objects that shouldn't be logged and not realize it's going to be logged.
-// General best practice is to explicitly log the fields you care about from objects
+/**
+ * Property types that can be logged.
+ *
+ * @remarks Logging entire objects is considered extremely dangerous from a telemetry point of view because people can
+ * easily add fields to objects that shouldn't be logged and not realize it's going to be logged.
+ * General best practice is to explicitly log the fields you care about from objects.
+ */
 export type TelemetryEventPropertyType = string | number | boolean | undefined;
 
 /**
@@ -20,6 +26,9 @@ export interface ITaggedTelemetryPropertyType {
     value: TelemetryEventPropertyType;
     tag: string;
 }
+/**
+ * JSON-serializable properties, which will be logged with telemetry.
+ */
 export interface ITelemetryProperties {
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
 }

--- a/common/lib/common-utils/api-report/common-utils.api.md
+++ b/common/lib/common-utils/api-report/common-utils.api.md
@@ -50,10 +50,10 @@ export class Deferred<T> {
 // @public
 export const delay: (timeMs: number) => Promise<void>;
 
-// @public (undocumented)
+// @public
 export function doIfNotDisposed<T>(disposable: IDisposable, f: (...args: any[]) => T): (...args: any[]) => T;
 
-// @public (undocumented)
+// @public
 export type EventEmitterEventType = EventEmitter extends {
     on(event: infer E, listener: any): any;
 } ? E : never;
@@ -73,10 +73,10 @@ export class EventForwarder<TEvent = IEvent> extends TypedEventEmitter<TEvent> i
     protected unforwardEvent(source: EventEmitter | IEventProvider<TEvent & IEvent>, ...events: string[]): void;
 }
 
-// @public (undocumented)
+// @public
 export const fromBase64ToUtf8: (input: string) => string;
 
-// @public (undocumented)
+// @public
 export const fromUtf8ToBase64: (input: string) => string;
 
 // @public
@@ -253,7 +253,7 @@ export class RateLimiter {
 }
 
 // @public
-export function safelyParseJSON(json: string): any;
+export function safelyParseJSON(json: string): any | undefined;
 
 // @public
 export function setLongTimeout(timeoutFn: () => void, timeoutMs: number, setTimeoutIdFn?: (timeoutId: ReturnType<typeof setTimeout>) => void): ReturnType<typeof setTimeout>;
@@ -328,7 +328,5 @@ export function Uint8ArrayToString(arr: Uint8Array, encoding?: string): string;
 
 // @public
 export function unreachableCase(_: never, message?: string): never;
-
-// (No @packageDocumentation comment for this package)
 
 ```

--- a/common/lib/common-utils/src/base64Encoding.ts
+++ b/common/lib/common-utils/src/base64Encoding.ts
@@ -5,8 +5,16 @@
 
 import { IsoBuffer } from "./indexNode";
 
+/**
+ * Converts the provided {@link https://en.wikipedia.org/wiki/Base64 | base64}-encoded string
+ * to {@link https://en.wikipedia.org/wiki/UTF-8 | utf-8}
+ */
 export const fromBase64ToUtf8 = (input: string): string => IsoBuffer.from(input, "base64").toString("utf-8");
 
+/**
+ * Converts the provided {@link https://en.wikipedia.org/wiki/UTF-8 | utf-8}-encoded string
+ * to {@link https://en.wikipedia.org/wiki/Base64 | base64}
+ */
 export const fromUtf8ToBase64 = (input: string): string => IsoBuffer.from(input, "utf8").toString("base64");
 
 /**

--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -31,7 +31,9 @@ export function Uint8ArrayToString(arr: Uint8Array, encoding?: string): string {
 }
 
 /**
- * Convert base64 or utf8 string to array buffer
+ * Converts a {@link https://en.wikipedia.org/wiki/Base64 | base64} or
+ * {@link https://en.wikipedia.org/wiki/UTF-8 | utf-8} string to array buffer.
+ *
  * @param encoding - input string's encoding
  */
 export const stringToBuffer = (input: string, encoding: string): ArrayBufferLike =>

--- a/common/lib/common-utils/src/bufferShared.ts
+++ b/common/lib/common-utils/src/bufferShared.ts
@@ -4,8 +4,8 @@
  */
 
 /**
- * Convert Uint8Array array to ArrayBuffer
- * @param array - array to convert to ArrayBuffer
+ * Converts a Uint8Array array to an ArrayBuffer
+ * @param array - Array to convert to ArrayBuffer
  */
 export function Uint8ArrayToArrayBuffer(array: Uint8Array): ArrayBuffer {
     if (array.byteOffset === 0 && array.byteLength === array.buffer.byteLength) {

--- a/common/lib/common-utils/src/delay.ts
+++ b/common/lib/common-utils/src/delay.ts
@@ -4,8 +4,8 @@
  */
 
 /**
- * Returns a promise that resolves after timeMs
- * @param timeMs - time in milliseconds to wait
+ * Returns a promise that resolves after `timeMs`.
+ * @param timeMs - Time in milliseconds to wait
  */
 export const delay = async (timeMs: number): Promise<void> =>
     new Promise((resolve) => setTimeout(() => resolve(), timeMs));

--- a/common/lib/common-utils/src/disposal.ts
+++ b/common/lib/common-utils/src/disposal.ts
@@ -5,6 +5,12 @@
 
 import { IDisposable } from "@fluidframework/common-definitions";
 
+/**
+ * Returns a wrapper around the provided function, which will only invoke the inner function if the provided
+ * {@link @fluidframework/common-definitions#IDisposable | disposable} object has not yet been disposed.
+ *
+ * @throws Will throw an error if the item has already been disposed.
+ */
 export function doIfNotDisposed<T>(
     disposable: IDisposable,
     f: (...args: any[]) => T,

--- a/common/lib/common-utils/src/eventForwarder.ts
+++ b/common/lib/common-utils/src/eventForwarder.ts
@@ -21,6 +21,9 @@ export class EventForwarder<TEvent = IEvent>
     private static readonly newListenerEvent = "newListener";
     private static readonly removeListenerEvent = "removeListener";
 
+    /**
+     * {@inheritDoc @fluidframework/common-definitions#IDisposable.disposed}
+     */
     public get disposed() { return this.isDisposed; }
     private isDisposed: boolean = false;
 
@@ -40,6 +43,9 @@ export class EventForwarder<TEvent = IEvent>
         }
     }
 
+    /**
+     * {@inheritDoc @fluidframework/common-definitions#IDisposable.dispose}
+     */
     public dispose() {
         this.isDisposed = true;
         for (const listenerRemovers of this.forwardingEvents.values()) {

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * This package contains common utility functions and classes used by the Fluid Framework.
+ *
+ * @packageDocumentation
+ */
+
 export * from "./assert";
 export * from "./indexNode";
 export * from "./base64Encoding";

--- a/common/lib/common-utils/src/promiseCache.ts
+++ b/common/lib/common-utils/src/promiseCache.ts
@@ -17,7 +17,7 @@ export type PromiseCacheExpiry = {
 };
 
 /**
- * Options for configuring the PromiseCache
+ * Options for configuring the {@link PromiseCache}
  */
 export interface PromiseCacheOptions {
     /** Common expiration policy for all items added to this cache */

--- a/common/lib/common-utils/src/rangeTracker.ts
+++ b/common/lib/common-utils/src/rangeTracker.ts
@@ -8,7 +8,7 @@ import cloneDeep from "lodash/cloneDeep";
 import { assert } from "./assert";
 
 /**
- * A range in the RangeTracker
+ * A range in the {@link RangeTracker}
  */
 export interface IRange {
     primary: number;
@@ -17,7 +17,7 @@ export interface IRange {
 }
 
 /**
- * A serialized version of the RangeTracker
+ * A serialized version of the {@link RangeTracker}
  */
 export interface IRangeTrackerSnapshot {
     ranges: IRange[];

--- a/common/lib/common-utils/src/safeParser.ts
+++ b/common/lib/common-utils/src/safeParser.ts
@@ -4,17 +4,20 @@
  */
 
 /**
- * Wrapper for JSON.parse to translate all exception to return undefined
+ * Wrapper for
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse | JSON.parse},
+ * which will return `undefined` in the case of an error, rather than throwing.
  *
- * @param json - the JSON string to parse
- * @returns the result JSON.parse is successful, undefined if exception happens
+ * @param json - The JSON string to parse
+ * @returns The result from `JSON.parse` if successful, otherwise `undefined`.
  */
-export function safelyParseJSON(json: string) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function safelyParseJSON(json: string): any | undefined {
     let parsed;
     try {
         parsed = JSON.parse(json);
     } catch (e) {
-        //
+        return undefined;
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return parsed;

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -5,9 +5,12 @@
 import { EventEmitter } from "events";
 import { IEvent, TransformedEvent, IEventTransformer, IEventProvider } from "@fluidframework/common-definitions";
 
-// the event emitter polyfill and the node event emitter have different event types:
-// string | symbol vs. string | number
-// this allow us to correctly handle either type
+/**
+ * The event emitter polyfill and the node event emitter have different event types:
+ * string | symbol vs. string | number
+ *
+ * This type allow us to correctly handle either type
+ */
 export type EventEmitterEventType = EventEmitter extends { on(event: infer E, listener: any); } ? E : never;
 
 export type TypedEventTransform<TThis, TEvent> =

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -42,9 +42,7 @@ export interface IAttachment {
 
 // @public
 export interface IBlob {
-    // (undocumented)
     contents: string;
-    // (undocumented)
     encoding: "utf-8" | "base64";
 }
 
@@ -386,7 +384,6 @@ export interface ISnapshotTree {
     trees: {
         [path: string]: ISnapshotTree;
     };
-    // (undocumented)
     unreferenced?: true;
 }
 
@@ -399,6 +396,9 @@ export interface ISnapshotTreeEx extends ISnapshotTree {
         [path: string]: ISnapshotTreeEx;
     };
 }
+
+// @public
+export type IsoDate = string;
 
 // @public
 export interface ISummaryAck {
@@ -517,9 +517,7 @@ export interface ITrace {
 export interface ITree {
     // (undocumented)
     entries: ITreeEntry[];
-    // (undocumented)
     id?: string;
-    // (undocumented)
     unreferenced?: true;
 }
 
@@ -551,11 +549,8 @@ export interface IUser {
 
 // @public
 export interface IVersion {
-    // (undocumented)
-    date?: string;
-    // (undocumented)
+    date?: IsoDate;
     id: string;
-    // (undocumented)
     treeId: string;
 }
 
@@ -645,7 +640,5 @@ export enum TreeEntry {
     // (undocumented)
     Tree = "Tree"
 }
-
-// (No @packageDocumentation comment for this package)
 
 ```

--- a/common/lib/protocol-definitions/src/date.ts
+++ b/common/lib/protocol-definitions/src/date.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 format} date: `YYYY-MM-DDTHH:MM:SSZ`
+ */
+ export type IsoDate = string;

--- a/common/lib/protocol-definitions/src/index.ts
+++ b/common/lib/protocol-definitions/src/index.ts
@@ -3,9 +3,17 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Core set of Fluid protocol interfaces shared between services and clients.
+ * These interfaces must always be back and forward compatible.
+ *
+ * @packageDocumentation
+ */
+
 export * from "./clients";
 export * from "./consensus";
 export * from "./config";
+export * from "./date";
 export * from "./protocol";
 export * from "./storage";
 export * from "./summary";

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { IsoDate } from "./date";
+
 export interface IDocumentAttributes {
     /**
      * Sequence number at which the snapshot was taken
@@ -31,10 +33,14 @@ export enum FileMode {
  * Raw blob stored within the tree
  */
 export interface IBlob {
-    // Contents of the blob
+    /**
+     * Contents of the blob
+     */
     contents: string;
 
-    // The encoding of the contents string
+    /**
+     * The encoding of the contents string
+     */
     encoding: "utf-8" | "base64";
 }
 
@@ -50,10 +56,15 @@ export interface ICreateBlobResponse {
  * A tree entry wraps a path with a type of node
  */
 export type ITreeEntry = {
-    // Path to the object
+    /**
+     * Path to the object
+     */
     path: string;
-    // The file mode; one of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree)
-    // or 120000 for a blob that specifies the path of a symlink
+
+    /**
+     * The file mode; one of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree)
+     * or 120000 for a blob that specifies the path of a symlink
+     */
     mode: FileMode;
 } & (
 {
@@ -78,10 +89,16 @@ export enum TreeEntry {
 
 export interface ITree {
     entries: ITreeEntry[];
-    // Unique ID representing all entries in the tree. Can be used to optimize snapshotting in the case
-    // it is known that the ITree has already been created and stored
+
+    /**
+     * Unique ID representing all entries in the tree. Can be used to optimize snapshotting in the case
+     * it is known that the `ITree` has already been created and stored
+     */
     id?: string;
-    // Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
+
+    /**
+     * Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
+     */
     unreferenced?: true;
 }
 
@@ -89,7 +106,10 @@ export interface ISnapshotTree {
     id?: string;
     blobs: { [path: string]: string; };
     trees: { [path: string]: ISnapshotTree; };
-    // Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
+
+    /**
+    * Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
+    */
     unreferenced?: true;
 }
 
@@ -102,13 +122,18 @@ export interface ISnapshotTreeEx extends ISnapshotTree {
  * Represents a version of the snapshot of a data store
  */
 export interface IVersion {
-    // Version ID
+    /**
+     * Version ID
+     */
     id: string;
 
-    // Tree ID for this version of the snapshot
+    /**
+     * Tree ID for this version of the snapshot
+     */
     treeId: string;
 
-    // Time when snapshot was generated.
-    // ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
-    date?: string;
+    /**
+     * Time when snapshot was generated.
+     */
+    date?: IsoDate;
 }

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -77,7 +77,7 @@ export interface IActorClient {
 }
 
 /**
- * The ITokenService abstracts the discovery of claims contained within a token
+ * Abstracts the discovery of claims contained within a token.
  */
 export interface ITokenService {
     extractClaims(token: string): ITokenClaims;


### PR DESCRIPTION
Adds API docs to a number of types in the `common/lib` packages, as well as package-summary documentation for each package.

Also...
- Adds an IsoDate type to encapsulate documentation repeated across the codebase
- Takes better advantage of TSDoc syntax

[ADO #969](https://dev.azure.com/fluidframework/internal/_workitems/edit/969)