### PR TITLE
Whiteboard undo redo bug

### DIFF
--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -82,9 +82,7 @@ export function revert(
 				if (nodesBuilt !== undefined) {
 					if (nodesBuilt.length === 0) {
 						builtNodes.delete(source);
-						if (logger) {
-							logger.sendTelemetryEvent({ eventName: 'reverting insertion of empty traits' });
-						}
+						logger?.sendTelemetryEvent({ eventName: 'reverting insertion of empty traits' });
 						continue;
 					}
 					result.unshift(createInvertedInsert(change, nodesBuilt));
@@ -92,9 +90,7 @@ export function revert(
 				} else if (nodesDetached !== undefined) {
 					if (nodesDetached.length === 0) {
 						detachedNodes.delete(source);
-						if (logger) {
-							logger.sendTelemetryEvent({ eventName: 'reverting insertion of empty traits' });
-						}
+						logger?.sendTelemetryEvent({ eventName: 'reverting insertion of empty traits' });
 						continue;
 					}
 					result.unshift(createInvertedInsert(change, nodesDetached, true));
@@ -117,9 +113,7 @@ export function revert(
 				const { invertedDetach, detachedNodeIds } = invert;
 
 				if (detachedNodeIds.length === 0) {
-					if (logger) {
-						logger.sendTelemetryEvent({ eventName: 'reverting detachment of empty traits' });
-					}
+					logger?.sendTelemetryEvent({ eventName: 'reverting detachment of empty traits' });
 					continue;
 				}
 

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -72,8 +72,9 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const { source } = change;
 				const nodesBuilt = builtNodes.get(source);
 				const nodesDetached = detachedNodes.get(source);
-
-				if (nodesBuilt !== undefined) {
+                if (nodesBuilt.length === 0) {
+                    return undefined;
+                } else if (nodesBuilt !== undefined) {
 					result.unshift(createInvertedInsert(change, nodesBuilt));
 					builtNodes.delete(source);
 				} else if (nodesDetached !== undefined) {

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -199,6 +199,10 @@ function createInvertedDetach(
 	const { trait: referenceTrait } = start;
 	const nodes = viewBeforeChange.getTrait(referenceTrait);
 
+	if (nodes.length === 0) {
+		return undefined;
+	}
+
 	const startIndex = viewBeforeChange.findIndexWithinTrait(start);
 	const endIndex = viewBeforeChange.findIndexWithinTrait(end);
 	const detachedNodeIds: NodeId[] = nodes.slice(startIndex, endIndex);

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -52,6 +52,9 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const { destination, source } = change;
 				assert(!builtNodes.has(destination), `Cannot revert Build: destination is already used by a Build`);
 				assert(!detachedNodes.has(destination), `Cannot revert Build: destination is already used by a Detach`);
+				if (source.length === 0) {
+					continue;
+				}
 				builtNodes.set(
 					destination,
 					source.reduce((ids: NodeId[], curr: BuildNodeInternal) => {
@@ -73,15 +76,9 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const nodesBuilt = builtNodes.get(source);
 				const nodesDetached = detachedNodes.get(source);
 				if (nodesBuilt !== undefined) {
-					if (nodesBuilt.length === 0) {
-						return undefined;
-					}
 					result.unshift(createInvertedInsert(change, nodesBuilt));
 					builtNodes.delete(source);
 				} else if (nodesDetached !== undefined) {
-					if (nodesDetached.length === 0) {
-						return undefined;
-					}
 					result.unshift(createInvertedInsert(change, nodesDetached, true));
 					detachedNodes.delete(source);
 				} else {

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -52,9 +52,6 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const { destination, source } = change;
 				assert(!builtNodes.has(destination), `Cannot revert Build: destination is already used by a Build`);
 				assert(!detachedNodes.has(destination), `Cannot revert Build: destination is already used by a Detach`);
-				if (source.length === 0) {
-					continue;
-				}
 				builtNodes.set(
 					destination,
 					source.reduce((ids: NodeId[], curr: BuildNodeInternal) => {
@@ -76,9 +73,17 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const nodesBuilt = builtNodes.get(source);
 				const nodesDetached = detachedNodes.get(source);
 				if (nodesBuilt !== undefined) {
+					if (nodesBuilt.length === 0) {
+						builtNodes.delete(source);
+						continue;
+					}
 					result.unshift(createInvertedInsert(change, nodesBuilt));
 					builtNodes.delete(source);
 				} else if (nodesDetached !== undefined) {
+					if (nodesDetached.length === 0) {
+						detachedNodes.delete(source);
+						continue;
+					}
 					result.unshift(createInvertedInsert(change, nodesDetached, true));
 					detachedNodes.delete(source);
 				} else {
@@ -98,9 +103,9 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				}
 				const { invertedDetach, detachedNodeIds } = invert;
 
-                if (detachedNodeIds.length === 0) {
-                    continue;
-                }
+				if (detachedNodeIds.length === 0) {
+					continue;
+				}
 
 				if (destination !== undefined) {
 					if (builtNodes.has(destination) || detachedNodes.has(destination)) {

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -72,13 +72,13 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const { source } = change;
 				const nodesBuilt = builtNodes.get(source);
 				const nodesDetached = detachedNodes.get(source);
-                if (nodesBuilt !== undefined) {
+				if (nodesBuilt !== undefined) {
 					result.unshift(createInvertedInsert(change, nodesBuilt));
 					builtNodes.delete(source);
 				} else if (nodesDetached !== undefined) {
-                    if (nodesDetached.length === 0) {
-                        return undefined;
-                    }
+					if (nodesDetached.length === 0) {
+						return undefined;
+					}
 					result.unshift(createInvertedInsert(change, nodesDetached, true));
 					detachedNodes.delete(source);
 				} else {

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -98,6 +98,10 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				}
 				const { invertedDetach, detachedNodeIds } = invert;
 
+                if (detachedNodeIds.length === 0) {
+                    continue;
+                }
+
 				if (destination !== undefined) {
 					if (builtNodes.has(destination) || detachedNodes.has(destination)) {
 						// Malformed: destination was already used by a prior build or detach
@@ -200,10 +204,6 @@ function createInvertedDetach(
 	const { start, end } = rangeFromStableRange(viewBeforeChange, validatedSource);
 	const { trait: referenceTrait } = start;
 	const nodes = viewBeforeChange.getTrait(referenceTrait);
-
-	if (nodes.length === 0) {
-		return undefined;
-	}
 
 	const startIndex = viewBeforeChange.findIndexWithinTrait(start);
 	const endIndex = viewBeforeChange.findIndexWithinTrait(end);

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -72,12 +72,13 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const { source } = change;
 				const nodesBuilt = builtNodes.get(source);
 				const nodesDetached = detachedNodes.get(source);
-                if (nodesBuilt.length === 0) {
-                    return undefined;
-                } else if (nodesBuilt !== undefined) {
+                if (nodesBuilt !== undefined) {
 					result.unshift(createInvertedInsert(change, nodesBuilt));
 					builtNodes.delete(source);
 				} else if (nodesDetached !== undefined) {
+                    if (nodesDetached.length === 0) {
+                        return undefined;
+                    }
 					result.unshift(createInvertedInsert(change, nodesDetached, true));
 					detachedNodes.delete(source);
 				} else {

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -73,6 +73,9 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const nodesBuilt = builtNodes.get(source);
 				const nodesDetached = detachedNodes.get(source);
 				if (nodesBuilt !== undefined) {
+					if (nodesBuilt.length === 0) {
+						return undefined;
+					}
 					result.unshift(createInvertedInsert(change, nodesBuilt));
 					builtNodes.delete(source);
 				} else if (nodesDetached !== undefined) {

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -72,6 +72,7 @@ export function revert(changes: readonly ChangeInternal[], before: RevisionView)
 				const { source } = change;
 				const nodesBuilt = builtNodes.get(source);
 				const nodesDetached = detachedNodes.get(source);
+
 				if (nodesBuilt !== undefined) {
 					if (nodesBuilt.length === 0) {
 						builtNodes.delete(source);

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -29,8 +29,9 @@ import { getChangeNodeFromViewNode } from './SerializationUtilities';
  * @param changes - the changes for which to produce an inverse.
  * @param before - a view of the tree state before `changes` are/were applied - used as a basis for generating the inverse.
  * @returns if the changes could be reverted, a sequence of changes _r_ that will produce `before` if applied to a view _A_, where _A_ is the result of
- * applying `changes` to `before`. Applying _r_ to views other than _A_ is legal but may cause the changes to fail to apply or may
- * not be a true semantic inverse. If the changes could not be reverted given the state of `before`, returns undefined.
+ * applying `changes` to `before`. Note that the size of the array of reverted changes may not be the same as the input array, and may even be empty in cases where
+ * the view did not change. Applying _r_ to views other than _A_ is legal but may cause the changes to fail to apply or may not be a true semantic inverse.
+ * If the changes could not be reverted given the state of `before`, returns undefined.
  *
  * TODO: what should this do if `changes` fails to apply to `before`?
  * TODO:#68574: Pass a view that corresponds to the appropriate Fluid reference sequence number rather than the view just before

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -1509,7 +1509,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * @internal
 	 */
 	public revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined {
-		return revert(changes as unknown as readonly ChangeInternal[], before);
+		return revert(changes as unknown as readonly ChangeInternal[], before, this.logger);
 	}
 
 	/**

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -112,6 +112,21 @@ describe('revert', () => {
 		expect(result).to.have.lengthOf(0);
 	});
 
+    it('handles reverting the insert of an empty trait', () => {
+		const emptyTraitNodeId = 0 as DetachedSequenceId;
+		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
+		const emptyTraitInsert = ChangeInternal.insert(emptyTraitNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
+		const result = expectDefined(
+            revert(
+                [emptyTraitBuild, emptyTraitInsert],
+                testTree.view
+		    )
+        );
+		expect(result).to.have.lengthOf(0);
+	});
+
 	describe('returns undefined for reverts that require more context than the view directly before the edit', () => {
 		describe('because the edit conflicted', () => {
 			it('when reverting a detach of a node that is not in the tree', () => {

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -124,26 +124,31 @@ describe('revert', () => {
 			it('handles reverting the insert of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
 				const result = revert(
-                    [
-                        ChangeInternal.build([], insertedNodeId),
-                        ChangeInternal.insert(insertedNodeId, {
-                            referenceTrait: testTree.left.traitLocation,
-                            side: Side.After,
-                        }),
-                    ],
-                    testTree.view);
+					[
+						ChangeInternal.build([], insertedNodeId),
+						ChangeInternal.insert(insertedNodeId, {
+							referenceTrait: testTree.left.traitLocation,
+							side: Side.After,
+						}),
+					],
+					testTree.view
+				);
 				expect(result).to.be.undefined;
 			});
 			it('handles reverting the detach of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
 				const result = revert(
-                    [
-                        ChangeInternal.detach(
-                            StableRangeInternal.all({ label: 'testTraitLabel' as TraitLabel, parent: testTree.identifier }),
-                            insertedNodeId
-                        )
-                    ],
-                    testTree.left.view);
+					[
+						ChangeInternal.detach(
+							StableRangeInternal.all({
+								label: 'testTraitLabel' as TraitLabel,
+								parent: testTree.identifier,
+							}),
+							insertedNodeId
+						),
+					],
+					testTree.left.view
+				);
 				expect(result).to.be.undefined;
 			});
 		});

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -123,22 +123,27 @@ describe('revert', () => {
 		describe('when reverting the insert/detach of an empty trait', () => {
 			it('handles reverting the insert of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
-				const insertedBuild = ChangeInternal.build([], insertedNodeId);
-				const insertChange = ChangeInternal.insert(insertedNodeId, {
-					referenceTrait: testTree.left.traitLocation,
-					side: Side.After,
-				});
-				const result = revert([insertedBuild, insertChange], testTree.view);
+				const result = revert(
+                    [
+                        ChangeInternal.build([], insertedNodeId),
+                        ChangeInternal.insert(insertedNodeId, {
+                            referenceTrait: testTree.left.traitLocation,
+                            side: Side.After,
+                        }),
+                    ],
+                    testTree.view);
 				expect(result).to.be.undefined;
 			});
 			it('handles reverting the detach of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
-				const node = testTree.buildLeafInternal();
-				const detachChange = ChangeInternal.detach(
-					StableRangeInternal.all({ label: 'testTraitLabel' as TraitLabel, parent: testTree.identifier }),
-					insertedNodeId
-				);
-				const result = revert([detachChange], testTree.left.view);
+				const result = revert(
+                    [
+                        ChangeInternal.detach(
+                            StableRangeInternal.all({ label: 'testTraitLabel' as TraitLabel, parent: testTree.identifier }),
+                            insertedNodeId
+                        )
+                    ],
+                    testTree.left.view);
 				expect(result).to.be.undefined;
 			});
 		});

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -120,5 +120,17 @@ describe('revert', () => {
 				).to.be.undefined;
 			});
 		});
+        describe('when reverting the insert/detach of an empty trait', () => {
+			it('when reverting a detach of an empty trait', () => {
+				const insertedNodeId = 0 as DetachedSequenceId;
+				const insertedBuild = ChangeInternal.build([], insertedNodeId);
+				const insertChange = ChangeInternal.insert(insertedNodeId, {
+						referenceTrait: testTree.left.traitLocation,
+						side: Side.After,
+				});
+				const result = revert([insertedBuild, insertChange], testTree.view);
+				expect(result).to.be.undefined;
+			});
+		});
 	});
 });

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -122,7 +122,7 @@ describe('revert', () => {
 		});
 		describe('when reverting the insert/detach of an empty trait', () => {
 			it('when reverting a detach of an empty trait', () => {
-				    const insertedNodeId = 0 as DetachedSequenceId;
+				const insertedNodeId = 0 as DetachedSequenceId;
 				const insertedBuild = ChangeInternal.build([], insertedNodeId);
 				const insertChange = ChangeInternal.insert(insertedNodeId, {
 					referenceTrait: testTree.left.traitLocation,

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -19,10 +19,9 @@ describe('revert', () => {
 		const firstBuild = ChangeInternal.build([node], firstDetachedId);
 		const insertedNodeId = 1 as DetachedSequenceId;
 		const insertedBuild = ChangeInternal.build([firstDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId, {
-			referenceTrait: testTree.left.traitLocation,
-			side: Side.After,
-		});
+		const insertChange = ChangeInternal.insert(insertedNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
 		const result = expectDefined(revert([firstBuild, insertedBuild, insertChange], testTree.view));
 		expect(result.length).to.equal(1);
 		const revertedChange = result[0] as DetachInternal;
@@ -39,10 +38,9 @@ describe('revert', () => {
 		const secondBuild = ChangeInternal.build([secondNode], secondDetachedId);
 		const insertedNodeId = 2 as DetachedSequenceId;
 		const insertedBuild = ChangeInternal.build([firstDetachedId, secondDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId, {
-			referenceTrait: testTree.left.traitLocation,
-			side: Side.After,
-		});
+		const insertChange = ChangeInternal.insert(insertedNodeId,
+            StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+        );
 		const result = expectDefined(revert([firstBuild, secondBuild, insertedBuild, insertChange], testTree.view));
 		expect(result.length).to.equal(1);
 		const revertedChange = result[0] as DetachInternal;
@@ -54,10 +52,9 @@ describe('revert', () => {
 		// build and insert of empty traits
 		const emptyTraitNodeId = 0 as DetachedSequenceId;
 		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
-		const emptyTraitInsert = ChangeInternal.insert(emptyTraitNodeId, {
-			referenceTrait: testTree.left.traitLocation,
-			side: Side.After,
-		});
+		const emptyTraitInsert = ChangeInternal.insert(emptyTraitNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
 
 		// build and insert of non-empty traits
 		const firstDetachedId = 1 as DetachedSequenceId;

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -76,6 +76,23 @@ describe('revert', () => {
 		expect(revertedChange.source.start.referenceSibling).to.deep.equal(firstNode.identifier);
 	});
 
+    /** This is a regression test for a bug where we make sure that any built/detached nodes are cleared when any
+     *  empty insert/detach change is skipped once encountered. The expected outcome is undefined, as during the second
+     *  empty insert (with the same DetachSequenceId), there should be no such node in the builtNodes.
+    */
+    it('handles reverting the insert of empty nodes, with subsequent empty nodes of same DetachedSequenceId', () => {
+		const emptyTraitNodeId = 0 as DetachedSequenceId;
+		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
+		const emptyTraitInsert = ChangeInternal.insert(emptyTraitNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
+		const result = revert(
+            [emptyTraitBuild, emptyTraitInsert, emptyTraitInsert],
+            testTree.view
+        );
+		expect(result).to.be.undefined;
+	});
+
 	it('handles reverting the detach of an empty trait', () => {
 		const insertedNodeId = 0 as DetachedSequenceId;
 		const result = expectDefined(

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -141,13 +141,13 @@ describe('revert', () => {
 					[
 						ChangeInternal.detach(
 							StableRangeInternal.all({
-								label: 'testTraitLabel' as TraitLabel,
+								label: 'someNonExistentTraitLabel' as TraitLabel,
 								parent: testTree.identifier,
 							}),
 							insertedNodeId
 						),
 					],
-					testTree.left.view
+					testTree.view
 				);
 				expect(result).to.be.undefined;
 			});

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -5,7 +5,7 @@
 
 import { expect } from 'chai';
 import { revert } from '../HistoryEditFactory';
-import { DetachedSequenceId } from '../Identifiers';
+import { DetachedSequenceId, TraitLabel } from '../Identifiers';
 import { ChangeInternal, DetachInternal, Side, StablePlaceInternal, StableRangeInternal } from '../persisted-types';
 import { expectDefined } from './utilities/TestCommon';
 import { refreshTestTree } from './utilities/TestUtilities';
@@ -121,7 +121,7 @@ describe('revert', () => {
 			});
 		});
 		describe('when reverting the insert/detach of an empty trait', () => {
-			it('when reverting a insert of an empty trait', () => {
+			it('handles reverting the insert of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
 				const insertedBuild = ChangeInternal.build([], insertedNodeId);
 				const insertChange = ChangeInternal.insert(insertedNodeId, {
@@ -131,15 +131,14 @@ describe('revert', () => {
 				const result = revert([insertedBuild, insertChange], testTree.view);
 				expect(result).to.be.undefined;
 			});
-			it('when reverting a detach of an empty trait', () => {
+			it('handles reverting the detach of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
-				const insertedBuild = ChangeInternal.build([], insertedNodeId);
-				const insertChange = ChangeInternal.insert(insertedNodeId, {
-					referenceTrait: testTree.left.traitLocation,
-					side: Side.After,
-				});
-				const detachChange = ChangeInternal.detach(StableRangeInternal.only(testTree.left), insertedNodeId);
-				const result = revert([insertedBuild, insertChange, detachChange], testTree.view);
+				const node = testTree.buildLeafInternal();
+				const detachChange = ChangeInternal.detach(
+					StableRangeInternal.all({ label: 'testTraitLabel' as TraitLabel, parent: testTree.identifier }),
+					insertedNodeId
+				);
+				const result = revert([detachChange], testTree.left.view);
 				expect(result).to.be.undefined;
 			});
 		});

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -19,7 +19,8 @@ describe('revert', () => {
 		const firstBuild = ChangeInternal.build([node], firstDetachedId);
 		const insertedNodeId = 1 as DetachedSequenceId;
 		const insertedBuild = ChangeInternal.build([firstDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId,
+		const insertChange = ChangeInternal.insert(
+			insertedNodeId,
 			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
 		);
 		const result = expectDefined(revert([firstBuild, insertedBuild, insertChange], testTree.view));
@@ -38,9 +39,10 @@ describe('revert', () => {
 		const secondBuild = ChangeInternal.build([secondNode], secondDetachedId);
 		const insertedNodeId = 2 as DetachedSequenceId;
 		const insertedBuild = ChangeInternal.build([firstDetachedId, secondDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId,
-            StablePlaceInternal.atStartOf(testTree.left.traitLocation)
-        );
+		const insertChange = ChangeInternal.insert(
+			insertedNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
 		const result = expectDefined(revert([firstBuild, secondBuild, insertedBuild, insertChange], testTree.view));
 		expect(result.length).to.equal(1);
 		const revertedChange = result[0] as DetachInternal;
@@ -52,7 +54,8 @@ describe('revert', () => {
 		// build and insert of empty traits
 		const emptyTraitNodeId = 0 as DetachedSequenceId;
 		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
-		const emptyTraitInsert = ChangeInternal.insert(emptyTraitNodeId,
+		const emptyTraitInsert = ChangeInternal.insert(
+			emptyTraitNodeId,
 			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
 		);
 
@@ -62,68 +65,60 @@ describe('revert', () => {
 		const firstBuild = ChangeInternal.build([firstNode], firstDetachedId);
 		const insertedNodeId = 3 as DetachedSequenceId;
 		const insertedBuild = ChangeInternal.build([firstDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId,
-            StablePlaceInternal.atStartOf(testTree.left.traitLocation)
-        );
+		const insertChange = ChangeInternal.insert(
+			insertedNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
 		const result = expectDefined(
-			revert(
-				[emptyTraitBuild, emptyTraitInsert, firstBuild, insertedBuild, insertChange],
-				testTree.view
-			)
+			revert([emptyTraitBuild, emptyTraitInsert, firstBuild, insertedBuild, insertChange], testTree.view)
 		);
 		expect(result.length).to.equal(1);
 		const revertedChange = result[0] as DetachInternal;
 		expect(revertedChange.source.start.referenceSibling).to.deep.equal(firstNode.identifier);
 	});
 
-    /** This is a regression test for a bug where we make sure that any built/detached nodes are cleared when any
-     *  empty insert/detach change is skipped once encountered. The expected outcome is undefined, as during the second
-     *  empty insert (with the same DetachSequenceId), there should be no such node in the builtNodes.
-    */
-    it('handles reverting the insert of empty nodes, with subsequent empty nodes of same DetachedSequenceId', () => {
+	/** This is a regression test for a bug where we make sure that any built/detached nodes are cleared when any
+	 *  empty insert/detach change is skipped once encountered. The expected outcome is undefined, as during the second
+	 *  empty insert (with the same DetachSequenceId), there should be no such node in the builtNodes.
+	 */
+	it('handles reverting the insert of empty nodes, with subsequent empty nodes of same DetachedSequenceId', () => {
 		const emptyTraitNodeId = 0 as DetachedSequenceId;
 		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
-		const emptyTraitInsert = ChangeInternal.insert(emptyTraitNodeId,
+		const emptyTraitInsert = ChangeInternal.insert(
+			emptyTraitNodeId,
 			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
 		);
-		const result = revert(
-            [emptyTraitBuild, emptyTraitInsert, emptyTraitInsert],
-            testTree.view
-        );
+		const result = revert([emptyTraitBuild, emptyTraitInsert, emptyTraitInsert], testTree.view);
 		expect(result).to.be.undefined;
 	});
 
 	it('handles reverting the detach of an empty trait', () => {
 		const insertedNodeId = 0 as DetachedSequenceId;
 		const result = expectDefined(
-            revert(
-                [
-                    ChangeInternal.detach(
-                        StableRangeInternal.all({
-                            label: 'someNonExistentTraitLabel' as TraitLabel,
-                            parent: testTree.identifier,
-                        }),
-                        insertedNodeId
-                    ),
-                ],
-                testTree.view
-		    )
-        );
+			revert(
+				[
+					ChangeInternal.detach(
+						StableRangeInternal.all({
+							label: 'someNonExistentTraitLabel' as TraitLabel,
+							parent: testTree.identifier,
+						}),
+						insertedNodeId
+					),
+				],
+				testTree.view
+			)
+		);
 		expect(result).to.have.lengthOf(0);
 	});
 
-    it('handles reverting the insert of an empty trait', () => {
+	it('handles reverting the insert of an empty trait', () => {
 		const emptyTraitNodeId = 0 as DetachedSequenceId;
 		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
-		const emptyTraitInsert = ChangeInternal.insert(emptyTraitNodeId,
+		const emptyTraitInsert = ChangeInternal.insert(
+			emptyTraitNodeId,
 			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
 		);
-		const result = expectDefined(
-            revert(
-                [emptyTraitBuild, emptyTraitInsert],
-                testTree.view
-		    )
-        );
+		const result = expectDefined(revert([emptyTraitBuild, emptyTraitInsert], testTree.view));
 		expect(result).to.have.lengthOf(0);
 	});
 

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -131,14 +131,14 @@ describe('revert', () => {
 				const result = revert([insertedBuild, insertChange], testTree.view);
 				expect(result).to.be.undefined;
 			});
-            it('when reverting a detach of an empty trait', () => {
+			it('when reverting a detach of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
 				const insertedBuild = ChangeInternal.build([], insertedNodeId);
 				const insertChange = ChangeInternal.insert(insertedNodeId, {
 					referenceTrait: testTree.left.traitLocation,
 					side: Side.After,
 				});
-                const detachChange = ChangeInternal.detach(StableRangeInternal.only(testTree.left), insertedNodeId);
+				const detachChange = ChangeInternal.detach(StableRangeInternal.only(testTree.left), insertedNodeId);
 				const result = revert([insertedBuild, insertChange, detachChange], testTree.view);
 				expect(result).to.be.undefined;
 			});

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -122,7 +122,7 @@ describe('revert', () => {
 		});
 		describe('when reverting the insert/detach of an empty trait', () => {
 			it('when reverting a detach of an empty trait', () => {
-				const insertedNodeId = 0 as DetachedSequenceId;
+				    const insertedNodeId = 0 as DetachedSequenceId;
 				const insertedBuild = ChangeInternal.build([], insertedNodeId);
 				const insertChange = ChangeInternal.insert(insertedNodeId, {
 					referenceTrait: testTree.left.traitLocation,

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -121,7 +121,7 @@ describe('revert', () => {
 			});
 		});
 		describe('when reverting the insert/detach of an empty trait', () => {
-			it('when reverting a detach of an empty trait', () => {
+			it('when reverting a insert of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
 				const insertedBuild = ChangeInternal.build([], insertedNodeId);
 				const insertChange = ChangeInternal.insert(insertedNodeId, {
@@ -129,6 +129,17 @@ describe('revert', () => {
 					side: Side.After,
 				});
 				const result = revert([insertedBuild, insertChange], testTree.view);
+				expect(result).to.be.undefined;
+			});
+            it('when reverting a detach of an empty trait', () => {
+				const insertedNodeId = 0 as DetachedSequenceId;
+				const insertedBuild = ChangeInternal.build([], insertedNodeId);
+				const insertChange = ChangeInternal.insert(insertedNodeId, {
+					referenceTrait: testTree.left.traitLocation,
+					side: Side.After,
+				});
+                const detachChange = ChangeInternal.detach(StableRangeInternal.only(testTree.left), insertedNodeId);
+				const result = revert([insertedBuild, insertChange, detachChange], testTree.view);
 				expect(result).to.be.undefined;
 			});
 		});

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -120,13 +120,13 @@ describe('revert', () => {
 				).to.be.undefined;
 			});
 		});
-        describe('when reverting the insert/detach of an empty trait', () => {
+		describe('when reverting the insert/detach of an empty trait', () => {
 			it('when reverting a detach of an empty trait', () => {
 				const insertedNodeId = 0 as DetachedSequenceId;
 				const insertedBuild = ChangeInternal.build([], insertedNodeId);
 				const insertChange = ChangeInternal.insert(insertedNodeId, {
-						referenceTrait: testTree.left.traitLocation,
-						side: Side.After,
+					referenceTrait: testTree.left.traitLocation,
+					side: Side.After,
 				});
 				const result = revert([insertedBuild, insertChange], testTree.view);
 				expect(result).to.be.undefined;

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -50,7 +50,7 @@ describe('revert', () => {
 		expect(revertedChange.source.end.referenceSibling).to.deep.equal(secondNode.identifier);
 	});
 
-	it('handles reverting the insert of empty nodes, with multiple subsequent non-empty nodes', () => {
+	it('handles reverting the insert of empty nodes, with subsequent non-empty nodes', () => {
 		// build and insert of empty traits
 		const emptyTraitNodeId = 0 as DetachedSequenceId;
 		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
@@ -63,25 +63,20 @@ describe('revert', () => {
 		const firstDetachedId = 1 as DetachedSequenceId;
 		const firstNode = testTree.buildLeafInternal();
 		const firstBuild = ChangeInternal.build([firstNode], firstDetachedId);
-		const secondDetachedId = 2 as DetachedSequenceId;
-		const secondNode = testTree.buildLeafInternal();
-		const secondBuild = ChangeInternal.build([secondNode], secondDetachedId);
 		const insertedNodeId = 3 as DetachedSequenceId;
-		const insertedBuild = ChangeInternal.build([firstDetachedId, secondDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId, {
-			referenceTrait: testTree.left.traitLocation,
-			side: Side.After,
-		});
+		const insertedBuild = ChangeInternal.build([firstDetachedId], insertedNodeId);
+		const insertChange = ChangeInternal.insert(insertedNodeId,
+            StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+        );
 		const result = expectDefined(
 			revert(
-				[emptyTraitBuild, emptyTraitInsert, firstBuild, secondBuild, insertedBuild, insertChange],
+				[emptyTraitBuild, emptyTraitInsert, firstBuild, insertedBuild, insertChange],
 				testTree.view
 			)
 		);
 		expect(result.length).to.equal(1);
 		const revertedChange = result[0] as DetachInternal;
 		expect(revertedChange.source.start.referenceSibling).to.deep.equal(firstNode.identifier);
-		expect(revertedChange.source.end.referenceSibling).to.deep.equal(secondNode.identifier);
 	});
 
 	it('handles reverting the detach of an empty trait', () => {

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -78,18 +78,20 @@ describe('revert', () => {
 
 	it('handles reverting the detach of an empty trait', () => {
 		const insertedNodeId = 0 as DetachedSequenceId;
-		const result = revert(
-			[
-				ChangeInternal.detach(
-					StableRangeInternal.all({
-						label: 'someNonExistentTraitLabel' as TraitLabel,
-						parent: testTree.identifier,
-					}),
-					insertedNodeId
-				),
-			],
-			testTree.view
-		);
+		const result = expectDefined(
+            revert(
+                [
+                    ChangeInternal.detach(
+                        StableRangeInternal.all({
+                            label: 'someNonExistentTraitLabel' as TraitLabel,
+                            parent: testTree.identifier,
+                        }),
+                        insertedNodeId
+                    ),
+                ],
+                testTree.view
+		    )
+        );
 		expect(result).to.have.lengthOf(0);
 	});
 


### PR DESCRIPTION
## Description

When an undo/redo of an empty trait is done, it can lead to a insert/detach of a malformed trait. This issue occurs when the following is done.

1. Detach/delete an empty trait
2. Undo: inserts empty traits
3. Redo: detaches empty traits, which is malformed

This PR aims to prevent this issue by skipping the change rather than performing an insertion/detachment of an empty trait. The undo/redo logic of the revert( ) method in HistoryEditFactory.ts is updated to achieve this. Additionally, an optional telemetry logger is passed through the function to track these events when they occur. More details regarding this issue can be found in [Bug 635](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Taylor/internal/CY22Q3/2022.07/Team%20Taylor%20-%202022.07?workitem=635)