### PR TITLE
Export buildForest, TextCursor and their deps

### DIFF
--- a/packages/dds/tree/src/changeset/format.ts
+++ b/packages/dds/tree/src/changeset/format.ts
@@ -10,7 +10,7 @@
 /**
  * Changeset that has may have been transposed (i.e., rebased and/or postbased).
  */
- export namespace Transposed {
+export namespace Transposed {
 	export interface Transaction extends Changeset {
 		/**
 		 * The reference sequence number of the transaction that this transaction was originally

--- a/packages/dds/tree/src/dependency-tracking/incrementalObservation.ts
+++ b/packages/dds/tree/src/dependency-tracking/incrementalObservation.ts
@@ -48,7 +48,7 @@ export interface ObservingDependent extends Dependent {
 	registerDependee(dependee: Dependee): void;
 
 	/**
-	 * {@inheritdoc Dependent.listDependees}
+	 * {@inheritdoc NamedComputation.listDependees}
      *
      * @override
 	 */

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -6,3 +6,4 @@
 export * from "./object-forest";
 export * from "./defaultRebaser";
 export * from "./forestIndex";
+export * from "./treeTextFormat";

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectAnchor.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectAnchor.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-    Anchor,
+    ForestAnchor,
     ITreeSubscriptionCursorState,
 } from "../../forest";
 import { PathShared } from "../../tree";
@@ -31,7 +31,7 @@ import { PathShared } from "../../tree";
  * Since anchors need to work even for unloaded/pending parts of the tree,
  * these are kept separate from the actual tree data.
  */
-export class ObjectAnchor implements Anchor {
+export class ObjectAnchor implements ForestAnchor {
     state: ITreeSubscriptionCursorState = ITreeSubscriptionCursorState.Current;
     public constructor(public readonly path: PathShared) { }
     free(): void {

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -8,8 +8,8 @@ import {
     DisposingDependee, ObservingDependent, recordDependency, SimpleDependee, SimpleObservingDependent,
 } from "../../dependency-tracking";
 import {
-    ITreeCursor, ITreeSubscriptionCursor, NodeId,
-    Anchor, IEditableForest,
+    ITreeCursor, ITreeSubscriptionCursor, ForestLocation,
+    ForestAnchor, IEditableForest,
     ITreeSubscriptionCursorState,
     TreeNavigationResult,
     FieldLocation, TreeLocation, isFieldLocation,
@@ -25,7 +25,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
     public readonly schema: StoredSchemaRepository = new StoredSchemaRepository();
     public readonly anchors: AnchorSet = new AnchorSet();
 
-    public root(range: DetachedRange): Anchor { return new RootAnchor(range); }
+    public root(range: DetachedRange): ForestAnchor { return new RootAnchor(range); }
     public readonly rootField: DetachedRange = this.newRange();
 
     private readonly roots: Map<DetachedRange, ObjectField> = new Map();
@@ -121,7 +121,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         this.roots.set(newRange, newField);
         return newRange;
     }
-    setValue(nodeId: NodeId, value: Value): void {
+    setValue(nodeId: ForestLocation, value: Value): void {
         this.beforeChange();
         const node = this.lookupNodeId(nodeId);
         node.value = value;
@@ -143,7 +143,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
     }
 
     tryGet(
-        destination: Anchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent | undefined,
+        destination: ForestAnchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent | undefined,
     ): TreeNavigationResult {
         assert(destination instanceof ObjectAnchor, 0x336 /* ObjectForest must only be given its own Anchors */);
         assert(cursorToMove instanceof Cursor, 0x337 /* ObjectForest must only be given its own Cursor type */);
@@ -170,7 +170,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         return TreeNavigationResult.NotFound;
     }
 
-    private lookupNodeId(id: NodeId): ObjectNode {
+    private lookupNodeId(id: ForestLocation): ObjectNode {
         if (id instanceof ObjectNode) {
             return id;
         }
@@ -233,7 +233,7 @@ export function nodeFromCursor(cursor: ITreeCursor): ObjectNode {
  * Simple anchor that just points to a node object.
  * This results in pretty basic anchor rebase policy.
  */
-abstract class ObjectAnchor implements Anchor {
+abstract class ObjectAnchor implements ForestAnchor {
     state: ITreeSubscriptionCursorState = ITreeSubscriptionCursorState.Current;
     free(): void {
         assert(this.state === ITreeSubscriptionCursorState.Current, 0x339 /* Anchor must not be double freed */);
@@ -351,7 +351,7 @@ class Cursor implements ITreeSubscriptionCursor {
         assert(this.state !== ITreeSubscriptionCursorState.Freed, 0x33f /* Cursor must not be double freed */);
         this.state = ITreeSubscriptionCursorState.Freed;
     }
-    buildAnchor(): Anchor {
+    buildAnchor(): ForestAnchor {
         return new NodeAnchor(this.getNode());
     }
     down(key: FieldKey, index: number): TreeNavigationResult {
@@ -398,4 +398,14 @@ class Cursor implements ITreeSubscriptionCursor {
     length(key: FieldKey): number {
         return (this.getNode().fields.get(key) ?? []).length;
     }
+}
+
+// This function is the only package level export for objectForest, and hides all the implementation types.
+// When other forest implementations are created (ex: optimized ones),
+// this function should likely be moved and updated to (at least conditionally) use them.
+/**
+ * @returns an implementation of {@link IEditableForest} with no data or schema.
+ */
+export function buildForest(): IEditableForest {
+    return new ObjectForest();
 }

--- a/packages/dds/tree/src/feature-libraries/treeTextFormat.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextFormat.ts
@@ -55,22 +55,8 @@ import {
  * Values are the content of the trait specified by the key.
  * @public
  */
- export interface FieldMap<TChild> {
-    [key: string]: TreeNodeSequence<TChild>;
-}
-
-/**
- * A sequence of Nodes that make up a trait under a Node
- * @public
- */
-export type TreeNodeSequence<TChild> = readonly TChild[];
-
-/**
- * An object which may have traits with children of the given type underneath it
- * @public
- */
-export interface WithFields<TChild> {
-    fields?: Readonly<FieldMap<TChild>>;
+export interface FieldMap<TChild> {
+    [key: string]: readonly TChild[];
 }
 
 /**
@@ -92,15 +78,18 @@ export interface NodeData {
 }
 
 /**
- * Satisfies `NodeData` and may contain children under traits (which may or may not be `TreeNodes`)
+ * Json comparable tree node, generic over child type.
+ * Json compatibility assumes `TChild` is also json compatible.
  * @public
  */
-export interface TreeNode<TChild> extends NodeData, WithFields<TChild> {}
+export interface GenericTreeNode<TChild> extends NodeData {
+    fields?: Readonly<FieldMap<TChild>>;
+}
 
 /**
- * A tree whose nodes are either TreeNodes or a placeholder
+ * A tree whose nodes are either tree nodes or a placeholders.
  */
-export type PlaceholderTree<TPlaceholder = never> = TreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
+export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
 
 /**
  * An ITreeCursor implementation for PlaceholderTree.

--- a/packages/dds/tree/src/feature-libraries/treeTextFormat.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextFormat.ts
@@ -87,7 +87,7 @@ export interface GenericTreeNode<TChild> extends NodeData {
 }
 
 /**
- * A tree whose nodes are either tree nodes or a placeholders.
+ * A tree whose nodes are either tree nodes or placeholders.
  */
 export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
 

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -6,7 +6,12 @@
 import { StoredSchemaRepository } from "../schema";
 import { AnchorSet, FieldKey, DetachedRange, Value } from "../tree";
 import { ITreeCursor } from "./cursor";
-import { IForestSubscription, NodeId } from "./forest";
+import { IForestSubscription, ITreeSubscriptionCursor, ForestAnchor } from "./forest";
+
+/**
+ * Ways to refer to a node in an IEditableForest.
+ */
+ export type ForestLocation = ITreeSubscriptionCursor | ForestAnchor;
 
 /**
  * Editing APIs.
@@ -65,7 +70,7 @@ export interface IEditableForest extends IForestSubscription {
      * @param nodeId - the id of the node
      * @param value - the new value
      */
-    setValue(nodeId: NodeId, value: Value): void;
+    setValue(nodeId: ForestLocation, value: Value): void;
 
     /**
      * Recursively deletes a range and its children.
@@ -87,5 +92,5 @@ export function isFieldLocation(range: FieldLocation | DetachedRange): range is 
  */
 export interface FieldLocation {
 	readonly key: FieldKey;
-    readonly parent: NodeId;
+    readonly parent: ForestLocation;
 }

--- a/packages/dds/tree/src/forest/forest.ts
+++ b/packages/dds/tree/src/forest/forest.ts
@@ -18,11 +18,6 @@ import { ITreeCursor, TreeNavigationResult } from "./cursor";
  */
 
 /**
- * Ways to refer to a node in an IForestSubscription.
- */
-export type NodeId = ITreeSubscriptionCursor | Anchor;
-
-/**
  * Invalidates whenever `current` changes.
  * For now (might change later) downloading new parts of the forest counts as a change.
  *
@@ -52,7 +47,7 @@ export interface IForestSubscription extends Dependee {
     /**
      * Anchor at the beginning of a root field.
      */
-    root(range: DetachedRange): Anchor;
+    root(range: DetachedRange): ForestAnchor;
 
     /**
      * If observer is provided, it will be invalidated if the value returned from this changes
@@ -62,7 +57,7 @@ export interface IForestSubscription extends Dependee {
      * Must provide a `cursorToMove` from this subscription (acquired via `allocateCursor`).
      */
     tryGet(
-        destination: Anchor,
+        destination: ForestAnchor,
         cursorToMove: ITreeSubscriptionCursor,
         observer?: ObservingDependent
     ): TreeNavigationResult;
@@ -107,7 +102,7 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
      * Construct an `Anchor` which the IForestSubscription will keep rebased to `current`.
      * Note that maintaining an Anchor has cost: free them to stop incurring that cost.
      */
-    buildAnchor(): Anchor;
+    buildAnchor(): ForestAnchor;
 
     /**
      * Current state.
@@ -129,7 +124,7 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
  * Anchors and thus use a ref count instead of allocating an object for each one.
  * This could be enabled by removing "state".
  */
-export interface Anchor {
+export interface ForestAnchor {
     /**
      * Release any resources this Anchor is holding onto.
      * After doing this, further use of this object other than reading `state` is forbidden (undefined behavior).

--- a/packages/dds/tree/src/forest/index.ts
+++ b/packages/dds/tree/src/forest/index.ts
@@ -9,4 +9,4 @@ export {
     mapCursorField,
 } from "./cursor";
 export * from "./forest";
-export { IEditableForest, FieldLocation, TreeLocation, isFieldLocation } from "./editableForest";
+export { IEditableForest, FieldLocation, TreeLocation, isFieldLocation, ForestLocation } from "./editableForest";

--- a/packages/dds/tree/src/forest/snapshot.ts
+++ b/packages/dds/tree/src/forest/snapshot.ts
@@ -17,7 +17,7 @@ import { ITreeCursor } from "./cursor";
  * Ways to refer to a node in a forest.
  * TODO: other ways. Support for rebase to other forests.
  */
- export type NodeId = ITreeCursor;
+export type NodeId = ITreeCursor;
 
 /**
  * An immutable forest.
@@ -28,7 +28,7 @@ import { ITreeCursor } from "./cursor";
  *
  * @public
  */
- export interface IForestSnapshot {
+export interface IForestSnapshot {
     /**
      * @returns the node associated with `id`. Should not be used if there is no node with the provided id.
      */
@@ -59,7 +59,7 @@ import { ITreeCursor } from "./cursor";
  *
  * @public
  */
- export interface ICowForestSnapshot extends IForestSnapshot {
+export interface ICowForestSnapshot extends IForestSnapshot {
     /**
      * Adds the supplied nodes to the forest. The nodes' IDs must be unique in the forest.
      * @param nodes - the sequence of nodes to add to the forest.

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -3,13 +3,33 @@
  * Licensed under the MIT License.
  */
 
-export { EmptyKey, FieldKey, TreeType, Value, TreeValue } from "./tree";
+export {
+    Dependee, Dependent, NamedComputation, ObservingDependent, InvalidationToken, recordDependency,
+    SimpleDependee,
+} from "./dependency-tracking";
 
-export { ITreeCursor, TreeNavigationResult } from "./forest";
+export {
+    EmptyKey, FieldKey, TreeType, Value, TreeValue, AnchorSet, DetachedRange,
+    PathShared, UpPath, Anchor, RootRange, PathCollection, PathNode, ChildCollection,
+    ChildLocation,
+} from "./tree";
+
+export { ITreeCursor, TreeNavigationResult, IEditableForest,
+    IForestSubscription,
+    TreeLocation,
+    FieldLocation,
+    ForestLocation,
+    ITreeSubscriptionCursor,
+    ForestAnchor,
+    ITreeSubscriptionCursorState,
+} from "./forest";
+
 export {
     LocalFieldKey, GlobalFieldKey, TreeSchemaIdentifier, NamedTreeSchema, Named,
     FieldSchema, ValueSchema, TreeSchema, FieldKind,
     emptyField, neverTree,
+    SchemaRepository, StoredSchemaRepository,
+    rootFieldKey,
 } from "./schema";
 
 export {
@@ -26,8 +46,26 @@ export {
 } from "./util";
 
 export {
+    Rebaser,
+    ChangeRebaser,
+    RevisionTag,
+    ChangeFromChangeRebaser,
+    FinalFromChangeRebaser,
+} from "./rebase";
+
+export {
     cursorToJsonObject,
     JsonCursor,
     jsonTypeSchema,
     jsonArray, jsonBoolean, jsonNull, jsonNumber, jsonObject, jsonString,
 } from "./domains";
+
+export {
+    buildForest,
+    TextCursor,
+    placeholderTreeFromCursor,
+    FieldMap,
+    NodeData,
+    GenericTreeNode,
+    PlaceholderTree,
+} from "./feature-libraries";

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -17,7 +17,7 @@ import { UpPath } from "./pathTree";
 /**
  * A way to refer to a particular tree location within a {@link Rebaser} instance's revision.
  */
- export type Anchor = Brand<number, "rebaser.Anchor">;
+export type Anchor = Brand<number, "rebaser.Anchor">;
 
 /**
  * Collection of Anchors at a specific revision.
@@ -65,7 +65,7 @@ export class AnchorSet {
 /**
  * Base type for nodes in a path tree.
  */
- export class PathShared<TParent extends ChildCollection = ChildCollection> implements UpPath {
+export class PathShared<TParent extends ChildCollection = ChildCollection> implements UpPath {
     // PathNode arrays are kept sorted by index for efficient search.
     protected readonly children: Map<TParent, PathNode[]> = new Map();
     // public constructor() {}
@@ -90,7 +90,7 @@ export class AnchorSet {
     }
 }
 
-class PathNode extends PathShared<FieldKey> {
+export class PathNode extends PathShared<FieldKey> {
     public constructor(public parentPath: PathShared<FieldKey>, location: ChildLocation) {
         super();
     }
@@ -111,7 +111,7 @@ class PathNode extends PathShared<FieldKey> {
  * Thus this can be thought of as a sparse copy of the subset of trees which are used as anchors
  * (and thus need parent paths).
  */
-class PathCollection extends PathShared<RootRange> {
+export class PathCollection extends PathShared<RootRange> {
     public constructor() {
         super();
     }

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -21,7 +21,7 @@ export const EmptyKey = "" as const as FieldKey;
  *
  * @public
  */
- export interface ChildLocation {
+export interface ChildLocation {
     readonly container: ChildCollection;
     readonly index: number;
 }

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -30,6 +30,6 @@ export function fail(message: string): never {
  *
  * @param never - The switch value
  */
- export function unreachableCase(never: never): never {
+export function unreachableCase(never: never): never {
     fail("unreachableCase was called");
 }


### PR DESCRIPTION
## Description

Export a way to build an editable forest, as well as TextCursor so that arbitrary trees constructed and inserted into said forest.

Also cleans up some whitespace, and a few names whish now have a larger scope.