### PR TITLE
Wrap the loader resolve/request calls to handle location redirection 

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -153,6 +153,8 @@ export interface IFluidModuleWithDetails {
 // @public (undocumented)
 export interface ILoaderOptions extends ILoaderOptions_2 {
     // (undocumented)
+    disableLocationRedirectionHandling?: boolean;
+    // (undocumented)
     summarizeProtocolTree?: boolean;
 }
 

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -68,6 +68,7 @@
     "@fluidframework/core-interfaces": "^2.0.0",
     "@fluidframework/driver-definitions": "^2.0.0",
     "@fluidframework/driver-utils": "^2.0.0",
+    "@fluidframework/location-redirection-utils": "^2.0.0",
     "@fluidframework/protocol-base": "^0.1037.1000-0",
     "@fluidframework/protocol-definitions": "^0.1029.1000-0",
     "@fluidframework/telemetry-utils": "^2.0.0",

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -385,11 +385,11 @@ export class Loader implements IHostLoader {
         const disableLocationRedirectionHandling =
             this.mc.config.getBoolean("Fluid.Container.disableLocationRedirectionHandling")
             ?? this.services.options.disableLocationRedirectionHandling;
-        if (disableLocationRedirectionHandling) {
+        if (disableLocationRedirectionHandling === true) {
             return this.resolveCore(request, pendingLocalState);
         }
-        return await resolveWithLocationRedirectionHandling(
-            (request: IRequest) => this.resolveCore(request, pendingLocalState),
+        return resolveWithLocationRedirectionHandling(
+            async (req: IRequest) => this.resolveCore(req, pendingLocalState),
             request,
             this.services.urlResolver,
             this.mc.logger,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -129,6 +129,8 @@ function createCachedResolver(resolver: IUrlResolver) {
 
 export interface ILoaderOptions extends ILoaderOptions1 {
     summarizeProtocolTree?: boolean;
+
+    disableLocationRedirectionHandling?: boolean;
 }
 
 /**
@@ -380,6 +382,12 @@ export class Loader implements IHostLoader {
         request: IRequest,
         pendingLocalState?: IPendingContainerState,
     ): Promise<{ container: Container; parsed: IParsedUrl; }> {
+        const disableLocationRedirectionHandling =
+            this.mc.config.getBoolean("Fluid.Container.disableLocationRedirectionHandling")
+            ?? this.services.options.disableLocationRedirectionHandling;
+        if (disableLocationRedirectionHandling) {
+            return this.resolveCore(request, pendingLocalState);
+        }
         return await resolveWithLocationRedirectionHandling(
             (request: IRequest) => this.resolveCore(request, pendingLocalState),
             request,

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -22,6 +22,7 @@ const loaderOptionsMatrix: OptionsMatrix<ILoaderOptions> = {
     provideScopeLoader: booleanCases,
     maxClientLeaveWaitTime: numberCases,
     summarizeProtocolTree: [undefined],
+    disableLocationRedirectionHandling: [undefined],
 };
 
 export function applyOverrides<T>(options: OptionsMatrix<T>, optionsOverrides: Partial<OptionsMatrix<T>> | undefined) {


### PR DESCRIPTION
## Description

1.) Wrap the loader resolve/request calls to handle location redirection so that no change is required in host/app.
2.) Disable it behind a feature flag.