### PR TITLE
Tree: use Delta directly in IEditableForest

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -213,14 +213,10 @@ export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKe
 
 // @public
 export interface IEditableForest extends IForestSubscription {
-    add(nodes: Iterable<ITreeCursor>): DetachedRange;
     readonly anchors: AnchorSet;
-    attachRangeOfChildren(destination: TreeLocation, toAttach: DetachedRange): void;
-    delete(ids: DetachedRange): void;
-    detachRangeOfChildren(range: FieldLocation | DetachedRange, startIndex: number, endIndex: number): DetachedRange;
+    applyDelta(delta: Delta.Root): void;
     // (undocumented)
     readonly schema: StoredSchemaRepository;
-    setValue(nodeId: ForestLocation, value: Value): void;
 }
 
 // @public

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -164,7 +164,6 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
         const placeholderTree = JSON.parse(decodedtree) as PlaceholderTree[];
 
         // TODO: maybe assert forest is empty?
-        // TODO: is this the correct delta?
         const insert: Delta.Insert = { type: Delta.MarkType.Insert, content: placeholderTree };
         this.forest.applyDelta([insert]);
 

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -18,8 +18,7 @@ import {
 import { Index, SummaryElement } from "../shared-tree-core";
 import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
 import { PlaceholderTree, Delta } from "../tree";
-import { applyDeltaToForest } from "../transaction";
-import { placeholderTreeFromCursor, TextCursor } from "./treeTextCursor";
+import { placeholderTreeFromCursor } from "./treeTextCursor";
 
 /**
  * Index which provides an editable forest for the current state for the document.
@@ -65,7 +64,7 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
     }
 
     newLocalState(changeDelta: Delta.Root): void {
-        applyDeltaToForest(this.forest, changeDelta);
+        this.forest.applyDelta(changeDelta);
     }
 
     /**
@@ -165,9 +164,9 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
         const placeholderTree = JSON.parse(decodedtree) as PlaceholderTree[];
 
         // TODO: maybe assert forest is empty?
-        const range = this.forest.add(placeholderTree.map((t) => new TextCursor(t)));
-        const dst = { index: 0, range: this.forest.rootField };
-        this.forest.attachRangeOfChildren(dst, range);
+        // TODO: is this the correct delta?
+        const insert: Delta.Insert = { type: Delta.MarkType.Insert, content: placeholderTree };
+        this.forest.applyDelta([insert]);
 
         // TODO: use decodedSchema to initialize forest.schema
         throw new Error("Method not implemented.");

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -16,7 +16,7 @@ import {
     mapCursorField,
 } from "../../forest";
 import { StoredSchemaRepository } from "../../schema";
-import { FieldKey, TreeType, DetachedRange, AnchorSet, Value } from "../../tree";
+import { FieldKey, TreeType, DetachedRange, AnchorSet, Value, Delta } from "../../tree";
 import { brand, fail } from "../../util";
 
 export class ObjectForest extends SimpleDependee implements IEditableForest {
@@ -38,6 +38,10 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         this.roots.set(this.rootField, []);
         // Invalidate forest if schema change.
         recordDependency(this.dependent, this.schema);
+    }
+
+    applyDelta(delta: Delta.Root): void {
+        throw new Error("Method not implemented.");
     }
 
     public observeItem(item: ObjectField | ObjectNode, observer: ObservingDependent | undefined): void {

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -4,26 +4,13 @@
  */
 
 import { StoredSchemaRepository } from "../schema";
-import { AnchorSet, FieldKey, DetachedRange, Value } from "../tree";
-import { ITreeCursor } from "./cursor";
+import { AnchorSet, FieldKey, DetachedRange, Delta } from "../tree";
 import { IForestSubscription, ITreeSubscriptionCursor, ForestAnchor } from "./forest";
 
 /**
- * Ways to refer to a node in an IEditableForest.
- */
- export type ForestLocation = ITreeSubscriptionCursor | ForestAnchor;
-
-/**
  * Editing APIs.
- *
- * These are sufficient to perform all possible edits,
- * but not particularly efficient (for large slice moves), or semantic.
- * They are also not particularly type safe (ex: you can pass a parented nodes into attach, which is invalid).
- *
- * TODO: improve these APIs, addressing the above.
  */
 export interface IEditableForest extends IForestSubscription {
-
     // Overrides field from IForestSubscription adding editing support.
     readonly schema: StoredSchemaRepository;
 
@@ -38,45 +25,18 @@ export interface IEditableForest extends IForestSubscription {
     readonly anchors: AnchorSet;
 
     /**
-     * Adds the supplied subtrees to the forest.
-     * @param nodes - the sequence of nodes to add to the forest.
-     *
-     * TODO: there should be a way to include existing detached ranges in the inserted trees.
+     * Applies the supplied Delta to the forest.
+     * Does NOT update anchors.
      */
-    add(nodes: Iterable<ITreeCursor>): DetachedRange;
-
-    /**
-     * Parents a set of nodes already in the forest at a specified location.
-     */
-    attachRangeOfChildren(
-        destination: TreeLocation,
-        toAttach: DetachedRange,
-    ): void;
-
-    /**
-     * Detaches a range of nodes from their parent. The detached nodes remain in the `Forest`.
-     * @param startIndex - the index of the first node in the range to detach
-     * @param endIndex - the index after the last node in the range to detach
-     * @returns a new `Forest` with the nodes detached, and a list of the ids of the nodes that were detached
-     */
-    detachRangeOfChildren(
-        range: FieldLocation | DetachedRange,
-        startIndex: number,
-        endIndex: number
-    ): DetachedRange;
-
-    /**
-     * Replaces a node's value. The node must exist in this `Forest`.
-     * @param nodeId - the id of the node
-     * @param value - the new value
-     */
-    setValue(nodeId: ForestLocation, value: Value): void;
-
-    /**
-     * Recursively deletes a range and its children.
-     */
-    delete(ids: DetachedRange): void;
+    applyDelta(delta: Delta.Root): void;
 }
+
+// TODO: Types below here may be useful for input into edit building APIs, but are no longer used here directly.
+
+/**
+ * Ways to refer to a node in an IEditableForest.
+ */
+ export type ForestLocation = ITreeSubscriptionCursor | ForestAnchor;
 
 export interface TreeLocation {
     readonly range: FieldLocation | DetachedRange;

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -13,15 +13,17 @@ import {
     fieldSchema, rootFieldKey,
     isNeverField, FieldKind,
 } from "../schema";
-import { IEditableForest, TreeNavigationResult } from "../forest";
+import { TreeNavigationResult } from "../forest";
 import { JsonCursor, cursorToJsonObject, jsonTypeSchema } from "../domains";
-import { recordDependency, SimpleObservingDependent } from "../dependency-tracking";
+import { recordDependency } from "../dependency-tracking";
 import { MockDependent } from "./utils";
 
 /**
  * Generic forest test suite
  */
-function testForest(suiteName: string, factory: () => IEditableForest): void {
+// TODO: when ObjectForest can apply deltas correctly
+// update these tests to use Delta, and apply to IEditableForest instead of just ObjectForest.
+function testForest(suiteName: string, factory: () => ObjectForest): void {
     describe(suiteName, () => {
         // Use Json Cursor to insert and extract some Json data
         describe("insert and extract json", () => {

--- a/packages/dds/tree/src/transaction/index.ts
+++ b/packages/dds/tree/src/transaction/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { runSynchronousTransaction, applyDeltaToForest } from "./transaction";
+export { runSynchronousTransaction } from "./transaction";

--- a/packages/dds/tree/src/transaction/transaction.ts
+++ b/packages/dds/tree/src/transaction/transaction.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Delta } from "../tree";
 import { IEditableForest, IForestSubscription } from "../forest";
 import { ChangeFamily, ProgressiveEditBuilder } from "../change-family";
 
@@ -22,7 +21,7 @@ class Transaction<
 > {
     public readonly editor: TEditor;
     constructor(private readonly forest: IEditableForest, changeFamily: ChangeFamily<TEditor, TChange>) {
-        this.editor = changeFamily.buildEditor((delta) => applyDeltaToForest(this.forest, delta), forest.anchors);
+        this.editor = changeFamily.buildEditor((delta) => this.forest.applyDelta(delta), forest.anchors);
     }
 }
 
@@ -44,7 +43,7 @@ export function runSynchronousTransaction<TEditor extends ProgressiveEditBuilder
         // TODO: maybe unify logic to edit forest and its anchors here with that in ProgressiveEditBuilder.
         // TODO: update schema in addition to anchors and tree data (in both places).
         checkout.changeFamily.rebaser.rebaseAnchors(checkout.forest.anchors, inverse);
-        applyDeltaToForest(checkout.forest, checkout.changeFamily.intoDelta(inverse));
+        checkout.forest.applyDelta(checkout.changeFamily.intoDelta(inverse));
 
         return result;
     }
@@ -52,13 +51,6 @@ export function runSynchronousTransaction<TEditor extends ProgressiveEditBuilder
     checkout.submitEdit(edit);
 
     return result;
-}
-
-/**
- * Does NOT update anchors.
- */
-export function applyDeltaToForest(forest: IEditableForest, delta: Delta.Root) {
-    // TODO
 }
 
 enum CommandResult {


### PR DESCRIPTION
## Description

Edit forests directly with deltas.

This saves a conversion step, and simplifies the API surface.