### PR TITLE
Removal of unused FluidContainer from MouseTracker constructor arguments

### DIFF
--- a/examples/data-objects/presence-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/presence-tracker/src/FocusTracker.ts
@@ -12,11 +12,11 @@ import {
     IServiceAudience,
 } from "fluid-framework";
 
-export interface IFocusTrackerEvents extends IEvent {
+export interface IFocusTrackerEvent extends IEvent {
     (event: "focusChanged", listener: () => void): void;
 }
 
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
+export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvent> {
     private static readonly focusSignalType = "changedFocus";
     private static readonly focusRequestType = "focusRequest";
 

--- a/examples/data-objects/presence-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/presence-tracker/src/FocusTracker.ts
@@ -12,11 +12,11 @@ import {
     IServiceAudience,
 } from "fluid-framework";
 
-export interface IFocusTrackerEvent extends IEvent {
+export interface IFocusTrackerEvents extends IEvent {
     (event: "focusChanged", listener: () => void): void;
 }
 
-export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvent> {
+export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     private static readonly focusSignalType = "changedFocus";
     private static readonly focusRequestType = "focusRequest";
 

--- a/examples/data-objects/presence-tracker/src/MouseTracker.ts
+++ b/examples/data-objects/presence-tracker/src/MouseTracker.ts
@@ -7,7 +7,6 @@ import { Signaler } from "@fluid-experimental/data-objects";
 import { IEvent } from "@fluidframework/common-definitions";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {
-    IFluidContainer,
     IMember,
     IServiceAudience,
 } from "fluid-framework";
@@ -47,7 +46,6 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
     };
 
     public constructor(
-        container: IFluidContainer,
         public readonly audience: IServiceAudience<IMember>,
         private readonly signaler: Signaler,
     ) {

--- a/examples/data-objects/presence-tracker/src/MouseTracker.ts
+++ b/examples/data-objects/presence-tracker/src/MouseTracker.ts
@@ -11,7 +11,7 @@ import {
     IServiceAudience,
 } from "fluid-framework";
 
-export interface IMouseTrackerEvent extends IEvent {
+export interface IMouseTrackerEvents extends IEvent {
     (event: "mousePositionChanged", listener: () => void): void;
 }
 
@@ -20,7 +20,7 @@ export interface IMousePosition {
     y: number;
 }
 
-export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvent> {
+export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
     private static readonly mouseSignalType = "positionChanged";
 
     /**

--- a/examples/data-objects/presence-tracker/src/MouseTracker.ts
+++ b/examples/data-objects/presence-tracker/src/MouseTracker.ts
@@ -11,7 +11,7 @@ import {
     IServiceAudience,
 } from "fluid-framework";
 
-export interface IMouseTrackerEvents extends IEvent {
+export interface IMouseTrackerEvent extends IEvent {
     (event: "mousePositionChanged", listener: () => void): void;
 }
 
@@ -20,7 +20,7 @@ export interface IMousePosition {
     y: number;
 }
 
-export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
+export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvent> {
     private static readonly mouseSignalType = "positionChanged";
 
     /**

--- a/examples/data-objects/presence-tracker/src/app.ts
+++ b/examples/data-objects/presence-tracker/src/app.ts
@@ -116,7 +116,6 @@ async function start(): Promise<void> {
         container.initialObjects.signaler as Signaler,
     );
     const mouseTracker = new MouseTracker(
-        container,
         services.audience,
         container.initialObjects.signaler as Signaler,
     );


### PR DESCRIPTION
## Description

FluidContainer is not used in MouseTracker so it's inclusion in the constructor argument should be removed. 

