### PR TITLE
Add support for sending signals in stress tests

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -30,8 +30,9 @@ export interface IRunConfig {
 }
 
 export interface ILoadTest {
-    run(config: IRunConfig, reset: boolean, logger): Promise<boolean>;
-    detached(config: Omit<IRunConfig, "runId">, logger): Promise<LoadTestDataStoreModel>;
+    run(config: IRunConfig, reset: boolean): Promise<boolean>;
+    detached(config: Omit<IRunConfig, "runId">): Promise<LoadTestDataStoreModel>;
+    getRuntime(): Promise<IFluidDataStoreRuntime>;
 }
 
 const taskManagerKey = "taskManager";

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -18,12 +18,12 @@ import { IContainer, LoaderHeader } from "@fluidframework/container-definitions"
 import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import { ILoadTest, IRunConfig } from "./loadTestDataStore";
 import { createCodeLoader, createTestDriver, getProfile, loggerP, safeExit } from "./utils";
 import { FaultInjectionDocumentServiceFactory } from "./faultInjectionDriver";
 import { generateConfigurations, generateLoaderOptions, generateRuntimeOptions } from "./optionsMatrix";
-import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 function printStatus(runConfig: IRunConfig, message: string) {
     if (runConfig.verbose) {

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -428,6 +428,27 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
             });
         }
 
+        if (submittedSignals > 0) {
+            logger.send({
+                category: "metric",
+                eventName: "Fluid Signals Submitted",
+                testHarnessEvent: true,
+                value: submittedSignals,
+                clientId: container.clientId,
+                userName: getUserName(container),
+            });
+        }
+        if (receivedSignals > 0) {
+            logger.send({
+                category: "metric",
+                eventName: "Fluid Signals Received",
+                testHarnessEvent: true,
+                value: receivedSignals,
+                clientId: container.clientId,
+                userName: getUserName(container),
+            });
+        }
+
         submitedOps = 0;
         receivedOps = 0;
         submittedSignals = 0;

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -392,15 +392,11 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
     });
 
     let submittedSignals = 0;
+    let receivedSignals = 0;
     testRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
         if (message.type === "generic-signal" && local === true) {
             submittedSignals += 1;
-        }
-    });
-
-    let receivedSignals = 0;
-    testRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
-        if (message.type === "generic-signal" && local === false) {
+        } else if (message.type === "generic-signal" && local === false) {
             receivedSignals += 1;
         }
     });

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -20,7 +20,9 @@ export interface ILoadTestConfig {
     progressIntervalMs: number;
     numClients: number;
     totalSendCount: number;
+    totalSignalsSendCount?: number;
     readWriteCycleMs: number;
+    signalsPerMin?: number;
     faultInjectionMaxMs?: number;
     faultInjectionMinMs?: number;
     /**

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -115,6 +115,17 @@
                     }
                 }
             }
+        },
+        "scale_with_signals":  {
+            "opRatePerMin":  7,
+            "signalsPerMin":  46,
+            "totalSignalsSendCount":  420000,
+            "progressIntervalMs":  20000,
+            "numClients":  10,
+            "totalSendCount":  70000,
+            "readWriteCycleMs":  30000,
+            "faultInjectionMinMs":  900000,
+            "faultInjectionMaxMs":  1800000
         }
     }
 }

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -2,9 +2,11 @@
     "profiles": {
         "ci": {
             "opRatePerMin": 10,
+            "signalsPerMin":  10,
             "progressIntervalMs": 15000,
             "numClients": 120,
             "totalSendCount": 10000,
+            "totalSignalsSendCount":  10000,
             "totalBlobCount": 480,
             "blobSize": 256,
             "readWriteCycleMs": 30000,


### PR DESCRIPTION
- Add a sendSignals() function to LoadTestDataStore, to add support for sending signals in stress tests
- Refactor support for sending ops in stress tests into a sendOps() function
- Add a profile for testing scale with signals in testConfig.json