### PR TITLE
[release/0.59.4000 > main]: Revert "Replace GetSharingInfo api with /LinkingUrl api (#10151)" (#10889) 

### DIFF
--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -14,8 +14,8 @@ describe("getFileLink", () => {
     const logger = new TelemetryUTLogger();
     const storageTokenFetcher = async () => "StorageToken";
     const fileItemResponse = {
-        webDavUrl: `${siteUrl}/fetchDavUrl`,
-        webUrl: `${siteUrl}/fetchWebUrl`,
+        webDavUrl: "fetchDavUrl",
+        webUrl: "fetchWebUrl",
     };
 
     it("should return share link with existing access", async () => {
@@ -23,7 +23,7 @@ describe("getFileLink", () => {
             async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId4" }, "Enterprise", logger),
             [
                 async () => okResponse({}, fileItemResponse),
-                async () => okResponse({}, { d: { LinkingUrl: "sharelink" } }),
+                async () => okResponse({}, { d: { directUrl: "sharelink" } }),
             ],
         );
         assert.strictEqual(


### PR DESCRIPTION
Revert to using /getSharingInfo instead of /linkingUrl as /linkingUrl does not handle files with .loop extension.