### PR TITLE
[main > release/1.0]: Fix for absent children prop in case of empty tree (#11128)

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -81,9 +81,11 @@ function readTreeSection(node: NodeCore) {
         if (records.value !== undefined) {
             assertBlobCoreInstance(records.value, "Blob value should be BlobCore");
             snapshotTree.blobs[path] = records.value.toString();
-        } else {
+        } else if (records.children !== undefined) {
             assertNodeCoreInstance(records.children, "Trees should be of type NodeCore");
             snapshotTree.trees[path] = readTreeSection(records.children);
+        } else {
+            snapshotTree.trees[path] = { blobs: {}, commits: {}, trees: {} };
         }
         if (records.unreferenced !== undefined) {
             assertBoolInstance(records.unreferenced, "Unreferenced flag should be bool");

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -60,9 +60,12 @@ function writeTreeSectionCore(treesNode: NodeCore, snapshotTree: ISnapshotTree) 
         if (snapshotTree.unreferenced) {
             addBoolProperty(treeNode, "unreferenced", snapshotTree.unreferenced);
         }
-        treeNode.addString("children", true);
-        const childNode = treeNode.addNode("list");
-        writeTreeSectionCore(childNode, value);
+        // Only write children prop if either blobs or trees are present.
+        if (Object.keys(value.blobs).length > 0 || Object.keys(value.trees).length > 0) {
+            treeNode.addString("children", true);
+            const childNode = treeNode.addNode("list");
+            writeTreeSectionCore(childNode, value);
+        }
     }
 
     if (snapshotTree.blobs) {

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -28,7 +28,7 @@ import {
     IOdspResponse,
     ISnapshotContents,
 } from "./odspUtils";
-import { convertOdspSnapshotToSnapsohtTreeAndBlobs } from "./odspSnapshotParser";
+import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "./odspSnapshotParser";
 import { currentReadVersion, parseCompactSnapshotResponse } from "./compactSnapshotParser";
 import { ReadBuffer } from "./ReadBufferUtils";
 import { EpochTracker } from "./epochTracker";
@@ -83,7 +83,7 @@ export async function fetchSnapshot(
         },
         async () => snapshotDownloader(url, { headers }),
     ) as IOdspResponse<IOdspSnapshot>;
-    return convertOdspSnapshotToSnapsohtTreeAndBlobs(response.content);
+    return convertOdspSnapshotToSnapshotTreeAndBlobs(response.content);
 }
 
 export async function fetchSnapshotWithRedeem(
@@ -491,7 +491,7 @@ export async function downloadSnapshot(
         const text = await response.content.text();
         const content: IOdspSnapshot = JSON.parse(text);
         response.propsToLog.bodySize = text.length;
-        const snapshotContents: ISnapshotContents = convertOdspSnapshotToSnapsohtTreeAndBlobs(content);
+        const snapshotContents: ISnapshotContents = convertOdspSnapshotToSnapshotTreeAndBlobs(content);
         finalSnapshotContents = { ...response, content: snapshotContents };
     } else {
         assert(contentType === "application/ms-fluid", 0x2c3 /* "Content type should be application/ms-fluid" */);

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -51,7 +51,7 @@ function buildHierarchy(flatTree: IOdspSnapshotCommit): api.ISnapshotTree {
  * Converts existing IOdspSnapshot to snapshot tree, blob array and ops
  * @param odspSnapshot - snapshot
  */
-export function convertOdspSnapshotToSnapsohtTreeAndBlobs(
+export function convertOdspSnapshotToSnapshotTreeAndBlobs(
     odspSnapshot: IOdspSnapshot,
 ): ISnapshotContents {
     const blobsWithBufferContent = new Map<string, ArrayBuffer>();

--- a/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
@@ -1,0 +1,114 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable max-len */
+
+import { strict as assert } from "assert";
+import { IOdspSnapshot } from "../contracts";
+import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "../odspSnapshotParser";
+
+const snapshotTree: IOdspSnapshot = {
+    id: "bBzkVAgAHAAAA",
+    trees: [
+        {
+            id: "bBzkVAgAHAAAA",
+            sequenceNumber: 1,
+            entries: [
+                {
+                    path: ".protocol",
+                    type: "tree",
+                },
+                {
+                    id: "bARA4itsHfCA5XZQaYhmASYpj",
+                    path: ".protocol/quorumMembers",
+                    type: "blob",
+                },
+                {
+                    path: ".app",
+                    type: "tree",
+                },
+                {
+                    path: ".app/.channels",
+                    type: "tree",
+                },
+                {
+                    path: ".app/.channels/23c54bd8-ef53-42fa-a898-413de4c6f0f2",
+                    type: "tree",
+                    unreferenced: true,
+                },
+                {
+                    id: "bARDoHhrwJMLoGao2yx8mD7nz",
+                    path: ".app/.channels/23c54bd8-ef53-42fa-a898-413de4c6f0f2/.attributes",
+                    type: "blob",
+                },
+                {
+                    path: ".app/.channels/23c54bd8-ef53-42fa-a898-413de4c6f0f2/d65a4af3-0bf8-4052-8442-a898651ad9b8",
+                    type: "tree",
+                },
+            ],
+        },
+    ],
+    blobs: [
+        {
+            id: "bARA4itsHfCA5XZQaYhmASYpj",
+            content: "   \n",
+            size: 4,
+            encoding: undefined,
+        },
+        {
+            id: "bARDoHhrwJMLoGao2yx8mD7nz",
+            content: "KR  \n",
+            size: 5,
+            encoding: undefined,
+        },
+    ],
+    ops: [
+        {
+            sequenceNumber: 2,
+            op: {
+                clientId: "38777331-8149-4d15-b734-cd8110295ab6",
+                clientSequenceNumber: 2,
+                contents: null,
+                metadata: {},
+                minimumSequenceNumber: 136505,
+                referenceSequenceNumber: 136505,
+                sequenceNumber: 2,
+                term: 1,
+                timestamp: 1657840275913,
+                type: "op",
+            },
+        },
+        {
+            sequenceNumber: 3,
+            op: {
+                clientId: "38777331-8149-4d15-b734-cd8110295ab6",
+                clientSequenceNumber: -1,
+                contents: null,
+                minimumSequenceNumber: 136505,
+                referenceSequenceNumber: -1,
+                sequenceNumber: 3,
+                term: 1,
+                timestamp: 1657840275922,
+                type: "join",
+            },
+        },
+    ],
+};
+
+describe("JSON Snapshot Format Conversion Tests", () => {
+    it("Conversion test", async () => {
+        const result = convertOdspSnapshotToSnapshotTreeAndBlobs(snapshotTree);
+        assert(result.sequenceNumber === 1, "Seq number should match");
+        assert(result.latestSequenceNumber === 3, "Latest sequence number should match");
+        assert(result.snapshotTree.id = snapshotTree.id, "Snapshot id should match");
+        assert(result.ops.length === 2, "2 ops should be there");
+        assert(result.blobs.size === 2, "2 blobs should be there");
+        assert(Object.keys(result.snapshotTree.trees).length === 2, "2 trees should be there");
+        const shouldBeEmptyTree = result.snapshotTree.trees[".app"]?.trees[".channels"]
+            ?.trees["23c54bd8-ef53-42fa-a898-413de4c6f0f2"]?.trees["d65a4af3-0bf8-4052-8442-a898651ad9b8"];
+        const emptyTree = { blobs: {}, trees: {}, commits: {}, unreferenced: undefined };
+        assert.deepStrictEqual(shouldBeEmptyTree, emptyTree, "Tree should have no blobs and trees");
+    });
+});

--- a/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
@@ -101,7 +101,6 @@ describe("JSON Snapshot Format Conversion Tests", () => {
     it("Conversion test", async () => {
         const result = convertOdspSnapshotToSnapshotTreeAndBlobs(snapshotTree);
         assert(result.sequenceNumber === 1, "Seq number should match");
-        assert(result.latestSequenceNumber === 3, "Latest sequence number should match");
         assert(result.snapshotTree.id = snapshotTree.id, "Snapshot id should match");
         assert(result.ops.length === 2, "2 ops should be there");
         assert(result.blobs.size === 2, "2 blobs should be there");


### PR DESCRIPTION
## Description
Currently while parsing "treeNodes" in wire format, client expects "children" prop in case it is not a blob(leaf node). Children represents a non-leaf node. But service does not encode "children" prop in case the trees is empty. So, client should not read it in case it is not there.