### PR TITLE
Add summarizeMessage event to allow deli to ack summaries

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -193,12 +193,12 @@ export interface IDeliLambdaEvents extends IEvent {
         listener: (type: NackMessagesType, contents: INackMessagesControlMessageContents | undefined) => void);
 
     /**
-     * Emitted when the lambda recieves a summarize message.
+     * Emitted when the lambda receives a summarize message.
      */
     (event: "summarizeMessage", listener: (summarizeMessage: ISequencedDocumentAugmentedMessage) => void);
 
     /**
-     * Emitted when the lambda recieves a custom control message.
+     * Emitted when the lambda receives a custom control message.
      */
     (event: "controlMessage", listener: (controlMessage: IControlMessage) => void);
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -186,13 +186,8 @@ export class ScribeLambda implements IPartitionLambda {
 
                 this.clearCache = false;
 
-                const isSummarizeMessage = value.operation.type === MessageType.Summarize;
-
                 // skip summarize messages that deli already acked
-                const shouldSkipSummarizeMessage = isSummarizeMessage && value.operation.serverMetadata &&
-                    typeof (value.operation.serverMetadata) === "object" && value.operation.serverMetadata.deliAcked;
-
-                if (isSummarizeMessage && !shouldSkipSummarizeMessage) {
+                if (value.operation.type === MessageType.Summarize && !value.operation.serverMetadata?.deliAcked) {
                     // Process up to the summary op ref seq to get the protocol state at the summary op.
                     // Capture state first in case the summary is nacked.
                     const prevState = {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -185,7 +185,14 @@ export class ScribeLambda implements IPartitionLambda {
                 }
 
                 this.clearCache = false;
-                if (value.operation.type === MessageType.Summarize) {
+
+                const isSummarizeMessage = value.operation.type === MessageType.Summarize;
+
+                // skip summarize messages that deli already acked
+                const shouldSkipSummarizeMessage = isSummarizeMessage && value.operation.serverMetadata &&
+                    typeof (value.operation.serverMetadata) === "object" && value.operation.serverMetadata.deliAcked;
+
+                if (isSummarizeMessage && !shouldSkipSummarizeMessage) {
                     // Process up to the summary op ref seq to get the protocol state at the summary op.
                     // Capture state first in case the summary is nacked.
                     const prevState = {

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -163,7 +163,6 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         enableNackMessages: true,
         enableOpHashing: true,
         enableAutoDSNUpdate: false,
-        enableAutoSummaryAcks: false,
         enableWriteClientSignals: false,
         clientTimeout: 5 * 60 * 1000,
         activityTimeout: 30 * 1000,

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -16,9 +16,6 @@ export interface IDeliServerConfiguration {
     // Enables automatically updating the DNS when sequencing a summaryAck
     enableAutoDSNUpdate: boolean;
 
-    // Enables automatically acking summaries when the summary includes the protocol tree
-    enableAutoSummaryAcks: boolean;
-
     // Enables creating join/leave signals for write clients
     enableWriteClientSignals: boolean;
 

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -16,6 +16,9 @@ export interface IDeliServerConfiguration {
     // Enables automatically updating the DNS when sequencing a summaryAck
     enableAutoDSNUpdate: boolean;
 
+    // Enables automatically acking summaries when the summary includes the protocol tree
+    enableAutoSummaryAcks: boolean;
+
     // Enables creating join/leave signals for write clients
     enableWriteClientSignals: boolean;
 
@@ -163,6 +166,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         enableNackMessages: true,
         enableOpHashing: true,
         enableAutoDSNUpdate: false,
+        enableAutoSummaryAcks: false,
         enableWriteClientSignals: false,
         clientTimeout: 5 * 60 * 1000,
         activityTimeout: 30 * 1000,


### PR DESCRIPTION
This is for the end state of the single-commit summary work. 
The server will eventually stop running scribe. That means it will be up to deli to submit summaryAck's for summarize messages.

This change adds an event that's emitted when deli gets a summarize message. The service should listen to the event and, if it wants to, set a server flag on the message to tell scribe to not do anything when it sees the summarize op.