### PR TITLE
Interfaces with less restrictive telem properties

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -283,6 +283,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     constructor(namespace?: string | undefined, properties?: ITelemetryLoggerPropertyBags | undefined);
     // (undocumented)
     static readonly eventNamespaceSeparator = ":";
+    static filterValidTelemetryProps(x: any): TelemetryEventPropertyType | null;
     // (undocumented)
     static formatTick(tick: number): number;
     // (undocumented)
@@ -290,7 +291,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     static numberFromString(str: string | null | undefined): string | number | undefined;
     static prepareErrorObject(event: ITelemetryBaseEvent, error: any, fetchStack: boolean): void;
     // (undocumented)
-    protected prepareEvent(event: ITelemetryBaseEvent): ITelemetryBaseEvent;
+    protected prepareEvent(event: ITelemetryBaseEvent | ITelemetryBaseEventExt): ITelemetryBaseEvent;
     // (undocumented)
     protected readonly properties?: ITelemetryLoggerPropertyBags | undefined;
     // (undocumented)
@@ -302,6 +303,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     protected sendTelemetryEventCore(event: ITelemetryGenericEvent & {
         category: TelemetryEventCategory;
     }, error?: any): void;
+    static stringifyEventFields(event: ITelemetryBaseEventExt): ITelemetryBaseEvent;
 }
 
 // @public

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -140,6 +140,14 @@ export function isTaggedTelemetryPropertyValue(x: any): x is ITaggedTelemetryPro
 export function isValidLegacyError(e: any): e is Omit<IFluidErrorBase, "errorInstanceId">;
 
 // @public (undocumented)
+export interface ITelemetryBaseEventExt extends ITelemetryPropertiesExt {
+    // (undocumented)
+    category: string;
+    // (undocumented)
+    eventName: string;
+}
+
+// @public (undocumented)
 export interface ITelemetryLoggerPropertyBag {
     // (undocumented)
     [index: string]: TelemetryEventPropertyTypes | (() => TelemetryEventPropertyTypes);
@@ -151,6 +159,12 @@ export interface ITelemetryLoggerPropertyBags {
     all?: ITelemetryLoggerPropertyBag;
     // (undocumented)
     error?: ITelemetryLoggerPropertyBag;
+}
+
+// @public (undocumented)
+export interface ITelemetryPropertiesExt {
+    // (undocumented)
+    [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType | (string | number | boolean)[];
 }
 
 // @public (undocumented)

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -48,6 +48,17 @@ export interface ITelemetryLoggerPropertyBags{
     error?: ITelemetryLoggerPropertyBag;
 }
 
+// Less restrictive telemetry properties to include arrays with primitives.
+export interface ITelemetryPropertiesExt {
+    [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType | (string | number | boolean)[];
+}
+
+// Base interface for logging telemetry statements allowing flat arrays containing primitives.
+export interface ITelemetryBaseEventExt extends ITelemetryPropertiesExt {
+    category: string;
+    eventName: string;
+}
+
 /**
  * TelemetryLogger class contains various helper telemetry methods,
  * encoding in one place schemas for various types of Fluid telemetry events.

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -121,6 +121,43 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         }
     }
 
+    /**
+     * Take in a event object, stringify any fields that are non-primitives, and return the new event object.
+     * @param event - Event with fields you want to stringify.
+     */
+     public static stringifyEventFields(event: ITelemetryBaseEventExt): ITelemetryBaseEvent {
+        const newEvent: ITelemetryBaseEvent = { category: event.category, eventName: event.eventName };
+        for (const key of Object.keys(event)) {
+            const filteredEventVal = TelemetryLogger.filterValidTelemetryProps(event[key]);
+            if (filteredEventVal !== null) {
+                newEvent[key] = filteredEventVal;
+            }
+        }
+        return newEvent;
+    }
+    /**
+     * Takes in parameter, if parameter is of primitive type, return the original value.
+     * If parameter is an array, stringify then return the result.
+     * @param x - parameter passed to validate/filter
+     */
+    public static filterValidTelemetryProps(x: any): TelemetryEventPropertyType | null {
+        switch (typeof x) {
+            case "string":
+            case "number":
+            case "boolean":
+            case "undefined":
+                return x;
+            default:
+                if (!Array.isArray(x)) {
+                    return null;
+                }
+                if (x.every((val) => this.filterValidTelemetryProps(val) !== null)) {
+                    return JSON.stringify(x);
+                }
+                return null;
+        }
+    }
+
     public constructor(
         protected readonly namespace?: string,
         protected readonly properties?: ITelemetryLoggerPropertyBags) {
@@ -196,11 +233,9 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         this.sendTelemetryEventCore(perfEvent, error);
     }
 
-    protected prepareEvent(event: ITelemetryBaseEvent): ITelemetryBaseEvent {
+    protected prepareEvent(event: ITelemetryBaseEvent | ITelemetryBaseEventExt): ITelemetryBaseEvent {
         const includeErrorProps = event.category === "error" || event.error !== undefined;
-        const newEvent: ITelemetryBaseEvent = {
-            ...event,
-        };
+        const newEvent: ITelemetryBaseEvent = TelemetryLogger.stringifyEventFields(event);
         if (this.namespace !== undefined) {
             newEvent.eventName = `${this.namespace}${TelemetryLogger.eventNamespaceSeparator}${newEvent.eventName}`;
         }

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -151,7 +151,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
                 if (!Array.isArray(x)) {
                     return null;
                 }
-                if (x.every((val) => this.filterValidTelemetryProps(val) !== null)) {
+                if (x.every((val) => typeof val === "boolean" || typeof val === "string" || typeof val === "number")) {
                     return JSON.stringify(x);
                 }
                 return null;


### PR DESCRIPTION
## Description

As there are cases where Telemetry Events may benefit from having fields with flat arrays (with primitives), a less restrictive version of TelemetryEventPropertyType is introduced to support this. Task 1104 - "Formalize support for logging flat arrays and object" in our internal work items was created for this issue.

This PR aims to make the following updates to our TelemetryLogger implementation:
1. Accept a less-restrictive type than TelemetryEventPropertyType which includes arrays or objects where the values are strictly primitives (TelemetryEventPropertyType).
2. Stringify these flat objects/arrays when passing to another logger.