### PR TITLE
Frs stress tests specfic config

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -33,7 +33,7 @@
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
     "start": "node ./dist/nodeStressTest.js",
-    "start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs",
+    "start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs --profile ci_frs",
     "start:mini": "node ./dist/nodeStressTest.js  --profile mini",
     "start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
     "start:odspdf": "node ./dist/nodeStressTest.js --driver odsp --driverEndpoint odsp-df",

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -31,20 +31,7 @@
             "totalSendCount": 10000,
             "readWriteCycleMs": 30000,
             "faultInjectionMinMs": 0,
-            "faultInjectionMaxMs": 150000,
-            "optionOverrides":{
-                "odsp":{
-                    "configurations":{
-                        "Fluid.Container.summarizeProtocolTree": [true, false]
-                    }
-                },
-                "odsp-odsp-df":{
-                    "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
-                        "Fluid.Container.summarizeProtocolTree": [true, false]
-                    }
-                }
-            }
+            "faultInjectionMaxMs": 150000
         },
         "full": {
             "opRatePerMin": 1920,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -24,6 +24,28 @@
                 }
             }
         },
+        "ci_frs": {
+            "opRatePerMin": 10,
+            "progressIntervalMs": 15000,
+            "numClients": 100,
+            "totalSendCount": 10000,
+            "readWriteCycleMs": 30000,
+            "faultInjectionMinMs": 0,
+            "faultInjectionMaxMs": 150000,
+            "optionOverrides":{
+                "odsp":{
+                    "configurations":{
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
+                    }
+                },
+                "odsp-odsp-df":{
+                    "configurations":{
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
+                    }
+                }
+            }
+        },
         "full": {
             "opRatePerMin": 1920,
             "progressIntervalMs": 1500000,


### PR DESCRIPTION
Immediate goal here is to get working baseline for FRS stress tests.

1. FRS does not support independent blob creation, therefore removing blob config from FRS stress test.
2. Max number of concurrent client connections is 100, for FRS. We should generally look to align any config with ODSP (120), but here we adopt 100 (in line with FRS team expectations) to unblock stress tests.