### PR TITLE
Hardcode default snapshotCacheExpiryMs to unblock Sweep logging (GCObjectDeleted event)

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -503,7 +503,7 @@ export class GarbageCollector implements IGarbageCollector {
                 (timer) => { this.sessionExpiryTimer = timer; },
             );
 
-            // TEMPORARY: Default to 2 days which is the value used in the ODSP driver.
+            // TEMPORARY: Hardcode a default of 2 days which is the value used in the ODSP driver.
             // This unblocks the Sweep Log (see logSweepEvents function).
             // This will be removed before sweep is fully implemented.
             const snapshotCacheExpiryMs = createParams.snapshotCacheExpiryMs ?? 2 * 24 * 60 * 60 * 1000;
@@ -543,7 +543,7 @@ export class GarbageCollector implements IGarbageCollector {
          * 3. Sweep should be enabled for this container (this.sweepEnabled). This can be overridden via runSweep
          *    feature flag.
          */
-        this.shouldRunSweep = false; // Until TEMPORARY measure above hardcoding snapshotCacheExpiryMs is removed, disable
+        this.shouldRunSweep = false; // disable while TEMPORARY measure hardcoding snapshotCacheExpiryMs is here
             // this.shouldRunGC
             // && this.sweepTimeoutMs !== undefined
             // && (this.mc.config.getBoolean(runSweepKey) ?? this.sweepEnabled);

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -63,7 +63,7 @@ export const gcBlobPrefix = "__gc";
 // Feature gate key to turn GC on / off.
 const runGCKey = "Fluid.GarbageCollection.RunGC";
 // Feature gate key to turn GC sweep on / off.
-const runSweepKey = "Fluid.GarbageCollection.RunSweep";
+// const runSweepKey = "Fluid.GarbageCollection.RunSweep";
 // Feature gate key to turn GC test mode on / off.
 const gcTestModeKey = "Fluid.GarbageCollection.GCTestMode";
 // Feature gate key to write GC data at the root of the summary tree.


### PR DESCRIPTION
Before he left Navin added the GCObjectDeleted event to log when an object would be deleted by Sweep.  But it will never run because sweepTimeout will always be undefined because snapshotCacheExpiryMs is always undefined.

This overrides that, but also sets `shouldRunSweep` to false, until this temporary measure is removed.