### PR TITLE
Import SignalManager as Signaler from @fluid-experimental package

### DIFF
--- a/examples/data-objects/presence-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/presence-tracker/src/FocusTracker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Signaler } from "@fluid-experimental/data-objects";
+import { SignalManager as Signaler } from "@fluid-experimental/data-objects";
 import { IEvent } from "@fluidframework/common-definitions";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {
@@ -80,7 +80,6 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
         container.on("connected", () => {
             this.signaler.submitSignal(FocusTracker.focusRequestType);
         });
-        this.signaler.submitSignal(FocusTracker.focusRequestType);
     }
 
     /**

--- a/examples/data-objects/presence-tracker/src/MouseTracker.ts
+++ b/examples/data-objects/presence-tracker/src/MouseTracker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Signaler } from "@fluid-experimental/data-objects";
+import { SignalManager as Signaler } from "@fluid-experimental/data-objects";
 import { IEvent } from "@fluidframework/common-definitions";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {

--- a/examples/data-objects/presence-tracker/src/app.ts
+++ b/examples/data-objects/presence-tracker/src/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Signaler } from "@fluid-experimental/data-objects";
+import { SignalManager as Signaler } from "@fluid-experimental/data-objects";
 import {
     IFluidContainer,
     ContainerSchema,


### PR DESCRIPTION
## Description

Currently, in the @fluid-experimental/data-objects package, it seems the rebranding of SignalManager to Signaler hasn't been updated yet. The workaround this PR does is importing SignalManager as Signaler, so the usage of Signaler is still valid throughout the example. This fixes the example and it now runs with no errors, but my next question would be what needs to be done to get the name change to the @fluid-experimental/data-objects npmjs pacakage.

## Other information or known dependencies

ADO link: [Bug 1364](https://dev.azure.com/fluidframework/internal/_workitems/edit/1364)
