### PR TITLE
reduce `SummaryAckWithoutOp` to generic log, rather than error

### DIFF
--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -370,7 +370,7 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
                 // Potential causes for it to be later than our initialSequenceNumber
                 // are that the summaryOp was nacked then acked, double-acked, or
                 // the summarySequenceNumber is incorrect.
-                this.logger.sendErrorEvent({
+                this.logger.sendTelemetryEvent({
                     eventName: "SummaryAckWithoutOp",
                     sequenceNumber: op.sequenceNumber, // summary ack seq #
                     summarySequenceNumber: seq, // missing summary seq #

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -351,10 +351,7 @@ export class ReplayTool {
 
         // GC will consider unreferenced node in old documents to be inactive. When such nodes receive ops or are
         // loaded, GC will log an error. Ignore those errors since we don't care about them when replaying old docs.
-        if (event.eventName.includes("GarbageCollector:inactiveObject_")
-            // there is something wrong with summary ops, but we don't run the summarizer, so it shouldn't matter
-            || event.eventName.includes("SummaryAckWithoutOp")
-        ) {
+        if (event.eventName.includes("GarbageCollector:inactiveObject_")) {
             return false;
         }
 
@@ -608,7 +605,6 @@ export class ReplayTool {
 
         const startOp = op - this.args.overlappingContainers * this.args.snapFreq;
         while (this.documentsWindow.length > 0
-            // eslint-disable-next-line no-unmodified-loop-condition
             && (final || this.documentsWindow[0].fromOp <= startOp)) {
             const doc = this.documentsWindow.shift();
             assert(doc.fromOp === startOp || final,


### PR DESCRIPTION

## Description

We currently suppress the `SummaryAckWithoutOp` event in snapshot tests as it logs deterministically in the `SharedMatrixDeletes` test. The reason for this is that this test in particular has a `summary ack` op on the boundary of a stress test snapshot -- i.e. op `#50` is a `summarize` op and op `#51` is a `summary ack` op and we take snapshots every 50 ops, resulting in the application of a `summary ack` op without a corresponding `summarize` op. In general, this case is not an error and is only something that is nice-to-know occurred. This change reduces the severity of the log from `error` to a generic telemetry log.