### PR TITLE
Alternative approach to propagate disconnected reason during 'disconnected' event

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -26,7 +26,7 @@ export interface IConnectionStateHandlerInputs {
     /** Log an issue encountered while in the Connecting state. details will be logged as a JSON string */
     logConnectionIssue: (eventName: string, details?: ITelemetryProperties) => void;
     /** Callback whenever the ConnectionState changes between Disconnected and Connected */
-    connectionStateChanged: () => void;
+    connectionStateChanged: (reason?: string) => void;
 }
 
 const JoinOpTimeoutMs = 45000;
@@ -365,7 +365,7 @@ export class ConnectionStateHandler {
         this.handler.logConnectionStateChangeTelemetry(this._connectionState, oldState, reason);
 
         // Propagate event across layers
-        this.handler.connectionStateChanged();
+        this.handler.connectionStateChanged(reason);
     }
 
     public initProtocol(protocol: IProtocolHandler) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -647,10 +647,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                         ...(details === undefined ? {} : { details: JSON.stringify(details) }),
                     });
                 },
-                connectionStateChanged: () => {
+                connectionStateChanged: (reason?: string) => {
                     // Fire events only if container is fully loaded and not closed
                     if (this._lifecycleState === "loaded") {
-                        this.propagateConnectionState();
+                        this.propagateConnectionState(reason);
                     }
                 },
             },
@@ -1667,7 +1667,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         }
     }
 
-    private propagateConnectionState() {
+    private propagateConnectionState(reason?: string) {
         const logOpsOnReconnect: boolean =
             this.connectionState === ConnectionState.Connected &&
             !this.firstConnection &&
@@ -1684,7 +1684,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.context.setConnectionState(state, this.clientId);
         }
         this.protocolHandler.setConnectionState(state, this.clientId);
-        raiseConnectedEvent(this.mc.logger, this, state, this.clientId);
+        raiseConnectedEvent(this.mc.logger, this, state, this.clientId, reason);
 
         if (logOpsOnReconnect) {
             this.mc.logger.sendTelemetryEvent(

--- a/packages/utils/telemetry-utils/src/events.ts
+++ b/packages/utils/telemetry-utils/src/events.ts
@@ -27,12 +27,13 @@ export function raiseConnectedEvent(
     logger: ITelemetryLogger,
     emitter: EventEmitter,
     connected: boolean,
-    clientId?: string) {
+    clientId?: string,
+    disconnectedReason?: string) {
     try {
         if (connected) {
             emitter.emit(connectedEventName, clientId);
         } else {
-            emitter.emit(disconnectedEventName);
+            emitter.emit(disconnectedEventName, disconnectedReason);
         }
     } catch (error) {
         logger.sendErrorEvent({ eventName: "RaiseConnectedEventError" }, error);


### PR DESCRIPTION
## Description

The container emits a disconnected event in event of a connection loss but it doesn't emit any additional details about why the connection was disconnected. This information is already available in the container in the form of reason and is also logged in Fluid Framework's telemetry but isn't accessible to the host that integrates with the Fluid Framework.

This change propagates reason when a disconnected event is raised by the container.

## Reviewer Guidance

This is an alternative and simpler approach to [Pull Request: Propagate disconnected reason during 'disconnected' event](https://github.com/microsoft/FluidFramework/pull/11258
)
## Does this introduce a breaking change?

No

## Other information or known dependencies

- The Microsoft Loop team is relying on this change to measure and improve connectivity reliability across Microsoft Loop experiences
- The **next steps** here would be to instrument in the host experience cases where we don't restore connection within an appropriate time and keep track of the disconnected reason that contribute to the loss of connection
