### PR TITLE
Properly plumb Snapshot Cache Expiry policy through driver and GC code

### DIFF
--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -11,6 +11,7 @@ import { IContainerPackageInfo } from '@fluidframework/driver-definitions';
 import { IdentityType } from '@fluidframework/odsp-driver-definitions';
 import { IDocumentService } from '@fluidframework/driver-definitions';
 import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
+import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions';
 import { IEntry } from '@fluidframework/odsp-driver-definitions';
 import { IFileEntry } from '@fluidframework/odsp-driver-definitions';
 import type { io } from 'socket.io-client';
@@ -54,6 +55,12 @@ export function createOdspUrl(l: OdspFluidDataStoreLocator): string;
 
 // @public (undocumented)
 export const currentReadVersion = "1.0";
+
+// @public (undocumented)
+export const defaultCacheExpiryTimeoutMs: number;
+
+// @public (undocumented)
+export const defaultStoragePolicy: Required<IDocumentStorageServicePolicies>;
 
 // @public
 export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocator): string;

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -57,9 +57,6 @@ export function createOdspUrl(l: OdspFluidDataStoreLocator): string;
 export const currentReadVersion = "1.0";
 
 // @public (undocumented)
-export const defaultCacheExpiryTimeoutMs: number;
-
-// @public (undocumented)
 export const defaultStoragePolicy: Required<IDocumentStorageServicePolicies>;
 
 // @public

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -23,7 +23,7 @@ import {
     IOdspErrorAugmentations,
     IOdspResolvedUrl,
 } from "@fluidframework/odsp-driver-definitions";
-import { DriverErrorType } from "@fluidframework/driver-definitions";
+import { DriverErrorType, IDocumentStorageServicePolicies } from "@fluidframework/driver-definitions";
 import { PerformanceEvent, isFluidError, normalizeError } from "@fluidframework/telemetry-utils";
 import { fetchAndParseAsJSONHelper, fetchArray, fetchHelper, getOdspResolvedUrl, IOdspResponse } from "./odspUtils";
 import {
@@ -34,6 +34,7 @@ import {
 import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
 import { ClpCompliantAppHeader } from "./contractsPublic";
 import { pkgVersion as driverVersion } from "./packageVersion";
+import { defaultCacheExpiryTimeoutMs } from "./odspDocumentStorageServiceBase";
 import { patchOdspResolvedUrl } from "./odspLocationRedirection";
 
 export type FetchType = "blob" | "createBlob" | "createFile" | "joinSession" | "ops" | "test" | "snapshotTree" |
@@ -43,9 +44,6 @@ export type FetchTypeInternal = FetchType | "cache";
 
 export const Odsp409Error = "Odsp409Error";
 
-// Please update the README file in odsp-driver-definitions if you change the defaultCacheExpiryTimeoutMs.
-export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
-
 /**
  * This class is a wrapper around fetch calls. It adds epoch to the request made so that the
  * server can match it with its epoch value in order to match the version.
@@ -54,6 +52,7 @@ export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
  */
 export class EpochTracker implements IPersistedFileCache {
     private _fluidEpoch: string | undefined;
+    private policies: { maximumCacheDurationMs: number; _initialized: boolean; };
 
     public readonly rateLimiter: RateLimiter;
     private readonly driverId = uuid();
@@ -67,6 +66,13 @@ export class EpochTracker implements IPersistedFileCache {
     ) {
         // Limits the max number of concurrent requests to 24.
         this.rateLimiter = new RateLimiter(24);
+        this.policies = { maximumCacheDurationMs: NaN, _initialized: false };
+    }
+
+    public initializePolicies(policies: IDocumentStorageServicePolicies) {
+        assert(!this.policies._initialized, "Cannot initialize policies twice");
+        this.policies._initialized = true;
+        this.policies.maximumCacheDurationMs = policies.maximumCacheDurationMs ?? defaultCacheExpiryTimeoutMs;
     }
 
     // public for UT purposes only!
@@ -103,17 +109,17 @@ export class EpochTracker implements IPersistedFileCache {
             } else if (this._fluidEpoch !== value.fluidEpoch) {
                 return undefined;
             }
-            // Expire the cached snapshot if it's older than the defaultCacheExpiryTimeoutMs and immediately
+            // Expire the cached snapshot if it's older than the maximumCacheDurationMs policy and immediately
             // expire all old caches that do not have cacheEntryTime
             if (entry.type === snapshotKey) {
                 const cacheTime = value.value?.cacheEntryTime;
                 const currentTime = Date.now();
-                if (cacheTime === undefined || currentTime - cacheTime >= defaultCacheExpiryTimeoutMs) {
+                if (cacheTime === undefined || currentTime - cacheTime >= this.policies.maximumCacheDurationMs) {
                     this.logger.sendTelemetryEvent(
                         {
                             eventName: "odspVersionsCacheExpired",
                             duration: currentTime - cacheTime,
-                            maxCacheAgeMs: defaultCacheExpiryTimeoutMs,
+                            maxCacheAgeMs: this.policies.maximumCacheDurationMs,
                         });
                     await this.removeEntries();
                     return undefined;
@@ -130,7 +136,7 @@ export class EpochTracker implements IPersistedFileCache {
     public async put(entry: IEntry, value: any) {
         assert(this._fluidEpoch !== undefined, 0x1dd /* "no epoch" */);
         // For snapshots, the value should have the cacheEntryTime. This will be used to expire snapshots older
-        // than the defaultCacheExpiryTimeoutMs.
+        // than the maximumCacheDurationMs policy.
         if (entry.type === snapshotKey) {
             value.cacheEntryTime = value.cacheEntryTime ?? Date.now();
         }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -35,7 +35,6 @@ import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contract
 import { ClpCompliantAppHeader } from "./contractsPublic";
 import { pkgVersion as driverVersion } from "./packageVersion";
 import { patchOdspResolvedUrl } from "./odspLocationRedirection";
-import { defaultCacheExpiryTimeoutMs } from "./odspDocumentServiceFactoryCore";
 
 export type FetchType = "blob" | "createBlob" | "createFile" | "joinSession" | "ops" | "test" | "snapshotTree" |
     "treesLatest" | "uploadSummary" | "push" | "versions";
@@ -61,8 +60,8 @@ export class EpochTracker implements IPersistedFileCache {
         protected readonly cache: IPersistedCache,
         protected readonly fileEntry: IFileEntry,
         protected readonly logger: ITelemetryLogger,
+        private readonly maximumCacheDurationMs: number,
         protected readonly clientIsSummarizer?: boolean,
-        private readonly maximumCacheDurationMs: number = defaultCacheExpiryTimeoutMs,
     ) {
         // Limits the max number of concurrent requests to 24.
         this.rateLimiter = new RateLimiter(24);
@@ -509,15 +508,15 @@ export function createOdspCacheAndTracker(
     nonpersistentCache: INonPersistentCache,
     fileEntry: IFileEntry,
     logger: ITelemetryLogger,
+    maximumCacheDurationMs: number,
     clientIsSummarizer?: boolean,
-    maximumCacheDurationMs: number = defaultCacheExpiryTimeoutMs,
 ): ICacheAndTracker {
     const epochTracker = new EpochTrackerWithRedemption(
         persistedCacheArg,
         fileEntry,
         logger,
-        clientIsSummarizer,
-        maximumCacheDurationMs);
+        maximumCacheDurationMs,
+        clientIsSummarizer);
     return {
         cache: {
             ...nonpersistentCache,

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -23,7 +23,7 @@ import {
     IOdspErrorAugmentations,
     IOdspResolvedUrl,
 } from "@fluidframework/odsp-driver-definitions";
-import { DriverErrorType, IDocumentStorageServicePolicies } from "@fluidframework/driver-definitions";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { PerformanceEvent, isFluidError, normalizeError } from "@fluidframework/telemetry-utils";
 import { fetchAndParseAsJSONHelper, fetchArray, fetchHelper, getOdspResolvedUrl, IOdspResponse } from "./odspUtils";
 import {
@@ -34,8 +34,8 @@ import {
 import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
 import { ClpCompliantAppHeader } from "./contractsPublic";
 import { pkgVersion as driverVersion } from "./packageVersion";
-import { defaultCacheExpiryTimeoutMs } from "./odspDocumentStorageServiceBase";
 import { patchOdspResolvedUrl } from "./odspLocationRedirection";
+import { defaultCacheExpiryTimeoutMs } from "./odspDocumentServiceFactoryCore";
 
 export type FetchType = "blob" | "createBlob" | "createFile" | "joinSession" | "ops" | "test" | "snapshotTree" |
     "treesLatest" | "uploadSummary" | "push" | "versions";
@@ -52,7 +52,6 @@ export const Odsp409Error = "Odsp409Error";
  */
 export class EpochTracker implements IPersistedFileCache {
     private _fluidEpoch: string | undefined;
-    private policies: { maximumCacheDurationMs: number; _initialized: boolean; };
 
     public readonly rateLimiter: RateLimiter;
     private readonly driverId = uuid();
@@ -63,16 +62,10 @@ export class EpochTracker implements IPersistedFileCache {
         protected readonly fileEntry: IFileEntry,
         protected readonly logger: ITelemetryLogger,
         protected readonly clientIsSummarizer?: boolean,
+        private readonly maximumCacheDurationMs: number = defaultCacheExpiryTimeoutMs,
     ) {
         // Limits the max number of concurrent requests to 24.
         this.rateLimiter = new RateLimiter(24);
-        this.policies = { maximumCacheDurationMs: NaN, _initialized: false };
-    }
-
-    public initializePolicies(policies: IDocumentStorageServicePolicies) {
-        assert(!this.policies._initialized, "Cannot initialize policies twice");
-        this.policies._initialized = true;
-        this.policies.maximumCacheDurationMs = policies.maximumCacheDurationMs ?? defaultCacheExpiryTimeoutMs;
     }
 
     // public for UT purposes only!
@@ -114,12 +107,12 @@ export class EpochTracker implements IPersistedFileCache {
             if (entry.type === snapshotKey) {
                 const cacheTime = value.value?.cacheEntryTime;
                 const currentTime = Date.now();
-                if (cacheTime === undefined || currentTime - cacheTime >= this.policies.maximumCacheDurationMs) {
+                if (cacheTime === undefined || currentTime - cacheTime >= this.maximumCacheDurationMs) {
                     this.logger.sendTelemetryEvent(
                         {
                             eventName: "odspVersionsCacheExpired",
                             duration: currentTime - cacheTime,
-                            maxCacheAgeMs: this.policies.maximumCacheDurationMs,
+                            maxCacheAgeMs: this.maximumCacheDurationMs,
                         });
                     await this.removeEntries();
                     return undefined;
@@ -516,8 +509,15 @@ export function createOdspCacheAndTracker(
     nonpersistentCache: INonPersistentCache,
     fileEntry: IFileEntry,
     logger: ITelemetryLogger,
-    clientIsSummarizer?: boolean): ICacheAndTracker {
-    const epochTracker = new EpochTrackerWithRedemption(persistedCacheArg, fileEntry, logger, clientIsSummarizer);
+    clientIsSummarizer?: boolean,
+    maximumCacheDurationMs: number = defaultCacheExpiryTimeoutMs,
+): ICacheAndTracker {
+    const epochTracker = new EpochTrackerWithRedemption(
+        persistedCacheArg,
+        fileEntry,
+        logger,
+        clientIsSummarizer,
+        maximumCacheDurationMs);
     return {
         cache: {
             ...nonpersistentCache,

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
@@ -14,6 +14,7 @@ import { IOdspSnapshot } from "../contracts";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "../odspSnapshotParser";
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser";
 import { ReadBuffer } from "../ReadBufferUtils";
+import { defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 
 /**
  * ODSP document storage service that works on a provided snapshot for all its processing.
@@ -26,7 +27,7 @@ export class LocalOdspDocumentStorageService extends OdspDocumentStorageServiceB
         private readonly logger: ITelemetryLogger,
         private readonly localSnapshot: Uint8Array | string,
     ) {
-        super();
+        super(defaultStoragePolicy);
     }
 
     private calledGetVersions = false;

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -15,7 +15,7 @@ import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import {
     TelemetryLogger,
     PerformanceEvent,
-    mixinMonitoringContext,
+    loggerToMonitoringContext,
     MonitoringContext,
 } from "@fluidframework/telemetry-utils";
 import {
@@ -46,7 +46,7 @@ import { INewFileInfo, getOdspResolvedUrl, createOdspLogger, toInstrumentedOdspT
 import { createNewFluidFile } from "./createFile";
 
 // Please update the README file in odsp-driver-definitions if you change the defaultCacheExpiryTimeoutMs.
-export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
+const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
 
 export const defaultStoragePolicy: Required<IDocumentStorageServicePolicies> = {
     // By default, ODSP tells the container not to prefetch/cache.
@@ -137,8 +137,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.nonPersistentCache,
             fileEntry,
             odspLogger,
-            clientIsSummarizer,
-            getMaximumCacheDurationMs(mixinMonitoringContext(odspLogger)));
+            getMaximumCacheDurationMs(loggerToMonitoringContext(odspLogger)),
+            clientIsSummarizer);
 
         return PerformanceEvent.timedExecAsync(
             odspLogger,
@@ -226,8 +226,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.nonPersistentCache,
             { resolvedUrl: odspResolvedUrl, docId: odspResolvedUrl.hashedDocumentId },
             odspLogger,
-            clientIsSummarizer,
-            getMaximumCacheDurationMs(mixinMonitoringContext(odspLogger)));
+            getMaximumCacheDurationMs(loggerToMonitoringContext(odspLogger)),
+            clientIsSummarizer);
 
         const storageTokenFetcher = toInstrumentedOdspTokenFetcher(
             odspLogger,
@@ -247,7 +247,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
 
         const storagePolicy: IDocumentStorageServicePolicies = {
             ...defaultStoragePolicy,
-            maximumCacheDurationMs: getMaximumCacheDurationMs(mixinMonitoringContext(odspLogger)),
+            maximumCacheDurationMs: getMaximumCacheDurationMs(loggerToMonitoringContext(odspLogger)),
         };
 
         return OdspDocumentService.create(

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -48,7 +48,7 @@ import { createNewFluidFile } from "./createFile";
 // Please update the README file in odsp-driver-definitions if you change the defaultCacheExpiryTimeoutMs.
 export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
 
-const defaultStoragePolicy: Required<IDocumentStorageServicePolicies> = {
+export const defaultStoragePolicy: Required<IDocumentStorageServicePolicies> = {
     // By default, ODSP tells the container not to prefetch/cache.
     caching: LoaderCachingPolicy.NoCaching,
 

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -7,12 +7,16 @@ import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import {
     IDocumentService,
     IDocumentServiceFactory,
+    IDocumentStorageServicePolicies,
     IResolvedUrl,
+    LoaderCachingPolicy,
 } from "@fluidframework/driver-definitions";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import {
     TelemetryLogger,
     PerformanceEvent,
+    mixinMonitoringContext,
+    MonitoringContext,
 } from "@fluidframework/telemetry-utils";
 import {
     getDocAttributesFromProtocolSummary,
@@ -40,6 +44,34 @@ import {
 import { OdspDocumentService } from "./odspDocumentService";
 import { INewFileInfo, getOdspResolvedUrl, createOdspLogger, toInstrumentedOdspTokenFetcher } from "./odspUtils";
 import { createNewFluidFile } from "./createFile";
+
+// Please update the README file in odsp-driver-definitions if you change the defaultCacheExpiryTimeoutMs.
+export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
+
+const defaultStoragePolicy: Required<IDocumentStorageServicePolicies> = {
+    // By default, ODSP tells the container not to prefetch/cache.
+    caching: LoaderCachingPolicy.NoCaching,
+
+    // ODSP storage works better if it has less number of blobs / edges
+    // Runtime creating many small blobs results in sub-optimal perf.
+    // 2K seems like the sweat spot:
+    // The smaller the number, less blobs we aggregate. Most storages are very likely to have notion
+    // of minimal "cluster" size, so having small blobs is wasteful
+    // At the same time increasing the limit ensure that more blobs with user content are aggregated,
+    // reducing possibility for de-duping of same blobs (i.e. .attributes rolled into aggregate blob
+    // are not reused across data stores, or even within data store, resulting in duplication of content)
+    // Note that duplication of content should not have significant impact for bytes over wire as
+    // compression of http payload mostly takes care of it, but it does impact storage size and in-memory sizes.
+    minBlobSize: 2048,
+    maximumCacheDurationMs: defaultCacheExpiryTimeoutMs,
+};
+
+function getMaximumCacheDurationMs(mc: MonitoringContext): number {
+    //* Change Key
+    return mc.config.getBoolean("SWEEPV0")
+        ? 0
+        : defaultStoragePolicy.maximumCacheDurationMs;
+}
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -103,7 +135,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.nonPersistentCache,
             fileEntry,
             odspLogger,
-            clientIsSummarizer);
+            clientIsSummarizer,
+            getMaximumCacheDurationMs(mixinMonitoringContext(odspLogger)));
 
         return PerformanceEvent.timedExecAsync(
             odspLogger,
@@ -191,7 +224,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.nonPersistentCache,
             { resolvedUrl: odspResolvedUrl, docId: odspResolvedUrl.hashedDocumentId },
             odspLogger,
-            clientIsSummarizer);
+            clientIsSummarizer,
+            getMaximumCacheDurationMs(mixinMonitoringContext(odspLogger)));
 
         const storageTokenFetcher = toInstrumentedOdspTokenFetcher(
             odspLogger,
@@ -209,6 +243,11 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
                 false /* throwOnNullToken */,
             )(options, "GetWebsocketToken");
 
+        const storagePolicy: IDocumentStorageServicePolicies = {
+            ...defaultStoragePolicy,
+            maximumCacheDurationMs: getMaximumCacheDurationMs(mixinMonitoringContext(odspLogger)),
+        };
+
         return OdspDocumentService.create(
             resolvedUrl,
             storageTokenFetcher,
@@ -216,7 +255,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             odspLogger,
             this.getSocketIOClient,
             cacheAndTracker.cache,
-            this.hostPolicy,
+            { hostPolicy: this.hostPolicy, storagePolicy },
             cacheAndTracker.epochTracker,
             this.socketReferenceKeyPrefix,
             clientIsSummarizer,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -66,11 +66,13 @@ const defaultStoragePolicy: Required<IDocumentStorageServicePolicies> = {
     maximumCacheDurationMs: defaultCacheExpiryTimeoutMs,
 };
 
+/**
+ * Get the appropriate value for storage policy maximumCacheDurationMs,
+ * allowing overrides via MonitoringContext.config
+ * @param mc - MonitoringContext to use to check for any override settings
+ */
 function getMaximumCacheDurationMs(mc: MonitoringContext): number {
-    //* Change Key
-    return mc.config.getBoolean("SWEEPV0")
-        ? 0
-        : defaultStoragePolicy.maximumCacheDurationMs;
+    return defaultStoragePolicy.maximumCacheDurationMs;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -10,6 +10,7 @@ import {
     delay,
 } from "@fluidframework/common-utils";
 import {
+    mixinMonitoringContext,
     PerformanceEvent,
 } from "@fluidframework/telemetry-utils";
 import * as api from "@fluidframework/protocol-definitions";
@@ -83,10 +84,12 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
     // limits the amount of parallel "attachment" blob uploads
     private readonly createBlobRateLimiter = new RateLimiter(1);
 
+    private get logger(): ITelemetryLogger { return this.mc.logger; }
+
     constructor(
         private readonly odspResolvedUrl: IOdspResolvedUrl,
         private readonly getStorageToken: InstrumentedStorageTokenFetcher,
-        private readonly logger: ITelemetryLogger,
+        logger: ITelemetryLogger,
         private readonly fetchFullSnapshot: boolean,
         private readonly cache: IOdspCache,
         private readonly hostPolicy: HostStoragePolicyInternal,
@@ -95,7 +98,9 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
         private readonly relayServiceTenantAndSessionId: () => string,
         private readonly snapshotFormatFetchType?: SnapshotFormatSupportType,
     ) {
-        super();
+        super(mixinMonitoringContext(logger));
+
+        epochTracker.initializePolicies(this.policies);
 
         this.documentId = this.odspResolvedUrl.hashedDocumentId;
         this.snapshotUrl = this.odspResolvedUrl.endpoints.snapshotStorageUrl;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -4,12 +4,16 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { IDocumentStorageService, ISummaryContext, LoaderCachingPolicy } from "@fluidframework/driver-definitions";
+// eslint-disable-next-line max-len
+import { IDocumentStorageService, IDocumentStorageServicePolicies, ISummaryContext, LoaderCachingPolicy } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
-import { defaultCacheExpiryTimeoutMs } from "./epochTracker";
+import { MonitoringContext } from "@fluidframework/telemetry-utils";
 import { ISnapshotContents } from "./odspPublicUtils";
 
 /* eslint-disable max-len */
+
+// Please update the README file in odsp-driver-definitions if you change the defaultCacheExpiryTimeoutMs.
+export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
 
 class BlobCache {
     // Save the timeout so we can cancel and reschedule it as needed
@@ -108,23 +112,34 @@ class BlobCache {
 }
 
 export abstract class OdspDocumentStorageServiceBase implements IDocumentStorageService {
-    readonly policies = {
-        // By default, ODSP tells the container not to prefetch/cache.
-        caching: LoaderCachingPolicy.NoCaching,
+    readonly policies: IDocumentStorageServicePolicies;
 
-        // ODSP storage works better if it has less number of blobs / edges
-        // Runtime creating many small blobs results in sub-optimal perf.
-        // 2K seems like the sweat spot:
-        // The smaller the number, less blobs we aggregate. Most storages are very likely to have notion
-        // of minimal "cluster" size, so having small blobs is wasteful
-        // At the same time increasing the limit ensure that more blobs with user content are aggregated,
-        // reducing possibility for de-duping of same blobs (i.e. .attributes rolled into aggregate blob
-        // are not reused across data stores, or even within data store, resulting in duplication of content)
-        // Note that duplication of content should not have significant impact for bytes over wire as
-        // compression of http payload mostly takes care of it, but it does impact storage size and in-memory sizes.
-        minBlobSize: 2048,
-        maximumCacheDurationMs: defaultCacheExpiryTimeoutMs,
-    };
+    protected constructor(
+        protected readonly mc: MonitoringContext,
+    ) {
+        //* Change Key
+        const maximumCacheDurationMs = this.mc.config.getBoolean("SWEEPV0")
+            ? 0
+            : defaultCacheExpiryTimeoutMs;
+
+        this.policies = {
+            // By default, ODSP tells the container not to prefetch/cache.
+            caching: LoaderCachingPolicy.NoCaching,
+
+            // ODSP storage works better if it has less number of blobs / edges
+            // Runtime creating many small blobs results in sub-optimal perf.
+            // 2K seems like the sweat spot:
+            // The smaller the number, less blobs we aggregate. Most storages are very likely to have notion
+            // of minimal "cluster" size, so having small blobs is wasteful
+            // At the same time increasing the limit ensure that more blobs with user content are aggregated,
+            // reducing possibility for de-duping of same blobs (i.e. .attributes rolled into aggregate blob
+            // are not reused across data stores, or even within data store, resulting in duplication of content)
+            // Note that duplication of content should not have significant impact for bytes over wire as
+            // compression of http payload mostly takes care of it, but it does impact storage size and in-memory sizes.
+            minBlobSize: 2048,
+            maximumCacheDurationMs,
+        };
+    }
 
     protected readonly commitCache: Map<string, api.ISnapshotTree> = new Map();
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -5,15 +5,11 @@
 
 import { assert } from "@fluidframework/common-utils";
 // eslint-disable-next-line max-len
-import { IDocumentStorageService, IDocumentStorageServicePolicies, ISummaryContext, LoaderCachingPolicy } from "@fluidframework/driver-definitions";
+import { IDocumentStorageService, IDocumentStorageServicePolicies, ISummaryContext } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
-import { MonitoringContext } from "@fluidframework/telemetry-utils";
 import { ISnapshotContents } from "./odspPublicUtils";
 
 /* eslint-disable max-len */
-
-// Please update the README file in odsp-driver-definitions if you change the defaultCacheExpiryTimeoutMs.
-export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
 
 class BlobCache {
     // Save the timeout so we can cancel and reschedule it as needed
@@ -112,34 +108,9 @@ class BlobCache {
 }
 
 export abstract class OdspDocumentStorageServiceBase implements IDocumentStorageService {
-    readonly policies: IDocumentStorageServicePolicies;
-
     protected constructor(
-        protected readonly mc: MonitoringContext,
-    ) {
-        //* Change Key
-        const maximumCacheDurationMs = this.mc.config.getBoolean("SWEEPV0")
-            ? 0
-            : defaultCacheExpiryTimeoutMs;
-
-        this.policies = {
-            // By default, ODSP tells the container not to prefetch/cache.
-            caching: LoaderCachingPolicy.NoCaching,
-
-            // ODSP storage works better if it has less number of blobs / edges
-            // Runtime creating many small blobs results in sub-optimal perf.
-            // 2K seems like the sweat spot:
-            // The smaller the number, less blobs we aggregate. Most storages are very likely to have notion
-            // of minimal "cluster" size, so having small blobs is wasteful
-            // At the same time increasing the limit ensure that more blobs with user content are aggregated,
-            // reducing possibility for de-duping of same blobs (i.e. .attributes rolled into aggregate blob
-            // are not reused across data stores, or even within data store, resulting in duplication of content)
-            // Note that duplication of content should not have significant impact for bytes over wire as
-            // compression of http payload mostly takes care of it, but it does impact storage size and in-memory sizes.
-            minBlobSize: 2048,
-            maximumCacheDurationMs,
-        };
-    }
+        readonly policies: IDocumentStorageServicePolicies,
+    ) { }
 
     protected readonly commitCache: Map<string, api.ISnapshotTree> = new Map();
 

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -13,6 +13,7 @@ import { EpochTracker } from "../epochTracker";
 import { getHashedDocumentId, ISnapshotContents } from "../odspPublicUtils";
 import { INewFileInfo, createCacheSnapshotKey } from "../odspUtils";
 import { LocalPersistentCache } from "../odspCache";
+import { defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 import { mockFetchOk } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache();
@@ -79,7 +80,8 @@ describe("Create New Utils Tests", () => {
                 docId: hashedDocumentId,
                 resolvedUrl,
             },
-            new TelemetryNullLogger());
+            new TelemetryNullLogger(),
+            defaultStoragePolicy.maximumCacheDurationMs);
         newFileParams = {
             driveId,
             siteUrl,

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -9,10 +9,12 @@ import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { OdspDeltaStorageService } from "../odspDeltaStorageService";
 import { LocalPersistentCache } from "../odspCache";
 import { EpochTracker } from "../epochTracker";
+import { defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 import { mockFetchOk } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache(2000);
-const createUtEpochTracker = (fileEntry, logger) => new EpochTracker(createUtLocalCache(), fileEntry, logger);
+const createUtEpochTracker = (fileEntry, logger) =>
+    new EpochTracker(createUtLocalCache(), fileEntry, logger, defaultStoragePolicy.maximumCacheDurationMs);
 
 describe("DeltaStorageService", () => {
     /*

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -15,6 +15,7 @@ import { EpochTracker } from "../epochTracker";
 import { LocalPersistentCache } from "../odspCache";
 import { getHashedDocumentId } from "../odspPublicUtils";
 import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts";
+import { defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 import { mockFetchOk, mockFetchSingle, createResponse } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache();
@@ -41,7 +42,8 @@ describe("Tests for Epoch Tracker", () => {
                 docId: hashedDocumentId,
                 resolvedUrl,
             },
-            new TelemetryNullLogger());
+            new TelemetryNullLogger(),
+            defaultStoragePolicy.maximumCacheDurationMs);
     });
 
     afterEach(async () => {

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -15,6 +15,7 @@ import {
 import { EpochTrackerWithRedemption } from "../epochTracker";
 import { LocalPersistentCache } from "../odspCache";
 import { getHashedDocumentId } from "../odspPublicUtils";
+import { defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 import { mockFetchSingle, mockFetchMultiple, okResponse, notFound } from "./mockFetch";
 
 class DeferralWithCallback extends Deferred<void> {
@@ -54,7 +55,8 @@ describe("Tests for Epoch Tracker With Redemption", () => {
                 docId: hashedDocumentId,
                 resolvedUrl,
             },
-            new TelemetryUTLogger());
+            new TelemetryUTLogger(),
+            defaultStoragePolicy.maximumCacheDurationMs);
         epochCallback = new DeferralWithCallback();
         (epochTracker as any).treesLatestDeferral = epochCallback;
     });

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -18,6 +18,7 @@ import { getHashedDocumentId, ISnapshotContents } from "../odspPublicUtils";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { ISnapshotRequestAndResponseOptions } from "../fetchSnapshot";
 import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
+import { defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 import { createResponse } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache();
@@ -87,7 +88,7 @@ describe("Tests for snapshot fetch", () => {
             logger,
             true,
             { ...nonPersistentCache, persistedCache: epochTracker },
-            hostPolicy,
+            { hostPolicy, storagePolicy: defaultStoragePolicy },
             epochTracker,
             async () => { return {}; },
             () => "tenantid/id",

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -79,6 +79,7 @@ describe("Tests for snapshot fetch", () => {
                 resolvedUrl,
             },
             new TelemetryNullLogger(),
+            defaultStoragePolicy.maximumCacheDurationMs,
         );
         epochTracker.setEpoch("epoch1", true, "test");
         const resolved = await resolver.resolve({ url: odspUrl });

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -24,7 +24,7 @@ import { createOdspUrl } from "../createOdspUrl";
 import { getHashedDocumentId, ISnapshotContents } from "../odspPublicUtils";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { OdspDocumentStorageService, defaultSummarizerCacheExpiryTimeout } from "../odspDocumentStorageManager";
-import { defaultCacheExpiryTimeoutMs, defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
+import { defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 import { mockFetchSingle, notFound, createResponse } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache();
@@ -116,6 +116,7 @@ describe("Tests for snapshot fetch", () => {
                     resolvedUrl,
                 },
                 new TelemetryNullLogger(),
+                defaultStoragePolicy.maximumCacheDurationMs,
             );
 
             const resolved = await resolver.resolve({ url: odspUrl });
@@ -217,7 +218,7 @@ describe("Tests for snapshot fetch", () => {
                 type: "snapshot",
                 file: { docId: hashedDocumentId, resolvedUrl },
             };
-            await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
+            await localCache.put(cacheEntry, valueWithExpiredCache(defaultStoragePolicy.maximumCacheDurationMs));
 
             const version = await mockFetchSingle(
                 async () => service.getVersions(null, 1),
@@ -236,7 +237,7 @@ describe("Tests for snapshot fetch", () => {
                 type: "snapshot",
                 file: { docId: hashedDocumentId, resolvedUrl },
             };
-            await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
+            await localCache.put(cacheEntry, valueWithExpiredCache(defaultStoragePolicy.maximumCacheDurationMs));
 
             await assert.rejects(async () => {
                 await mockFetchSingle(
@@ -258,6 +259,7 @@ describe("Tests for snapshot fetch", () => {
                     resolvedUrl,
                 },
                 new TelemetryNullLogger(),
+                defaultStoragePolicy.maximumCacheDurationMs,
             );
 
             const resolved = await resolver.resolve({ url: odspUrl });

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -3,13 +3,15 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable max-len */
+
 import { strict as assert } from "assert";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import {
     IOdspResolvedUrl,
     ICacheEntry,
 } from "@fluidframework/odsp-driver-definitions";
-import { EpochTracker, defaultCacheExpiryTimeoutMs } from "../epochTracker";
+import { EpochTracker } from "../epochTracker";
 import {
     IOdspSnapshot,
     HostStoragePolicyInternal,
@@ -22,6 +24,7 @@ import { createOdspUrl } from "../createOdspUrl";
 import { getHashedDocumentId, ISnapshotContents } from "../odspPublicUtils";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { OdspDocumentStorageService, defaultSummarizerCacheExpiryTimeout } from "../odspDocumentStorageManager";
+import { defaultCacheExpiryTimeoutMs, defaultStoragePolicy } from "../odspDocumentServiceFactoryCore";
 import { mockFetchSingle, notFound, createResponse } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache();
@@ -122,7 +125,7 @@ describe("Tests for snapshot fetch", () => {
                 logger,
                 true,
                 { ...nonPersistentCache, persistedCache: epochTracker },
-                GetHostStoragePolicyInternal(),
+                { hostPolicy: GetHostStoragePolicyInternal(), storagePolicy: defaultStoragePolicy },
                 epochTracker,
                 async () => { return {}; },
                 () => "tenantid/id",
@@ -264,7 +267,7 @@ describe("Tests for snapshot fetch", () => {
                 logger,
                 true,
                 { ...nonPersistentCache, persistedCache: epochTracker },
-                GetHostStoragePolicyInternal(true /* isSummarizer */),
+                { hostPolicy: GetHostStoragePolicyInternal(true /* isSummarizer */), storagePolicy: defaultStoragePolicy },
                 epochTracker,
                 async () => { return {}; },
                 () => "tenantid/id",

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1270,6 +1270,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             getNodePackagePath: async (nodePath: string) => this.getGCNodePackagePath(nodePath),
             getLastSummaryTimestampMs: () => this.messageAtLastSummary?.timestamp,
             readAndParseBlob: async <T>(id: string) => readAndParse<T>(this.storage, id),
+            snapshotCacheExpiryMs: _storage.policies?.maximumCacheDurationMs,
         });
 
         const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;


### PR DESCRIPTION
## Description

This is a prerequisite for #11084.  We have to pass the `maximumCacheDurationMs` storage policy into GC because it's used to calculate the Sweep Timeout.  And we need this value to be the same one that's actually used in `epochTracker`.

In order to get the same policy applied throughout (GC, Storage Service, and epochTracker) I had to move ownership of the storage policy up to the Document Service Factory (not the Document Storage Manager classes).

To Do
- [ ] Update tests

## Does this introduce a breaking change?

No, thanks to sensible exports in odsp-driver's index.ts!