### PR TITLE
Can create DDS in detached container and attach / update it fix

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Container } from '@fluidframework/container-loader';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
@@ -82,6 +83,9 @@ export enum DataObjectFactoryType {
 
 // @public (undocumented)
 export const defaultTimeoutDurationMs = 250;
+
+// @public (undocumented)
+export function ensureContainerConnected(container: Container): Promise<void>;
 
 // @public
 export class EventAndErrorTrackingLogger extends TelemetryLogger {

--- a/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "@fluidframework/aqueduct";
 import { Container } from "@fluidframework/container-loader";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ITestObjectProvider, timeoutPromise } from "@fluidframework/test-utils";
+import { ITestObjectProvider, timeoutPromise, ensureContainerConnected } from "@fluidframework/test-utils";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -44,12 +44,6 @@ describeFullCompat("Audience correctness", (getTestObjectProvider) => {
 
     const createContainer = async (): Promise<Container> => await provider.createContainer(runtimeFactory) as Container;
     const loadContainer = async (): Promise<Container> => await provider.loadContainer(runtimeFactory) as Container;
-
-    async function ensureContainerConnected(container: Container): Promise<void> {
-        if (!container.connected) {
-            return new Promise((resolve) => container.once("connected", () => resolve()));
-        }
-    }
 
     /** Function to wait for a client with the given clientId to be added to the audience of the given container. */
     async function waitForClientAdd(container: Container, clientId: string, errorMsg: string) {

--- a/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
@@ -15,6 +15,7 @@ import {
     ITestContainerConfig,
     ITestObjectProvider,
     DataObjectFactoryType,
+    ensureContainerConnected,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 
@@ -32,12 +33,6 @@ const lots = 30;
 const testValue = "test value";
 
 type MapCallback = (container: IContainer, dataStore: ITestFluidObject, map: SharedMap) => void | Promise<void>;
-
-async function ensureContainerConnected(container: Container): Promise<void> {
-    if (!container.connected) {
-        return new Promise((resolve) => container.once("connected", () => resolve()));
-    }
-}
 
 const getPendingStateWithoutClose = (container: IContainer): string => {
     const containerClose = container.close;

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -17,7 +17,7 @@ import {
     LocalCodeLoader,
     SupportedExportInterfaces,
     TestFluidObjectFactory,
-    timeoutPromise,
+    ensureContainerConnected,
 } from "@fluidframework/test-utils";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { Deferred, TelemetryNullLogger } from "@fluidframework/common-utils";
@@ -72,12 +72,6 @@ const createFluidObject = (async (
         await dataStoreContext.containerRuntime.createDataStore(type),
         "");
 });
-
-async function ensureContainerConnected(container: Container): Promise<void> {
-    if (!container.connected) {
-        return timeoutPromise((resolve) => container.once("connected", () => resolve()));
-    }
-}
 
 describeFullCompat("Detached Container", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
@@ -14,6 +14,7 @@ import {
     ITestObjectProvider,
     ITestContainerConfig,
     DataObjectFactoryType,
+    ensureContainerConnected,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 
@@ -34,12 +35,6 @@ describeNoCompat("Flush mode validation", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     let dataObject1: ITestFluidObject;
     let dataObject1map1: SharedMap;
-
-    async function ensureContainerConnected(container: Container): Promise<void> {
-        if (!container.connected) {
-            return new Promise((resolve) => container.once("connected", () => resolve()));
-        }
-    }
 
     before(function() {
         provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
@@ -10,7 +10,7 @@ import { IContainerRuntime } from "@fluidframework/container-runtime-definitions
 import { IFluidHandle, IFluidRouter, IRequest } from "@fluidframework/core-interfaces";
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ITestObjectProvider, timeoutPromise } from "@fluidframework/test-utils";
+import { ITestObjectProvider, ensureContainerConnected } from "@fluidframework/test-utils";
 import {
     describeNoCompat,
     ITestDataObject,
@@ -68,12 +68,6 @@ async function getAndValidateDataObject(
     await assert.doesNotReject(requestTestObjectWithoutWait(container, dataObject._context.id),
         `Data object for key ${key} must be visible`);
     return dataObject;
-}
-
-async function ensureContainerConnected(container: Container): Promise<void> {
-    if (!container.connected) {
-        return timeoutPromise((resolve) => container.once("connected", () => resolve()));
-    }
 }
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -24,7 +24,6 @@ import {
     ITestObjectProvider,
     DataObjectFactoryType,
     createAndAttachContainer,
-    ensureContainerConnected,
 } from "@fluidframework/test-utils";
 import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
 import { ConnectionState } from "@fluidframework/container-loader";
@@ -65,6 +64,12 @@ const lots = 30;
 const testKey = "test key";
 const testKey2 = "another test key";
 const testValue = "test value";
+
+const ensureContainerConnected = async (container: IContainer) => {
+    if (container.connectionState !== ConnectionState.Connected) {
+        return new Promise<void>((resolve) => container.once("connected", () => resolve()));
+    }
+};
 
 const getPendingStateWithoutClose = (container: IContainer): string => {
     const containerClose = container.close;

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -24,6 +24,7 @@ import {
     ITestObjectProvider,
     DataObjectFactoryType,
     createAndAttachContainer,
+    ensureContainerConnected,
 } from "@fluidframework/test-utils";
 import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
 import { ConnectionState } from "@fluidframework/container-loader";
@@ -64,12 +65,6 @@ const lots = 30;
 const testKey = "test key";
 const testKey2 = "another test key";
 const testValue = "test value";
-
-const ensureContainerConnected = async (container: IContainer) => {
-    if (container.connectionState !== ConnectionState.Connected) {
-        return new Promise<void>((resolve) => container.once("connected", () => resolve()));
-    }
-};
 
 const getPendingStateWithoutClose = (container: IContainer): string => {
     const containerClose = container.close;

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { Container } from "@fluidframework/container-loader";
+
 export const defaultTimeoutDurationMs = 250;
 
 export interface TimeoutWithError {
@@ -21,6 +23,12 @@ export async function timeoutAwait<T = void>(
     timeoutOptions: TimeoutWithError | TimeoutWithValue<T> = {},
 ) {
     return Promise.race([promise, timeoutPromise<T>(() => { }, timeoutOptions)]);
+}
+
+export async function ensureContainerConnected(container: Container): Promise<void> {
+    if (!container.connected) {
+        return timeoutPromise((resolve) => container.once("connected", () => resolve()));
+    }
 }
 
 export async function timeoutPromise<T = void>(


### PR DESCRIPTION
The bug seems to be that with current approach, when the second container is loaded, the url/id is completely different than the one that was first assigned to the original container. The failure rate I saw was 100%. I believe it is because loadTestContainer instantiate a different loader and also the documentId is never updated. After these changes, the test seems to be stable.