### PR TITLE
Tree: move delta

### DIFF
--- a/packages/dds/tree/src/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/change-family/changeFamily.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { Delta } from "../changeset";
 import { ChangeRebaser } from "../rebase";
-import { AnchorSet } from "../tree";
+import { AnchorSet, Delta } from "../tree";
 
 export interface ChangeFamily<TEditor, TChange> {
     buildEditor(deltaReceiver: (delta: Delta.Root) => void, anchorSet: AnchorSet): TEditor;

--- a/packages/dds/tree/src/change-family/progressiveEditBuilder.ts
+++ b/packages/dds/tree/src/change-family/progressiveEditBuilder.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Delta } from "../changeset";
-import { AnchorSet } from "../tree";
+import { AnchorSet, Delta } from "../tree";
 import { ChangeFamily } from "./changeFamily";
 
 export abstract class ProgressiveEditBuilder<TChange> {

--- a/packages/dds/tree/src/changeset/index.ts
+++ b/packages/dds/tree/src/changeset/index.ts
@@ -7,10 +7,6 @@
  * This module contains the changeset format and related operations.
  */
 
-// Split this up into seperate import and export for compatibility with API-Extractor.
-import * as Delta from "./delta";
-export { Delta };
-
 export * from "./format";
 export * from "./toDelta";
 export * from "./visit";

--- a/packages/dds/tree/src/changeset/toDelta.ts
+++ b/packages/dds/tree/src/changeset/toDelta.ts
@@ -5,8 +5,7 @@
 
 import { unreachableCase } from "@fluidframework/common-utils";
 import { brand, clone, fail, OffsetListFactory } from "../util";
-import { FieldKey, Value } from "../tree";
-import * as Delta from "./delta";
+import { FieldKey, Value, Delta } from "../tree";
 import { ProtoNode, Transposed as T } from "./format";
 
 /**

--- a/packages/dds/tree/src/changeset/visit.ts
+++ b/packages/dds/tree/src/changeset/visit.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKey, Value } from "../tree";
+import { FieldKey, Value, Delta } from "../tree";
 import { fail, unreachableCase } from "../util";
-import * as Delta from "./delta";
 
 /**
  * Implementation notes:

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -17,8 +17,7 @@ import {
 } from "../forest";
 import { Index, SummaryElement } from "../shared-tree-core";
 import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
-import { Delta } from "../changeset";
-import { PlaceholderTree } from "../tree";
+import { PlaceholderTree, Delta } from "../tree";
 import { applyDeltaToForest } from "../transaction";
 import { placeholderTreeFromCursor, TextCursor } from "./treeTextCursor";
 

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeFamily.ts
@@ -4,8 +4,7 @@
  */
 
 import { ChangeFamily } from "../../change-family";
-import { Delta } from "../../changeset";
-import { AnchorSet } from "../../tree";
+import { AnchorSet, Delta } from "../../tree";
 import { sequenceChangeRebaser } from "./sequenceChangeRebaser";
 import { SequenceChangeset } from "./sequenceChangeset";
 import { SequenceEditBuilder } from "./sequenceEditBuilder";

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
@@ -4,9 +4,8 @@
  */
 
 import { ProgressiveEditBuilder } from "../../change-family";
-import { Delta } from "../../changeset";
 import { ITreeCursor } from "../../forest";
-import { AnchorSet, UpPath, Value } from "../../tree";
+import { AnchorSet, UpPath, Value, Delta } from "../../tree";
 import { sequenceChangeFamily } from "./sequenceChangeFamily";
 import { SequenceChangeset } from "./sequenceChangeset";
 

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -12,6 +12,7 @@ export {
     EmptyKey, FieldKey, TreeType, Value, TreeValue, AnchorSet, DetachedRange,
     PathShared, UpPath, Anchor, RootRange, PathCollection, PathNode, ChildCollection,
     ChildLocation, FieldMap, NodeData, GenericTreeNode, PlaceholderTree, JsonableTree,
+    Delta,
 } from "./tree";
 
 export { ITreeCursor, TreeNavigationResult, IEditableForest,
@@ -53,10 +54,6 @@ export {
     FinalFromChangeRebaser,
     ChangeSetFromChangeRebaser,
 } from "./rebase";
-
-export {
-    Delta,
-} from "./changeset";
 
 export {
     cursorToJsonObject,

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -9,9 +9,9 @@ import {
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ITelemetryContext, ISummaryTreeWithStats, IGarbageCollectionData } from "@fluidframework/runtime-definitions";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
-import { Delta, toDelta } from "../changeset";
+import { toDelta } from "../changeset";
 import { ChangeRebaser, FinalFromChangeRebaser, Rebaser, RevisionTag } from "../rebase";
-import { AnchorSet } from "../tree";
+import { AnchorSet, Delta } from "../tree";
 import { fail } from "../util";
 import { LazyPageTree } from "./lazyPageTree";
 

--- a/packages/dds/tree/src/test/changeset/toDelta.spec.ts
+++ b/packages/dds/tree/src/test/changeset/toDelta.spec.ts
@@ -6,12 +6,11 @@
 import { strict as assert } from "assert";
 import { TreeSchemaIdentifier } from "../..";
 import {
-    Delta,
     ProtoNode,
     toDelta as toDeltaImpl,
     Transposed as T,
 } from "../../changeset";
-import { FieldKey } from "../../tree";
+import { FieldKey, Delta } from "../../tree";
 import { brand } from "../../util";
 import { deepFreeze } from "../utils";
 

--- a/packages/dds/tree/src/test/changeset/visit.spec.ts
+++ b/packages/dds/tree/src/test/changeset/visit.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "assert";
 import { jsonString } from "../..";
-import { Delta, DeltaVisitor, visitDelta } from "../../changeset";
-import { FieldKey } from "../../tree";
+import { DeltaVisitor, visitDelta } from "../../changeset";
+import { FieldKey, Delta } from "../../tree";
 import { brandOpaque } from "../../util";
 import { deepFreeze } from "../utils";
 

--- a/packages/dds/tree/src/transaction/transaction.ts
+++ b/packages/dds/tree/src/transaction/transaction.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Delta } from "../changeset";
+import { Delta } from "../tree";
 import { IEditableForest, IForestSubscription } from "../forest";
 import { ChangeFamily, ProgressiveEditBuilder } from "../change-family";
 

--- a/packages/dds/tree/src/tree/delta.ts
+++ b/packages/dds/tree/src/tree/delta.ts
@@ -4,8 +4,9 @@
  */
 
 import { unreachableCase } from "@fluidframework/common-utils";
-import { FieldKey, JsonableTree, Value } from "../tree";
 import { Brand, Opaque } from "../util";
+import { FieldKey, Value } from "./types";
+import { JsonableTree } from "./treeTextFormat";
 
 /**
  * This format describes changes that must be applied to a document tree in order to update it.

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -18,3 +18,7 @@ export {
 export * from "./pathTree";
 export * from "./anchorSet";
 export * from "./treeTextFormat";
+
+// Split this up into separate import and export for compatibility with API-Extractor.
+import * as Delta from "./delta";
+export { Delta };


### PR DESCRIPTION
## Description

Move `delta` to `tree`. This will enable changing the forest editing API to just take a delta.
