### PR TITLE
Protocol handler refactoring part 3

### DIFF
--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -31,7 +31,6 @@ export type ProtocolHandlerBuilder = (
 
 export interface IProtocolHandler extends IBaseProtocolHandler {
     readonly audience: IAudienceOwner;
-    // To be removed after the server package dependency is upgraded. ADO:1026
     processSignal(message: ISignalMessage);
 }
 

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -20,7 +20,6 @@ import { IQuorumProposalsEvents } from '@fluidframework/protocol-definitions';
 import { ISequencedClient } from '@fluidframework/protocol-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISequencedProposal } from '@fluidframework/protocol-definitions';
-import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTreeEx } from '@fluidframework/protocol-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { ITree as ITree_2 } from '@fluidframework/gitresources';
@@ -90,8 +89,6 @@ export interface IProtocolHandler {
     // (undocumented)
     processMessage(message: ISequencedDocumentMessage, local: boolean): IProcessMessageResult;
     // (undocumented)
-    processSignal(message: ISignalMessage): any;
-    // (undocumented)
     readonly quorum: IQuorum;
     // (undocumented)
     setConnectionState(connected: boolean, clientId: string | undefined): any;
@@ -144,8 +141,6 @@ export class ProtocolOpHandler implements IProtocolHandler {
     minimumSequenceNumber: number;
     // (undocumented)
     processMessage(message: ISequencedDocumentMessage, local: boolean): IProcessMessageResult;
-    // (undocumented)
-    processSignal(_message: ISignalMessage): void;
     // (undocumented)
     get quorum(): Quorum;
     // (undocumented)

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -60,7 +60,6 @@ export interface IProtocolHandler {
 
     close(): void;
     processMessage(message: ISequencedDocumentMessage, local: boolean): IProcessMessageResult;
-    processSignal(message: ISignalMessage);
     getProtocolState(): IScribeProtocolState;
 }
 
@@ -112,8 +111,6 @@ export class ProtocolOpHandler implements IProtocolHandler {
     public close() {
         this._quorum.close();
     }
-
-    public processSignal(_message: ISignalMessage) {}
 
     public processMessage(message: ISequencedDocumentMessage, local: boolean): IProcessMessageResult {
         // verify it's moving sequentially

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -15,7 +15,6 @@ import {
     ISequencedDocumentSystemMessage,
     ISequencedProposal,
     MessageType,
-    ISignalMessage,
 } from "@fluidframework/protocol-definitions";
 import { IQuorumSnapshot, Quorum } from "./quorum";
 


### PR DESCRIPTION
## Description

Cleanup after https://github.com/microsoft/FluidFramework/pull/11109. Initially, the goal was to upgrade server then remove `processSignal` from `IProtocolHandler` in the loader. However, I believe a better approach would be to abandon the idea of having this method in the `protocol-base` protocol handler interface at all, considering the server does not (and will not) use it. If the latter changes, it can be added. But for now, adding it in the first place on the server side doesn't really make sense, considering it also has an empty implementation which nobody is using.

## Does this introduce a breaking change?

Yes but it does not matter. This PR removes a method from an interface, but the method was added yesterday, it is not used and there have been no releases in the meantime. I don't believe this to require a BREAKING.md change.