### PR TITLE
"Using Signals in Fluid" Recipe for FF.com

### DIFF
--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -109,12 +109,12 @@ private sendMouseSignal(position: IMousePosition) {
 But what is the point of sending a signal if nobody is listening to it? To listen to the `mouseSignalType`, we use `Signaler`'s `onSignal` function. We then update the local data using the payload information from the signal. To display the new presence data, we then emit `mousePositionChanged` to let the view know to re-render:
 
 ```typescript
-this.signaler.onSignal(MouseTracker.mouseSignalType, (clientId: string, local: boolean, payload: Jsonable) => {
+this.signaler.onSignal(MouseTracker.mouseSignalType, (clientId: string, local: boolean, payload: IMouseSignalPayload) => {
   this.onMouseSignalFn(clientId, payload);
 });
 ```
 ```typescript
-private readonly onMouseSignalFn = (clientId: string, payload: Jsonable) => {
+private readonly onMouseSignalFn = (clientId: string, payload: IMouseSignalPayload) => {
     const userId: string = payload.userId;
     const position: IMousePosition = payload.pos;
 
@@ -126,6 +126,14 @@ private readonly onMouseSignalFn = (clientId: string, payload: Jsonable) => {
     clientIdMap.set(clientId, position);
     this.emit("mousePositionChanged");
 };
+```
+Note: The app defines `IMouseSignalPayload` to be the corresponding payload that is sent attached to the `mouseSignalType`
+
+```typescript
+export interface IMouseSignalPayload {
+    userId: string;
+    pos: IMousePosition;
+}
 ```
 
 ## FocusTracker
@@ -140,6 +148,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     /*...*/
 }
 ```
+
 The class then initializes a local map of boolean values for all of the connected clients. The boolean denotes whether or not the client is focused on the document:
 
 ```typescript
@@ -200,12 +209,12 @@ private sendFocusSignal(hasFocus: boolean) {
 To make sure all connected clients are notified of this focus change, we use the `onSignal` function to listen to the `focusSignalType`. We then update the local data using the payload information from the signal and emit a `focusChanged` event to re-render:
 
 ```typescript
-this.signaler.onSignal(FocusTracker.focusSignalType, (clientId: string, local: boolean, payload: Jsonable) => {
+this.signaler.onSignal(FocusTracker.focusSignalType, (clientId: string, local: boolean, payload: IFocusSignalPayload) => {
     this.onFocusSignalFn(clientId, payload);
 });
 ```
 ```typescript
-private readonly onFocusSignalFn = (clientId: string, payload: any) => {
+private readonly onFocusSignalFn = (clientId: string, payload: IFocusSignalPayload) => {
     const userId: string = payload.userId;
     const hasFocus: boolean = payload.focus;
 
@@ -218,6 +227,16 @@ private readonly onFocusSignalFn = (clientId: string, payload: any) => {
     this.emit("focusChanged");
 };
 ```
+
+Note: The app defines `IFocusSignalPayload` to be the corresponding payload that is sent attached to the `focusSignalType`
+
+```typescript
+export interface IFocusSignalPayload {
+    userId: string;
+    focus: boolean;
+}
+```
+
 `FocusTracker` differs from `MouseTracker` as it uses the `Signal Request` pattern. This is when a newly joining client requests a specific signal to be sent from other connected clients, so that the new client can receive pertinent information immediately after connecting to the container.
 
 To achieve this pattern, `FocusTracker` defines the `focusRequestType` that will be sent to request the focus status of all the connected clients:

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -4,7 +4,7 @@ menuPosition: 5
 draft: true
 ---
 
-In this recipe, we will go over the `PresenceTracker` example to learn how the `Signaler` DataObject is used in a Fluid application to deal with a couple user presence scenarios. The two forms of presence covered in this example are focus tracking and mouse tracking. This article will go over how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to achieve user presence in a Fluid application. You can find the completed code for this example in the Fluid Repo [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
+In this recipe, we will go over the `PresenceTracker` example to learn how the `Signaler` DataObject is used in a Fluid application to share user presence information between collaborators. We'll cover how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to share mouse position and focus state. You can find the completed code for this example in the Fluid Repo [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
 
 ## Creation
 
@@ -23,437 +23,218 @@ The `FluidContainer` is then created (or fetched if it already exists) alongside
 
 ## MouseTracker
 
-Let's look at how the `MouseTracker` class uses the `Signaler` DataObject to achieve the first form of user presence within the application.
+Let's look at how the `MouseTracker` class uses the `Signaler` DataObject to share mouse position information.
 
 The class defines the `mouseSignalType` that will be sent and listened to the connected clients when there is a presence change:
 
 ```typescript
-export interface IMouseTrackerEvents extends IEvent {
-    (event: "mousePositionChanged", listener: () => void): void;
-}
-
 export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
     private static readonly mouseSignalType = "positionChanged";
-
     /*...*/
 }
 ```
-The class also initializes a local map of `IMousePosition` values for all of the connected clients. Each userID can have multiple clientIDs (e.g. same user on separate devices), which explains the nested `Map`. This local map is what populates the view and what will be updated on `mouseSignalType` signals:
+The class also initializes a local map (`posMap`) of `IMousePosition` values for all of the connected clients. Each audience member has a single userID and can have multiple clientIDs, representing each active connection the member has to the container (e.g., the same user connected to a container separate devices). This the reason for the nesting of the position `Map`, which is used to populate the view and what will be updated on `mouseSignalType` signals. To learn more about audience members and connections click [here](https://fluidframework.com/docs/build/audience/).
 
 ```typescript
-export interface IMouseTrackerEvents extends IEvent {
-    (event: "mousePositionChanged", listener: () => void): void;
-}
-
+private readonly posMap = new Map<string, Map<string, IMousePosition>>();
+```
+```typescript
 export interface IMousePosition {
     x: number;
     y: number;
 }
-
-export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
-    private static readonly mouseSignalType = "positionChanged";
-
-    /**
-     * Local map of mouse position status for clients
-     *
-     * ```
-     * Map<userId, Map<clientid, position>>
-     * ```
-     */
-    private readonly posMap = new Map<string, Map<string, IMousePosition>>();
-
-    /*...*/
-}
 ```
-Now that we have clarity about what `posMap` and `mouseSignalType` are, we can move to the constructor to see what other behavior our `MouseTracker` has.
+
+Now that we have clarity about what `posMap` and `mouseSignalType` are, we need to use the `audience` and `Signaler` to send, receive, and interpret the positions.  We provide these in the constructor.
 
 We'll begin by looking at the constructor arguments. `MouseTracker` takes in the `audience` and the `Signaler` instance from `initialObjects`:
 
 ```typescript
-export interface IMouseTrackerEvents extends IEvent {
-    (event: "mousePositionChanged", listener: () => void): void;
-}
+constructor(
+  public readonly audience: IServiceAudience<IMember>,
+  private readonly signaler: Signaler,
+) {
+  super();
 
-export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
-    /*...*/
-
-    public constructor(
-      public readonly audience: IServiceAudience<IMember>,
-      private readonly signaler: Signaler,
-    ){
-      super();
-
-      /*...*/
-    }
-
-    /*...*/
+  /*...*/
 }
 ```
-Whenever a member leaves the audience (e.g., a client disconnects from the container), we would want to remove their presence from our local data. After this is done, we would have to let the view know that the local presence data has changed. To do this, we emit our `mousePositionChanged` event so the view knows to re-render:
+Whenever there is any change to a client's mouse position, we'll fire a `mousePositionChanged` event to notify listeners that updated data is available.
 
 ```typescript
 export interface IMouseTrackerEvents extends IEvent {
     (event: "mousePositionChanged", listener: () => void): void;
 }
-
-export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
-    /*...*/
-
-    public constructor(
-      public readonly audience: IServiceAudience<IMember>,
-      private readonly signaler: Signaler,
-    ){
-      super();
-
-      this.audience.on("memberRemoved", (clientId: string, member: IMember) => {
-        const clientIdMap = this.posMap.get(member.userId);
-        if (clientIdMap !== undefined) {
-            clientIdMap.delete(clientId);
-
-            //If UserID has no connected clients, remove user from local data
-            if (clientIdMap.size === 0) {
-                this.posMap.delete(member.userId);
-            }
-        }
-        this.emit("mousePositionChanged");
-      });
-
-        /*...*/
-    }
-
-    /*...*/
-}
 ```
-We know that `MouseTracker` must be able to share information to all connected clients about where the current client's mouse position is. This is where `Signaler` comes in handy, as it specializes in communicating transient data to connected clients within a Fluid application.
-
-To track the client's mouse position, we use the `mousemouve` event to obtain the client's x and y coordinates. To alert the connected clients of a mouse position change, we then submit a `mouseSignalType` signal with the client's userID and updated position value as the paylod:
+When a member leaves the audience (e.g., a client disconnects from the container), we would want to remove their presence from our local data. After this is done, we would have to let the view know that the local presence data has changed. To do this, we emit our `mousePositionChanged` event so the view knows to re-render:
 
 ```typescript
-export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
-    /*...*/
+this.audience.on("memberRemoved", (clientId: string, member: IMember) => {
+  const clientIdMap = this.posMap.get(member.userId);
+  if (clientIdMap !== undefined) {
+      clientIdMap.delete(clientId);
 
-    public constructor(
-      public readonly audience: IServiceAudience<IMember>,
-      private readonly signaler: Signaler,
-    ){
-      super();
+      //If UserID has no connected clients, remove user from local data
+      if (clientIdMap.size === 0) {
+          this.posMap.delete(member.userId);
+      }
+  }
+  this.emit("mousePositionChanged");
+});
+```
+`MouseTracker` must share information to all connected clients about where the local client's mouse position is. This is where `Signaler` comes in handy, as it specializes in communicating transient data to connected clients within a Fluid application.
 
-      /*...*/
+To track the client's mouse position, we use the `mousemove` event to obtain the client's x and y coordinates. To alert the connected clients of a mouse position change, we then submit a `mouseSignalType` signal with the client's userID and updated position value as the payload:
 
-      window.addEventListener("mousemove", (e) => {
-        const position: IMousePosition = {
-            x: e.clientX,
-            y: e.clientY,
-        };
-        this.sendMouseSignal(position);
-      });
-
-        /*...*/
-    }
-
-    /**
-     * Alert all connected clients that there has been a change to a client's mouse position
-     */
-    private sendMouseSignal(position: IMousePosition) {
-        this.signaler.submitSignal(
-            MouseTracker.mouseSignalType,
-            { userId: this.audience.getMyself()?.userId, pos: position },
-        );
-    }
-
-    /*...*/
+```typescript
+window.addEventListener("mousemove", (e) => {
+    const position: IMousePosition = {
+        x: e.clientX,
+        y: e.clientY,
+    };
+    this.sendMouseSignal(position);
+});
+```
+```typescript
+/**
+* Alert all connected clients that there has been a change to a client's mouse position
+*/
+private sendMouseSignal(position: IMousePosition) {
+    this.signaler.submitSignal(
+        MouseTracker.mouseSignalType,
+        { userId: this.audience.getMyself()?.userId, pos: position },
+    );
 }
 ```
 But what is the point of sending a signal if nobody is listening to it? To listen to the `mouseSignalType`, we use `Signaler`'s `onSignal` function. We then update the local data using the payload information from the signal. To display the new presence data, we then emit `mousePositionChanged` to let the view know to re-render:
 
 ```typescript
-export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
-    /*...*/
-
-    public constructor(
-        public readonly audience: IServiceAudience<IMember>,
-        private readonly signaler: Signaler,
-    ){
-        super();
-
-        /*...*/
-
-        this.signaler.onSignal(MouseTracker.mouseSignalType, (clientId, local, payload) => {
-          this.onMouseSignalFn(clientId, payload);
-        });
-
-        window.addEventListener("mousemove", (e) => {
-            const position: IMousePosition = {
-                x: e.clientX,
-                y: e.clientY,
-            };
-            this.sendMouseSignal(position);
-        });
-
-
-        /*...*/
-    }
-
-    /*...*/
-
-    private readonly onMouseSignalFn = (clientId: string, payload: any) => {
-        const userId: string = payload.userId;
-        const position: IMousePosition = payload.pos;
-
-        let clientIdMap = this.posMap.get(userId);
-        if (clientIdMap === undefined) {
-            clientIdMap = new Map<string, IMousePosition>();
-            this.posMap.set(userId, clientIdMap);
-        }
-        clientIdMap.set(clientId, position);
-        this.emit("mousePositionChanged");
-    };
-
-    /**
-     * Alert all connected clients that there has been a change to a client's mouse position
-     */
-    private sendMouseSignal(position: IMousePosition) {
-        this.signaler.submitSignal(
-            MouseTracker.mouseSignalType,
-            { userId: this.audience.getMyself()?.userId, pos: position },
-        );
-    }
-
-    /*...*/
-}
+this.signaler.onSignal(MouseTracker.mouseSignalType, (clientId: string, local: boolean, payload: Jsonable) => {
+  this.onMouseSignalFn(clientId, payload);
+});
 ```
+```typescript
+private readonly onMouseSignalFn = (clientId: string, payload: Jsonable) => {
+    const userId: string = payload.userId;
+    const position: IMousePosition = payload.pos;
 
+    let clientIdMap = this.posMap.get(userId);
+    if (clientIdMap === undefined) {
+        clientIdMap = new Map<string, IMousePosition>();
+        this.posMap.set(userId, clientIdMap);
+    }
+    clientIdMap.set(clientId, position);
+    this.emit("mousePositionChanged");
+};
+```
 
 ## FocusTracker
 
-Let's now look at how the `FocusTracker` class uses the `Signaler` DataObject to achieve the second form of user presence within the application.
+Let's now look at how the `FocusTracker` class uses the `Signaler` DataObject to share user focus infomation.
 
 The class defines the `focusSignalType` that will be sent and listened to the connected clients when there is a presence change:
 
 ```typescript
-export interface IFocusTrackerEvents extends IEvent {
-    (event: "focusChanged", listener: () => void): void;
-}
-
 export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     private static readonly focusSignalType = "changedFocus";
-
     /*...*/
 }
 ```
 The class then initializes a local map of boolean values for all of the connected clients. The boolean denotes whether or not the client has focus or not:
 
 ```typescript
-export interface IFocusTrackerEvents extends IEvent {
-    (event: "focusChanged", listener: () => void): void;
-}
-
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
-    private static readonly focusSignalType = "changedFocus";
-
-    /**
-     * Local map of focus status for clients
-     *
-     * @example
-     * ```typescript
-     * Map<userId, Map<clientid, hasFocus>>
-     * ```
-     */
-    private readonly focusMap = new Map<string, Map<string, boolean>>();
-}
+private readonly focusMap = new Map<string, Map<string, boolean>>();
 ```
 We can now move to the constructor where we can see that `FocusTracker` takes in the `container`, the `audience`, and the `Signaler` instance from `initialObjects` as arguments:
 
 ```typescript
-export interface IFocusTrackerEvents extends IEvent {
-    (event: "focusChanged", listener: () => void): void;
-}
+constructor(
+  container: IFluidContainer,
+  public readonly audience: IServiceAudience<IMember>,
+  private readonly signaler: Signaler,
+) {
+  super();
 
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
-    /*...*/
-
-     public constructor(
-        container: IFluidContainer,
-        public readonly audience: IServiceAudience<IMember>,
-        private readonly signaler: Signaler,
-    ) {
-        super();
-
-        /*...*/
-    }
-
-    /*...*/
+  /*...*/
 }
 ```
-Just like in the `MouseTracker` class, whenever a member leaves the audience we need to remove their presence from our local data and emit an event to let the view know that it needs to re-render to display the updated presence:
+Just like in the `MouseTracker` class, whenever there is any change to a client's focus status we'll fire a `focusChanged` event to notify listeners that updated data is available:
 
 ```typescript
 export interface IFocusTrackerEvents extends IEvent {
     (event: "focusChanged", listener: () => void): void;
 }
-
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
-    /*...*/
-
-     public constructor(
-        container: IFluidContainer,
-        public readonly audience: IServiceAudience<IMember>,
-        private readonly signaler: Signaler,
-    ) {
-        super();
-
-        this.audience.on("memberRemoved", (clientId: string, member: IMember) => {
-            const focusClientIdMap = this.focusMap.get(member.userId);
-            if (focusClientIdMap !== undefined) {
-                focusClientIdMap.delete(clientId);
-                if (focusClientIdMap.size === 0) {
-                    this.focusMap.delete(member.userId);
-                }
-            }
-            this.emit("focusChanged");
-        });
-
-        /*...*/
-    }
-
-    /*...*/
-}
 ```
+Also similar to `MouseTracker`, a member leaves the audience we need to remove their presence from our local data and emit an event to let the view know that it needs to re-render to display the updated presence:
 
+```typescript
+this.audience.on("memberRemoved", (clientId: string, member: IMember) => {
+    const focusClientIdMap = this.focusMap.get(member.userId);
+    if (focusClientIdMap !== undefined) {
+        focusClientIdMap.delete(clientId);
+        if (focusClientIdMap.size === 0) {
+            this.focusMap.delete(member.userId);
+        }
+    }
+    this.emit("focusChanged");
+});
+```
 To track the local client's focus status, we use the `focus` and `blur` events to know when the focus boolean must be updated. To alert the connected clients of this focus change, we then submit a `focusSignalType` signal with the client's userID and updated focus status as the paylod:
 
 ```typescript
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
-    /*...*/
-
-     public constructor(
-        container: IFluidContainer,
-        public readonly audience: IServiceAudience<IMember>,
-        private readonly signaler: Signaler,
-    ) {
-        super();
-
-        /*...*/
-
-        window.addEventListener("focus", () => {
-            this.sendFocusSignal(true);
-        });
-        window.addEventListener("blur", () => {
-            this.sendFocusSignal(false);
-        });
-
-        /*...*/
-    }
-
-    /*...*/
-
-    /**
-     * Alert all connected clients that there has been a change to a client's focus
-     */
-    private sendFocusSignal(hasFocus: boolean) {
-        this.signaler.submitSignal(
-            FocusTracker.focusSignalType,
-            { userId: this.audience.getMyself()?.userId, focus: hasFocus },
-        );
-    }
-
-    /*...*/
+window.addEventListener("focus", () => {
+    this.sendFocusSignal(true);
+});
+window.addEventListener("blur", () => {
+    this.sendFocusSignal(false);
+});
+```
+```typescript
+private sendFocusSignal(hasFocus: boolean) {
+    this.signaler.submitSignal(
+        FocusTracker.focusSignalType,
+        { userId: this.audience.getMyself()?.userId, focus: hasFocus },
+    );
 }
 ```
 To make sure all connected clients are notified of this focus change, we use the `onSignal` function to listen to the `focusSignalType`. We then update the local data using the payload information from the signal and emit a `focusChanged` event to re-render:
 
 ```typescript
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
-    /*...*/
+this.signaler.onSignal(FocusTracker.focusSignalType, (clientId, local, payload) => {
+    this.onFocusSignalFn(clientId, payload);
+});
+```
+```typescript
+private readonly onFocusSignalFn = (clientId: string, payload: any) => {
+    const userId: string = payload.userId;
+    const hasFocus: boolean = payload.focus;
 
-     public constructor(
-        container: IFluidContainer,
-        public readonly audience: IServiceAudience<IMember>,
-        private readonly signaler: Signaler,
-    ) {
-        super();
-
-        /*...*/
-
-        this.signaler.onSignal(FocusTracker.focusSignalType, (clientId, local, payload) => {
-            this.onFocusSignalFn(clientId, payload);
-        });
-
-        window.addEventListener("focus", () => {
-            this.sendFocusSignal(true);
-        });
-        window.addEventListener("blur", () => {
-            this.sendFocusSignal(false);
-        });
-
-        /*...*/
+    let clientIdMap = this.focusMap.get(userId);
+    if (clientIdMap === undefined) {
+        clientIdMap = new Map<string, boolean>();
+        this.focusMap.set(userId, clientIdMap);
     }
-
-    /*...*/
-
-    private readonly onFocusSignalFn = (clientId: string, payload: any) => {
-        const userId: string = payload.userId;
-        const hasFocus: boolean = payload.focus;
-
-        let clientIdMap = this.focusMap.get(userId);
-        if (clientIdMap === undefined) {
-            clientIdMap = new Map<string, boolean>();
-            this.focusMap.set(userId, clientIdMap);
-        }
-        clientIdMap.set(clientId, hasFocus);
-        this.emit("focusChanged");
-    };
-
-    /**
-     * Alert all connected clients that there has been a change to a client's focus
-     */
-    private sendFocusSignal(hasFocus: boolean) {
-        this.signaler.submitSignal(
-            FocusTracker.focusSignalType,
-            { userId: this.audience.getMyself()?.userId, focus: hasFocus },
-        );
-    }
-
-    /*...*/
-}
+    clientIdMap.set(clientId, hasFocus);
+    this.emit("focusChanged");
+};
 ```
 `FocusTracker` differs from `MouseTracker` as it uses the `Signal Request` pattern. This is when a newly joining client requests a specific signal to be sent from other connected clients, so that the new client can receive pertinent information immediately after connecting to the container.
 
 To achieve this pattern, `FocusTracker` defines the `focusRequestType` that will be sent to request the focus status of all the connected clients:
 
 ```typescript
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
-    private static readonly focusRequestType = "focusRequest";
-
-    /*...*/
-}
+private static readonly focusRequestType = "focusRequest";
 ```
 `FocusTracker` then sends this signal request immediately after the new client connects to the container. Once again, the `onSignal` function is used to listen to this `focusRequestType` signal and each client responds to the signal request with their current focus status:
 
 ```typescript
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
-    private static readonly focusRequestType = "focusRequest";
+this.signaler.onSignal(FocusTracker.focusRequestType, () => {
+    this.sendFocusSignal(document.hasFocus());
+});
 
-    /*...*/
-
-    public constructor(
-        container: IFluidContainer,
-        public readonly audience: IServiceAudience<IMember>,
-        private readonly signaler: Signaler,
-    ) {
-        super();
-
-        /*...*/
-
-        this.signaler.onSignal(FocusTracker.focusRequestType, () => {
-            this.sendFocusSignal(document.hasFocus());
-        });
-
-        container.on("connected", () => {
-            this.signaler.submitSignal(FocusTracker.focusRequestType);
-        });
-    }
-}
+container.on("connected", () => {
+    this.signaler.submitSignal(FocusTracker.focusRequestType);
+});
 ```
 
 ## View
@@ -485,29 +266,60 @@ async function start(): Promise<void> {
 start().catch(console.error);
 ```
 
-The view then renders the focus data by using `renderFocusPresence`, which uses the local focus status map to display which users are in focus and which users are not. It also renders the mouse position data by using `renderMousePresence`, which uses the local position map to display the name of each user where they currently are in the window:
-
+The view then renders the focus data by using `renderFocusPresence`, which uses the local focus status map to display which users are in focus and which users are. In the function, the `FocusTracker` instance listens to the `focusChanged` events that are fired every time there is a focus change to one of the clients. This triggers the re-render by calling `onFocusChanged` to display the updated the focus statuses:
 ```typescript
-async function start(): Promise<void> {
-    /*...*/
+renderFocusPresence(focusTracker, contentDiv);
+```
+```typescript
+function renderFocusPresence(focusTracker: FocusTracker, div: HTMLDivElement) {
+    const wrapperDiv = document.createElement("div");
+    wrapperDiv.style.textAlign = "left";
+    wrapperDiv.style.margin = "70px";
+    div.appendChild(wrapperDiv);
 
-    // Render presence information for audience members
-    const contentDiv = document.getElementById("focus-content") as HTMLDivElement;
-    const mouseContentDiv = document.getElementById("mouse-position") as HTMLDivElement;
-    const focusTracker = new FocusTracker(
-        container,
-        services.audience,
-        container.initialObjects.signaler as Signaler,
-    );
-    const mouseTracker = new MouseTracker(
-        services.audience,
-        container.initialObjects.signaler as Signaler,
-    );
-    renderFocusPresence(focusTracker, contentDiv);
-    renderMousePresence(mouseTracker, focusTracker, mouseContentDiv);
+    const focusDiv = document.createElement("div");
+    focusDiv.style.fontSize = "14px";
+
+    //Displays focus status of all users
+    const onFocusChanged = () => {
+        focusDiv.innerHTML = `
+            Current user: ${(focusTracker.audience.getMyself() as TinyliciousMember)?.userName}</br>
+            ${getFocusPresencesString("</br>", focusTracker)}
+        `;
+    };
+
+    onFocusChanged();
+    focusTracker.on("focusChanged", onFocusChanged);
+
+    wrapperDiv.appendChild(focusDiv);
 }
 
-start().catch(console.error);
+```
+
+The view then renders the mouse position data by using `renderMousePresence`, which uses the local position map to display the name of each user where they currently are in the window. In the function, the `MouseTracker` instance listens to the `mousePositionChanged` events that are fired every time there is a mouse position change to one of the clients. This triggers the re-render by calling `onPositionChanged` to display the updated mouse positions. The `FocusTracker` instance is also passed in to the function to add bold font to currently focused users:
+```typescript
+renderMousePresence(mouseTracker, focusTracker, mouseContentDiv);
+```
+```typescript
+function renderMousePresence(mouseTracker: MouseTracker, focusTracker: FocusTracker, div: HTMLDivElement) {
+    const onPositionChanged = () => {
+      div.innerHTML = "";
+      mouseTracker.getMousePresences().forEach((mousePosition, userName) => {
+          const posDiv = document.createElement("div");
+          posDiv.textContent = userName;
+          posDiv.style.position = "absolute";
+          posDiv.style.left = `${mousePosition.x}px`;
+          posDiv.style.top = `${mousePosition.y}px`;
+          if (focusTracker.getFocusPresences().get(userName) === true) {
+            posDiv.style.fontWeight = "bold";
+          }
+          div.appendChild(posDiv);
+      });
+    };
+
+    onPositionChanged();
+    mouseTracker.on("mousePositionChanged", onPositionChanged);
+}
 ```
 
 ## Next Steps

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -6,14 +6,14 @@ draft: true
 
 In this recipe, you'll learn how the `Signaler` DataObject is used in a Fluid application to deal with a couple user presence scenarios. The two forms of presence that are covered in this example are focus tracking and mouse tracking. This article will go over how the `Signaler` DataObject is created, how both `MouseTracker` and `FocusTracker` classes work using the `Signaler` object, and how the view uses both classes to render the presence data.
 
-# Creation
+## Creation
 
 
-# MouseTracker
+## MouseTracker
 
-# FocusTracker
+## FocusTracker
 
-# View
+## View
 
 
 

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -4,7 +4,7 @@ menuPosition: 5
 draft: true
 ---
 
-In this recipe, you'll learn how the `Signaler` DataObject is used in a Fluid application to deal with a couple user presence scenarios. The two forms of presence that are covered in this example are focus tracking and mouse tracking. This article will go over how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to achieve user presence in a FLuid application.
+In this recipe, we will go over the `PresenceTracker` example to learn how the `Signaler` DataObject is used in a Fluid application to deal with a couple user presence scenarios. The two forms of presence covered in this example are focus tracking and mouse tracking. This article will go over how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to achieve user presence in a Fluid application. You can find the completed code for this example in the Fluid Repo [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
 
 ## Creation
 
@@ -19,11 +19,11 @@ const containerSchema: ContainerSchema = {
 };
 ```
 
-The `FluidContainer` is then created (or fetched if it already exists) alongside the `services` object, since audience will be required in this application. To learn more about how to create a new Fluid container and load an exisiting container, see our [DiceRoller Tutorial](https://fluidframework.com/docs/start/tutorial/).
+The `FluidContainer` is then created (or fetched if it already exists) alongside the `services` object, since audience will be required in this application. To learn more about how to create a new Fluid container and load an existing container, see our [DiceRoller Tutorial](https://fluidframework.com/docs/start/tutorial/).
 
 ## MouseTracker
 
-Let's now take a look at how the `MouseTracker` class uses the `Signaler` DataObject to achieve the first form of user presence within the application.
+Let's look at how the `MouseTracker` class uses the `Signaler` DataObject to achieve the first form of user presence within the application.
 
 The class defines the `mouseSignalType` that will be sent and listened to the connected clients when there is a presence change:
 
@@ -38,7 +38,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
     /*...*/
 }
 ```
-The class also initializes a local map of `IMousePosition` values for all of the connected clients. Each userID can have multiple clientIDs (e.g. same user on seperate devices), which explains the nested `Map`. This local map is what populates the view and what will be updated on `mouseSignalType` signals:
+The class also initializes a local map of `IMousePosition` values for all of the connected clients. Each userID can have multiple clientIDs (e.g. same user on separate devices), which explains the nested `Map`. This local map is what populates the view and what will be updated on `mouseSignalType` signals:
 
 ```typescript
 export interface IMouseTrackerEvents extends IEvent {
@@ -89,7 +89,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
     /*...*/
 }
 ```
-Whenever a member leaves the audience (e.g. a client disconnects from the container), we would want to remove their presence from our local data. After this is done, we would have to let the view know that the local presence data has changed. To do this, we emit our `mousePositionChanged` `IMouseTrackerEvent` so the view knows to re-render:
+Whenever a member leaves the audience (e.g., a client disconnects from the container), we would want to remove their presence from our local data. After this is done, we would have to let the view know that the local presence data has changed. To do this, we emit our `mousePositionChanged` event so the view knows to re-render:
 
 ```typescript
 export interface IMouseTrackerEvents extends IEvent {
@@ -164,7 +164,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
     /*...*/
 }
 ```
-But, what point is there of sending a signal if nobody is listening to it? To listen to the `mouseSignalType`, we use `Signaler`'s `onSignal` function. We then update the local data using the payload information from the signal. To display the new presence data, we then emit `mousePositionChanged` to let the view know to re-render:
+But what is the point of sending a signal if nobody is listening to it? To listen to the `mouseSignalType`, we use `Signaler`'s `onSignal` function. We then update the local data using the payload information from the signal. To display the new presence data, we then emit `mousePositionChanged` to let the view know to re-render:
 
 ```typescript
 export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
@@ -226,7 +226,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
 
 ## FocusTracker
 
-Let's now take a look at how the `FocusTracker` class uses the `Signaler` DataObject to achieve the second form of user presence within the application.
+Let's now look at how the `FocusTracker` class uses the `Signaler` DataObject to achieve the second form of user presence within the application.
 
 The class defines the `focusSignalType` that will be sent and listened to the connected clients when there is a presence change:
 
@@ -241,7 +241,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     /*...*/
 }
 ```
-The class then initializes a local map of boolean values for all of the connected clients. The boolean denotes wheter or not the client has has focus or not:
+The class then initializes a local map of boolean values for all of the connected clients. The boolean denotes whether or not the client has focus or not:
 
 ```typescript
 export interface IFocusTrackerEvents extends IEvent {
@@ -360,7 +360,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     /*...*/
 }
 ```
-To make sure all conected clients are notified of this focus change, we use the `onSignal` function to listen to the `focusSignalType`. We then update the local data using the payload information from the signal and emit a `focusChanged` event to re-render:
+To make sure all connected clients are notified of this focus change, we use the `onSignal` function to listen to the `focusSignalType`. We then update the local data using the payload information from the signal and emit a `focusChanged` event to re-render:
 
 ```typescript
 export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
@@ -417,7 +417,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     /*...*/
 }
 ```
-`FocusTracker` differs from `MouseTracker` as it uses the `Signal Request` pattern. This is when a newly joining client requests a specific sigal to be sent from other connected clients, so that the new client can recieve pertinent information immediately after connecting to the container.
+`FocusTracker` differs from `MouseTracker` as it uses the `Signal Request` pattern. This is when a newly joining client requests a specific signal to be sent from other connected clients, so that the new client can receive pertinent information immediately after connecting to the container.
 
 To achieve this pattern, `FocusTracker` defines the `focusRequestType` that will be sent to request the focus status of all the connected clients:
 
@@ -485,7 +485,7 @@ async function start(): Promise<void> {
 start().catch(console.error);
 ```
 
-The view then renders the focus data by using `renderFocusPresence`, which uses the local focus status map to display which users are in focus and which users aren't. It also renders the mouse position data by using `renderMousePresence`, which uses the local position map to display the name of each user where they currently are in the window:
+The view then renders the focus data by using `renderFocusPresence`, which uses the local focus status map to display which users are in focus and which users are not. It also renders the mouse position data by using `renderMousePresence`, which uses the local position map to display the name of each user where they currently are in the window:
 
 ```typescript
 async function start(): Promise<void> {
@@ -510,6 +510,7 @@ async function start(): Promise<void> {
 start().catch(console.error);
 ```
 
-
-
+## Next Steps
+- You can find the completed code for this example in the Fluid GitHub repository [here]((https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
+- Try extending the `PresenceTracker` to track some other form of presence using signals!
 

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -8,8 +8,58 @@ In this recipe, you'll learn how the `Signaler` DataObject is used in a Fluid ap
 
 ## Creation
 
+The `Signaler` DataObject is first included in the `initialObjects` of the Fluid `ContainerSchema` which defines which shared objects will be at our disposal in the new container.
+
+```typescript
+const containerSchema: ContainerSchema = {
+    initialObjects: {
+        /* [id]: DataObject */
+        signaler: Signaler,
+    },
+};
+```
+
+The `FluidContainer` is then created (or fetched if it already exists) alongside the `services` object, since audience will be required in this application. To learn more about how to create a new Fluid container and load an exisiting container, see our [DiceRoller Tutorial](https://fluidframework.com/docs/start/tutorial/).
 
 ## MouseTracker
+
+Let's now take a look at how the `MouseTracker` class uses the `Signaler` DataObject to achieve the first form of user presence within the application.
+
+The `MouseTracker` constructor takes the `audience` and the `Signaler` instance as arguments:
+
+```typescript
+export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
+    /*...*/
+    public constructor(
+      public readonly audience: IServiceAudience<IMember>,
+      private readonly signaler: Signaler,
+    ){
+      super();
+      /*...*/
+    }
+    /*...*/
+}
+```
+
+The class first defines what signal types will need to be sent to the connected clients when there is a presence change:
+
+```typescript
+export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
+    private static readonly mouseSignalType = "positionChanged";
+    /*...*/
+    public constructor(
+      public readonly audience: IServiceAudience<IMember>,
+      private readonly signaler: Signaler,
+    ){
+      super();
+      /*...*/
+    }
+    /*...*/
+}
+```
+
+
+
 
 ## FocusTracker
 

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -4,7 +4,7 @@ menuPosition: 5
 draft: true
 ---
 
-In this recipe, we will go over the `PresenceTracker` example to learn how the `Signaler` DataObject is used in a Fluid application to share user presence information between collaborators. We'll cover how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to share mouse position and focus state. You can find the completed code for this example in the Fluid Repo [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
+In this article, we will go over the `PresenceTracker` example to learn how the [`Signaler`](https://github.com/microsoft/FluidFramework/tree/main/experimental/framework/data-objects/src/signaler) DataObject is used in a Fluid application to share user presence information between collaborators. We'll cover how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to share mouse position and focus state. You can find the completed code for this example in the Fluid Repo [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
 
 ## Creation
 
@@ -19,13 +19,13 @@ const containerSchema: ContainerSchema = {
 };
 ```
 
-The `FluidContainer` is then created (or fetched if it already exists) alongside the `services` object, since audience will be required in this application. To learn more about how to create a new Fluid container and load an existing container, see our [DiceRoller Tutorial](https://fluidframework.com/docs/start/tutorial/).
+The `FluidContainer` is then created (or loaded if it already exists) alongside the `services` object, since audience will be required in this application. To learn more about how to create a new Fluid container and load an existing container, see our [DiceRoller Tutorial](https://fluidframework.com/docs/start/tutorial/).
 
 ## MouseTracker
 
 Let's look at how the `MouseTracker` class uses the `Signaler` DataObject to share mouse position information.
 
-The class defines the `mouseSignalType` that will be sent and listened to the connected clients when there is a presence change:
+The class defines the `mouseSignalType` that will be sent to the connected clients when there is a presence change:
 
 ```typescript
 export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
@@ -33,7 +33,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
     /*...*/
 }
 ```
-The class also initializes a local map (`posMap`) of `IMousePosition` values for all of the connected clients. Each audience member has a single userID and can have multiple clientIDs, representing each active connection the member has to the container (e.g., the same user connected to a container separate devices). This the reason for the nesting of the position `Map`, which is used to populate the view and what will be updated on `mouseSignalType` signals. To learn more about audience members and connections click [here](https://fluidframework.com/docs/build/audience/).
+The class also initializes a local map (`posMap`) of `IMousePosition` values for all of the connected clients. Each audience member has a single userID along with multiple clientIDs representing each active connection the member has to the container (e.g., the same user connected to a container separate devices). In the circumstance that one user is connected on mulitple client devices, both of the user's mouse presences on each devices would appear seperately on the page. This the reason for the nesting of the position `Map`, which is used to populate the view and what will be updated on `mouseSignalType` signals. To learn more about audience members and connections click [here](https://fluidframework.com/docs/build/audience/).
 
 ```typescript
 private readonly posMap = new Map<string, Map<string, IMousePosition>>();
@@ -59,7 +59,7 @@ constructor(
   /*...*/
 }
 ```
-Whenever there is any change to a client's mouse position, we'll fire a `mousePositionChanged` event to notify listeners that updated data is available.
+Whenever there is any change to a client's mouse position, a `mousePositionChanged` event is fired to notify listeners that updated data is available.
 
 ```typescript
 export interface IMouseTrackerEvents extends IEvent {
@@ -130,7 +130,7 @@ private readonly onMouseSignalFn = (clientId: string, payload: Jsonable) => {
 
 ## FocusTracker
 
-Let's now look at how the `FocusTracker` class uses the `Signaler` DataObject to share user focus infomation.
+HTML documents and elements within the documents can be focused on by users. Knowing which users are currently focused on the document is another intriuging form of user presence to explore. Let's now look at how the `FocusTracker` class uses the `Signaler` DataObject to share user focus infomation.
 
 The class defines the `focusSignalType` that will be sent and listened to the connected clients when there is a presence change:
 
@@ -140,7 +140,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     /*...*/
 }
 ```
-The class then initializes a local map of boolean values for all of the connected clients. The boolean denotes whether or not the client has focus or not:
+The class then initializes a local map of boolean values for all of the connected clients. The boolean denotes whether or not the client is focused on the document:
 
 ```typescript
 private readonly focusMap = new Map<string, Map<string, boolean>>();
@@ -200,7 +200,7 @@ private sendFocusSignal(hasFocus: boolean) {
 To make sure all connected clients are notified of this focus change, we use the `onSignal` function to listen to the `focusSignalType`. We then update the local data using the payload information from the signal and emit a `focusChanged` event to re-render:
 
 ```typescript
-this.signaler.onSignal(FocusTracker.focusSignalType, (clientId, local, payload) => {
+this.signaler.onSignal(FocusTracker.focusSignalType, (clientId: string, local: boolean, payload: Jsonable) => {
     this.onFocusSignalFn(clientId, payload);
 });
 ```
@@ -253,11 +253,11 @@ async function start(): Promise<void> {
     const focusTracker = new FocusTracker(
         container,
         services.audience,
-        container.initialObjects.signaler as Signaler,
+        container.initialObjects.signaler,
     );
     const mouseTracker = new MouseTracker(
         services.audience,
-        container.initialObjects.signaler as Signaler,
+        container.initialObjects.signaler,
     );
 
     /*...*/

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -1,0 +1,21 @@
+---
+title: Using Signals in Fluid
+menuPosition: 5
+draft: true
+---
+
+In this recipe, you'll learn how the `Signaler` DataObject is used in a Fluid application to deal with a couple user presence scenarios. The two forms of presence that are covered in this example are focus tracking and mouse tracking. This article will go over how the `Signaler` DataObject is created, how both `MouseTracker` and `FocusTracker` classes work using the `Signaler` object, and how the view uses both classes to render the presence data.
+
+# Creation
+
+
+# MouseTracker
+
+# FocusTracker
+
+# View
+
+
+
+
+

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -4,7 +4,7 @@ menuPosition: 5
 draft: true
 ---
 
-In this recipe, you'll learn how the `Signaler` DataObject is used in a Fluid application to deal with a couple user presence scenarios. The two forms of presence that are covered in this example are focus tracking and mouse tracking. This article will go over how the `Signaler` DataObject is created, how both `MouseTracker` and `FocusTracker` classes work using the `Signaler` object, and how the view uses both classes to render the presence data.
+In this recipe, you'll learn how the `Signaler` DataObject is used in a Fluid application to deal with a couple user presence scenarios. The two forms of presence that are covered in this example are focus tracking and mouse tracking. This article will go over how the `Signaler` DataObject is used in both the `MouseTracker` and `FocusTracker` classes to achieve user presence in a FLuid application.
 
 ## Creation
 
@@ -452,18 +452,63 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
         container.on("connected", () => {
             this.signaler.submitSignal(FocusTracker.focusRequestType);
         });
-
-        //Requests focus state of everyone on connection
-        this.signaler.submitSignal(FocusTracker.focusRequestType);
     }
 }
 ```
 
-
-
-
 ## View
 
+In `app.ts`, we create instances of the `MouseTracker` and the `FocusTracker` to use in our application:
+
+```typescript
+/*...*/
+
+async function start(): Promise<void> {
+    /*...*/
+
+    // Render presence information for audience members
+    const contentDiv = document.getElementById("focus-content") as HTMLDivElement;
+    const mouseContentDiv = document.getElementById("mouse-position") as HTMLDivElement;
+    const focusTracker = new FocusTracker(
+        container,
+        services.audience,
+        container.initialObjects.signaler as Signaler,
+    );
+    const mouseTracker = new MouseTracker(
+        services.audience,
+        container.initialObjects.signaler as Signaler,
+    );
+
+    /*...*/
+}
+
+start().catch(console.error);
+```
+
+The view then renders the focus data by using `renderFocusPresence`, which uses the local focus status map to display which users are in focus and which users aren't. It also renders the mouse position data by using `renderMousePresence`, which uses the local position map to display the name of each user where they currently are in the window:
+
+```typescript
+async function start(): Promise<void> {
+    /*...*/
+
+    // Render presence information for audience members
+    const contentDiv = document.getElementById("focus-content") as HTMLDivElement;
+    const mouseContentDiv = document.getElementById("mouse-position") as HTMLDivElement;
+    const focusTracker = new FocusTracker(
+        container,
+        services.audience,
+        container.initialObjects.signaler as Signaler,
+    );
+    const mouseTracker = new MouseTracker(
+        services.audience,
+        container.initialObjects.signaler as Signaler,
+    );
+    renderFocusPresence(focusTracker, contentDiv);
+    renderMousePresence(mouseTracker, focusTracker, mouseContentDiv);
+}
+
+start().catch(console.error);
+```
 
 
 


### PR DESCRIPTION
## Description

This is a draft of a Fluid Recipe describing how Signaler is used in the [PresenceTracker example](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker). This recipe is meant to be descriptive based rather than a tutorial, and its main goal is to explain how the MouseTracker and FocusTracker work to achieve user presence within a Fluid application. 

## Reviewer Guidance

- Wording and content feedback 
- Are the current headers appropriate? Are there any other suggested sections that should be added?
- Is each section clear and simple to understand? If more clarity is needed in any area, please say where.

## Other information or known dependencies

- ADO link: [FF.com Signaler Example Recipe](https://dev.azure.com/fluidframework/internal/_workitems/edit/1308) 