### PR TITLE
Use JsonableTree in ObjectForest

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -309,6 +309,9 @@ export enum ITreeSubscriptionCursorState {
 export interface JsonableTree extends PlaceholderTree {
 }
 
+// @public
+export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree;
+
 // @public (undocumented)
 export const jsonArray: NamedTreeSchema;
 
@@ -545,9 +548,6 @@ export class PathShared<TParent extends ChildCollection = ChildCollection> imple
 export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
 
 // @public
-export function placeholderTreeFromCursor(cursor: ITreeCursor): PlaceholderTree;
-
-// @public
 type ProtoNode = JsonableTree;
 
 // @public
@@ -634,15 +634,15 @@ export class StoredSchemaRepository extends SimpleDependee implements SchemaRepo
 
 // @public
 export class TextCursor implements ITreeCursor {
-    constructor(root: PlaceholderTree);
+    constructor(root: JsonableTree);
     // (undocumented)
     down(key: FieldKey, index: number): TreeNavigationResult;
     // (undocumented)
-    getField(key: FieldKey): readonly PlaceholderTree[];
+    getField(key: FieldKey): readonly JsonableTree[];
     // (undocumented)
-    getFields(): Readonly<FieldMap<PlaceholderTree>>;
+    getFields(): Readonly<FieldMap<JsonableTree>>;
     // (undocumented)
-    getNode(): PlaceholderTree;
+    getNode(): JsonableTree;
     // (undocumented)
     get keys(): Iterable<FieldKey>;
     // (undocumented)

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -18,7 +18,7 @@ import {
 import { Index, SummaryElement } from "../shared-tree-core";
 import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
 import { PlaceholderTree, Delta } from "../tree";
-import { placeholderTreeFromCursor } from "./treeTextCursor";
+import { jsonableTreeFromCursor } from "./treeTextCursor";
 
 /**
  * Index which provides an editable forest for the current state for the document.
@@ -81,7 +81,7 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
         const roots: PlaceholderTree[] = [];
         let result = this.forest.tryGet(rootAnchor, this.cursor);
         while (result === TreeNavigationResult.Ok) {
-            roots.push(placeholderTreeFromCursor(this.cursor));
+            roots.push(jsonableTreeFromCursor(this.cursor));
             result = this.cursor.seek(1).result;
         }
         this.cursor.clear();

--- a/packages/dds/tree/src/feature-libraries/object-forest/fence.json
+++ b/packages/dds/tree/src/feature-libraries/object-forest/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": [ "object-forest" ],
     "exports": [ "index"],
-    "imports": ["schema","tree","dependency-tracking","forest","util","rebase"]
+    "imports": ["schema","tree","dependency-tracking","forest","util","rebase","feature-libraries"]
 }

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -13,11 +13,14 @@ import {
     ITreeSubscriptionCursorState,
     TreeNavigationResult,
     FieldLocation, TreeLocation, isFieldLocation,
-    mapCursorField,
 } from "../../forest";
 import { StoredSchemaRepository } from "../../schema";
-import { FieldKey, TreeType, DetachedField, AnchorSet, Value, Delta } from "../../tree";
+import {
+    FieldKey, TreeType, DetachedField, AnchorSet,
+    Value, Delta, JsonableTree, getGenericTreeField, FieldMap,
+} from "../../tree";
 import { brand, fail } from "../../util";
+import { jsonableTreeFromCursor } from "../treeTextCursor";
 
 export class ObjectForest extends SimpleDependee implements IEditableForest {
     private readonly dependent = new SimpleObservingDependent(() => this.invalidateDependents());
@@ -28,7 +31,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
 
     private readonly roots: Map<DetachedField, ObjectField> = new Map();
 
-    private readonly dependees: Map<ObjectField | ObjectNode, DisposingDependee> = new Map();
+    private readonly dependees: Map<ObjectField | JsonableTree, DisposingDependee> = new Map();
 
     // All cursors that are in the "Current" state. Must be empty when editing.
     public readonly currentCursors: Set<Cursor> = new Set();
@@ -44,7 +47,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         throw new Error("Method not implemented.");
     }
 
-    public observeItem(item: ObjectField | ObjectNode, observer: ObservingDependent | undefined): void {
+    public observeItem(item: ObjectField | JsonableTree, observer: ObservingDependent | undefined): void {
         let result = this.dependees.get(item);
         if (result === undefined) {
             result = new DisposingDependee("ObjectForest item");
@@ -75,7 +78,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         this.beforeChange();
         const range = this.newRange();
         assert(!this.roots.has(range), "new range must not already exist");
-        const field: ObjectField = Array.from(nodes, nodeFromCursor);
+        const field: ObjectField = Array.from(nodes, jsonableTreeFromCursor);
         this.roots.set(range, field);
         return range;
     }
@@ -97,18 +100,8 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         if (!isFieldLocation(range)) {
             return this.getRoot(range);
         } else {
-            const children = this.lookupNodeId(range.parent).fields;
-            const field = children.get(range.key);
-            if (field !== undefined) {
-                    return field;
-            }
-            // Handle missing fields:
-            if (create === false) {
-                    return [];
-            }
-            const newField: ObjectField = [];
-            children.set(range.key, newField);
-            return newField;
+            const node = this.lookupNodeId(range.parent);
+            return getGenericTreeField(node, range.key, create);
         }
     }
 
@@ -172,9 +165,9 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         return TreeNavigationResult.NotFound;
     }
 
-    private lookupNodeId(id: ForestLocation): ObjectNode {
-        if (id instanceof ObjectNode) {
-            return id;
+    private lookupNodeId(id: ForestLocation): JsonableTree {
+        if (id instanceof Cursor) {
+            return id.getNode();
         }
 
         // TODO: this could be much more efficient (and not use cursor)
@@ -187,7 +180,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         return node;
     }
 
-    private search(destination: ObjectNode, cursor: Cursor): TreeNavigationResult {
+    private search(destination: JsonableTree, cursor: Cursor): TreeNavigationResult {
         if (cursor.getNode() === destination) {
             return TreeNavigationResult.Ok;
         }
@@ -222,15 +215,6 @@ function assertValidIndex(index: number, array: unknown[], allowOnePastEnd: bool
     }
 }
 
-export function nodeFromCursor(cursor: ITreeCursor): ObjectNode {
-    const node = new ObjectNode(cursor.type, cursor.value);
-    for (const key of cursor.keys) {
-        const field: ObjectField = mapCursorField(cursor, key, nodeFromCursor);
-        node.fields.set(key, field);
-    }
-    return node;
-}
-
 /**
  * Simple anchor that just points to a node object.
  * This results in pretty basic anchor rebase policy.
@@ -246,14 +230,14 @@ abstract class ObjectAnchor implements ForestAnchor {
      * Gets object node for anchor.
      * May return an object node thats no longer in the tree.
      */
-    abstract find(forest: ObjectForest, observer: ObservingDependent | undefined): ObjectNode | undefined;
+    abstract find(forest: ObjectForest, observer: ObservingDependent | undefined): JsonableTree | undefined;
 }
 
 class RootAnchor extends ObjectAnchor {
     constructor(public readonly range: DetachedField) {
         super();
     }
-    find(forest: ObjectForest, observer: ObservingDependent | undefined): ObjectNode | undefined {
+    find(forest: ObjectForest, observer: ObservingDependent | undefined): JsonableTree | undefined {
         const field = forest.getRoot(this.range);
         return field[0];
     }
@@ -264,29 +248,22 @@ class RootAnchor extends ObjectAnchor {
  * This results in pretty basic anchor rebase policy.
  */
 class NodeAnchor extends ObjectAnchor {
-    public constructor(public readonly node: ObjectNode) {
+    public constructor(public readonly node: JsonableTree) {
         super();
     }
 
-    find(forest: ObjectForest): ObjectNode | undefined {
+    find(forest: ObjectForest): JsonableTree | undefined {
         return this.node;
     }
 }
 
-class ObjectNode {
-    state: ITreeSubscriptionCursorState = ITreeSubscriptionCursorState.Current;
-    public readonly fields: Map<FieldKey, ObjectField> = new Map();
-    public constructor(public type: TreeType, public value: Value = undefined) { }
-    free(): void {
-        assert(this.state !== ITreeSubscriptionCursorState.Freed, 0x33a /* Anchor must not be double freed */);
-        this.state = ITreeSubscriptionCursorState.Freed;
-    }
-}
-
-type ObjectField = ObjectNode[];
+type ObjectField = JsonableTree[];
 
 /**
  * TODO: track observations.
+ *
+ * TODO: TextCursor is mostly a subset of this functionality.
+ * Maybe do a refactoring to deduplicate this.
  */
 class Cursor implements ITreeSubscriptionCursor {
     state: ITreeSubscriptionCursorState = ITreeSubscriptionCursorState.Cleared;
@@ -299,13 +276,13 @@ class Cursor implements ITreeSubscriptionCursor {
     private root: DetachedField | undefined;
 
     // Ancestors traversed to visit this node (including this node).
-    private readonly parentStack: ObjectNode[] = [];
+    private readonly parentStack: JsonableTree[] = [];
     // Keys traversed to visit this node
     private readonly keyStack: FieldKey[] = [];
     // Indices traversed to visit this node
     private readonly indexStack: number[] = [];
 
-    private siblings?: readonly ObjectNode[];
+    private siblings?: readonly JsonableTree[];
 
     public clear(): void {
         assert(this.state !== ITreeSubscriptionCursorState.Freed, 0x33b /* Cursor must not be freed */);
@@ -329,10 +306,21 @@ class Cursor implements ITreeSubscriptionCursor {
         this.forest.currentCursors.add(this);
     }
 
-    getNode(): ObjectNode {
+    getNode(): JsonableTree {
         assert(this.state === ITreeSubscriptionCursorState.Current, 0x33d /* Cursor must be current to be used */);
         assert(this.parentStack.length > 0, 0x33e /* Cursor must be current to be used */);
         return this.parentStack[this.parentStack.length - 1];
+    }
+
+    getFields(): Readonly<FieldMap<JsonableTree>> {
+        return this.getNode().fields ?? {};
+    }
+
+    getField(key: FieldKey): readonly JsonableTree[] {
+        // Save result to a constant to work around linter bug:
+        // https://github.com/typescript-eslint/typescript-eslint/issues/5014
+        const field: readonly JsonableTree[] = this.getFields()[key as string] ?? [];
+        return field;
     }
 
     get value(): Value {
@@ -343,7 +331,7 @@ class Cursor implements ITreeSubscriptionCursor {
         return this.getNode().type;
     }
     get keys(): Iterable<FieldKey> {
-        return this.getNode().fields.keys();
+        return Object.getOwnPropertyNames(this.getFields()) as Iterable<FieldKey>;
     }
 
     fork(observer?: ObservingDependent | undefined): ITreeSubscriptionCursor {
@@ -357,7 +345,7 @@ class Cursor implements ITreeSubscriptionCursor {
         return new NodeAnchor(this.getNode());
     }
     down(key: FieldKey, index: number): TreeNavigationResult {
-        const siblings = (this.getNode().fields.get(key) ?? []);
+        const siblings = this.getField(key);
         const child = siblings[index];
         if (child !== undefined) {
             this.parentStack.push(child);
@@ -382,7 +370,6 @@ class Cursor implements ITreeSubscriptionCursor {
         return { result: TreeNavigationResult.NotFound, moved: 0 };
     }
     up(): TreeNavigationResult {
-        assert(this.state === ITreeSubscriptionCursorState.Current, 0x341 /* Cursor must be current to be used */);
         if (this.parentStack.length === 0) {
             return TreeNavigationResult.NotFound;
         }
@@ -391,14 +378,15 @@ class Cursor implements ITreeSubscriptionCursor {
         this.keyStack.pop();
         // TODO: maybe compute siblings lazily or store in stack? Store instead of keyStack?
         this.siblings = this.parentStack.length === 0 ?
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.forest.getRoot(this.root!) :
-            this.parentStack[this.parentStack.length - 1].fields.get(this.keyStack[this.keyStack.length - 1]);
+            (this.parentStack[this.parentStack.length - 1].fields ?? {}
+                )[this.keyStack[this.keyStack.length - 1] as string];
         return TreeNavigationResult.Ok;
     }
 
     length(key: FieldKey): number {
-        return (this.getNode().fields.get(key) ?? []).length;
+        return this.getField(key).length;
     }
 }
 

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -11,7 +11,7 @@ import {
 import {
     FieldKey,
     FieldMap,
-    PlaceholderTree,
+    JsonableTree,
     TreeType,
     Value,
 } from "../tree";
@@ -35,46 +35,46 @@ import {
  * Note:
  * Currently a lot of Tree's codebase is using json for serialization.
  * Because putting json strings inside json works poorly (adds lots of escaping),
- * for now this library actually outputs and inputs the Json compatible type PlaceholderTree
+ * for now this library actually outputs and inputs the Json compatible type JsonableTree
  * rather than actual strings.
  */
 
 /**
- * An ITreeCursor implementation for PlaceholderTree.
+ * An ITreeCursor implementation for JsonableTree.
  *
  * TODO: object-forest's cursor is mostly a superset of this functionality.
  * Maybe do a refactoring to deduplicate this.
  */
 export class TextCursor implements ITreeCursor {
     // Ancestors traversed to visit this node (including this node).
-    private readonly parentStack: PlaceholderTree[] = [];
+    private readonly parentStack: JsonableTree[] = [];
     // Keys traversed to visit this node
     private readonly keyStack: FieldKey[] = [];
     // Indices traversed to visit this node
     private readonly indexStack: number[] = [];
 
-    private siblings: readonly PlaceholderTree[];
-    private readonly root: readonly PlaceholderTree[];
+    private siblings: readonly JsonableTree[];
+    private readonly root: readonly JsonableTree[];
 
-    public constructor(root: PlaceholderTree) {
+    public constructor(root: JsonableTree) {
         this.root = [root];
         this.indexStack.push(0);
         this.siblings = this.root;
         this.parentStack.push(root);
     }
 
-    getNode(): PlaceholderTree {
+    getNode(): JsonableTree {
         return this.parentStack[this.parentStack.length - 1];
     }
 
-    getFields(): Readonly<FieldMap<PlaceholderTree>> {
+    getFields(): Readonly<FieldMap<JsonableTree>> {
         return this.getNode().fields ?? {};
     }
 
-    getField(key: FieldKey): readonly PlaceholderTree[] {
+    getField(key: FieldKey): readonly JsonableTree[] {
         // Save result to a constant to work around linter bug:
         // https://github.com/typescript-eslint/typescript-eslint/issues/5014
-        const field: readonly PlaceholderTree[] = this.getFields()[key as string] ?? [];
+        const field: readonly JsonableTree[] = this.getFields()[key as string] ?? [];
         return field;
     }
 
@@ -136,17 +136,17 @@ export class TextCursor implements ITreeCursor {
 }
 
 /**
- * Extract a PlaceholderTree from the contents of the given ITreeCursor's current node.
+ * Extract a JsonableTree from the contents of the given ITreeCursor's current node.
  */
-export function placeholderTreeFromCursor(cursor: ITreeCursor): PlaceholderTree {
-    let fields: FieldMap<PlaceholderTree> | undefined;
+export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree {
+    let fields: FieldMap<JsonableTree> | undefined;
     for (const key of cursor.keys) {
         fields ??= {};
-        const field: PlaceholderTree[] = mapCursorField(cursor, key, placeholderTreeFromCursor);
+        const field: JsonableTree[] = mapCursorField(cursor, key, jsonableTreeFromCursor);
         fields[key as string] = field;
     }
 
-    const node: PlaceholderTree = {
+    const node: JsonableTree = {
         type: cursor.type,
         value: cursor.value,
         fields,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -65,5 +65,5 @@ export {
 export {
     buildForest,
     TextCursor,
-    placeholderTreeFromCursor,
+    jsonableTreeFromCursor,
 } from "./feature-libraries";

--- a/packages/dds/tree/src/test/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/treeTextCursor.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
-import { placeholderTreeFromCursor, TextCursor } from "../feature-libraries/treeTextCursor";
+import { jsonableTreeFromCursor, TextCursor } from "../feature-libraries/treeTextCursor";
 
 import { PlaceholderTree } from "../tree";
 import { brand } from "../util";
@@ -23,7 +23,7 @@ describe("textTreeFormat", () => {
 		for (const [name, data] of testCases) {
 			it(name, () => {
 				const cursor = new TextCursor(data);
-				const clone = placeholderTreeFromCursor(cursor);
+				const clone = jsonableTreeFromCursor(cursor);
 				assert.deepEqual(clone, data);
 				// Check objects are actually json compatible
 				const text = JSON.stringify(clone);

--- a/packages/dds/tree/src/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/tree/treeTextFormat.ts
@@ -4,7 +4,7 @@
  */
 
 import { TreeSchemaIdentifier } from "../schema";
-import { TreeValue } from "./types";
+import { FieldKey, TreeValue } from "./types";
 
 /**
  * This modules provides a simple human readable (and editable) tree format.
@@ -73,3 +73,46 @@ export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderT
  * Can be passed to `JSON.stringify()` to produce a human-readable/editable JSON tree.
  */
 export interface JsonableTree extends PlaceholderTree {}
+
+/**
+ * Get a field from `node`, optionally modifying the tree to create it if missing.
+ */
+export function getGenericTreeField<T>(node: GenericTreeNode<T>, key: FieldKey, createIfMissing: boolean): T[] {
+    const children = getGenericTreeFieldMap(node, createIfMissing);
+
+    const field = children[key as string];
+    if (field !== undefined) {
+        return field;
+    }
+    // Handle missing field:
+    if (createIfMissing === false) {
+        return [];
+    }
+    const newField: T[] = [];
+    children[key as string] = newField;
+    return newField;
+}
+
+/**
+ * Get a FieldMap from `node`, optionally modifying the tree to create it if missing.
+ */
+ export function getGenericTreeFieldMap<T>(node: GenericTreeNode<T>, createIfMissing: boolean): FieldMap<T> {
+    let children = node.fields;
+    if (children === undefined) {
+        children = {};
+        // Handle missing fields:
+        if (createIfMissing) {
+            node.fields = children;
+        }
+    }
+
+    return children;
+}
+
+/**
+ * Sets a field on `node`.
+ */
+export function setGenericTreeField<T>(node: GenericTreeNode<T>, key: FieldKey, content: T[]): void {
+    const children = getGenericTreeFieldMap(node, true);
+    children[key as string] = content;
+}


### PR DESCRIPTION
This reduces the number of types needed in the codebase, and allows more sharing of functions