### PR TITLE
improvement(tree): Add telemetry event on local malformed edit

### DIFF
--- a/api-report/experimental-tree.api.md
+++ b/api-report/experimental-tree.api.md
@@ -849,8 +849,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     loadSerializedSummary(blobData: string): ITelemetryProperties;
     // @internal
     loadSummary(summary: SharedTreeSummaryBase): void;
-    // (undocumented)
-    protected readonly logger: ITelemetryLogger;
+    readonly logger: ITelemetryLogger;
     get logViewer(): LogViewer;
     mergeEditsFrom(other: SharedTree, edits: Iterable<Edit<InternalizedChange>>, stableIdRemapper?: (id: StableNodeId) => StableNodeId): EditId[];
     // (undocumented)

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -454,7 +454,10 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 		return this.cachingLogViewer;
 	}
 
-	protected readonly logger: ITelemetryLogger;
+	/**
+	 * logger for SharedTree events.
+	 */
+	public readonly logger: ITelemetryLogger;
 	private readonly sequencedEditAppliedLogger: ITelemetryLogger;
 
 	private readonly encoder_0_0_2: SharedTreeEncoder_0_0_2;


### PR DESCRIPTION
# Description

Adds a telemetry event with diagnostic validation information on local malformed/invalid edits to Checkout.
