### PR TITLE
Improvements to benchmark tool

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -26,7 +26,7 @@
     "eslint:fix": "eslint src --fix",
     "lint": "npm run prettier && npm run eslint",
     "lint:fix": "npm run prettier:fix && npm run eslint:fix",
-    "perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit -r node_modules/@fluidframework/mocha-test-setup --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
+    "perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit -r node_modules/@fluidframework/mocha-test-setup --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
     "perf:measure": "npm run perf -- --fgrep @Measurement",
     "prettier": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",
     "prettier:fix": "prettier --write \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -26,7 +26,7 @@
     "eslint:fix": "eslint src --fix",
     "lint": "npm run prettier && npm run eslint",
     "lint:fix": "npm run prettier:fix && npm run eslint:fix",
-    "perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict --expose-gc --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
+    "perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit -r node_modules/@fluidframework/mocha-test-setup --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
     "perf:measure": "npm run perf -- --fgrep @Measurement",
     "prettier": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",
     "prettier:fix": "prettier --write \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",


### PR DESCRIPTION
## Description

- Address the issue of `global.gc()` not working in child processes. The issue was a combination of two things:
  - node-specific flags need to be provided before the script to execute when calling node, i.e. `node <node-flags> <script> <script-flags>`, but we were passing them after `<script>`.
  - If mocha detects any node-specific flags in its arguments, it spawns a node process with those flags in the correct position, but for some reason mishandles `--expose-gc`.
- Remove any `--inspect*` or `--debug*` args when spawning child processes so they don't fail to start because the default debug port 9229 is already in use. This could be improved to pass a different port to each child process, but I left it out of scope for now.

## Reviewer Guidance

I tested this by `npm link`ing the tools/benchmark package from experimental/tree, removing the protections on the call to `global.gc()` [here](https://github.com/alexvy86/FluidFramework/blob/408cb7bdcbe141136adc9578593dedd102e3c327/tools/benchmark/src/Runner.ts#L139) and running the tests for experimental/tree with two versions of the `npm run perf` script.

First the current one, plus the `--parentProcess` flag.

`cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --inspect-brk --unhandled-rejections=strict --expose-gc --exit -r node_modules/@fluidframework/mocha-test-setup --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000`

With that version, `--expose-gc` does not show up in `process.execArgv` and thus it is not forwarded to the child process:

![image](https://user-images.githubusercontent.com/716334/178853244-e022ac90-4d9b-4dbc-bee9-458cd5f9bbd7.png)

Which means that `global.gc` is not defined there and the tests fail:

![image](https://user-images.githubusercontent.com/716334/178851942-aeb81235-7c12-4e36-af1a-4b0bd8a91737.png)

Then with a version that uses `--node-option` to pass the node-specific flags to mocha, so it handles them correctly:

`cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc,inspect-brk --exit -r node_modules/@fluidframework/mocha-test-setup --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000`

Now `expose-gc` shows in execArgv as expected:

![image](https://user-images.githubusercontent.com/716334/178854133-b1777617-5c82-47e1-96a9-eb180de57a52.png)

And the tests pass (I deliberately made one of the tests fail for a different reason, that error is expected):

![image](https://user-images.githubusercontent.com/716334/178851984-c30c8ec1-6cdd-4bf3-9ccd-ae4d89243263.png)
