### PR TITLE
Move JsonableTree into the tree module

### DIFF
--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -18,8 +18,9 @@ import {
 import { Index, SummaryElement } from "../shared-tree-core";
 import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
 import { Delta } from "../changeset";
+import { PlaceholderTree } from "../tree";
 import { ObjectForest } from "./object-forest";
-import { PlaceholderTree, placeholderTreeFromCursor, TextCursor } from "./treeTextFormat";
+import { placeholderTreeFromCursor, TextCursor } from "./treeTextCursor";
 
 /**
  * Index which provides an editable forest for the current state for the document.

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -6,4 +6,4 @@
 export * from "./object-forest";
 export * from "./defaultRebaser";
 export * from "./forestIndex";
-export * from "./treeTextFormat";
+export * from "./treeTextCursor";

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -8,11 +8,11 @@ import {
     TreeNavigationResult,
     mapCursorField,
 } from "../forest";
-import { TreeSchemaIdentifier } from "../schema";
 import {
     FieldKey,
+    FieldMap,
+    PlaceholderTree,
     TreeType,
-    TreeValue,
     Value,
 } from "../tree";
 
@@ -24,16 +24,6 @@ import {
  *
  * It's suitable for testing and debugging,
  * though it could also reasonably be used as a fallback for edge cases or for small trees.
- *
- * The serialized format is valid utf-8, and also includes a json compatible intermediate in memory format.
- *
- * This format is currently not stable: its internal contents are not considered public APIs and may change.
- * There is currently no guarantee that data serialized with this library will
- * be loadable with a different version of this library.
- *
- * TODO: stabilize this format (probably after schema are more stable).
- *
- * This format does not include schema: typically schema would be stored alongside data in this format.
  *
  * TODO: Use placeholders.
  * build / add operations should be able to include detached ranges instead of children directly.
@@ -48,54 +38,6 @@ import {
  * for now this library actually outputs and inputs the Json compatible type PlaceholderTree
  * rather than actual strings.
  */
-
-/**
- * Json compatible map as object.
- * Keys are TraitLabels,
- * Values are the content of the trait specified by the key.
- * @public
- */
-export interface FieldMap<TChild> {
-    [key: string]: TChild[];
-}
-
-/**
- * The fields required by a node in a tree
- * @public
- */
-export interface NodeData {
-    /**
-     * A payload of arbitrary serializable data
-     */
-    value?: TreeValue;
-
-    /**
-     * The meaning of this node.
-     * Provides contexts/semantics for this node and its content.
-     * Typically use to associate a node with metadata (including a schema) and source code (types, behaviors, etc).
-     */
-    readonly type: TreeSchemaIdentifier;
-}
-
-/**
- * Json comparable tree node, generic over child type.
- * Json compatibility assumes `TChild` is also json compatible.
- * @public
- */
-export interface GenericTreeNode<TChild> extends NodeData {
-    fields?: FieldMap<TChild>;
-}
-
-/**
- * A tree whose nodes are either tree nodes or placeholders.
- */
-export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
-
-/**
- * A tree represented using plain JavaScript objects.
- * Can be passed to `JSON.stringify()` to produce a human-readable/editable JSON tree.
- */
-export interface JsonableTree extends PlaceholderTree {}
 
 /**
  * An ITreeCursor implementation for PlaceholderTree.

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -11,7 +11,7 @@ export {
 export {
     EmptyKey, FieldKey, TreeType, Value, TreeValue, AnchorSet, DetachedRange,
     PathShared, UpPath, Anchor, RootRange, PathCollection, PathNode, ChildCollection,
-    ChildLocation,
+    ChildLocation, FieldMap, NodeData, GenericTreeNode, PlaceholderTree,
 } from "./tree";
 
 export { ITreeCursor, TreeNavigationResult, IEditableForest,
@@ -64,8 +64,4 @@ export {
     buildForest,
     TextCursor,
     placeholderTreeFromCursor,
-    FieldMap,
-    NodeData,
-    GenericTreeNode,
-    PlaceholderTree,
 } from "./feature-libraries";

--- a/packages/dds/tree/src/test/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/treeTextCursor.spec.ts
@@ -7,8 +7,9 @@ import { strict as assert } from "assert";
 
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
-import { PlaceholderTree, placeholderTreeFromCursor, TextCursor } from "../feature-libraries/treeTextFormat";
+import { placeholderTreeFromCursor, TextCursor } from "../feature-libraries/treeTextCursor";
 
+import { PlaceholderTree } from "../tree";
 import { brand } from "../util";
 
 const testCases: [string, PlaceholderTree][] = [

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -17,3 +17,4 @@ export {
 
 export * from "./pathTree";
 export * from "./anchorSet";
+export * from "./treeTextFormat";

--- a/packages/dds/tree/src/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/tree/treeTextFormat.ts
@@ -1,0 +1,75 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TreeSchemaIdentifier } from "../schema";
+import { TreeValue } from "./types";
+
+/**
+ * This modules provides a simple human readable (and editable) tree format.
+ *
+ * This implementation can handle all trees (so it does not need a fallback for any special cases),
+ * and is not optimized.
+ *
+ * It's suitable for testing and debugging,
+ * though it could also reasonably be used as a fallback for edge cases or for small trees.
+ *
+ * The serialized format is valid utf-8, and also includes a json compatible intermediate in memory format.
+ *
+ * This format is currently not stable: its internal contents are not considered public APIs and may change.
+ * There is currently no guarantee that data serialized with this library will
+ * be loadable with a different version of this library.
+ *
+ * TODO: stabilize this format (probably after schema are more stable).
+ *
+ * This format does not include schema: typically schema would be stored alongside data in this format.
+ */
+
+/**
+ * Json compatible map as object.
+ * Keys are TraitLabels,
+ * Values are the content of the trait specified by the key.
+ * @public
+ */
+export interface FieldMap<TChild> {
+    [key: string]: TChild[];
+}
+
+/**
+ * The fields required by a node in a tree
+ * @public
+ */
+export interface NodeData {
+    /**
+     * A payload of arbitrary serializable data
+     */
+    value?: TreeValue;
+
+    /**
+     * The meaning of this node.
+     * Provides contexts/semantics for this node and its content.
+     * Typically use to associate a node with metadata (including a schema) and source code (types, behaviors, etc).
+     */
+    readonly type: TreeSchemaIdentifier;
+}
+
+/**
+ * Json comparable tree node, generic over child type.
+ * Json compatibility assumes `TChild` is also json compatible.
+ * @public
+ */
+export interface GenericTreeNode<TChild> extends NodeData {
+    fields?: FieldMap<TChild>;
+}
+
+/**
+ * A tree whose nodes are either tree nodes or placeholders.
+ */
+export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
+
+/**
+ * A tree represented using plain JavaScript objects.
+ * Can be passed to `JSON.stringify()` to produce a human-readable/editable JSON tree.
+ */
+export interface JsonableTree extends PlaceholderTree {}


### PR DESCRIPTION
This PR moves the tree `JsonableTree` format type/interface definitions into the tree module while keeping the cursor implementation for it in the feature-libraries.