### PR TITLE
Support for flat arrays in TelemetryLogger

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -26,9 +26,9 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 // @public
 export class ChildLogger extends TelemetryLogger {
     // (undocumented)
-    protected readonly baseLogger: ITelemetryBaseLogger;
-    static create(baseLogger?: ITelemetryBaseLogger, namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
-    send(event: ITelemetryBaseEvent): void;
+    protected readonly baseLogger: ITelemetryBaseLoggerExt;
+    static create(baseLogger?: ITelemetryBaseLoggerExt, namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
+    send(event: ITelemetryBaseEventExt): void;
 }
 
 // @public (undocumented)
@@ -42,7 +42,7 @@ export class DebugLogger extends TelemetryLogger {
     constructor(debug: IDebugger, debugErr: IDebugger, properties?: ITelemetryLoggerPropertyBags);
     static create(namespace: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
     static mixinDebugLogger(namespace: string, baseLogger?: ITelemetryBaseLogger, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
-    send(event: ITelemetryBaseEvent): void;
+    send(event: ITelemetryBaseEventExt): void;
 }
 
 // @public (undocumented)
@@ -140,11 +140,25 @@ export function isTaggedTelemetryPropertyValue(x: any): x is ITaggedTelemetryPro
 export function isValidLegacyError(e: any): e is Omit<IFluidErrorBase, "errorInstanceId">;
 
 // @public (undocumented)
+export interface ITaggedTelemetryPropertyTypeExt {
+    // (undocumented)
+    tag: string;
+    // (undocumented)
+    value: TelemetryEventPropertyTypeExt;
+}
+
+// @public (undocumented)
 export interface ITelemetryBaseEventExt extends ITelemetryPropertiesExt {
     // (undocumented)
     category: string;
     // (undocumented)
     eventName: string;
+}
+
+// @public (undocumented)
+export interface ITelemetryBaseLoggerExt {
+    // (undocumented)
+    send(event: ITelemetryBaseEventExt): void;
 }
 
 // @public (undocumented)
@@ -178,7 +192,7 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
 // @public (undocumented)
 export interface ITelemetryPropertiesExt {
     // (undocumented)
-    [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType | TelemetryEventPropertyTypeExt;
+    [index: string]: ITaggedTelemetryPropertyTypeExt | TelemetryEventPropertyTypeExt;
 }
 
 // @public (undocumented)
@@ -230,7 +244,7 @@ export class MultiSinkLogger extends TelemetryLogger {
     addLogger(logger?: ITelemetryBaseLogger): void;
     // (undocumented)
     protected loggers: ITelemetryBaseLogger[];
-    send(event: ITelemetryBaseEvent): void;
+    send(event: ITelemetryBaseEventExt): void;
 }
 
 // @public
@@ -277,8 +291,8 @@ export class SampledTelemetryHelper implements IDisposable {
 export const sessionStorageConfigProvider: Lazy<IConfigProviderBase>;
 
 // @public @deprecated (undocumented)
-export class TaggedLoggerAdapter implements ITelemetryBaseLogger {
-    constructor(logger: ITelemetryBaseLogger);
+export class TaggedLoggerAdapter implements ITelemetryBaseLoggerExt {
+    constructor(logger: ITelemetryBaseLoggerExt);
     // (undocumented)
     send(eventWithTagsMaybe: ITelemetryBaseEvent): void;
 }
@@ -308,14 +322,14 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     // (undocumented)
     protected readonly namespace?: string | undefined;
     static numberFromString(str: string | null | undefined): string | number | undefined;
-    static prepareErrorObject(event: ITelemetryBaseEvent, error: any, fetchStack: boolean): void;
+    static prepareErrorObject(event: ITelemetryBaseEventExt, error: any, fetchStack: boolean): void;
     // (undocumented)
-    protected prepareEvent(event: ITelemetryBaseEvent): ITelemetryBaseEvent;
+    protected prepareEvent(event: ITelemetryBaseEventExt): ITelemetryBaseEventExt;
     // (undocumented)
     protected readonly properties?: ITelemetryLoggerPropertyBags | undefined;
     // (undocumented)
     static sanitizePkgName(name: string): string;
-    abstract send(event: ITelemetryBaseEvent | ITelemetryBaseEventExt): void;
+    abstract send(event: ITelemetryBaseEventExt): void;
     sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void;
     sendPerformanceEvent(event: ITelemetryPerformanceEvent | ITelemetryPerformanceEventExt, error?: any): void;
     sendTelemetryEvent(event: ITelemetryGenericEvent | ITelemetryGenericEventExt, error?: any): void;

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -289,6 +289,9 @@ export type TelemetryEventPropertyTypeExt = string | number | boolean | undefine
 // @public (undocumented)
 export type TelemetryEventPropertyTypes = TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
 
+// @public (undocumented)
+export type TelemetryEventTypes = ITelemetryBaseEvent | ITelemetryBaseEventExt | ITelemetryGenericEvent | ITelemetryGenericEventExt;
+
 // @public
 export abstract class TelemetryLogger implements ITelemetryLogger {
     constructor(namespace?: string | undefined, properties?: ITelemetryLoggerPropertyBags | undefined);

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -140,6 +140,22 @@ export function isTaggedTelemetryPropertyValue(x: any): x is ITaggedTelemetryPro
 export function isValidLegacyError(e: any): e is Omit<IFluidErrorBase, "errorInstanceId">;
 
 // @public (undocumented)
+export interface ITelemetryBaseEventExt extends ITelemetryPropertiesExt {
+    // (undocumented)
+    category: string;
+    // (undocumented)
+    eventName: string;
+}
+
+// @public (undocumented)
+export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
+    // (undocumented)
+    category?: TelemetryEventCategory;
+    // (undocumented)
+    eventName: string;
+}
+
+// @public (undocumented)
 export interface ITelemetryLoggerPropertyBag {
     // (undocumented)
     [index: string]: TelemetryEventPropertyTypes | (() => TelemetryEventPropertyTypes);
@@ -151,6 +167,12 @@ export interface ITelemetryLoggerPropertyBags {
     all?: ITelemetryLoggerPropertyBag;
     // (undocumented)
     error?: ITelemetryLoggerPropertyBag;
+}
+
+// @public (undocumented)
+export interface ITelemetryPropertiesExt {
+    // (undocumented)
+    [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType | TelemetryEventPropertyTypeExt;
 }
 
 // @public (undocumented)
@@ -284,10 +306,10 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     protected readonly properties?: ITelemetryLoggerPropertyBags | undefined;
     // (undocumented)
     static sanitizePkgName(name: string): string;
-    abstract send(event: ITelemetryBaseEvent): void;
+    abstract send(event: ITelemetryBaseEvent | ITelemetryBaseEventExt): void;
     sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void;
     sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;
-    sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any): void;
+    sendTelemetryEvent(event: ITelemetryGenericEvent | ITelemetryGenericEventExt, error?: any): void;
     protected sendTelemetryEventCore(event: ITelemetryGenericEvent & {
         category: TelemetryEventCategory;
     }, error?: any): void;

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -262,6 +262,9 @@ export enum TelemetryDataTag {
 }
 
 // @public (undocumented)
+export type TelemetryEventPropertyTypeExt = string | number | boolean | undefined | (string | number | boolean)[];
+
+// @public (undocumented)
 export type TelemetryEventPropertyTypes = TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
 
 // @public

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -317,7 +317,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     static sanitizePkgName(name: string): string;
     abstract send(event: ITelemetryBaseEvent | ITelemetryBaseEventExt): void;
     sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void;
-    sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;
+    sendPerformanceEvent(event: ITelemetryPerformanceEvent | ITelemetryPerformanceEventExt, error?: any): void;
     sendTelemetryEvent(event: ITelemetryGenericEvent | ITelemetryGenericEventExt, error?: any): void;
     protected sendTelemetryEventCore(event: ITelemetryGenericEvent & {
         category: TelemetryEventCategory;

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -170,6 +170,12 @@ export interface ITelemetryLoggerPropertyBags {
 }
 
 // @public (undocumented)
+export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt {
+    // (undocumented)
+    duration?: number;
+}
+
+// @public (undocumented)
 export interface ITelemetryPropertiesExt {
     // (undocumented)
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType | TelemetryEventPropertyTypeExt;
@@ -290,7 +296,7 @@ export type TelemetryEventPropertyTypeExt = string | number | boolean | undefine
 export type TelemetryEventPropertyTypes = TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
 
 // @public (undocumented)
-export type TelemetryEventTypes = ITelemetryBaseEvent | ITelemetryBaseEventExt | ITelemetryGenericEvent | ITelemetryGenericEventExt;
+export type TelemetryEventTypes = ITelemetryBaseEvent | ITelemetryBaseEventExt | ITelemetryGenericEvent | ITelemetryGenericEventExt | ITelemetryPerformanceEvent | ITelemetryPerformanceEventExt;
 
 // @public
 export abstract class TelemetryLogger implements ITelemetryLogger {

--- a/packages/utils/telemetry-utils/src/debugLogger.ts
+++ b/packages/utils/telemetry-utils/src/debugLogger.ts
@@ -3,14 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import {
-    ITelemetryBaseEvent,
-    ITelemetryBaseLogger,
-    ITelemetryProperties,
-} from "@fluidframework/common-definitions";
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { performance } from "@fluidframework/common-utils";
 import { debug as registerDebug, IDebugger } from "debug";
-import { TelemetryLogger, MultiSinkLogger, ChildLogger, ITelemetryLoggerPropertyBags } from "./logger";
+import {
+    TelemetryLogger,
+    MultiSinkLogger,
+    ChildLogger,
+    ITelemetryLoggerPropertyBags,
+    ITelemetryPropertiesExt,
+    ITelemetryBaseEventExt,
+} from "./logger";
 
 /**
  * Implementation of debug logger
@@ -80,8 +83,8 @@ export class DebugLogger extends TelemetryLogger {
      *
      * @param event - the event to send
      */
-    public send(event: ITelemetryBaseEvent): void {
-        const newEvent: ITelemetryProperties = this.prepareEvent(event);
+    public send(event: ITelemetryBaseEventExt): void {
+        const newEvent: ITelemetryPropertiesExt = this.prepareEvent(event);
         const isError = newEvent.category === "error";
         let logger = isError ? this.debugErr : this.debug;
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -561,3 +561,40 @@ export class PerformanceEvent {
         throw error;
     }
 }
+
+/**
+     * Take in a event object, stringify any fields that are non-primitives, and return the new event object.
+     * @param event - Event with fields you want to stringify.
+     */
+function stringifyEventFields(event: ITelemetryBaseEvent): ITelemetryBaseEvent {
+    const newEvent: ITelemetryBaseEvent = { category: event.category, eventName: event.eventName };
+    for (const key of Object.keys(event)) {
+        const filteredEventVal = filterValidTelemetryProps(event[key]);
+        if (filteredEventVal !== null) {
+            newEvent[key] = filteredEventVal;
+        }
+    }
+    return newEvent;
+}
+/**
+ * Takes in parameter, if parameter is of primitive type, return the original value.
+ * If parameter is an array, stringify then return the result.
+ * @param x - parameter passed to validate/filter
+ */
+function filterValidTelemetryProps(x: any): TelemetryEventPropertyType | null {
+    switch (typeof x) {
+        case "string":
+        case "number":
+        case "boolean":
+        case "undefined":
+            return x;
+        default:
+            if (!Array.isArray(x)) {
+                return null;
+            }
+            if (x.every((val) => filterValidTelemetryProps(val) !== null)) {
+                return JSON.stringify(x);
+            }
+            return null;
+    }
+}

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -591,7 +591,7 @@ function filterValidTelemetryProps(x: any): TelemetryEventPropertyType | null {
             if (!Array.isArray(x)) {
                 return null;
             }
-            if (x.every((val) => filterValidTelemetryProps(val) !== null)) {
+            if (x.every((val) => typeof val === "boolean" || typeof val === "string" || typeof val === "number")) {
                 return JSON.stringify(x);
             }
             return null;

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -50,6 +50,22 @@ export interface ITelemetryLoggerPropertyBags{
     error?: ITelemetryLoggerPropertyBag;
 }
 
+// Less restrictive telemetry properties to include arrays with primitives.
+export interface ITelemetryPropertiesExt {
+    [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType | TelemetryEventPropertyTypeExt;
+}
+
+// Base interface for logging telemetry statements allowing flat arrays containing primitives.
+export interface ITelemetryBaseEventExt extends ITelemetryPropertiesExt {
+    category: string;
+    eventName: string;
+}
+
+export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
+    eventName: string;
+    category?: TelemetryEventCategory;
+}
+
 /**
  * TelemetryLogger class contains various helper telemetry methods,
  * encoding in one place schemas for various types of Fluid telemetry events.
@@ -122,7 +138,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      *
      * @param event - the event to send
      */
-    public abstract send(event: ITelemetryBaseEvent): void;
+    public abstract send(event: ITelemetryBaseEvent | ITelemetryBaseEventExt): void;
 
     /**
      * Send a telemetry event with the logger
@@ -130,7 +146,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param event - the event to send
      * @param error - optional error object to log
      */
-    public sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any) {
+    public sendTelemetryEvent(event: ITelemetryGenericEvent | ITelemetryGenericEventExt, error?: any) {
         this.sendTelemetryEventCore({ ...event, category: event.category ?? "generic" }, error);
     }
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -66,6 +66,12 @@ export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
     category?: TelemetryEventCategory;
 }
 
+export type TelemetryEventTypes =
+    | ITelemetryBaseEvent
+    | ITelemetryBaseEventExt
+    | ITelemetryGenericEvent
+    | ITelemetryGenericEventExt;
+
 /**
  * TelemetryLogger class contains various helper telemetry methods,
  * encoding in one place schemas for various types of Fluid telemetry events.
@@ -147,6 +153,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param error - optional error object to log
      */
     public sendTelemetryEvent(event: ITelemetryGenericEvent | ITelemetryGenericEventExt, error?: any) {
+        stringifyEventFields(event);
         this.sendTelemetryEventCore({ ...event, category: event.category ?? "generic" }, error);
     }
 
@@ -585,7 +592,7 @@ export class PerformanceEvent {
      * Take in a event object, stringify any fields that are non-primitives, and return the new event object.
      * @param event - Event with fields you want to stringify.
      */
-function stringifyEventFields(event: ITelemetryBaseEvent): void {
+function stringifyEventFields(event: TelemetryEventTypes): void {
     for (const key of Object.keys(event)) {
         const filteredEventVal = filterValidTelemetryProps(event[key]);
         if (filteredEventVal !== null) {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -230,6 +230,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         const newEvent: ITelemetryBaseEventExt = {
             ...event,
         };
+        stringifyEventFields(event);
         if (this.namespace !== undefined) {
             newEvent.eventName = `${this.namespace}${TelemetryLogger.eventNamespaceSeparator}${newEvent.eventName}`;
         }

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -38,6 +38,8 @@ export enum TelemetryDataTag {
     UserData = "UserData",
 }
 
+export type TelemetryEventPropertyTypeExt = string | number | boolean | undefined | (string | number | boolean)[];
+
 export type TelemetryEventPropertyTypes = TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
 
 export interface ITelemetryLoggerPropertyBag {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -110,6 +110,43 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         }
     }
 
+    /**
+     * Take in a event object, stringify any fields that are non-primitives, and return the new event object.
+     * @param event - Event with fields you want to stringify.
+     */
+     public static stringifyEventFields(event: ITelemetryBaseEvent): ITelemetryBaseEvent {
+        const newEvent: ITelemetryBaseEvent = { category: event.category, eventName: event.eventName };
+        for (const key of Object.keys(event)) {
+            const filteredEventVal = TelemetryLogger.filterValidTelemetryProps(event[key]);
+            if (filteredEventVal !== null) {
+                newEvent[key] = filteredEventVal;
+            }
+        }
+        return newEvent;
+    }
+    /**
+     * Takes in parameter, if parameter is of primitive type, return the original value.
+     * If parameter is an array, stringify then return the result.
+     * @param x - parameter passed to validate/filter
+     */
+    public static filterValidTelemetryProps(x: any): TelemetryEventPropertyType | null {
+        switch (typeof x) {
+            case "string":
+            case "number":
+            case "boolean":
+            case "undefined":
+                return x;
+            default:
+                if (!Array.isArray(x)) {
+                    return null;
+                }
+                if (x.every((val) => this.filterValidTelemetryProps(val) !== null)) {
+                    return JSON.stringify(x);
+                }
+                return null;
+        }
+    }
+
     public constructor(
         protected readonly namespace?: string,
         protected readonly properties?: ITelemetryLoggerPropertyBags) {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -110,43 +110,6 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         }
     }
 
-    /**
-     * Take in a event object, stringify any fields that are non-primitives, and return the new event object.
-     * @param event - Event with fields you want to stringify.
-     */
-     public static stringifyEventFields(event: ITelemetryBaseEvent): ITelemetryBaseEvent {
-        const newEvent: ITelemetryBaseEvent = { category: event.category, eventName: event.eventName };
-        for (const key of Object.keys(event)) {
-            const filteredEventVal = TelemetryLogger.filterValidTelemetryProps(event[key]);
-            if (filteredEventVal !== null) {
-                newEvent[key] = filteredEventVal;
-            }
-        }
-        return newEvent;
-    }
-    /**
-     * Takes in parameter, if parameter is of primitive type, return the original value.
-     * If parameter is an array, stringify then return the result.
-     * @param x - parameter passed to validate/filter
-     */
-    public static filterValidTelemetryProps(x: any): TelemetryEventPropertyType | null {
-        switch (typeof x) {
-            case "string":
-            case "number":
-            case "boolean":
-            case "undefined":
-                return x;
-            default:
-                if (!Array.isArray(x)) {
-                    return null;
-                }
-                if (x.every((val) => this.filterValidTelemetryProps(val) !== null)) {
-                    return JSON.stringify(x);
-                }
-                return null;
-        }
-    }
-
     public constructor(
         protected readonly namespace?: string,
         protected readonly properties?: ITelemetryLoggerPropertyBags) {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -65,12 +65,17 @@ export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
     eventName: string;
     category?: TelemetryEventCategory;
 }
+export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt {
+    duration?: number; // Duration of event (optional)
+}
 
 export type TelemetryEventTypes =
     | ITelemetryBaseEvent
     | ITelemetryBaseEventExt
     | ITelemetryGenericEvent
-    | ITelemetryGenericEventExt;
+    | ITelemetryGenericEventExt
+    | ITelemetryPerformanceEvent
+    | ITelemetryPerformanceEventExt;
 
 /**
  * TelemetryLogger class contains various helper telemetry methods,

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -206,7 +206,8 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param event - Event to send
      * @param error - optional error object to log
      */
-    public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {
+    public sendPerformanceEvent(event: ITelemetryPerformanceEvent | ITelemetryPerformanceEventExt, error?: any): void {
+        stringifyEventFields(event);
         const perfEvent = {
             ...event,
             category: event.category ?? "performance",

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -386,6 +386,7 @@ export class MultiSinkLogger extends TelemetryLogger {
      */
     public send(event: ITelemetryBaseEvent): void {
         const newEvent = this.prepareEvent(event);
+        stringifyEventFields(newEvent);
         this.loggers.forEach((logger: ITelemetryBaseLogger) => {
             logger.send(newEvent);
         });
@@ -566,15 +567,13 @@ export class PerformanceEvent {
      * Take in a event object, stringify any fields that are non-primitives, and return the new event object.
      * @param event - Event with fields you want to stringify.
      */
-function stringifyEventFields(event: ITelemetryBaseEvent): ITelemetryBaseEvent {
-    const newEvent: ITelemetryBaseEvent = { category: event.category, eventName: event.eventName };
+function stringifyEventFields(event: ITelemetryBaseEvent): void {
     for (const key of Object.keys(event)) {
         const filteredEventVal = filterValidTelemetryProps(event[key]);
         if (filteredEventVal !== null) {
-            newEvent[key] = filteredEventVal;
+            event[key] = filteredEventVal;
         }
     }
-    return newEvent;
 }
 /**
  * Takes in parameter, if parameter is of primitive type, return the original value.

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "assert";
 import sinon from "sinon";
 import { v4 as uuid } from "uuid";
 import { ITelemetryBaseEvent, ITelemetryProperties } from "@fluidframework/common-definitions";
-import { TelemetryDataTag, TelemetryLogger, TaggedLoggerAdapter } from "../logger";
+import { TelemetryDataTag, TelemetryLogger, TaggedLoggerAdapter, ITelemetryBaseEventExt } from "../logger";
 import {
     LoggingError,
     isTaggedTelemetryPropertyValue,
@@ -121,10 +121,10 @@ describe("Error Logging", () => {
         });
     });
     describe("TaggedLoggerAdapter", () => {
-        const events: ITelemetryBaseEvent[] = [];
+        const events: ITelemetryBaseEventExt[] = [];
         class TestTelemetryLogger extends TelemetryLogger {
-            public events: ITelemetryBaseEvent[] = [];
-            public send(event: ITelemetryBaseEvent): void {
+            public events: ITelemetryBaseEventExt[] = [];
+            public send(event: ITelemetryBaseEventExt): void {
                 events.push(this.prepareEvent(event));
             }
         }

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -4,12 +4,16 @@
  */
 
 import assert from "assert";
-import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
-import { ITelemetryLoggerPropertyBags, ITelemetryLoggerPropertyBag, TelemetryLogger } from "../logger";
+import {
+    ITelemetryLoggerPropertyBags,
+    ITelemetryLoggerPropertyBag,
+    TelemetryLogger,
+    ITelemetryBaseEventExt,
+} from "../logger";
 
 class TestTelemetryLogger extends TelemetryLogger {
-    public events: ITelemetryBaseEvent[] = [];
-    public send(event: ITelemetryBaseEvent): void {
+    public events: ITelemetryBaseEventExt[] = [];
+    public send(event: ITelemetryBaseEventExt): void {
         this.events.push(this.prepareEvent(event));
     }
 }


### PR DESCRIPTION
## Description

When using the telemetry logger, there are specific instances where logging a flat array or JSON object to an event field is necessary. To accommodate for these scenarios, this pull request focuses on making the following changes to the implementation of the TelemetryLogger class.

1. Accept a less-restrictive type than TelemetryEventPropertyType which includes arrays or objects where the values are strictly primitives (TelemetryEventPropertyType).
2. Stringify these flat objects/arrays when passing to another logger.

## Reviewer Guidance

### Questions
1. As mentioned by @markfields in the original internal task 1104, updating `TelemetryEventPropertyType` should maybe be avoided, as it would be quite a breaking change. Instead, I defined the following types/interfaces within the logger.ts file where our TelemetryLogger is implemented (instead of @fluidframework/common-definitions).

- TelemetryEventPropertyTypeExt
- ITelemetryBaseEventExt
- ITelemetryGenericEventExt
- ITelemetryPerformanceEventExt;

However, would it be best to instead change the update the existing types/interfaces defined in the @fluidframework/common-definitions instead?

2. As this pull request aims to provide support for flat arrays, which test cases should be updated/added to both the end-to-end and unit tests?

Link to Internal [Task #1104](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Taylor/internal/CY22Q3/2022.07/Team%20Taylor%20-%202022.07?workitem=1104)
