### PR TITLE
Add TestOverride setting to disable ODSP snapshot cache

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -24,7 +24,12 @@ import {
     IOdspResolvedUrl,
 } from "@fluidframework/odsp-driver-definitions";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
-import { PerformanceEvent, isFluidError, normalizeError } from "@fluidframework/telemetry-utils";
+import {
+    PerformanceEvent,
+    isFluidError,
+    normalizeError,
+    loggerToMonitoringContext,
+} from "@fluidframework/telemetry-utils";
 import { fetchAndParseAsJSONHelper, fetchArray, fetchHelper, getOdspResolvedUrl, IOdspResponse } from "./odspUtils";
 import {
     IOdspCache,
@@ -55,6 +60,7 @@ export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
 export class EpochTracker implements IPersistedFileCache {
     private _fluidEpoch: string | undefined;
 
+    private readonly snapshotCacheExpiryTimeoutMs: number;
     public readonly rateLimiter: RateLimiter;
     private readonly driverId = uuid();
     // This tracks the request number made by the driver instance.
@@ -67,6 +73,12 @@ export class EpochTracker implements IPersistedFileCache {
     ) {
         // Limits the max number of concurrent requests to 24.
         this.rateLimiter = new RateLimiter(24);
+
+        // We need this for GC testing until we can plumb through the snapshot expiration policy (see PR #11168)
+        this.snapshotCacheExpiryTimeoutMs =
+            loggerToMonitoringContext(logger).config.getBoolean("Fluid.Driver.Odsp.DisableSnapshotCache")
+                ? 0
+                : defaultCacheExpiryTimeoutMs;
     }
 
     // public for UT purposes only!
@@ -103,17 +115,17 @@ export class EpochTracker implements IPersistedFileCache {
             } else if (this._fluidEpoch !== value.fluidEpoch) {
                 return undefined;
             }
-            // Expire the cached snapshot if it's older than the defaultCacheExpiryTimeoutMs and immediately
+            // Expire the cached snapshot if it's older than snapshotCacheExpiryTimeoutMs and immediately
             // expire all old caches that do not have cacheEntryTime
             if (entry.type === snapshotKey) {
                 const cacheTime = value.value?.cacheEntryTime;
                 const currentTime = Date.now();
-                if (cacheTime === undefined || currentTime - cacheTime >= defaultCacheExpiryTimeoutMs) {
+                if (cacheTime === undefined || currentTime - cacheTime >= this.snapshotCacheExpiryTimeoutMs) {
                     this.logger.sendTelemetryEvent(
                         {
                             eventName: "odspVersionsCacheExpired",
                             duration: currentTime - cacheTime,
-                            maxCacheAgeMs: defaultCacheExpiryTimeoutMs,
+                            maxCacheAgeMs: this.snapshotCacheExpiryTimeoutMs,
                         });
                     await this.removeEntries();
                     return undefined;
@@ -129,8 +141,8 @@ export class EpochTracker implements IPersistedFileCache {
 
     public async put(entry: IEntry, value: any) {
         assert(this._fluidEpoch !== undefined, 0x1dd /* "no epoch" */);
-        // For snapshots, the value should have the cacheEntryTime. This will be used to expire snapshots older
-        // than the defaultCacheExpiryTimeoutMs.
+        // For snapshots, the value should have the cacheEntryTime.
+        // This will be used to expire snapshots older than snapshotCacheExpiryTimeoutMs.
         if (entry.type === snapshotKey) {
             value.cacheEntryTime = value.cacheEntryTime ?? Date.now();
         }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -74,9 +74,9 @@ export class EpochTracker implements IPersistedFileCache {
         // Limits the max number of concurrent requests to 24.
         this.rateLimiter = new RateLimiter(24);
 
-        // We need this for GC testing until we can plumb through the snapshot expiration policy (see PR #11168)
+        // We need this for GC testing until we properly plumb through the snapshot expiration policy (see PR #11168)
         this.snapshotCacheExpiryTimeoutMs =
-            loggerToMonitoringContext(logger).config.getBoolean("Fluid.Driver.Odsp.DisableSnapshotCache")
+            loggerToMonitoringContext(logger).config.getBoolean("Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache")
                 ? 0
                 : defaultCacheExpiryTimeoutMs;
     }


### PR DESCRIPTION
## Description

We have a problem where GC has a dependency on the driver's snapshot cache expiration policy, but this value is not plumbed through both driver and runtime layers properly for ODSP (see #11168). btw it's not even implemented in other drivers, but that's not relevant for this PR.

In order to support test modes where the sweep timeout is tighted up to the order of minutes instead of days, we need to be able to disable snapshot caching in the driver so we can use "0" for the snapshot cache expiration when computing sweep timeout in GC.  Here's a picture showing the dependencies between these durations for reference:

![image](https://user-images.githubusercontent.com/12305068/179999161-927de304-197b-45b4-9400-245ee8694261.png)

So in that image the Max Snapshot Expiry segment (red) would be 0, in the presence of this TestOverride setting.  If a document is loaded that has "Sweep V0" shortened timeouts, we would assert that this TestOverride setting is also set - otherwise close the container (will be a follow-on to #11084)

Once we properly address the challenges in #11168, this should no longer be necessary.  But it will improve our testing experience in the short term.  So that's why I'm implementing it in terms of setting the expiration to 0 rather than some other more direct means - so it's obvious when updating this same code to use the proper policy rather than these hardcoded expirations.
