### PR TITLE
[GitRest] Updating repoPath so that summaries be placed within a dedicated folder

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -14,6 +14,7 @@ export enum Constants {
 export interface IStorageDirectoryConfig {
     useRepoOwner: boolean;
     baseDir?: string;
+    suffixPath?: string;
 }
 
 export interface IExternalWriterConfig {

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -143,7 +143,7 @@ export function getRepoPath(
 }
 
 export function getGitDirectory(repoPath: string, baseDir?: string): string {
-    return baseDir ? `${baseDir}/${repoPath}` : repoPath;
+    return baseDir ? `${baseDir}/${repoPath}/summaries` : `${repoPath}/summaries`;
 }
 
 export function parseStorageRoutingId(storageRoutingId?: string): IStorageRoutingId | undefined {

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -142,8 +142,8 @@ export function getRepoPath(
     return [owner, tenantId, documentId].filter((x) => x !== undefined).join("/");
 }
 
-export function getGitDirectory(repoPath: string, baseDir?: string): string {
-    return baseDir ? `${baseDir}/${repoPath}/summaries` : `${repoPath}/summaries`;
+export function getGitDirectory(repoPath: string, baseDir?: string, suffixPath?: string): string {
+    return [baseDir, repoPath, suffixPath].filter((x) => x !== undefined).join("/");
 }
 
 export function parseStorageRoutingId(storageRoutingId?: string): IStorageRoutingId | undefined {

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -145,7 +145,10 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
             params.repoName,
             undefined,
             this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
-        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
+        const directoryPath = helpers.getGitDirectory(
+            repoPath,
+            this.storageDirectoryConfig.baseDir,
+            this.storageDirectoryConfig.suffixPath);
 
         return this.internalHandlerCore(
             params,

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -117,7 +117,10 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
             params.storageRoutingId.tenantId,
             params.storageRoutingId.documentId,
             this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
-        const directoryPath = helpers.getGitDirectory(repoPath, this.storageDirectoryConfig.baseDir);
+        const directoryPath = helpers.getGitDirectory(
+            repoPath,
+            this.storageDirectoryConfig.baseDir,
+            this.storageDirectoryConfig.suffixPath);
         const repoName = `${params.storageRoutingId.tenantId}/${params.storageRoutingId.documentId}`;
 
         return this.internalHandlerCore(


### PR DESCRIPTION
## Description
Currently, summary data generated through GitRest would be placed in the filesystem under a filepath that represents either the tenant or the more specific document (if repo-per-doc feature is enabled). In Fluid Relay (and also in the reference implementation here) there might be situations where we want to store more than just summary data in the filesystem. Therefore, to keep things tidy, this PR updates how we generate the repository path to optionally include a new subpath specific to summaries. That subpath is called `suffixPath` and can be optionally defined in config.json, like in this example:
```json
"storageDir": {
        "baseDir": "/home/node/documents",
        "suffixPath": "summaries",
        "useRepoOwner": true
    },
```
If suffixPath is not present in the config, then the changes in this PR do not change GitRest behavior.

## Breaking changes
None, since the repoPath will only change if an optional `suffixPath` configuration under `storageDir` is defined.