### PR TITLE
Factor out mapCursorField

### DIFF
--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -7,6 +7,7 @@ import { assert } from "@fluidframework/common-utils";
 import { Jsonable } from "@fluidframework/datastore-definitions";
 import {
     ITreeCursor,
+    mapCursorField,
     TreeNavigationResult,
 } from "../../forest";
 import {
@@ -197,15 +198,7 @@ export function cursorToJsonObject(reader: ITreeCursor): unknown {
         case jsonString.name:
             return reader.value;
         case jsonArray.name: {
-            const length = reader.length(EmptyKey);
-            const result = new Array(length);
-            for (let index = 0; index < result.length; index++) {
-                assert(reader.down(EmptyKey, index) === TreeNavigationResult.Ok, "expected navigation ok");
-                result[index] = cursorToJsonObject(reader);
-                assert(reader.up() === TreeNavigationResult.Ok, "expected navigation ok");
-            }
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            const result = mapCursorField(reader, EmptyKey, cursorToJsonObject);
             return result;
         }
         case jsonObject.name: {

--- a/packages/dds/tree/src/forest/cursor.ts
+++ b/packages/dds/tree/src/forest/cursor.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { FieldKey, TreeType, Value } from "../tree";
 
 export const enum TreeNavigationResult {
@@ -59,4 +60,30 @@ export interface ITreeCursor {
 
     /** value associated with the currently selected node. */
     readonly value: Value;
+}
+
+/**
+ * @param cursor - tree who's field will be visited.
+ * @param key - the filed to visit.
+ * @param f - builds output from field member, which will be selected in cursor when cursor is provided.
+ *  If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
+ * @returns array resulting from applying `f` to each item of field `key` on `cursor`'s current node.
+ * Returns an empty array if the field is empty or not present (which are considered the same).
+ */
+export function mapCursorField<T>(cursor: ITreeCursor, key: FieldKey, f: (cursor: ITreeCursor) => T): T[] {
+    const output: T[] = [];
+    let result = cursor.down(key, 0);
+    if (result !== TreeNavigationResult.Ok) {
+        assert(result === TreeNavigationResult.NotFound, "pending not supported in mapCursorField");
+        // This has to be special cased (and not fall through the code below)
+        // since the call to `up` needs to be skipped.
+        return [];
+    }
+    while (result === TreeNavigationResult.Ok) {
+        output.push(f(cursor));
+        result = cursor.seek(1).result;
+    }
+    assert(result === TreeNavigationResult.NotFound, "expected enumeration to end at end of field");
+    cursor.up();
+    return output;
 }

--- a/packages/dds/tree/src/forest/cursor.ts
+++ b/packages/dds/tree/src/forest/cursor.ts
@@ -64,7 +64,7 @@ export interface ITreeCursor {
 
 /**
  * @param cursor - tree who's field will be visited.
- * @param key - the filed to visit.
+ * @param key - the field to visit.
  * @param f - builds output from field member, which will be selected in cursor when cursor is provided.
  *  If `f` moves cursor, it must put it back to where it was at the beginning of `f` before returning.
  * @returns array resulting from applying `f` to each item of field `key` on `cursor`'s current node.

--- a/packages/dds/tree/src/forest/index.ts
+++ b/packages/dds/tree/src/forest/index.ts
@@ -6,6 +6,7 @@
 export {
     ITreeCursor,
     TreeNavigationResult,
+    mapCursorField,
 } from "./cursor";
 export * from "./forest";
 export { IEditableForest, FieldLocation, TreeLocation, isFieldLocation } from "./editableForest";


### PR DESCRIPTION
## Description

Factor out mapCursorField from object-forest, and reuse it in JsonCursor.
This lets JsonCursor benefit from the seek based implementation (instead of its up and down based one) which shows perf gains in the benchmark.

Also extends the mapCursorField logic to handle empty fields instead of error on them (so JsonCursor does not need to special case empty arrays).

This will also be reused in future cursor reading code.