### PR TITLE
Bypass cache during refreshLatestSummaryAck from storage

### DIFF
--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -153,7 +153,7 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
     downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
     getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
-    getVersions(versionId: string | null, count: number, scenarioName?: string): Promise<IVersion[]>;
+    getVersions(versionId: string | null, count: number, scenarioName?: string, bypassCache?: boolean): Promise<IVersion[]>;
     readonly policies?: IDocumentStorageServicePolicies;
     readBlob(id: string): Promise<ArrayBufferLike>;
     // (undocumented)

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -60,6 +60,14 @@ export interface DriverPreCheckInfo {
 }
 
 // @public (undocumented)
+export enum FetchSource {
+    // (undocumented)
+    default = "default",
+    // (undocumented)
+    noCache = "noCache"
+}
+
+// @public (undocumented)
 export interface IAuthorizationError extends IDriverErrorBase {
     // (undocumented)
     readonly claims?: string;
@@ -153,7 +161,7 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
     downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
     getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
-    getVersions(versionId: string | null, count: number, scenarioName?: string, bypassCache?: boolean): Promise<IVersion[]>;
+    getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;
     readonly policies?: IDocumentStorageServicePolicies;
     readBlob(id: string): Promise<ArrayBufferLike>;
     // (undocumented)

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -151,7 +151,7 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
     // (undocumented)
     getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
     // (undocumented)
-    getVersions(versionId: string | null, count: number, scenarioName?: string): Promise<IVersion[]>;
+    getVersions(versionId: string | null, count: number, scenarioName?: string, bypassCache?: boolean): Promise<IVersion[]>;
     // (undocumented)
     protected readonly internalStorageService: IDocumentStorageService;
     set policies(policies: IDocumentStorageServicePolicies | undefined);

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { DriverErrorType } from '@fluidframework/driver-definitions';
+import { FetchSource } from '@fluidframework/driver-definitions';
 import { IAuthorizationError } from '@fluidframework/driver-definitions';
 import { ICommittedProposal } from '@fluidframework/protocol-definitions';
 import { ICreateBlobResponse } from '@fluidframework/protocol-definitions';
@@ -151,7 +152,7 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
     // (undocumented)
     getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
     // (undocumented)
-    getVersions(versionId: string | null, count: number, scenarioName?: string, bypassCache?: boolean): Promise<IVersion[]>;
+    getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;
     // (undocumented)
     protected readonly internalStorageService: IDocumentStorageService;
     set policies(policies: IDocumentStorageServicePolicies | undefined);

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -129,15 +129,16 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
      * @param count - Number of the versions to be fetched.
      * @param scenarioName - scenario in which this api is called. This will be recorded by server and would help
      *  in debugging purposes to see why this call was made.
-     * @param bypassCache - Driver may choose to cache requests and serve data from cache. That will result in
-     *  stale info returned. Callers can disable this functionality by passing bypassCache = true and ensuring
-     *  that driver will return latest information from storage.
+     * @param fetchSource - Callers can specify the source of the response. For ex. Driver may choose to cache
+     *  requests and serve data from cache. That will result in stale info returned. Callers can disable this
+     *  functionality by passing fetchSource = noCache and ensuring that driver will return latest information
+     *  from storage.
      */
     getVersions(
         versionId: string | null,
         count: number,
         scenarioName?: string,
-        bypassCache?: boolean,
+        fetchSource?: FetchSource,
     ): Promise<IVersion[]>;
 
     /**
@@ -362,4 +363,9 @@ export interface ISummaryContext {
     readonly ackHandle: string | undefined;
 
     readonly referenceSequenceNumber: number;
+}
+
+export enum FetchSource {
+    default = "default",
+    noCache = "noCache",
 }

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -128,8 +128,10 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
      * @param versionId - Version id of the requested version.
      * @param count - Number of the versions to be fetched.
      * @param scenarioName - scenario in which this api is called. This will be recorded by server and would help
-     * @param bypassCache - True to bypass cache for getting versions and get it from the server.
-    *  in debugging purposes to see why this call was made.
+     *  in debugging purposes to see why this call was made.
+     * @param bypassCache - Driver may choose to cache requests and serve data from cache. That will result in
+     *  stale info returned. Callers can disable this functionality by passing bypassCache = true and ensuring
+     *  that driver will return latest information from storage.
      */
     getVersions(
         versionId: string | null,

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -128,9 +128,15 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
      * @param versionId - Version id of the requested version.
      * @param count - Number of the versions to be fetched.
      * @param scenarioName - scenario in which this api is called. This will be recorded by server and would help
-     *  in debugging purposes to see why this call was made.
+     * @param bypassCache - True to bypass cache for getting versions and get it from the server.
+    *  in debugging purposes to see why this call was made.
      */
-    getVersions(versionId: string | null, count: number, scenarioName?: string): Promise<IVersion[]>;
+    getVersions(
+        versionId: string | null,
+        count: number,
+        scenarioName?: string,
+        bypassCache?: boolean,
+    ): Promise<IVersion[]>;
 
     /**
      * Creates a blob out of the given buffer

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -237,9 +237,6 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
                     const props: GetVersionsTelemetryProps = {};
                     let retrievedSnapshot: ISnapshotContents | undefined;
 
-                    // Based on the concurrentSnapshotFetch policy:
-                    // Either retrieve both the network and cache snapshots concurrently and pick the first to return,
-                    // or grab the cache value and then the network value if the cache value returns undefined.
                     let method: string;
                     if (bypassCache) {
                         retrievedSnapshot = await this.fetchSnapshot(hostSnapshotOptions, scenarioName);
@@ -274,6 +271,9 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
                                 return snapshotCachedEntry;
                             });
 
+                        // Based on the concurrentSnapshotFetch policy:
+                        // Either retrieve both the network and cache snapshots concurrently and pick the first to return,
+                        // or grab the cache value and then the network value if the cache value returns undefined.
                         if (this.hostPolicy.concurrentSnapshotFetch && !this.hostPolicy.summarizerClient) {
                             const networkSnapshotP = this.fetchSnapshot(hostSnapshotOptions, scenarioName);
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -206,7 +206,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
         return super.getSnapshotTree(version, scenarioName);
     }
 
-    public async getVersions(blobid: string | null, count: number, scenarioName?: string): Promise<api.IVersion[]> {
+    public async getVersions(blobid: string | null, count: number, scenarioName?: string, bypassCache?: boolean): Promise<api.IVersion[]> {
         // Regular load workflow uses blobId === documentID to indicate "latest".
         if (blobid !== this.documentId && blobid) {
             // FluidFetch & FluidDebugger tools use empty sting to query for versions
@@ -232,14 +232,22 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
             const hostSnapshotOptions = this.hostPolicy.snapshotOptions;
             const odspSnapshotCacheValue: ISnapshotContents = await PerformanceEvent.timedExecAsync(
                 this.logger,
-                { eventName: "ObtainSnapshot" },
+                { eventName: "ObtainSnapshot", bypassCache },
                 async (event: PerformanceEvent) => {
                     const props: GetVersionsTelemetryProps = {};
                     let retrievedSnapshot: ISnapshotContents | undefined;
-                    // Here's the logic to grab the persistent cache snapshot implemented by the host
-                    // Epoch tracker is responsible for communicating with the persistent cache, handling epochs and cache versions
-                    const cachedSnapshotP: Promise<ISnapshotContents | undefined> =
-                        this.epochTracker.get(createCacheSnapshotKey(this.odspResolvedUrl))
+
+                    // Based on the concurrentSnapshotFetch policy:
+                    // Either retrieve both the network and cache snapshots concurrently and pick the first to return,
+                    // or grab the cache value and then the network value if the cache value returns undefined.
+                    let method: string;
+                    if (bypassCache) {
+                        retrievedSnapshot = await this.fetchSnapshot(hostSnapshotOptions, scenarioName);
+                        method = "network";
+                    } else {
+                        // Here's the logic to grab the persistent cache snapshot implemented by the host
+                        // Epoch tracker is responsible for communicating with the persistent cache, handling epochs and cache versions
+                        const cachedSnapshotP: Promise<ISnapshotContents | undefined> = this.epochTracker.get(createCacheSnapshotKey(this.odspResolvedUrl))
                             .then(async (snapshotCachedEntry: ISnapshotCachedEntry) => {
                                 if (snapshotCachedEntry !== undefined) {
                                     // If the cached entry does not contain the entry time, then assign it a default of 30 days old.
@@ -266,46 +274,43 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
                                 return snapshotCachedEntry;
                             });
 
-                    // Based on the concurrentSnapshotFetch policy:
-                    // Either retrieve both the network and cache snapshots concurrently and pick the first to return,
-                    // or grab the cache value and then the network value if the cache value returns undefined.
-                    let method: string;
-                    if (this.hostPolicy.concurrentSnapshotFetch && !this.hostPolicy.summarizerClient) {
-                        const networkSnapshotP = this.fetchSnapshot(hostSnapshotOptions, scenarioName);
+                        if (this.hostPolicy.concurrentSnapshotFetch && !this.hostPolicy.summarizerClient) {
+                            const networkSnapshotP = this.fetchSnapshot(hostSnapshotOptions, scenarioName);
 
-                        // Ensure that failures on both paths are ignored initially.
-                        // I.e. if cache fails for some reason, we will proceed with network result.
-                        // And vice versa - if (for example) client is offline and network request fails first, we
-                        // do want to attempt to succeed with cached data!
-                        const promiseRaceWinner = await promiseRaceWithWinner([
-                            cachedSnapshotP.catch(() => undefined),
-                            networkSnapshotP.catch(() => undefined),
-                        ]);
-                        retrievedSnapshot = promiseRaceWinner.value;
-                        method = promiseRaceWinner.index === 0 ? "cache" : "network";
+                            // Ensure that failures on both paths are ignored initially.
+                            // I.e. if cache fails for some reason, we will proceed with network result.
+                            // And vice versa - if (for example) client is offline and network request fails first, we
+                            // do want to attempt to succeed with cached data!
+                            const promiseRaceWinner = await promiseRaceWithWinner([
+                                cachedSnapshotP.catch(() => undefined),
+                                networkSnapshotP.catch(() => undefined),
+                            ]);
+                            retrievedSnapshot = promiseRaceWinner.value;
+                            method = promiseRaceWinner.index === 0 ? "cache" : "network";
 
-                        if (retrievedSnapshot === undefined) {
-                            // if network failed -> wait for cache ( then return network failure)
-                            // If cache returned empty or failed -> wait for network (success of failure)
-                            if (promiseRaceWinner.index === 1) {
-                                retrievedSnapshot = await cachedSnapshotP;
-                                method = "cache";
-                            }
                             if (retrievedSnapshot === undefined) {
-                                retrievedSnapshot = await networkSnapshotP;
-                                method = "network";
+                                // if network failed -> wait for cache ( then return network failure)
+                                // If cache returned empty or failed -> wait for network (success of failure)
+                                if (promiseRaceWinner.index === 1) {
+                                    retrievedSnapshot = await cachedSnapshotP;
+                                    method = "cache";
+                                }
+                                if (retrievedSnapshot === undefined) {
+                                    retrievedSnapshot = await networkSnapshotP;
+                                    method = "network";
+                                }
                             }
-                        }
-                    } else {
-                        // Note: There's a race condition here - another caller may come past the undefined check
-                        // while the first caller is awaiting later async code in this block.
+                        } else {
+                            // Note: There's a race condition here - another caller may come past the undefined check
+                            // while the first caller is awaiting later async code in this block.
 
-                        retrievedSnapshot = await cachedSnapshotP;
+                            retrievedSnapshot = await cachedSnapshotP;
 
-                        method = retrievedSnapshot !== undefined ? "cache" : "network";
+                            method = retrievedSnapshot !== undefined ? "cache" : "network";
 
-                        if (retrievedSnapshot === undefined) {
-                            retrievedSnapshot = await this.fetchSnapshot(hostSnapshotOptions, scenarioName);
+                            if (retrievedSnapshot === undefined) {
+                                retrievedSnapshot = await this.fetchSnapshot(hostSnapshotOptions, scenarioName);
+                            }
                         }
                     }
                     if (method === "network") {

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -6,6 +6,7 @@
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions";
 import {
+    FetchSource,
     IDocumentStorageService,
     IDocumentStorageServicePolicies,
     ISummaryContext,
@@ -69,9 +70,9 @@ export class ContainerStorageAdapter implements IDocumentStorageService {
         versionId: string | null,
         count: number,
         scenarioName?: string,
-        bypassCache?: boolean,
+        fetchSource?: FetchSource,
     ): Promise<IVersion[]> {
-        return this.storageGetter().getVersions(versionId, count, scenarioName, bypassCache);
+        return this.storageGetter().getVersions(versionId, count, scenarioName, fetchSource);
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -65,8 +65,13 @@ export class ContainerStorageAdapter implements IDocumentStorageService {
         return this.storageGetter().readBlob(id);
     }
 
-    public async getVersions(versionId: string | null, count: number, scenarioName?: string): Promise<IVersion[]> {
-        return this.storageGetter().getVersions(versionId, count, scenarioName);
+    public async getVersions(
+        versionId: string | null,
+        count: number,
+        scenarioName?: string,
+        bypassCache?: boolean,
+    ): Promise<IVersion[]> {
+        return this.storageGetter().getVersions(versionId, count, scenarioName, bypassCache);
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -54,9 +54,14 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
         );
     }
 
-    public async getVersions(versionId: string | null, count: number, scenarioName?: string): Promise<IVersion[]> {
+    public async getVersions(
+        versionId: string | null,
+        count: number,
+        scenarioName?: string,
+        bypassCache?: boolean,
+    ): Promise<IVersion[]> {
         return this.runWithRetry(
-            async () => this.internalStorageService.getVersions(versionId, count, scenarioName),
+            async () => this.internalStorageService.getVersions(versionId, count, scenarioName, bypassCache),
             "storage_getVersions",
         );
     }

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -6,6 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { GenericError } from "@fluidframework/container-utils";
 import {
+    FetchSource,
     IDocumentStorageService,
     IDocumentStorageServicePolicies,
     ISummaryContext,
@@ -58,10 +59,10 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
         versionId: string | null,
         count: number,
         scenarioName?: string,
-        bypassCache?: boolean,
+        fetchSource?: FetchSource,
     ): Promise<IVersion[]> {
         return this.runWithRetry(
-            async () => this.internalStorageService.getVersions(versionId, count, scenarioName, bypassCache),
+            async () => this.internalStorageService.getVersions(versionId, count, scenarioName, fetchSource),
             "storage_getVersions",
         );
     }

--- a/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    FetchSource,
     IDocumentStorageService,
     IDocumentStorageServicePolicies,
     ISummaryContext,
@@ -41,9 +42,9 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
         versionId: string | null,
         count: number,
         scenarioName?: string,
-        bypassCache?: boolean,
+        fetchSource?: FetchSource,
     ): Promise<IVersion[]> {
-        return this.internalStorageService.getVersions(versionId, count, scenarioName, bypassCache);
+        return this.internalStorageService.getVersions(versionId, count, scenarioName, fetchSource);
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {

--- a/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
@@ -37,8 +37,13 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
         return this.internalStorageService.getSnapshotTree(version, scenarioName);
     }
 
-    public async getVersions(versionId: string | null, count: number, scenarioName?: string): Promise<IVersion[]> {
-        return this.internalStorageService.getVersions(versionId, count, scenarioName);
+    public async getVersions(
+        versionId: string | null,
+        count: number,
+        scenarioName?: string,
+        bypassCache?: boolean,
+    ): Promise<IVersion[]> {
+        return this.internalStorageService.getVersions(versionId, count, scenarioName, bypassCache);
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -44,7 +44,7 @@ import {
     MonitoringContext,
     loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils";
-import { DriverHeader, IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
+import { DriverHeader, FetchSource, IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
 import { readAndParse, isUnpackedRuntimeMessage } from "@fluidframework/driver-utils";
 import {
     DataCorruptionError,
@@ -3134,7 +3134,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 eventName: "RefreshLatestSummaryGetSnapshot",
                 fetchLatest: true,
             },
-            true,
+            FetchSource.noCache,
         );
 
         const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
@@ -3155,7 +3155,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     private async fetchSnapshotFromStorage(
-        versionId: string | null, logger: ITelemetryLogger, event: ITelemetryGenericEvent, bypassCache?: boolean) {
+        versionId: string | null,
+        logger: ITelemetryLogger,
+        event: ITelemetryGenericEvent,
+        fetchSource?: FetchSource,
+    ) {
         return PerformanceEvent.timedExecAsync(
             logger, event, async (perfEvent: {
                 end: (arg0: {
@@ -3167,7 +3171,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const trace = Trace.start();
 
             const versions = await this.storage.getVersions(
-                versionId, 1, "refreshLatestSummaryAckFromServer", bypassCache);
+                versionId, 1, "refreshLatestSummaryAckFromServer", fetchSource);
             assert(!!versions && !!versions[0], 0x137 /* "Failed to get version from storage" */);
             stats.getVersionDuration = trace.trace().duration;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -44,7 +44,12 @@ import {
     MonitoringContext,
     loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils";
-import { DriverHeader, FetchSource, IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
+import {
+    DriverHeader,
+    FetchSource,
+    IDocumentStorageService,
+    ISummaryContext,
+} from "@fluidframework/driver-definitions";
 import { readAndParse, isUnpackedRuntimeMessage } from "@fluidframework/driver-utils";
 import {
     DataCorruptionError,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3131,9 +3131,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     private async refreshLatestSummaryAckFromServer(summaryLogger: ITelemetryLogger): Promise<number> {
         const snapshot = await this.fetchSnapshotFromStorage(null, summaryLogger, {
-            eventName: "RefreshLatestSummaryGetSnapshot",
-            fetchLatest: true,
-        });
+                eventName: "RefreshLatestSummaryGetSnapshot",
+                fetchLatest: true,
+            },
+            true,
+        );
 
         const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
         const snapshotRefSeq = await seqFromTree(snapshot, readAndParseBlob);
@@ -3153,7 +3155,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     private async fetchSnapshotFromStorage(
-        versionId: string | null, logger: ITelemetryLogger, event: ITelemetryGenericEvent) {
+        versionId: string | null, logger: ITelemetryLogger, event: ITelemetryGenericEvent, bypassCache?: boolean) {
         return PerformanceEvent.timedExecAsync(
             logger, event, async (perfEvent: {
                 end: (arg0: {
@@ -3164,7 +3166,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const stats: { getVersionDuration?: number; getSnapshotDuration?: number; } = {};
             const trace = Trace.start();
 
-            const versions = await this.storage.getVersions(versionId, 1);
+            const versions = await this.storage.getVersions(
+                versionId, 1, "refreshLatestSummaryAckFromServer", bypassCache);
             assert(!!versions && !!versions[0], 0x137 /* "Failed to get version from storage" */);
             stats.getVersionDuration = trace.trace().duration;
 


### PR DESCRIPTION
## Description
This is a bug I found during testing single commit summary. In the flow where we want to refresh the latest summary ack from server due to updating the info about parent summary handle, we call getVersion which could server the response from the cache. This will lead to not updating the latest info and the purpose will not be served.