### PR TITLE
Propagate disconnected reason during 'disconnected' event

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -229,7 +229,7 @@ export class PerformanceEvent {
 }
 
 // @public (undocumented)
-export function raiseConnectedEvent(logger: ITelemetryLogger, emitter: EventEmitter, connected: boolean, clientId?: string): void;
+export function raiseConnectedEvent(logger: ITelemetryLogger, emitter: EventEmitter, connected: boolean, clientId?: string, disconnectedReason?: string): void;
 
 // @public (undocumented)
 export function safeRaiseEvent(emitter: EventEmitter, logger: ITelemetryLogger, event: string, ...args: any[]): void;

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -29,15 +29,17 @@ export interface IConnectionStateHandlerInputs {
     connectionStateChanged: () => void;
 }
 
-/** A type that contains details pertaining to the connection state */
+/** 
+ * A type that contains details pertaining to the connection state 
+ */
 export type ConnectionStateDetails =
-| {
-    state: ConnectionState.Connected | ConnectionState.CatchingUp;
-}
-| {
-    state: ConnectionState.Disconnected;
-    reason?: string;
-};
+    | {
+        state: ConnectionState.Connected | ConnectionState.CatchingUp;
+    }
+    | {
+        state: ConnectionState.Disconnected;
+        reason?: string;
+    };
 
 const JoinOpTimeoutMs = 45000;
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1676,7 +1676,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.messageCountAfterDisconnection = 0;
         }
 
-        const state = this.connectionState === ConnectionState.Connected;
+        const connectionDetails = this.connectionStateHandler.connectionStateDetails;
+        const disconnectedReason =
+            connectionDetails.state === ConnectionState.Disconnected ? connectionDetails.reason : undefined;
+        const state = connectionDetails.state === ConnectionState.Connected;
 
         // Both protocol and context should not be undefined if we got so far.
 
@@ -1684,7 +1687,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.context.setConnectionState(state, this.clientId);
         }
         this.protocolHandler.setConnectionState(state, this.clientId);
-        raiseConnectedEvent(this.mc.logger, this, state, this.clientId);
+        raiseConnectedEvent(this.mc.logger, this, state, this.clientId, disconnectedReason);
 
         if (logOpsOnReconnect) {
             this.mc.logger.sendTelemetryEvent(

--- a/packages/utils/telemetry-utils/src/events.ts
+++ b/packages/utils/telemetry-utils/src/events.ts
@@ -27,12 +27,14 @@ export function raiseConnectedEvent(
     logger: ITelemetryLogger,
     emitter: EventEmitter,
     connected: boolean,
-    clientId?: string) {
+    clientId?: string,
+    disconnectedReason?: string,
+) {
     try {
         if (connected) {
             emitter.emit(connectedEventName, clientId);
         } else {
-            emitter.emit(disconnectedEventName);
+            emitter.emit(disconnectedEventName, disconnectedReason);
         }
     } catch (error) {
         logger.sendErrorEvent({ eventName: "RaiseConnectedEventError" }, error);


### PR DESCRIPTION
## Description

The container emits a `disconnected` event in event of a connection loss but it doesn't emit any additional details about why the connection was disconnected. This information is already available in the container in the form of `reason` and is also logged in Fluid Framework's telemetry but isn't accessible to the host that integrates with the Fluid Framework. 

This change propagates `reason` when a `disconnected` event is raised by the container. 

## Reviewer Guidance

We initially started off with passing the `reason` as an extra parameter through each of the methods being called as we progressed through the stack 
Here is the [draft PR for the alternative approach](https://github.com/microsoft/FluidFramework/pull/11261). 

The changes in the initial approach above were much more minor but it contrasted with a current design pattern. Currently, the `ConnectionState` is encapsulated within `ConnectionStateHandler` and the `Container` queries the `ConnectionStateHandler` to get the latest connection state in event of a request to propagateConnectionState(). [[Link to the specific location where this happens](https://github.com/microsoft/FluidFramework/blob/ff6850da29c168bfc68c392c5cb934a4855c50bc/packages/loader/container-loader/src/container.ts#L1647)]

Pair programmed with @markfields and introduced `ConnectionStateDetails` to ensure we follow the same design pattern.

## Does this introduce a breaking change?

No

## Other information or known dependencies

- The Microsoft Loop team is relying on this change to measure and improve connectivity reliability across Microsoft Loop experiences
- The **next steps** here would be to instrument in the host experience cases where we don't restore connection within an appropriate time and keep track of the disconnected reason that contribute to the loss of connection

