### PR TITLE
Delete code dealing with differentiation summaries

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -314,10 +314,7 @@ export interface ISummarizerNode {
     // (undocumented)
     getChild(id: string): ISummarizerNode | undefined;
     invalidate(sequenceNumber: number): void;
-    loadBaseSummary(snapshot: ISnapshotTree, readAndParseBlob: <T>(id: string) => Promise<T>): Promise<{
-        baseSummary: ISnapshotTree;
-        outstandingOps: ISequencedDocumentMessage[];
-    }>;
+    loadBaseSummary(snapshot: ISnapshotTree, readAndParseBlob: <T>(id: string) => Promise<T>): Promise<ISnapshotTree>;
     loadBaseSummaryWithoutDifferential(snapshot: ISnapshotTree): void;
     recordChange(op: ISequencedDocumentMessage): void;
     readonly referenceSequenceNumber: number;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -813,11 +813,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 
         const localReadAndParse = async <T>(id: string) => readAndParse<T>(this.storage, id);
         if (tree) {
-            const loadedSummary = await this.summarizerNode.loadBaseSummary(tree, localReadAndParse);
-            tree = loadedSummary.baseSummary;
-            // Prepend outstanding ops to pending queue of ops to process.
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this.pending = loadedSummary.outstandingOps.concat(this.pending!);
+            tree = await this.summarizerNode.loadBaseSummary(tree, localReadAndParse);
         }
 
         if (!!tree && tree.blobs[dataStoreAttributesBlobName] !== undefined) {

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -175,7 +175,7 @@ export interface ISummarizerNode {
     loadBaseSummary(
         snapshot: ISnapshotTree,
         readAndParseBlob: <T>(id: string) => Promise<T>,
-    ): Promise<{ baseSummary: ISnapshotTree; outstandingOps: ISequencedDocumentMessage[]; }>;
+    ): Promise<ISnapshotTree>;
     /**
      * Records an op representing a change to this node/subtree.
      * @param op - op of change to record

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -24,9 +24,6 @@ import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { mergeStats, convertToSummaryTree, calculateStats } from "../summaryUtils";
 import { ReadAndParseBlob } from "../utils";
 import {
-    decodeSummary,
-    encodeSummary,
-    EncodeSummaryParam,
     EscapedPath,
     ICreateChildDetails,
     IInitialSummary,
@@ -63,7 +60,6 @@ export class SummarizerNode implements IRootSummarizerNode {
 
     protected readonly children = new Map<string, SummarizerNode>();
     protected readonly pendingSummaries = new Map<string, SummaryNode>();
-    private readonly outstandingOps: ISequencedDocumentMessage[] = [];
     private wipReferenceSequenceNumber: number | undefined;
     private wipLocalPaths: { localPath: EscapedPath; additionalPath?: EscapedPath; } | undefined;
     private wipSkipRecursion = false;
@@ -112,52 +108,12 @@ export class SummarizerNode implements IRootSummarizerNode {
             }
         }
 
-        try {
-            const result = await this.summarizeInternalFn(fullTree, true, telemetryContext);
-            this.wipLocalPaths = { localPath: EscapedPath.create(result.id) };
-            if (result.pathPartsForChildren !== undefined) {
-                this.wipLocalPaths.additionalPath = EscapedPath.createAndConcat(result.pathPartsForChildren);
-            }
-            return { summary: result.summary, stats: result.stats };
-        } catch (error) {
-            if (this.throwOnError || this.trackingSequenceNumber < this._changeSequenceNumber) {
-                throw error;
-            }
-            const latestSummary = this._latestSummary;
-            const initialSummary = this.initialSummary;
-
-            let encodeParam: EncodeSummaryParam;
-            let localPath: EscapedPath;
-            if (latestSummary !== undefined) {
-                // Create using handle of latest acked summary
-                encodeParam = {
-                    fromSummary: true,
-                    summaryNode: latestSummary,
-                };
-                localPath = latestSummary.localPath;
-            } else if (initialSummary?.summary !== undefined) {
-                // Create using initial summary from attach op
-                encodeParam = {
-                    fromSummary: false,
-                    initialSummary: initialSummary.summary,
-                };
-                localPath = EscapedPath.create(initialSummary.id);
-            } else {
-                // No base summary to reference
-                throw error;
-            }
-            this.wipSummaryLogger.sendErrorEvent({
-                eventName: "SummarizingWithBasePlusOps",
-            },
-            error);
-            const summary = encodeSummary(encodeParam, this.outstandingOps);
-            this.wipLocalPaths = {
-                localPath,
-                additionalPath: summary.additionalPath,
-            };
-            this.wipSkipRecursion = true;
-            return { summary: summary.summary, stats: summary.stats };
+        const result = await this.summarizeInternalFn(fullTree, true, telemetryContext);
+        this.wipLocalPaths = { localPath: EscapedPath.create(result.id) };
+        if (result.pathPartsForChildren !== undefined) {
+            this.wipLocalPaths.additionalPath = EscapedPath.createAndConcat(result.pathPartsForChildren);
         }
+        return { summary: result.summary, stats: result.stats };
     }
 
     /**
@@ -334,15 +290,14 @@ export class SummarizerNode implements IRootSummarizerNode {
 
         this.refreshLatestSummaryCore(referenceSequenceNumber);
 
-        const { baseSummary, pathParts } = decodeSummary(snapshotTree, correlatedSummaryLogger);
-
         this._latestSummary = new SummaryNode({
             referenceSequenceNumber,
             basePath,
             localPath,
         });
 
-        const { childrenTree, childrenPathPart } = parseSummaryForSubtrees(baseSummary);
+        const pathParts: string[] = [];
+        const { childrenTree, childrenPathPart } = parseSummaryForSubtrees(snapshotTree);
         if (childrenPathPart !== undefined) {
             pathParts.push(childrenPathPart);
         }
@@ -376,14 +331,6 @@ export class SummarizerNode implements IRootSummarizerNode {
                 this.pendingSummaries.delete(key);
             }
         }
-
-        // Clear earlier outstanding ops
-        while (
-            this.outstandingOps.length > 0
-            && this.outstandingOps[0].sequenceNumber <= referenceSequenceNumber
-        ) {
-            this.outstandingOps.shift();
-        }
     }
 
     public loadBaseSummaryWithoutDifferential(snapshot: ISnapshotTree) {
@@ -398,46 +345,22 @@ export class SummarizerNode implements IRootSummarizerNode {
     public async loadBaseSummary(
         snapshot: ISnapshotTree,
         readAndParseBlob: ReadAndParseBlob,
-    ): Promise<{ baseSummary: ISnapshotTree; outstandingOps: ISequencedDocumentMessage[]; }> {
-        const decodedSummary = decodeSummary(snapshot, this.defaultLogger);
-        const outstandingOps = await decodedSummary.getOutstandingOps(readAndParseBlob);
-
-        const { childrenPathPart } = parseSummaryForSubtrees(decodedSummary.baseSummary);
+    ): Promise<ISnapshotTree> {
+        const pathParts: string[] = [];
+        const { childrenPathPart } = parseSummaryForSubtrees(snapshot);
         if (childrenPathPart !== undefined) {
-            decodedSummary.pathParts.push(childrenPathPart);
+            pathParts.push(childrenPathPart);
         }
 
-        if (decodedSummary.pathParts.length > 0 && this._latestSummary !== undefined) {
-            this._latestSummary.additionalPath = EscapedPath.createAndConcat(decodedSummary.pathParts);
+        if (pathParts.length > 0 && this._latestSummary !== undefined) {
+            this._latestSummary.additionalPath = EscapedPath.createAndConcat(pathParts);
         }
 
-        // Defensive assertion: tracking number should already exceed this number.
-        // This is probably a little excessive; can remove when stable.
-        if (outstandingOps.length > 0) {
-            const newOpsLatestSeq = outstandingOps[outstandingOps.length - 1].sequenceNumber;
-            assert(
-                newOpsLatestSeq <= this.trackingSequenceNumber,
-                0x1a9 /* "When loading base summary, expected outstanding ops <= tracking sequence number" */,
-            );
-        }
-
-        return {
-            baseSummary: decodedSummary.baseSummary,
-            outstandingOps,
-        };
+        return snapshot;
     }
 
     public recordChange(op: ISequencedDocumentMessage): void {
-        const lastOp = this.outstandingOps[this.outstandingOps.length - 1];
-        if (lastOp !== undefined) {
-            assert(
-                lastOp.sequenceNumber < op.sequenceNumber,
-                0x1aa /* Out of order change recorded */,
-            );
-        }
         this.invalidate(op.sequenceNumber);
-        this.trackingSequenceNumber = op.sequenceNumber;
-        this.outstandingOps.push(op);
     }
 
     public invalidate(sequenceNumber: number): void {
@@ -460,13 +383,6 @@ export class SummarizerNode implements IRootSummarizerNode {
     }
 
     private readonly canReuseHandle: boolean;
-    private readonly throwOnError: boolean;
-    /**
-     * Sequence number of latest tracked op. This updates during recordChange,
-     * but not for invalidate since we don't have the op. If this drifts from
-     * changeSequenceNumber and we try to create a differential summary we assert.
-     */
-    private trackingSequenceNumber: number;
 
     /**
      * Do not call constructor directly.
@@ -483,11 +399,6 @@ export class SummarizerNode implements IRootSummarizerNode {
         protected wipSummaryLogger?: ITelemetryLogger,
     ) {
         this.canReuseHandle = config.canReuseHandle ?? true;
-        // BUGBUG: Seeing issues with differential summaries.
-        // this will disable them, and throw instead
-        // while we continue to investigate
-        this.throwOnError = true; // config.throwOnFailure ?? false;
-        this.trackingSequenceNumber = this._changeSequenceNumber;
     }
 
     public createChild(

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -4,21 +4,13 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert } from "@fluidframework/common-utils";
 import {
     ISnapshotTree,
-    ISequencedDocumentMessage,
-    SummaryType,
     ISummaryTree,
     SummaryObject,
 } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
-import { SummaryTreeBuilder } from "../summaryUtils";
 import { ReadAndParseBlob } from "../utils";
-
-const baseSummaryTreeKey = "_baseSummary";
-const outstandingOpsBlobKey = "_outstandingOps";
-const maxDecodeDepth = 100;
 
 /**
  * Return value of refreshSummaryAck function. There can be three different scenarios based on the passed params:
@@ -137,88 +129,6 @@ export class SummaryNode {
     }
 }
 
-/** Result from decoding summary which may have been a differential summary. */
-interface IDecodedSummary {
-    /** The innermost base summary which is not itself a differential summary */
-    readonly baseSummary: ISnapshotTree;
-    /** The entire path name to the innermost base summary */
-    readonly pathParts: string[];
-    /** Function to fetch all outstanding ops since the innermost base summary */
-    getOutstandingOps(readAndParseBlob: ReadAndParseBlob): Promise<ISequencedDocumentMessage[]>;
-}
-
-/**
- * Checks if the snapshot is created by referencing a previous successful
- * summary plus outstanding ops. If so, it will recursively "decode" it until
- * it gets to the last successful summary (the base summary) and returns that
- * as well as a function for fetching the outstanding ops. Also returns the
- * full path to the previous base summary for child summarizer nodes to use as
- * their base path when necessary.
- * @param snapshot - snapshot tree to decode
- */
-export function decodeSummary(
-    snapshot: ISnapshotTree,
-    logger: Pick<ITelemetryLogger, "sendTelemetryEvent">,
-): IDecodedSummary {
-    let baseSummary = snapshot;
-    const pathParts: string[] = [];
-    const opsBlobs: string[] = [];
-
-    for (let i = 0; ; i++) {
-        if (i > maxDecodeDepth) {
-            logger.sendTelemetryEvent({
-                eventName: "DecodeSummaryMaxDepth",
-                maxDecodeDepth,
-            });
-        }
-        const outstandingOpsBlob = baseSummary.blobs[outstandingOpsBlobKey];
-        const newBaseSummary = baseSummary.trees[baseSummaryTreeKey];
-        if (outstandingOpsBlob === undefined && newBaseSummary === undefined) {
-            return {
-                baseSummary,
-                pathParts,
-                async getOutstandingOps(readAndParseBlob: ReadAndParseBlob) {
-                    let outstandingOps: ISequencedDocumentMessage[] = [];
-                    for (const opsBlob of opsBlobs) {
-                        const newOutstandingOps = await readAndParseBlob<ISequencedDocumentMessage[]>(opsBlob);
-                        if (outstandingOps.length > 0 && newOutstandingOps.length > 0) {
-                            const latestSeq = outstandingOps[outstandingOps.length - 1].sequenceNumber;
-                            const newEarliestSeq = newOutstandingOps[0].sequenceNumber;
-                            if (newEarliestSeq <= latestSeq) {
-                                logger.sendTelemetryEvent({
-                                    eventName: "DuplicateOutstandingOps",
-                                    // eslint-disable-next-line max-len
-                                    message: `newEarliestSeq <= latestSeq in decodeSummary: ${newEarliestSeq} <= ${latestSeq}`,
-                                });
-                                while (newOutstandingOps.length > 0
-                                    && newOutstandingOps[0].sequenceNumber <= latestSeq) {
-                                    newOutstandingOps.shift();
-                                }
-                            }
-                        }
-                        outstandingOps = outstandingOps.concat(newOutstandingOps);
-                    }
-                    return outstandingOps;
-                },
-            };
-        }
-
-        assert(!!outstandingOpsBlob, 0x1af /* "Outstanding ops blob missing, but base summary tree exists" */);
-        assert(newBaseSummary !== undefined, 0x1b0 /* "Base summary tree missing, but outstanding ops blob exists" */);
-        baseSummary = newBaseSummary;
-        pathParts.push(baseSummaryTreeKey);
-        opsBlobs.unshift(outstandingOpsBlob);
-    }
-}
-
-/**
- * Summary tree which is a handle of the previous successfully acked summary
- * and a blob of the outstanding ops since that summary.
- */
-interface IEncodedSummary extends ISummaryTreeWithStats {
-    readonly additionalPath: EscapedPath;
-}
-
 /**
  * Parameter to help encode summary with conditional behavior.
  * When fromSummary is true, it will contain the SummaryNode of
@@ -233,42 +143,6 @@ export type EncodeSummaryParam = {
     fromSummary: false;
     initialSummary: ISummaryTreeWithStats;
 };
-
-/**
- * Creates a summary tree which is a handle of the previous successfully acked summary
- * and a blob of the outstanding ops since that summary. If there is no acked summary yet,
- * it will create with the tree found in the initial attach op and the blob of outstanding ops.
- * @param summaryParam - information about last acked summary and paths to encode if from summary,
- * otherwise the initial summary from the attach op.
- * @param outstandingOps - outstanding ops since last acked summary
- */
-export function encodeSummary(
-    summaryParam: EncodeSummaryParam,
-    outstandingOps: ISequencedDocumentMessage[],
-): IEncodedSummary {
-    let additionalPath = EscapedPath.create(baseSummaryTreeKey);
-
-    const builder = new SummaryTreeBuilder();
-    builder.addBlob(outstandingOpsBlobKey, JSON.stringify(outstandingOps));
-
-    if (summaryParam.fromSummary) {
-        // Create using handle of latest acked summary
-        const summaryNode = summaryParam.summaryNode;
-        if (summaryNode.additionalPath !== undefined) {
-            additionalPath = additionalPath.concat(summaryNode.additionalPath);
-        }
-        builder.addHandle(baseSummaryTreeKey, SummaryType.Tree, summaryNode.fullPath.path);
-    } else {
-        // Create using initial summary from attach op
-        builder.addWithStats(baseSummaryTreeKey, summaryParam.initialSummary);
-    }
-
-    const summary = builder.getSummaryTree();
-    return {
-        ...summary,
-        additionalPath,
-    };
-}
 
 /**
  * Information about the initial summary tree found from an attach op.

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -195,9 +195,7 @@ describe("Runtime", () => {
 
                 it("Load base summary should do nothing for simple snapshot", async () => {
                     createRoot({ refSeq: 1 });
-                    const { baseSummary, outstandingOps } = await rootNode.loadBaseSummary(
-                        simpleSnapshot, readAndParseBlob);
-                    assert.strictEqual(outstandingOps.length, 0, "no outstanding ops");
+                    const baseSummary = await rootNode.loadBaseSummary(simpleSnapshot, readAndParseBlob);
                     assert.strictEqual(Object.keys(baseSummary.trees).length, 2, "only 2 subtrees");
                     assert(baseSummary.trees[ids[1]] !== undefined, "mid subtree");
 
@@ -209,9 +207,7 @@ describe("Runtime", () => {
 
                 it("Load base summary should strip channels subtree", async () => {
                     createRoot({ refSeq: 1 });
-                    const { baseSummary, outstandingOps } = await rootNode.loadBaseSummary(
-                        channelsSnapshot, readAndParseBlob);
-                    assert.strictEqual(outstandingOps.length, 0, "no outstanding ops");
+                    const baseSummary = await rootNode.loadBaseSummary(channelsSnapshot, readAndParseBlob);
                     assert.strictEqual(Object.keys(baseSummary.trees).length, 2, "only 2 subtrees");
                     assert(baseSummary.trees[channelsTreeName] !== undefined, "channels subtree");
 


### PR DESCRIPTION
It was disabled November 2020 - see https://github.com/microsoft/FluidFramework/pull/4285/files. Even before that, it was problematic - I think we kept it around for short period of time, it was causing problems, so we disabled it.
It feels safe to remove it. @leeviana - thoughts? I think GA was spring of 2021, and early preview was around that timeframe when we disabled it.