### PR TITLE
Enable no-namespace eslint rule in minimal config

### DIFF
--- a/common/build/eslint-config-fluid/eslint7.js
+++ b/common/build/eslint-config-fluid/eslint7.js
@@ -77,7 +77,6 @@ module.exports = {
         "@typescript-eslint/no-invalid-this": "off",
         "@typescript-eslint/no-magic-numbers": "off",
         "@typescript-eslint/no-misused-new": "error",
-        "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-non-null-assertion": "error",
         "@typescript-eslint/no-parameter-properties": "off",
         "@typescript-eslint/no-require-imports": "error",

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -186,7 +186,7 @@
             "error"
         ],
         "@typescript-eslint/no-namespace": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/no-non-null-asserted-optional-chain": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -186,7 +186,7 @@
             "error"
         ],
         "@typescript-eslint/no-namespace": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/no-non-null-asserted-optional-chain": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -200,7 +200,7 @@
             "error"
         ],
         "@typescript-eslint/no-namespace": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/no-non-null-asserted-optional-chain": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -210,7 +210,7 @@
             "error"
         ],
         "@typescript-eslint/no-namespace": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/no-non-null-asserted-optional-chain": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -186,7 +186,7 @@
             "error"
         ],
         "@typescript-eslint/no-namespace": [
-            "off"
+            "error"
         ],
         "@typescript-eslint/no-non-null-asserted-optional-chain": [
             "error"


### PR DESCRIPTION
From the [rule documentation](https://typescript-eslint.io/rules/no-namespace):

> Custom TypeScript modules (`module foo {}`) and namespaces (`namespace foo {}`) are considered outdated ways to organize TypeScript code. ES2015 module syntax is now preferred (`import`/`export`).