### PR TITLE
Add a createTestId flag that allows user to create document with given testId

### DIFF
--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -75,9 +75,9 @@ Launches each test runner with `--inspect-brk` and a unique Node debugging port.
 
 #### --createTestId	
 
-If the `testId`argument is specified, the `createTestId`flag determines whether to load an exisiting
-document corresponding to the `testId`specified, or create a new one. When `createTestId`is set to true,
-a new document is created, and when `createTestId`is false, we try to load an existing document.
+If the `testId` argument is specified, the `createTestId` flag determines whether to load an exisiting
+document corresponding to the `testId` specified, or create a new one. When `createTestId` is set to true,
+a new document is created, and when `createTestId` is false, we try to load an existing document.
 
 #### --log, -l
 

--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -73,6 +73,12 @@ If present, launch in Test Runner mode with the given runId (to distinguish from
 
 Launches each test runner with `--inspect-brk` and a unique Node debugging port. (Not compatible with `--runId`)
 
+#### --createTestId	
+
+If the `testId`argument is specified, the `createTestId`flag determines whether to load an exisiting
+document corresponding to the `testId`specified, or create a new one. When `createTestId`is set to true,
+a new document is created, and when `createTestId`is false, we try to load an existing document.
+
 #### --log, -l
 
 Overrides DEBUG environment variable for telemetry logging to console.

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -52,6 +52,8 @@ async function main() {
         .option("-v, --verbose", "Enables verbose logging")
         .option("-b, --browserAuth", "Enables browser auth which may require a user to open a url in a browser.")
         .option("-m, --enableMetrics", "Enable capturing client & ops metrics")
+        .option("-createId", "--createTestId", "Flag indicating whether to create a document corresponding \
+        to the testId passed")
         .parse(process.argv);
 
     const driver: TestDriverTypes = commander.driver;
@@ -65,6 +67,7 @@ async function main() {
     const browserAuth: true | undefined = commander.browserAuth;
     const credFile: string | undefined = commander.credFile;
     const enableMetrics: boolean = commander.enableMetrics ?? false;
+    const createTestId: boolean = commander.createTestId ?? false;
 
     const profile = getProfile(profileArg);
 
@@ -78,7 +81,7 @@ async function main() {
         driver,
         endpoint,
         { ...profile, name: profileArg, testUsers },
-        { testId, debug, verbose, seed, browserAuth, enableMetrics });
+        { testId, debug, verbose, seed, browserAuth, enableMetrics, createTestId });
 }
 
 /**
@@ -89,7 +92,7 @@ async function orchestratorProcess(
     endpoint: DriverEndpoint | undefined,
     profile: ILoadTestConfig & { name: string; testUsers?: ITestUserConfig; },
     args: { testId?: string; debug?: true; verbose?: true; seed?: number; browserAuth?: true;
-        enableMetrics?: boolean; },
+        enableMetrics?: boolean; createTestId?: boolean; },
 ) {
     const seed = args.seed ?? Date.now();
     const seedArg = `0x${seed.toString(16)}`;
@@ -102,10 +105,15 @@ async function orchestratorProcess(
         undefined,
         args.browserAuth);
 
-    // Create a new file if a testId wasn't provided
-    const url = args.testId !== undefined
-        ? await testDriver.createContainerUrl(args.testId)
-        : await initialize(testDriver, seed, profile, args.verbose === true);
+    let url;
+    if (args.testId !== undefined && args.createTestId === false) {
+        // If testId is provided and createTestId is false, then load the file;
+        url = await testDriver.createContainerUrl(args.testId);
+    } else {
+        // If no testId is provided, (or) if testId is provided but createTestId is not false, then create a file;
+        // In case testId is provided, name of the file to be created is taken as the testId provided
+        url = await initialize(testDriver, seed, profile, args.verbose === true, args.testId);
+    }
 
     const estRunningTimeMin = Math.floor(2 * profile.totalSendCount / (profile.opRatePerMin * profile.numClients));
     console.log(`Connecting to ${args.testId !== undefined ? "existing" : "new"}`);

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -52,7 +52,7 @@ async function main() {
         .option("-v, --verbose", "Enables verbose logging")
         .option("-b, --browserAuth", "Enables browser auth which may require a user to open a url in a browser.")
         .option("-m, --enableMetrics", "Enable capturing client & ops metrics")
-        .option("-createId", "--createTestId", "Flag indicating whether to create a document corresponding \
+        .option("--createTestId", "Flag indicating whether to create a document corresponding \
         to the testId passed")
         .parse(process.argv);
 

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -178,8 +178,8 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
 
     // Currently odsp binary snapshot format only works for special file names. This won't affect any other test
     // since we have a unique dateId as prefix. So we can just add the required suffix.
-    const testId = (typeof testIdn !== "undefined") ?
-                    testIdn : `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`;
+    const testId = testIdn ?? `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`;
+    assert(testId !== "", "testId specified cannot be an empty string");
     const request = testDriver.createCreateNewRequest(testId);
     await container.attach(request);
     assert(container.resolvedUrl !== undefined, "Container missing resolved URL after attach");

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -126,7 +126,8 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
     }
 }
 
-export async function initialize(testDriver: ITestDriver, seed: number, testConfig: ILoadTestConfig, verbose: boolean) {
+export async function initialize(testDriver: ITestDriver, seed: number, testConfig: ILoadTestConfig,
+    verbose: boolean, testIdn?: string) {
     const randEng = random.engines.mt19937();
     randEng.seed(seed);
     const optionsOverride =
@@ -177,7 +178,8 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
 
     // Currently odsp binary snapshot format only works for special file names. This won't affect any other test
     // since we have a unique dateId as prefix. So we can just add the required suffix.
-    const testId = `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`;
+    const testId = (typeof testIdn !== "undefined") ?
+                    testIdn : `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`;
     const request = testDriver.createCreateNewRequest(testId);
     await container.attach(request);
     assert(container.resolvedUrl !== undefined, "Container missing resolved URL after attach");


### PR DESCRIPTION
- Ref: https://github.com/microsoft/FluidFramework/pull/10976
- The PR linked above became messy after several changes and a rebase, so created a new PR here to keep it clean
- This PR adds a new optional parameter createTestId. 
- When createTestId is false or undefined, the behavior is unchanged (same as previous/default behaviour). 
When createTestId is true, we create a document with specified testId for running the stress tests rather than a document with the name `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4`.  
When createTestId is true, but no testId is specified (or) testId is undefined, we create a document with the name `${Date.now().toString()}-WireFormatV1RWOptimizedSnapshot_45e4` (again, this is the previous default behaviour).