### PR TITLE
Run `npm i`

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2236,32 +2236,32 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.0.tgz",
-			"integrity": "sha512-RUs7rbD83B7sF+ojA6YXaesVzF/be9Q5FzqhPmnYI4JT9rQ1PlPQgFkRc6zvlsX3J9kmovzcGZZ+tCy476Fh1Q==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.1.tgz",
+			"integrity": "sha512-uQka9Pl/A5kHW+Q8aP6DLO+Sl9LSt0E88UNvLPgK0wLchHdfFhFgaFsLkaWGZDERk1kTsiKFkYOHzTlLqyJbzA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.0",
+				"@fluidframework/aqueduct": "^1.2.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/local-driver": "^1.2.0",
-				"@fluidframework/odsp-doclib-utils": "^1.2.0",
-				"@fluidframework/odsp-driver": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/local-driver": "^1.2.1",
+				"@fluidframework/odsp-doclib-utils": "^1.2.1",
+				"@fluidframework/odsp-driver": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/test-runtime-utils": "^1.2.0",
-				"@fluidframework/tool-utils": "^1.2.0",
-				"@fluidframework/view-adapters": "^1.2.0",
-				"@fluidframework/view-interfaces": "^1.2.0",
-				"@fluidframework/web-code-loader": "^1.2.0",
+				"@fluidframework/test-runtime-utils": "^1.2.1",
+				"@fluidframework/tool-utils": "^1.2.1",
+				"@fluidframework/view-adapters": "^1.2.1",
+				"@fluidframework/view-interfaces": "^1.2.1",
+				"@fluidframework/web-code-loader": "^1.2.1",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
 				"nconf": "^0.11.4",
@@ -2457,25 +2457,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.0.tgz",
-			"integrity": "sha512-Yey7dJlnAj8CUZr0aYh34WEtmeHjJiQUtn/OwYrg5PasRFMrYTM0vaM8XRYEUZMDdI0JpiOgpgsAK/iNpkGuCg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.1.tgz",
+			"integrity": "sha512-UvakWsTakNiXPJbAwYO3hsYDbo02yITZPLH+eEkmQkynP0WFRvE6CItEadXtYg2jhCIfHJIj6OBd6oTMlHFhsA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/container-runtime": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/map": "^1.2.0",
-				"@fluidframework/request-handler": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/synthesize": "^1.2.0",
-				"@fluidframework/view-interfaces": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/container-runtime": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/request-handler": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/synthesize": "^1.2.1",
+				"@fluidframework/view-interfaces": "^1.2.1",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -2599,17 +2599,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.0.tgz",
-			"integrity": "sha512-zkrzssBwx3/1bgl0ZlhxLSRJP40MlflhL5OmuHO4AT/qU69csrvk5TSilROCpAzl+kU1Qu3yhEynH1uqp0ectA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.1.tgz",
+			"integrity": "sha512-7Zn7Eb0ZOr8TVLI0SRcyyXBDjECQwFFaHoOmOl7r/Q/TYzsL37sDg075spu3ltKirIxnRUvMJ1g1Y8gbctvqag==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -2672,13 +2672,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.0.tgz",
-			"integrity": "sha512-Zx/L15OCB3LB26yvrFpNDKsIdd8p0Z1qK5/wSyB3uvLnyZ7wHjr3BJDqtTk89U9ORRn3202hOqFYe8L6GeLzGA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.1.tgz",
+			"integrity": "sha512-v5IGtw1Vvc431gZYmXuWHDRtN7lXVoOfExzkqAO0GvLwYq35XnX4pNyqtH/kX5sC307032qR5obUR5t2zX6Izw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -2714,20 +2714,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.0.tgz",
-			"integrity": "sha512-/PSbKypP+5233kkQ5daq/XLQ4uBNJIpIS25MnfQ2DNkRKR3DqP0YBUm7IfySf7ub1gLWCk9sMGelBwhQR7dL9g==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.1.tgz",
+			"integrity": "sha512-loWcHga/+R3OKNBaS0/jy6nCkiidvgWNFcDElT0GOaOdf1WljKBkLqTuOsrXVzbiuDymd1Fe/L47KaeVlho+eA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2761,20 +2761,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.0.tgz",
-			"integrity": "sha512-/PSbKypP+5233kkQ5daq/XLQ4uBNJIpIS25MnfQ2DNkRKR3DqP0YBUm7IfySf7ub1gLWCk9sMGelBwhQR7dL9g==",
+			"version": "npm:@fluidframework/container-loader@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.1.tgz",
+			"integrity": "sha512-loWcHga/+R3OKNBaS0/jy6nCkiidvgWNFcDElT0GOaOdf1WljKBkLqTuOsrXVzbiuDymd1Fe/L47KaeVlho+eA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2808,25 +2808,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.0.tgz",
-			"integrity": "sha512-/4TnxjrfzllfMD8PbaqGg4XdBQ0yg2bUxmx5N5FzWQxzyy0KwjDBV3uvBa3antmpcF3V1HzFBhzGJ4dnlwZcSw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.1.tgz",
+			"integrity": "sha512-64BVZEaG5RftaqblMsVXqLiveaUI5pZ6nTo2cHLmJH8zi56geH8O+EUYmrMlGswqgpjTCfIGTkrkisvJVeO2Dw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/garbage-collector": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/garbage-collector": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -2858,16 +2858,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.0.tgz",
-			"integrity": "sha512-XQQt3z/c1N0IOboC0dBAY1IlVhXl7VVdW9GWVAFA0APEug8QXMAJ3wC958+uVe05+eEcip8EBYL+k5X3yWLsQw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.1.tgz",
+			"integrity": "sha512-bzwyjIkxGKZYwFwLkl6icbMpPFONP6uIpnPTKrmk7Js6rNK66CbaIKMHfFgGw6G4hn624zXWbNwqZC17UkEBAQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -2882,16 +2882,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.0.tgz",
-			"integrity": "sha512-XQQt3z/c1N0IOboC0dBAY1IlVhXl7VVdW9GWVAFA0APEug8QXMAJ3wC958+uVe05+eEcip8EBYL+k5X3yWLsQw==",
+			"version": "npm:@fluidframework/container-runtime-definitions@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.1.tgz",
+			"integrity": "sha512-bzwyjIkxGKZYwFwLkl6icbMpPFONP6uIpnPTKrmk7Js6rNK66CbaIKMHfFgGw6G4hn624zXWbNwqZC17UkEBAQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -2906,25 +2906,25 @@
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.0.tgz",
-			"integrity": "sha512-/4TnxjrfzllfMD8PbaqGg4XdBQ0yg2bUxmx5N5FzWQxzyy0KwjDBV3uvBa3antmpcF3V1HzFBhzGJ4dnlwZcSw==",
+			"version": "npm:@fluidframework/container-runtime@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.1.tgz",
+			"integrity": "sha512-64BVZEaG5RftaqblMsVXqLiveaUI5pZ6nTo2cHLmJH8zi56geH8O+EUYmrMlGswqgpjTCfIGTkrkisvJVeO2Dw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/garbage-collector": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/garbage-collector": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -2956,15 +2956,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.0.tgz",
-			"integrity": "sha512-D/kbhfESuyeqXM5YmEAOHO0U/Kns1Lt4xWYlxUrfGnZY+rjSbXgkel2MndkqengVewwQQNuEoK2Kh9n1yRRItQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.1.tgz",
+			"integrity": "sha512-IiTVL0yVq9Skol7CEQ5pCxeReNiHOndKIJApx3VvqifdHnbW1+P7AcbJUEGnnezXvERgRVZ3RrYUdMhHBaasnw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -2978,15 +2978,15 @@
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.0.tgz",
-			"integrity": "sha512-D/kbhfESuyeqXM5YmEAOHO0U/Kns1Lt4xWYlxUrfGnZY+rjSbXgkel2MndkqengVewwQQNuEoK2Kh9n1yRRItQ==",
+			"version": "npm:@fluidframework/container-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.1.tgz",
+			"integrity": "sha512-IiTVL0yVq9Skol7CEQ5pCxeReNiHOndKIJApx3VvqifdHnbW1+P7AcbJUEGnnezXvERgRVZ3RrYUdMhHBaasnw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3000,9 +3000,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.0.tgz",
-			"integrity": "sha512-jYzIO9idQSRNe2DJ08VzWie4cVUe59o8sl6A7r17mcRqUymVxgbeSdBY4NvmCb3gwW8Rm20P8OJr4/uXNgAI1Q=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.1.tgz",
+			"integrity": "sha512-s6vP8rPHxd7APaLAkj1G2xjtOv2tczyFnnD7B0VlFUaeMO8aeEegtwgo2l3f2OSmt2alY5hQxLRiOkeLmPrjCA=="
 		},
 		"@fluidframework/core-interfaces-previous": {
 			"version": "npm:@fluidframework/core-interfaces@1.1.0",
@@ -3010,17 +3010,17 @@
 			"integrity": "sha512-lwZTJwF67dQJjw7VHVeqJyLukarD/apxYOBcVDHMFFFA5yvkHMOTfN6rAOrjQ6TmJ3uwzamZxRm3+3wUU2rBVA=="
 		},
 		"@fluidframework/counter": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.0.tgz",
-			"integrity": "sha512-3vQRI7KjclnP4ejPKSPzQ0CDxurqAGRSQxUvMXHk1veQS/03y/vbL/c0M0Jspu30lAeCwPVR/akLG7CxDdOu+A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.1.tgz",
+			"integrity": "sha512-hs79CmcmkWWg+INCZ2mGc/BeeyhXth/q2Yt0N7XPNMiwO9Ciqf2krAHKCyi+vuebBJ58k47hxQWEeweENVThcg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3034,17 +3034,17 @@
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.0.tgz",
-			"integrity": "sha512-3vQRI7KjclnP4ejPKSPzQ0CDxurqAGRSQxUvMXHk1veQS/03y/vbL/c0M0Jspu30lAeCwPVR/akLG7CxDdOu+A==",
+			"version": "npm:@fluidframework/counter@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.1.tgz",
+			"integrity": "sha512-hs79CmcmkWWg+INCZ2mGc/BeeyhXth/q2Yt0N7XPNMiwO9Ciqf2krAHKCyi+vuebBJ58k47hxQWEeweENVThcg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3076,24 +3076,24 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.0.tgz",
-			"integrity": "sha512-dx/xgdfERQJvEhuEhPlS9s0+kZPKUPTDPFHRXkm92Uv3q/5c2+pBqDUogfXcEwk52Kg6vnNZxef5CaMtmXsL9A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.1.tgz",
+			"integrity": "sha512-Q+d3pB2TfmgQ+Xji2TE83GaC//1w4Ow08ES4rO0Ehh/qZ59rd0Ouu9JdgeIEfItB2o7Efo/TpnZ4jeLf1B7xJg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/garbage-collector": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/garbage-collector": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3125,16 +3125,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.0.tgz",
-			"integrity": "sha512-x/HqRiYdDVtRUahAvQtExVZDJni8H7W2k7EYUTy2xOnDXT5paYAif0nVlqDHGHy/yHShhV0e4J5opX6EOsYl9Q==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.1.tgz",
+			"integrity": "sha512-ezcknk2m6R1w23ufxX8h7OFZ4RtcRI6y4hLWXToHGIWp57Ct3Tz4zj+3rqCfP95ZRSLQyHfsKU8g+sl39eUxLA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3149,16 +3149,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.0.tgz",
-			"integrity": "sha512-x/HqRiYdDVtRUahAvQtExVZDJni8H7W2k7EYUTy2xOnDXT5paYAif0nVlqDHGHy/yHShhV0e4J5opX6EOsYl9Q==",
+			"version": "npm:@fluidframework/datastore-definitions@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.1.tgz",
+			"integrity": "sha512-ezcknk2m6R1w23ufxX8h7OFZ4RtcRI6y4hLWXToHGIWp57Ct3Tz4zj+3rqCfP95ZRSLQyHfsKU8g+sl39eUxLA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3173,24 +3173,24 @@
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.0.tgz",
-			"integrity": "sha512-dx/xgdfERQJvEhuEhPlS9s0+kZPKUPTDPFHRXkm92Uv3q/5c2+pBqDUogfXcEwk52Kg6vnNZxef5CaMtmXsL9A==",
+			"version": "npm:@fluidframework/datastore@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.1.tgz",
+			"integrity": "sha512-Q+d3pB2TfmgQ+Xji2TE83GaC//1w4Ow08ES4rO0Ehh/qZ59rd0Ouu9JdgeIEfItB2o7Efo/TpnZ4jeLf1B7xJg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/garbage-collector": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/garbage-collector": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3222,15 +3222,15 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.0.tgz",
-			"integrity": "sha512-tVvKwwJnkV9SO2OR0SvQsarCoNG1oTWKGkyVGA3NMHc8HjdE6FJ2TXuKmW/LJ08lUAFEQN3LkVLbEXgI4qCL2A==",
+			"version": "npm:@fluidframework/dds-interceptions@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.1.tgz",
+			"integrity": "sha512-HarZynQR0l99gIqjnWTDnXY5+m7mNQax0dtS2TwFnqsLulxYx3hoBzJaUU9g9YuUmlEBxLtA/taRH3MyaguIgA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^1.2.0",
-				"@fluidframework/merge-tree": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/sequence": "^1.2.0"
+				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/merge-tree": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/sequence": "^1.2.1"
 			}
 		},
 		"@fluidframework/debugger-previous": {
@@ -3257,16 +3257,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.0.tgz",
-			"integrity": "sha512-L5ab7RNe8VPFu2WdCKt2dJN/K/j+QNd/cyx8EB5bGjSxgOgumitHh230Y4lrNkyCDs8AzqNli0ZszLeh27vlHA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.1.tgz",
+			"integrity": "sha512-9RhRicdjFH3vS0poHCjLuaSwNKBp392PEkES2pD0UrO8GI8UVjIm0fO1GPz6ukst0MR6PAjOrlvyyxi6DSDZng==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3303,12 +3303,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.0.tgz",
-			"integrity": "sha512-lwvM7G9Qa62E541DA1mKruMvu2QGEDzqBYEWzuqIDgAfa2ham2IlW0hZU43vCFqkcQJZ/1W+oZ7VhStPiovCqQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.1.tgz",
+			"integrity": "sha512-DCCwfb69dM4T+RcKaWgYd1tc9wvP0yoGm8gyn9IXEZ5HWHxOfXIicXmdMM48LUbFYEMgdyJscFnB/lmOqWckLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -3343,18 +3343,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.0.tgz",
-			"integrity": "sha512-y5N5a2F3oEqd6o6+Xp1jxsKVzgZoOGCNASzgY7R5lf6XckETk9gIhmRKvQcd0h1Tmw2jSIMUmrnT5/kaOHSEkg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.1.tgz",
+			"integrity": "sha512-01ATt8afRUClZV+PwvBsVQ2bMrUoMb/mIQZXb1GvPd+G9JLbCZSjAWvUgEYoJQSVc8lYcdoqY00/6GhBwe6sBA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3386,18 +3386,18 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.0.tgz",
-			"integrity": "sha512-y5N5a2F3oEqd6o6+Xp1jxsKVzgZoOGCNASzgY7R5lf6XckETk9gIhmRKvQcd0h1Tmw2jSIMUmrnT5/kaOHSEkg==",
+			"version": "npm:@fluidframework/driver-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.1.tgz",
+			"integrity": "sha512-01ATt8afRUClZV+PwvBsVQ2bMrUoMb/mIQZXb1GvPd+G9JLbCZSjAWvUgEYoJQSVc8lYcdoqY00/6GhBwe6sBA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3429,13 +3429,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.0.tgz",
-			"integrity": "sha512-SbHXoSI1YsHhVE7s4ndDRdF+t2p8xfFQrZJY3ukhhxfZFaNqdYw8ytUeqZ95zStOKKY/vFNzlkw6L2GDA9ClEw==",
+			"version": "npm:@fluidframework/driver-web-cache@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.1.tgz",
+			"integrity": "sha512-addWBUeiUOFALjF3poQ+jlrbY1r9jgZPnTowjlCl1ZjDXFBRFYxFJ9rAvXfHvO9jWLR/tBTFqcwwZ3OchsWcNg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3482,22 +3482,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.0.tgz",
-			"integrity": "sha512-sp79UNflkejT7nLTc7Iv2m0hCsfSfQY4OTKXcMMdvOFK0PJfBxCqFnS/ReccywI4bjW7ARbVhA4M6K9owd1nvA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.1.tgz",
+			"integrity": "sha512-QCQURqqv/PR9oxQLzllgD016eIO4PzN7sl9rwfm19UYT8lIr8bmH0HmSIULztm93aAKoqi2bD46GLxnIYXF/Kw==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.0",
+				"@fluidframework/aqueduct": "^1.2.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0"
+				"@fluidframework/request-handler": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3511,22 +3511,22 @@
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.0.tgz",
-			"integrity": "sha512-sp79UNflkejT7nLTc7Iv2m0hCsfSfQY4OTKXcMMdvOFK0PJfBxCqFnS/ReccywI4bjW7ARbVhA4M6K9owd1nvA==",
+			"version": "npm:@fluidframework/fluid-static@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.1.tgz",
+			"integrity": "sha512-QCQURqqv/PR9oxQLzllgD016eIO4PzN7sl9rwfm19UYT8lIr8bmH0HmSIULztm93aAKoqi2bD46GLxnIYXF/Kw==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.0",
+				"@fluidframework/aqueduct": "^1.2.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0"
+				"@fluidframework/request-handler": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -3540,23 +3540,23 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.0.tgz",
-			"integrity": "sha512-+06VAzl07md9aiX9Rq7/+a4QPMpJD+pHLM3+3LCa+yWqczfZqHR8xyzTAQt29j0zP14lY2Qe8mI2UX/B9PwTWw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.1.tgz",
+			"integrity": "sha512-xK0sg2sI/aVyhJJQ0Xq6JoH/ImWGfEoHMfwYmU5Kv4aHJyPyNG7slKvoHtrXF/F7VKBUUzAo2XIKCvEup5Odgg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.0.tgz",
-			"integrity": "sha512-+06VAzl07md9aiX9Rq7/+a4QPMpJD+pHLM3+3LCa+yWqczfZqHR8xyzTAQt29j0zP14lY2Qe8mI2UX/B9PwTWw==",
+			"version": "npm:@fluidframework/garbage-collector@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.1.tgz",
+			"integrity": "sha512-xK0sg2sI/aVyhJJQ0Xq6JoH/ImWGfEoHMfwYmU5Kv4aHJyPyNG7slKvoHtrXF/F7VKBUUzAo2XIKCvEup5Odgg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -3590,17 +3590,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.0.tgz",
-			"integrity": "sha512-/q56V3WANjE8IItJMDBsacHLC2q954ngMCuhagsNi4V4apRnTmryW2p0SC7ZNISuoM4eNagrhKJkYRBzhVWRkg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.1.tgz",
+			"integrity": "sha512-5xjp61tctTRU0Qeb3UbyYqwaiQt1vFKrSf+IjkhOAwGEu7/6bCcrYGjxepEsVnk5dK6CtlMowMujVDYevFxLkw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -3615,17 +3615,17 @@
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.0.tgz",
-			"integrity": "sha512-/q56V3WANjE8IItJMDBsacHLC2q954ngMCuhagsNi4V4apRnTmryW2p0SC7ZNISuoM4eNagrhKJkYRBzhVWRkg==",
+			"version": "npm:@fluidframework/ink@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.1.tgz",
+			"integrity": "sha512-5xjp61tctTRU0Qeb3UbyYqwaiQt1vFKrSf+IjkhOAwGEu7/6bCcrYGjxepEsVnk5dK6CtlMowMujVDYevFxLkw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -3640,18 +3640,18 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.0.tgz",
-			"integrity": "sha512-CIrIMcO4SKB6h9tqUvKpYBRmbYHTuMkML1Dau+3SuYrfwQFVQG2TuC75HW5hoZCcI5Wt/J1xK36A1ouYkL8ESQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.1.tgz",
+			"integrity": "sha512-EEepZk68gZkNK7/Ge+NcygEvQkM1IYgzAo/TfeBqPJHMgFYttmvP6nh6KcX2+yv7azHHyjySEbfAqdyInbaRqw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-base": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-base": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -3827,18 +3827,18 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.0.tgz",
-			"integrity": "sha512-CIrIMcO4SKB6h9tqUvKpYBRmbYHTuMkML1Dau+3SuYrfwQFVQG2TuC75HW5hoZCcI5Wt/J1xK36A1ouYkL8ESQ==",
+			"version": "npm:@fluidframework/local-driver@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.1.tgz",
+			"integrity": "sha512-EEepZk68gZkNK7/Ge+NcygEvQkM1IYgzAo/TfeBqPJHMgFYttmvP6nh6KcX2+yv7azHHyjySEbfAqdyInbaRqw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-base": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-base": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -4014,20 +4014,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.0.tgz",
-			"integrity": "sha512-lbOdtoG/aCAe5a4URywSG/8ThFIb15FbvrTgDxMBNjfkDpuWDvkx60pQfAYwXJ2UXAO2lUMv6FoS4zfgP19FOg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.1.tgz",
+			"integrity": "sha512-uW2b+3j5+Zf1BkB1wAk3amLoj10SJ3cbpDKIU2MTdNK59WW6h4YGzltY4Rnr108ZIkrlfkkBWd1kODE9vjBbzg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4042,20 +4042,20 @@
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.0.tgz",
-			"integrity": "sha512-lbOdtoG/aCAe5a4URywSG/8ThFIb15FbvrTgDxMBNjfkDpuWDvkx60pQfAYwXJ2UXAO2lUMv6FoS4zfgP19FOg==",
+			"version": "npm:@fluidframework/map@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.1.tgz",
+			"integrity": "sha512-uW2b+3j5+Zf1BkB1wAk3amLoj10SJ3cbpDKIU2MTdNK59WW6h4YGzltY4Rnr108ZIkrlfkkBWd1kODE9vjBbzg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4070,21 +4070,21 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.0.tgz",
-			"integrity": "sha512-8Nju7EkLknDeO9S+9eE6+wUVhDssQSVKVkmGfQERv/8lmfsGDnv5vdBFIN7FwRA8xkCQE71J50yuaisqhNHk3Q==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.1.tgz",
+			"integrity": "sha512-NFU1r6lP8MPudEexHdZ/sbaSOGbtBYt4G8oUytvDzarXzOig9fiRJUCtXinKZx5ubum8DyxPvzITxrHCImK+Mw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/merge-tree": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/merge-tree": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4116,21 +4116,21 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.0.tgz",
-			"integrity": "sha512-8Nju7EkLknDeO9S+9eE6+wUVhDssQSVKVkmGfQERv/8lmfsGDnv5vdBFIN7FwRA8xkCQE71J50yuaisqhNHk3Q==",
+			"version": "npm:@fluidframework/matrix@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.1.tgz",
+			"integrity": "sha512-NFU1r6lP8MPudEexHdZ/sbaSOGbtBYt4G8oUytvDzarXzOig9fiRJUCtXinKZx5ubum8DyxPvzITxrHCImK+Mw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/merge-tree": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/merge-tree": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4162,21 +4162,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.0.tgz",
-			"integrity": "sha512-QHe1LM0gxcCTFZWtgRS8cRcMsbITXY0V9npBvjp8vYGq4BCnxKf0TnflVWYOK8Jy8/Nh0j6SVX8wCVxQXdTzxA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.1.tgz",
+			"integrity": "sha512-8yt1rPI2upS4vmwsaLOZnKbd3XpVYknw7JmOoHppyonREO9Tz+JbLXdUXHq4ycnhbGJxwoMCIwCwGyaWLW8y8g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4190,21 +4190,21 @@
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.0.tgz",
-			"integrity": "sha512-QHe1LM0gxcCTFZWtgRS8cRcMsbITXY0V9npBvjp8vYGq4BCnxKf0TnflVWYOK8Jy8/Nh0j6SVX8wCVxQXdTzxA==",
+			"version": "npm:@fluidframework/merge-tree@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.1.tgz",
+			"integrity": "sha512-8yt1rPI2upS4vmwsaLOZnKbd3XpVYknw7JmOoHppyonREO9Tz+JbLXdUXHq4ycnhbGJxwoMCIwCwGyaWLW8y8g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4218,12 +4218,12 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.0.tgz",
-			"integrity": "sha512-ChtEnou4SeO8NsSKaVjIfkQsZ+0yVMAjjj7BDg7lgBQqFJUgmilz8pl/+2Sf1uAV5AUUq4sto9a9QqdT6AAGAQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.1.tgz",
+			"integrity": "sha512-QYA0lW1G+I1Nn23o+7WwVzHpAXdRUv7bqdrCPXh8Ge76B6jxNg7JizDgkbuvF5NbpWIH2WCAV1KtdAJ9nltaNg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.2.0",
+				"@fluidframework/test-driver-definitions": "^1.2.1",
 				"mocha": "^10.0.0"
 			}
 		},
@@ -4238,50 +4238,50 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.0.tgz",
-			"integrity": "sha512-qgnS0bV5vKgV6deW0LAqrPLFvTNlHwl4Z2gOtug8dDrs+7aSYv9IYyPDtB1I+nf7zWfbZx/+EBE779TvjAvlng==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.1.tgz",
+			"integrity": "sha512-G+k6sW4ClrBfdplCG6muDBksjzMALjN0o0/etnJ1z09g7zLr5lV5m91hFAttVjN8WhrjbOqhu2KTBVHFmymzXA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.0.tgz",
-			"integrity": "sha512-qgnS0bV5vKgV6deW0LAqrPLFvTNlHwl4Z2gOtug8dDrs+7aSYv9IYyPDtB1I+nf7zWfbZx/+EBE779TvjAvlng==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.1.tgz",
+			"integrity": "sha512-G+k6sW4ClrBfdplCG6muDBksjzMALjN0o0/etnJ1z09g7zLr5lV5m91hFAttVjN8WhrjbOqhu2KTBVHFmymzXA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.0.tgz",
-			"integrity": "sha512-hCd0UDxNI3ZL0SAzozHrxXp0wKQwGURIExLEr0+jhTc8gg1gPAVsBKP62DXV+lqdutKpfvgA8gSEr7wsbGG4jQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.1.tgz",
+			"integrity": "sha512-+lgMhWP6yHQ5vQ0YnCKI0oxXPV9FEasMuf+rl4g6y9nYT2qnGDKAfUGOvBw5CSQnf3ep5CfiRQSHNBEDzAFc6A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-base": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-base": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
+				"@fluidframework/odsp-doclib-utils": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4315,38 +4315,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.0.tgz",
-			"integrity": "sha512-v2A4QGNlyZOp9+tom7hQBTT01mjji1tcPjbE3uQBil7rxASdniLjF1O925haHOjxYFJDzNGDxkNMAHFLuUu+lw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.1.tgz",
+			"integrity": "sha512-9sd/Z0Gmvy9EILYrPEZKZk2B9tpLrDtjO7O1CmF59aVVR2+Jd+ieIC2rgaTXFLy7t3mwZvuuhiUJ42P8P6JF7g==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.0"
+				"@fluidframework/driver-definitions": "^1.2.1"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.0.tgz",
-			"integrity": "sha512-v2A4QGNlyZOp9+tom7hQBTT01mjji1tcPjbE3uQBil7rxASdniLjF1O925haHOjxYFJDzNGDxkNMAHFLuUu+lw==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.1.tgz",
+			"integrity": "sha512-9sd/Z0Gmvy9EILYrPEZKZk2B9tpLrDtjO7O1CmF59aVVR2+Jd+ieIC2rgaTXFLy7t3mwZvuuhiUJ42P8P6JF7g==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.0"
+				"@fluidframework/driver-definitions": "^1.2.1"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.0.tgz",
-			"integrity": "sha512-hCd0UDxNI3ZL0SAzozHrxXp0wKQwGURIExLEr0+jhTc8gg1gPAVsBKP62DXV+lqdutKpfvgA8gSEr7wsbGG4jQ==",
+			"version": "npm:@fluidframework/odsp-driver@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.1.tgz",
+			"integrity": "sha512-+lgMhWP6yHQ5vQ0YnCKI0oxXPV9FEasMuf+rl4g6y9nYT2qnGDKAfUGOvBw5CSQnf3ep5CfiRQSHNBEDzAFc6A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-base": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-base": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
+				"@fluidframework/odsp-doclib-utils": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4380,39 +4380,39 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.0.tgz",
-			"integrity": "sha512-clO0gNsPRXk2hsnX1LoO2EJUbPY5Un32bMkmAHkBznlVkikpYgZyos04lhEgvNLvrNjL8ykcXGecr55jFb8obQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.1.tgz",
+			"integrity": "sha512-Y/pa5n07HB4u1bMEKYNC4qS9RwXjA9SyCuzTRV+0DLsQ/aTbdKRF3ylI+UOoAKGRbSHh475V12PfXS0JsEmu+A==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/odsp-driver": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0"
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/odsp-driver": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.0.tgz",
-			"integrity": "sha512-clO0gNsPRXk2hsnX1LoO2EJUbPY5Un32bMkmAHkBznlVkikpYgZyos04lhEgvNLvrNjL8ykcXGecr55jFb8obQ==",
+			"version": "npm:@fluidframework/odsp-urlresolver@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.1.tgz",
+			"integrity": "sha512-Y/pa5n07HB4u1bMEKYNC4qS9RwXjA9SyCuzTRV+0DLsQ/aTbdKRF3ylI+UOoAKGRbSHh475V12PfXS0JsEmu+A==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/odsp-driver": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0"
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/odsp-driver": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.0.tgz",
-			"integrity": "sha512-zozWQkrAz7OmCaNjwnic7rjNbwSGOg19zTFrun0HCMTnmy3VpbrDJ5Hz+U9h+BgBym02WUFm8UTOz+YdtowQag==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.1.tgz",
+			"integrity": "sha512-TG5HDTIi/kxPHhifg60Dsr6yCh/Qlgr4AG/wHXTLCh1fuBhuKIAt3cUajjrTKefYe4ot9s+0bAQdw6qF9QVEWA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4427,17 +4427,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.0.tgz",
-			"integrity": "sha512-zozWQkrAz7OmCaNjwnic7rjNbwSGOg19zTFrun0HCMTnmy3VpbrDJ5Hz+U9h+BgBym02WUFm8UTOz+YdtowQag==",
+			"version": "npm:@fluidframework/ordered-collection@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.1.tgz",
+			"integrity": "sha512-TG5HDTIi/kxPHhifg60Dsr6yCh/Qlgr4AG/wHXTLCh1fuBhuKIAt3cUajjrTKefYe4ot9s+0bAQdw6qF9QVEWA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4481,17 +4481,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.0.tgz",
-			"integrity": "sha512-I9q8q5+8qA/xkX82YIMmw6gCrSJ2JvywbOqlNocboIvNKRz+sRYPHSOMMubjkqGyE1Cm1tfk6rvFPy3SvrWRzQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.1.tgz",
+			"integrity": "sha512-ja/ZK1+rckGiibTwd+tApTd1KMhkV3DoeMFbZFArmrIxkCzPNHnP4m4RmTC+xgE0QYPBC/HOKeNd+gMlIwGDcw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4521,17 +4521,17 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.0.tgz",
-			"integrity": "sha512-I9q8q5+8qA/xkX82YIMmw6gCrSJ2JvywbOqlNocboIvNKRz+sRYPHSOMMubjkqGyE1Cm1tfk6rvFPy3SvrWRzQ==",
+			"version": "npm:@fluidframework/register-collection@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.1.tgz",
+			"integrity": "sha512-ja/ZK1+rckGiibTwd+tApTd1KMhkV3DoeMFbZFArmrIxkCzPNHnP4m4RmTC+xgE0QYPBC/HOKeNd+gMlIwGDcw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4561,16 +4561,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.0.tgz",
-			"integrity": "sha512-JrYriu5ZwOtcfdzw36nvJxxvjn9R6spkP22k6zhqzW1ozdAnNpq4wtAbd8CKiqVjFZZviyYD7QoLt2bf8dZ/dQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.1.tgz",
+			"integrity": "sha512-3lv0gEs7c2EjdGkzSdoCvI/wQZoSbh6UwIlr12kI7eUaUyFbiRS+9jidTNhRR2az8HyYeXNcmyw6sIKML/i8eQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4584,16 +4584,16 @@
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.0.tgz",
-			"integrity": "sha512-JrYriu5ZwOtcfdzw36nvJxxvjn9R6spkP22k6zhqzW1ozdAnNpq4wtAbd8CKiqVjFZZviyYD7QoLt2bf8dZ/dQ==",
+			"version": "npm:@fluidframework/replay-driver@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.1.tgz",
+			"integrity": "sha512-3lv0gEs7c2EjdGkzSdoCvI/wQZoSbh6UwIlr12kI7eUaUyFbiRS+9jidTNhRR2az8HyYeXNcmyw6sIKML/i8eQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -4607,44 +4607,44 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.0.tgz",
-			"integrity": "sha512-IrcWa+6be8mhaRZmLjrMBtgCgyhCCNH+4xQ0ez7rk+HQkJ++fS4JJCCYrf5ZPLllfRcDIlFM2/5VrS07F+0c+Q==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.1.tgz",
+			"integrity": "sha512-BdRtF6Qid/1MXDV6fILvHoS0ggBvMhrFqbTCJCQrpNCBVLaTOhpmG34DtSzbAGR8+FlqxbDrydSEhhSkN2UGxA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0"
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.0.tgz",
-			"integrity": "sha512-IrcWa+6be8mhaRZmLjrMBtgCgyhCCNH+4xQ0ez7rk+HQkJ++fS4JJCCYrf5ZPLllfRcDIlFM2/5VrS07F+0c+Q==",
+			"version": "npm:@fluidframework/request-handler@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.1.tgz",
+			"integrity": "sha512-BdRtF6Qid/1MXDV6fILvHoS0ggBvMhrFqbTCJCQrpNCBVLaTOhpmG34DtSzbAGR8+FlqxbDrydSEhhSkN2UGxA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0"
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.0.tgz",
-			"integrity": "sha512-eK/hhdSzjTt3KaPERejZoIznKrOE0OEsMN/stI5I6cMwspL5etOp8c4NjTbSY9N9mAhuk11JFxCcxIiA6SNc7g==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.1.tgz",
+			"integrity": "sha512-4QyhRzvhSCicU+W2BjU625yoWg+zQcOE0WGZsHWnDEPTBWAuHOTTqNQ+PBrFfGjL8Yabg4n3SIu5l57yMFEsAA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/driver-base": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4705,20 +4705,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.0.tgz",
-			"integrity": "sha512-eK/hhdSzjTt3KaPERejZoIznKrOE0OEsMN/stI5I6cMwspL5etOp8c4NjTbSY9N9mAhuk11JFxCcxIiA6SNc7g==",
+			"version": "npm:@fluidframework/routerlicious-driver@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.1.tgz",
+			"integrity": "sha512-4QyhRzvhSCicU+W2BjU625yoWg+zQcOE0WGZsHWnDEPTBWAuHOTTqNQ+PBrFfGjL8Yabg4n3SIu5l57yMFEsAA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/driver-base": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4779,13 +4779,13 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.0.tgz",
-			"integrity": "sha512-2AWSxDcr1tyMJ/UToav25WfKJMM2wUZC5dMj+dTp1cPt4dFUU5VF60HxV5IfWgIl/SJ9FeDJ5CzJ70B+HeNXzQ==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.1.tgz",
+			"integrity": "sha512-z9I34kvrihv2CvgU2xr91zQJdvBYQSux7cN4Gmk8WCMEU5ufCVXaJ2gJhWuEigD5+AzmIjPU82lsurnQfyfxCg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"nconf": "^0.11.4"
 			},
@@ -4801,15 +4801,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.0.tgz",
-			"integrity": "sha512-uYyF4wowCvN/vhvkEwGiEY4Ldu53IxYiJ5fKY+V/Kd1OfW0Nhuw41CoOji22tZFuZyQwWXJJy9cW2ahvHcs+yQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.1.tgz",
+			"integrity": "sha512-RT8cWIXR0PrcV05UabqxPIRX9agxoGsf0K6/4SZYkM7KMwKZqLPfgLs038q83uo9aZBmfr5/e5eRv95VbJoHfw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -4825,15 +4825,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.0.tgz",
-			"integrity": "sha512-uYyF4wowCvN/vhvkEwGiEY4Ldu53IxYiJ5fKY+V/Kd1OfW0Nhuw41CoOji22tZFuZyQwWXJJy9cW2ahvHcs+yQ==",
+			"version": "npm:@fluidframework/runtime-definitions@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.1.tgz",
+			"integrity": "sha512-RT8cWIXR0PrcV05UabqxPIRX9agxoGsf0K6/4SZYkM7KMwKZqLPfgLs038q83uo9aZBmfr5/e5eRv95VbJoHfw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -4849,21 +4849,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.0.tgz",
-			"integrity": "sha512-9ChM6j76mWiEXaMBcAP1EgiPcvaqewvyIk3Xg8LjH853ykIlX7R4iLBUgN5g/SKfVFgkpyjnD6WumWTplr6npQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.1.tgz",
+			"integrity": "sha512-X5PURvg5m3KWwHG9CKts+fE7JcjvffiC0IopA51aM+AGM7E04M4biRyrCAQazR1OwheM3M3z/pMHRfBI2eaFaQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/garbage-collector": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/garbage-collector": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4893,21 +4893,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.0.tgz",
-			"integrity": "sha512-9ChM6j76mWiEXaMBcAP1EgiPcvaqewvyIk3Xg8LjH853ykIlX7R4iLBUgN5g/SKfVFgkpyjnD6WumWTplr6npQ==",
+			"version": "npm:@fluidframework/runtime-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.1.tgz",
+			"integrity": "sha512-X5PURvg5m3KWwHG9CKts+fE7JcjvffiC0IopA51aM+AGM7E04M4biRyrCAQazR1OwheM3M3z/pMHRfBI2eaFaQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/garbage-collector": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/garbage-collector": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -4937,21 +4937,21 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.0.tgz",
-			"integrity": "sha512-3vbc+38xHPASsa74lkobAe1LhIjwrrYiubswz7MrxLz4yoiiXE/fTIYiV9l3gJMKVSxNAaOuyfekRKNWG6tlPA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.1.tgz",
+			"integrity": "sha512-2np0sho6uZpbz/d+ndvyGBz3A5iP4CYZTvrngw+2nuvJE22XKd8UkwIOxn08lsPcPaKPS38JOyAOk27P4RiTcQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/merge-tree": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/merge-tree": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4966,21 +4966,21 @@
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.0.tgz",
-			"integrity": "sha512-3vbc+38xHPASsa74lkobAe1LhIjwrrYiubswz7MrxLz4yoiiXE/fTIYiV9l3gJMKVSxNAaOuyfekRKNWG6tlPA==",
+			"version": "npm:@fluidframework/sequence@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.1.tgz",
+			"integrity": "sha512-2np0sho6uZpbz/d+ndvyGBz3A5iP4CYZTvrngw+2nuvJE22XKd8UkwIOxn08lsPcPaKPS38JOyAOk27P4RiTcQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/merge-tree": "^1.2.0",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/merge-tree": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6138,22 +6138,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.0.tgz",
-			"integrity": "sha512-Bm+8TniHWWI3se0pDFBQ/+4uowznKyKf+tfdbn46CLMUKl3evSJz7oHqWnaPM7Lmcycr0Yp5dhHSwIKd5M/8vA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.1.tgz",
+			"integrity": "sha512-Ybsf4x+KRDQdKzQNvsHIkchKwPMtnEbFNJfspuJYnRwN/Ujzq1CO4gCzyX7nvXm+DFMhlMi/JmfAKD+rnJrEHg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-runtime": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-runtime": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6168,22 +6168,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.0.tgz",
-			"integrity": "sha512-Bm+8TniHWWI3se0pDFBQ/+4uowznKyKf+tfdbn46CLMUKl3evSJz7oHqWnaPM7Lmcycr0Yp5dhHSwIKd5M/8vA==",
+			"version": "npm:@fluidframework/shared-object-base@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.1.tgz",
+			"integrity": "sha512-Ybsf4x+KRDQdKzQNvsHIkchKwPMtnEbFNJfspuJYnRwN/Ujzq1CO4gCzyX7nvXm+DFMhlMi/JmfAKD+rnJrEHg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-runtime": "^1.2.0",
-				"@fluidframework/container-utils": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-runtime": "^1.2.1",
+				"@fluidframework/container-utils": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6198,17 +6198,17 @@
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.0.tgz",
-			"integrity": "sha512-45bhEeE0AfDZdHXuqPitozj4lYG1oH8NM71r2IUUGPdTFhuMSY+9/9GcLczyszkiC2V3n9nOjsYCqhHvxxPaoQ==",
+			"version": "npm:@fluidframework/shared-summary-block@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.1.tgz",
+			"integrity": "sha512-vfN4cspbBAdVhcV3B99An2amh4bOhNurZMTncXjg7JKArxMuF544iCCC+YWJqmeSymRqE/WndXFZOs4TzaLWfQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/shared-object-base": "^1.2.0"
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/shared-object-base": "^1.2.1"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -6222,19 +6222,19 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.0.tgz",
-			"integrity": "sha512-3EmzbkWBPYloAhqCCFxJIwIWSxBIQ7lVmnP++Od1kxTa4UmpNBv0q7cwinV+yxXrZmWBAKnnHmoTk6IyboNCLA=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.1.tgz",
+			"integrity": "sha512-XLD2wyUcj7QMsjOSBgZpMNKAiuycXrF5dPwyRbMB35DgxuA1MggCPw1sl7D1b22YRf7v/WrHPI4Vz9CUqAVUbA=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.0.tgz",
-			"integrity": "sha512-3EmzbkWBPYloAhqCCFxJIwIWSxBIQ7lVmnP++Od1kxTa4UmpNBv0q7cwinV+yxXrZmWBAKnnHmoTk6IyboNCLA=="
+			"version": "npm:@fluidframework/synthesize@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.1.tgz",
+			"integrity": "sha512-XLD2wyUcj7QMsjOSBgZpMNKAiuycXrF5dPwyRbMB35DgxuA1MggCPw1sl7D1b22YRf7v/WrHPI4Vz9CUqAVUbA=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.0.tgz",
-			"integrity": "sha512-nTKgh1+6pVpR9ptjx9c34xcsVx+ByAHDEz3bYYpH/I/W6T4o66pgvrb9NeJQ1ob6EGxU/FvRm254Lrqmkb/58g==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.1.tgz",
+			"integrity": "sha512-kUlHkQsDC6xkT0dButPJjtclYXM7TmnT30+zQEiLbLMP5X39vjz0uDcFX+nhorevaiHRoHbcN3RdlAza7m1DqA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6244,9 +6244,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.0.tgz",
-			"integrity": "sha512-nTKgh1+6pVpR9ptjx9c34xcsVx+ByAHDEz3bYYpH/I/W6T4o66pgvrb9NeJQ1ob6EGxU/FvRm254Lrqmkb/58g==",
+			"version": "npm:@fluidframework/telemetry-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.1.tgz",
+			"integrity": "sha512-kUlHkQsDC6xkT0dButPJjtclYXM7TmnT30+zQEiLbLMP5X39vjz0uDcFX+nhorevaiHRoHbcN3RdlAza7m1DqA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -6256,12 +6256,12 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.0.tgz",
-			"integrity": "sha512-57TkQIeaW3EZTNgtlbkNjUovoGNtDBjOfitzNheoUaQhOWvRj8ImzqNeRRI8PBYy7OeHNdODny8picvTS9GIrg==",
+			"version": "npm:@fluidframework/test-client-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.1.tgz",
+			"integrity": "sha512-j5L3xr2GVn8sWDA9Rss8THOxLEtx7P21SlY3EdBO4BZLupbDSpZHGopYPMg68qhVQPuBZ1nHNcWHWUIYIxViBA==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/test-runtime-utils": "^1.2.0",
+				"@fluidframework/test-runtime-utils": "^1.2.1",
 				"sillyname": "^0.1.0"
 			},
 			"dependencies": {
@@ -6276,13 +6276,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.0.tgz",
-			"integrity": "sha512-rwqr9xwceXbCgJ6Q3ftb2xu7ggrxP6u0uvT2vTw35pTQWCF2X2zqTh6qYXrtfq4HF30gHTHQHIESP75+BR4U6A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.1.tgz",
+			"integrity": "sha512-uffs1vMcqJMijddaV6vPnEj7jKf6cPEF+4gYn8QOP98UESAbZs4XL1YI3M71uCGDZBQ12KR/MIrspFnqZH7QXg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			},
@@ -6320,27 +6320,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.0.tgz",
-			"integrity": "sha512-yPlSLmbj+yLioeTZA9qf3iqQH3c5pF2tZ9WgTKLj0Ar0SM8PljQHzoFkACV4lz+sGLtEckxv/hR9auSa7XyNsg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.1.tgz",
+			"integrity": "sha512-l2F0ucCEOqXBSpHvSzuU7RnA2m6OmCKNu0vxFKlflu6hr2BWTF8I/HdNy23gWJasQI7w2JQREP8V70/B4Xy7Iw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/local-driver": "^1.2.0",
-				"@fluidframework/odsp-doclib-utils": "^1.2.0",
-				"@fluidframework/odsp-driver": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
-				"@fluidframework/odsp-urlresolver": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/local-driver": "^1.2.1",
+				"@fluidframework/odsp-doclib-utils": "^1.2.1",
+				"@fluidframework/odsp-driver": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/odsp-urlresolver": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.0",
-				"@fluidframework/test-pairwise-generator": "^1.2.0",
-				"@fluidframework/test-runtime-utils": "^1.2.0",
-				"@fluidframework/tinylicious-driver": "^1.2.0",
-				"@fluidframework/tool-utils": "^1.2.0",
+				"@fluidframework/test-driver-definitions": "^1.2.1",
+				"@fluidframework/test-pairwise-generator": "^1.2.1",
+				"@fluidframework/test-runtime-utils": "^1.2.1",
+				"@fluidframework/tinylicious-driver": "^1.2.1",
+				"@fluidframework/tool-utils": "^1.2.1",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -6513,27 +6513,27 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.0.tgz",
-			"integrity": "sha512-yPlSLmbj+yLioeTZA9qf3iqQH3c5pF2tZ9WgTKLj0Ar0SM8PljQHzoFkACV4lz+sGLtEckxv/hR9auSa7XyNsg==",
+			"version": "npm:@fluidframework/test-drivers@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.1.tgz",
+			"integrity": "sha512-l2F0ucCEOqXBSpHvSzuU7RnA2m6OmCKNu0vxFKlflu6hr2BWTF8I/HdNy23gWJasQI7w2JQREP8V70/B4Xy7Iw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/local-driver": "^1.2.0",
-				"@fluidframework/odsp-doclib-utils": "^1.2.0",
-				"@fluidframework/odsp-driver": "^1.2.0",
-				"@fluidframework/odsp-driver-definitions": "^1.2.0",
-				"@fluidframework/odsp-urlresolver": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/local-driver": "^1.2.1",
+				"@fluidframework/odsp-doclib-utils": "^1.2.1",
+				"@fluidframework/odsp-driver": "^1.2.1",
+				"@fluidframework/odsp-driver-definitions": "^1.2.1",
+				"@fluidframework/odsp-urlresolver": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.0",
-				"@fluidframework/test-pairwise-generator": "^1.2.0",
-				"@fluidframework/test-runtime-utils": "^1.2.0",
-				"@fluidframework/tinylicious-driver": "^1.2.0",
-				"@fluidframework/tool-utils": "^1.2.0",
+				"@fluidframework/test-driver-definitions": "^1.2.1",
+				"@fluidframework/test-pairwise-generator": "^1.2.1",
+				"@fluidframework/test-runtime-utils": "^1.2.1",
+				"@fluidframework/tinylicious-driver": "^1.2.1",
+				"@fluidframework/tool-utils": "^1.2.1",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -6706,14 +6706,14 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.0.tgz",
-			"integrity": "sha512-6+tIileT6RTStTkVmEb9orRmZM2BrnjMCv0ELRfRvSq7ffNZNGd4RAEW+2L51fVLwuLT+MbmuMhsaFydqZLsbg==",
+			"version": "npm:@fluidframework/test-loader-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.1.tgz",
+			"integrity": "sha512-SqVm2z4Uh0Ni9CCGs6rmHIQbXomImnN4/PVo9etCQ1I4jmx4PNODzhYDYRZr+HauUSy1twrQsty31inSzvPD+Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -6728,40 +6728,40 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.0.tgz",
-			"integrity": "sha512-IAmbUsFNhmjeh0EyeLEPxC9Jmt1Obr7OaEHAQfbUQ24WTph9lsHoqpESmNhcGu5XtY2dxnuf5nonJH03qhAihw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.1.tgz",
+			"integrity": "sha512-B2q5gPJsEaVY8Ue0Csu3yQimBlpRAnghpv9jS48P5RRSocQqOEOgps2bsNkJcHcU+btCxGRiME35pLC8kXgWFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.0.tgz",
-			"integrity": "sha512-IAmbUsFNhmjeh0EyeLEPxC9Jmt1Obr7OaEHAQfbUQ24WTph9lsHoqpESmNhcGu5XtY2dxnuf5nonJH03qhAihw==",
+			"version": "npm:@fluidframework/test-pairwise-generator@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.1.tgz",
+			"integrity": "sha512-B2q5gPJsEaVY8Ue0Csu3yQimBlpRAnghpv9jS48P5RRSocQqOEOgps2bsNkJcHcU+btCxGRiME35pLC8kXgWFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.0.tgz",
-			"integrity": "sha512-TMurPhAy40N8O52x236p4HRWiKAr1MiBFK/keVysDB10o4P/fXMmT3V72yZC/uN8uUCfuwRurdfKKN8T9lR+cA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.1.tgz",
+			"integrity": "sha512-uqnXdRwZ1PiNtf8bvEv5fXALYiaM9G/sHkAgi00fbawZVHjPw7PlRjiSKMYOVItv4p6xWoM0eO3RZXEUJC808A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6778,22 +6778,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.0.tgz",
-			"integrity": "sha512-TMurPhAy40N8O52x236p4HRWiKAr1MiBFK/keVysDB10o4P/fXMmT3V72yZC/uN8uUCfuwRurdfKKN8T9lR+cA==",
+			"version": "npm:@fluidframework/test-runtime-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.1.tgz",
+			"integrity": "sha512-uqnXdRwZ1PiNtf8bvEv5fXALYiaM9G/sHkAgi00fbawZVHjPw7PlRjiSKMYOVItv4p6xWoM0eO3RZXEUJC808A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6816,32 +6816,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.0.tgz",
-			"integrity": "sha512-63cVTPhbvWRbJMo1tBRNonSOm7X/A4BcJCFsoxXtfwFPGsDMVX0MjNmb69PTfKIzdHs9bMm8MMBLXAjRG7rzcQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.1.tgz",
+			"integrity": "sha512-4zjHa17f1i4SUDFnnDOVGkX2kYVAVyrqSJT6Scm3Jj0GW9lMAWKkERySdzykwyB/zmYmhHqzdnYngsTUrQH9VA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.0",
+				"@fluidframework/aqueduct": "^1.2.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/container-runtime": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/local-driver": "^1.2.0",
-				"@fluidframework/map": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/container-runtime": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/local-driver": "^1.2.1",
+				"@fluidframework/map": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.0",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
-				"@fluidframework/test-driver-definitions": "^1.2.0",
-				"@fluidframework/test-runtime-utils": "^1.2.0",
+				"@fluidframework/request-handler": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/test-driver-definitions": "^1.2.1",
+				"@fluidframework/test-runtime-utils": "^1.2.1",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -6857,32 +6857,32 @@
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.0.tgz",
-			"integrity": "sha512-63cVTPhbvWRbJMo1tBRNonSOm7X/A4BcJCFsoxXtfwFPGsDMVX0MjNmb69PTfKIzdHs9bMm8MMBLXAjRG7rzcQ==",
+			"version": "npm:@fluidframework/test-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.1.tgz",
+			"integrity": "sha512-4zjHa17f1i4SUDFnnDOVGkX2kYVAVyrqSJT6Scm3Jj0GW9lMAWKkERySdzykwyB/zmYmhHqzdnYngsTUrQH9VA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.0",
+				"@fluidframework/aqueduct": "^1.2.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/container-runtime": "^1.2.0",
-				"@fluidframework/container-runtime-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/datastore": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/local-driver": "^1.2.0",
-				"@fluidframework/map": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/container-runtime": "^1.2.1",
+				"@fluidframework/container-runtime-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/datastore": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/local-driver": "^1.2.1",
+				"@fluidframework/map": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.0",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/telemetry-utils": "^1.2.0",
-				"@fluidframework/test-driver-definitions": "^1.2.0",
-				"@fluidframework/test-runtime-utils": "^1.2.0",
+				"@fluidframework/request-handler": "^1.2.1",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/telemetry-utils": "^1.2.1",
+				"@fluidframework/test-driver-definitions": "^1.2.1",
+				"@fluidframework/test-runtime-utils": "^1.2.1",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -6898,34 +6898,34 @@
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.0.tgz",
-			"integrity": "sha512-/Sma1TMrCSwmQs7az6ieGXmu8NKwC4qiQgRWg15kJbjoHMtw2XqjMwXnGC9Wiuc9ycn0EJM9SmA22UQr3IRvgQ==",
+			"version": "npm:@fluidframework/test-version-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.1.tgz",
+			"integrity": "sha512-QKjRsdg/R264TxrWyOhZ1U7t0a5JB/X1c48/hplc971BLpxm6xOL1rd1Q/HanYNbwaKv/JY47q3yl/JcwdIw7g==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.0",
-				"@fluidframework/cell": "^1.2.0",
+				"@fluidframework/aqueduct": "^1.2.1",
+				"@fluidframework/cell": "^1.2.1",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/container-runtime": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/counter": "^1.2.0",
-				"@fluidframework/datastore-definitions": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/ink": "^1.2.0",
-				"@fluidframework/map": "^1.2.0",
-				"@fluidframework/matrix": "^1.2.0",
-				"@fluidframework/mocha-test-setup": "^1.2.0",
-				"@fluidframework/ordered-collection": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/container-runtime": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/counter": "^1.2.1",
+				"@fluidframework/datastore-definitions": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/ink": "^1.2.1",
+				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/matrix": "^1.2.1",
+				"@fluidframework/mocha-test-setup": "^1.2.1",
+				"@fluidframework/ordered-collection": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/register-collection": "^1.2.0",
-				"@fluidframework/runtime-definitions": "^1.2.0",
-				"@fluidframework/sequence": "^1.2.0",
-				"@fluidframework/test-driver-definitions": "^1.2.0",
-				"@fluidframework/test-drivers": "^1.2.0",
-				"@fluidframework/test-utils": "^1.2.0",
+				"@fluidframework/register-collection": "^1.2.1",
+				"@fluidframework/runtime-definitions": "^1.2.1",
+				"@fluidframework/sequence": "^1.2.1",
+				"@fluidframework/test-driver-definitions": "^1.2.1",
+				"@fluidframework/test-drivers": "^1.2.1",
+				"@fluidframework/test-utils": "^1.2.1",
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
@@ -6942,22 +6942,22 @@
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.0.tgz",
-			"integrity": "sha512-VwydMP6mzXhz58ARCbf2vZTOLsVwKh/GgcdwZzDoyIPh7c5DeJokNBSPxRl9WftVQCR01prW9HgLkYtC0fGoRw==",
+			"version": "npm:@fluidframework/tinylicious-client@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.1.tgz",
+			"integrity": "sha512-RDPowAv8ZZlTpBxbKRK6odcnfOO5Z3nsbjNpPAXN61Y+n98rRgldTSq0J+SRuqviVeqQkbw7KwJZ4iHPwFnmQA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
-				"@fluidframework/fluid-static": "^1.2.0",
-				"@fluidframework/map": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
+				"@fluidframework/fluid-static": "^1.2.1",
+				"@fluidframework/map": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
-				"@fluidframework/runtime-utils": "^1.2.0",
-				"@fluidframework/tinylicious-driver": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
+				"@fluidframework/runtime-utils": "^1.2.1",
+				"@fluidframework/tinylicious-driver": "^1.2.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6972,15 +6972,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.0.tgz",
-			"integrity": "sha512-yjEMHQzRYSEOP3FmNig1yGhqSekWgOjJ361UDrwToHieB+LrpIGfYHtctuoIQs/6fZ6C8Pht1+xgdTSpIt4NtQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.1.tgz",
+			"integrity": "sha512-8LXtxctyluRyhalY3geomoYjRfLPii8x6hGRM8e3hcVpwOc9ZZayVmovHeB2qwZJZTNEA57BPHZVibMv41FPhw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -7038,15 +7038,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.0.tgz",
-			"integrity": "sha512-yjEMHQzRYSEOP3FmNig1yGhqSekWgOjJ361UDrwToHieB+LrpIGfYHtctuoIQs/6fZ6C8Pht1+xgdTSpIt4NtQ==",
+			"version": "npm:@fluidframework/tinylicious-driver@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.1.tgz",
+			"integrity": "sha512-8LXtxctyluRyhalY3geomoYjRfLPii8x6hGRM8e3hcVpwOc9ZZayVmovHeB2qwZJZTNEA57BPHZVibMv41FPhw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/driver-definitions": "^1.2.0",
-				"@fluidframework/driver-utils": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/driver-definitions": "^1.2.1",
+				"@fluidframework/driver-utils": "^1.2.1",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.0",
+				"@fluidframework/routerlicious-driver": "^1.2.1",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -7104,12 +7104,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.0.tgz",
-			"integrity": "sha512-aP6AGBWwHWpWgq8SEKtHeYJmvFmMyw8bDs2lji+2lTG7taNxZivNTYWcz4L/Z1tTjBAWGpFvbBj2kOVy6TelYA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.1.tgz",
+			"integrity": "sha512-jyx9QtxJleK2vXi8HL0Fg0a83E/LLoyGT7sWKbnjRQ8b193ExAkzBIkHACCyADDsgLysVuH3esBAHdWsEqTIsg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.0",
+				"@fluidframework/odsp-doclib-utils": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -7145,12 +7145,12 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.0.tgz",
-			"integrity": "sha512-aP6AGBWwHWpWgq8SEKtHeYJmvFmMyw8bDs2lji+2lTG7taNxZivNTYWcz4L/Z1tTjBAWGpFvbBj2kOVy6TelYA==",
+			"version": "npm:@fluidframework/tool-utils@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.1.tgz",
+			"integrity": "sha512-jyx9QtxJleK2vXi8HL0Fg0a83E/LLoyGT7sWKbnjRQ8b193ExAkzBIkHACCyADDsgLysVuH3esBAHdWsEqTIsg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.0",
+				"@fluidframework/odsp-doclib-utils": "^1.2.1",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -7186,71 +7186,71 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.0.tgz",
-			"integrity": "sha512-dCmWamSviQlQPsMMm0HyaGa99Na4KCI3jhGowKfwiOEVj39iyoW6D83yljs3TpDI4fcarcy/tzmSoUXiKiBUew==",
+			"version": "npm:@fluidframework/undo-redo@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.1.tgz",
+			"integrity": "sha512-yzxNEAFVIVPFUh+mdasTtLGbcNN7s8IzneabWCpaNe78a9CzSUaPyIE/QMQkc48jpVEPxfjbe+E2KUJlT2SX3Q==",
 			"requires": {
-				"@fluidframework/map": "^1.2.0",
-				"@fluidframework/matrix": "^1.2.0",
-				"@fluidframework/merge-tree": "^1.2.0",
-				"@fluidframework/sequence": "^1.2.0"
+				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/matrix": "^1.2.1",
+				"@fluidframework/merge-tree": "^1.2.1",
+				"@fluidframework/sequence": "^1.2.1"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.0.tgz",
-			"integrity": "sha512-iLpnZpgeGVvJBSyUoBfS2mC6kj1AnqqcFH8kq0MgmbDLW6xGFIHofl640l6AIhmCXWUEfbYPLpiE/WN7d9uEVQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.1.tgz",
+			"integrity": "sha512-I0NDsMv7f5zHUoL6qbENiZer+LwJ0dBnx/SO3oyBG5XqqJwHvdqOya9eC2K1A2uznO8KwurrV9xltXWLswsaZA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/view-interfaces": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/view-interfaces": "^1.2.1",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.0.tgz",
-			"integrity": "sha512-iLpnZpgeGVvJBSyUoBfS2mC6kj1AnqqcFH8kq0MgmbDLW6xGFIHofl640l6AIhmCXWUEfbYPLpiE/WN7d9uEVQ==",
+			"version": "npm:@fluidframework/view-adapters@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.1.tgz",
+			"integrity": "sha512-I0NDsMv7f5zHUoL6qbENiZer+LwJ0dBnx/SO3oyBG5XqqJwHvdqOya9eC2K1A2uznO8KwurrV9xltXWLswsaZA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0",
-				"@fluidframework/view-interfaces": "^1.2.0",
+				"@fluidframework/core-interfaces": "^1.2.1",
+				"@fluidframework/view-interfaces": "^1.2.1",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.0.tgz",
-			"integrity": "sha512-L1ftL7WPlBWnx9CQYXUTtEuJmtGYdwl1eTFtqwKteoFgxSEoctHZWPcWilffNJL8dNujffbG/FoOk9It+T4YBw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.1.tgz",
+			"integrity": "sha512-twZlmk9dHffYvZDMq7uJPRw4wjH35XbsWe5ssEtQanYTeNfqXATb1LXcpJOiOLJD0xtGYD0QgdoBWhglYJhbcQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0"
+				"@fluidframework/core-interfaces": "^1.2.1"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.0.tgz",
-			"integrity": "sha512-L1ftL7WPlBWnx9CQYXUTtEuJmtGYdwl1eTFtqwKteoFgxSEoctHZWPcWilffNJL8dNujffbG/FoOk9It+T4YBw==",
+			"version": "npm:@fluidframework/view-interfaces@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.1.tgz",
+			"integrity": "sha512-twZlmk9dHffYvZDMq7uJPRw4wjH35XbsWe5ssEtQanYTeNfqXATb1LXcpJOiOLJD0xtGYD0QgdoBWhglYJhbcQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.0"
+				"@fluidframework/core-interfaces": "^1.2.1"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.0.tgz",
-			"integrity": "sha512-egCQ+WWs46HBtoXMxuO6+ljvJfsuGxBpB4X57MVtz5m4G+t0vrBbjOTMDbQTDK5Cp/9Rcxlh9E8qmHkfTu8Pbw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.1.tgz",
+			"integrity": "sha512-m9UHWK+wjo0ciT1uFe42HSQm/Pa8kqB5Z5o4uFn8TcOJJZxc/mWA4/vy74/jkwn2kuMUmPh4g0YQmeNv7L9ZkA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.0.tgz",
-			"integrity": "sha512-egCQ+WWs46HBtoXMxuO6+ljvJfsuGxBpB4X57MVtz5m4G+t0vrBbjOTMDbQTDK5Cp/9Rcxlh9E8qmHkfTu8Pbw==",
+			"version": "npm:@fluidframework/web-code-loader@1.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.1.tgz",
+			"integrity": "sha512-m9UHWK+wjo0ciT1uFe42HSQm/Pa8kqB5Z5o4uFn8TcOJJZxc/mWA4/vy74/jkwn2kuMUmPh4g0YQmeNv7L9ZkA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/core-interfaces": "^1.2.0",
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/core-interfaces": "^1.2.1",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
@@ -22474,7 +22474,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
 			"integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
 				"depd": "^1.1.2",
@@ -22741,48 +22740,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
 			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
 		},
 		"arg": {
 			"version": "4.1.3",
@@ -31797,15 +31754,15 @@
 			"integrity": "sha512-OapHwT5Ug1c3iiv8JNrwh/3XGjP45l/2iwfl25chePrvCgl0786ZvsJK+hxCCaUZjPm1lHdh5LHZhmKRxunziA=="
 		},
 		"fluid-framework-previous": {
-			"version": "npm:fluid-framework@1.2.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.0.tgz",
-			"integrity": "sha512-0PZVQ9x5axtmnhyoYZlMnSSoafk7Hpe/ycAXJCltdSU61AiTQicpHYBfxA/3Nz5DI5Zz+Vh7H75zC6mCywAeiw==",
+			"version": "npm:fluid-framework@1.2.1",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.1.tgz",
+			"integrity": "sha512-VYO1WyD80hn/i3cfctKmugigbTeXhE2/DRQMxbNYshLHryWxLPsyZLcZlfWRp/9Zn3m3Vm7RZJBCK/9r6y7+eg==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.0",
-				"@fluidframework/container-loader": "^1.2.0",
-				"@fluidframework/fluid-static": "^1.2.0",
-				"@fluidframework/map": "^1.2.0",
-				"@fluidframework/sequence": "^1.2.0"
+				"@fluidframework/container-definitions": "^1.2.1",
+				"@fluidframework/container-loader": "^1.2.1",
+				"@fluidframework/fluid-static": "^1.2.1",
+				"@fluidframework/map": "^1.2.1",
+				"@fluidframework/sequence": "^1.2.1"
 			}
 		},
 		"flush-write-stream": {
@@ -32171,15 +32128,6 @@
 				}
 			}
 		},
-		"fs-minipass": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-			"dev": true,
-			"requires": {
-				"minipass": "^2.6.0"
-			}
-		},
 		"fs-monkey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
@@ -32359,59 +32307,6 @@
 			"requires": {
 				"@types/is-windows": "^1.0.0",
 				"is-windows": "^1.0.2"
-			}
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
 			}
 		},
 		"gensync": {
@@ -33970,7 +33865,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
 			}
@@ -34772,8 +34666,7 @@
 		"is-lambda": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-			"dev": true
+			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
 		},
 		"is-lower-case": {
 			"version": "2.0.2",
@@ -39779,16 +39672,6 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"minipass": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
-			}
-		},
 		"minipass-collect": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
@@ -39816,7 +39699,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
 			"integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.12",
 				"minipass": "^3.1.0",
@@ -39828,7 +39710,6 @@
 					"version": "3.3.4",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
 					"integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -39934,7 +39815,6 @@
 					"version": "3.3.4",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
 					"integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -39944,15 +39824,6 @@
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
-			}
-		},
-		"minizlib": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-			"dev": true,
-			"requires": {
-				"minipass": "^2.9.0"
 			}
 		},
 		"mississippi": {
@@ -40929,8 +40800,7 @@
 		"negotiator": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-			"dev": true
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -41988,16 +41858,6 @@
 				"readable-stream": "~1.0.31"
 			}
 		},
-		"nopt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-			"dev": true,
-			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
-			}
-		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -42940,18 +42800,6 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
 				"path-key": "^2.0.0"
-			}
-		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
 			}
 		},
 		"nth-check": {
@@ -43979,16 +43827,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
 		},
 		"ot-json1": {
 			"version": "1.0.2",
@@ -51322,21 +51160,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
-		},
-		"tar": {
-			"version": "4.4.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-			"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.8.6",
-				"minizlib": "^1.2.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.3"
-			}
 		},
 		"tar-fs": {
 			"version": "1.16.3",


### PR DESCRIPTION
## Description

delete node_modules  (and thus avoiding the sha1 vs sha512 problem, replicating what a clean checkout will experience), revert any local changes to lerna_package_lock.json and run `npm i`.

This results in a lerna_package_lock.json that actually reflects what a new user of this repo would get.
This I think of this as making the lerna_package_lock.json more accurate, rather than changing what packages are used.

This also reduces the deltas in unrelated changes which might accidently include some of this.