### PR TITLE
Rollback for string annotate

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -28,7 +28,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     // @internal @deprecated (undocumented)
     ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs, mergeTree: MergeTree): boolean;
     // (undocumented)
-    addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number, collabWindow?: CollaborationWindow): PropertySet | undefined;
+    addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number, collabWindow?: CollaborationWindow, rollback?: PropertiesRollback): PropertySet | undefined;
     // (undocumented)
     protected addSerializedProps(jseg: IJSONSegment): void;
     // (undocumented)
@@ -754,7 +754,7 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
     // @internal @deprecated
     ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs, mergeTree: MergeTree): boolean;
     // (undocumented)
-    addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number, collabWindow?: CollaborationWindow): PropertySet | undefined;
+    addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number, collabWindow?: CollaborationWindow, rollback?: PropertiesRollback): PropertySet | undefined;
     // (undocumented)
     append(segment: ISegment): void;
     // (undocumented)
@@ -1006,7 +1006,7 @@ export class MergeTree {
     ackPendingSegment(opArgs: IMergeTreeDeltaOpArgs): void;
     // (undocumented)
     addMinSeqListener(minRequired: number, onMinGE: (minSeq: number) => void): void;
-    annotateRange(start: number, end: number, props: PropertySet, combiningOp: ICombiningOp | undefined, refSeq: number, clientId: number, seq: number, opArgs: IMergeTreeDeltaOpArgs): void;
+    annotateRange(start: number, end: number, props: PropertySet, combiningOp: ICombiningOp | undefined, refSeq: number, clientId: number, seq: number, opArgs: IMergeTreeDeltaOpArgs, rollback?: PropertiesRollback): void;
     // (undocumented)
     blockClone(block: IMergeBlock, segments?: ISegment[]): MergeBlock;
     // (undocumented)
@@ -1188,11 +1188,18 @@ export class PropertiesManager {
     // (undocumented)
     ackPendingProperties(annotateOp: IMergeTreeAnnotateMsg): void;
     // (undocumented)
-    addProperties(oldProps: PropertySet, newProps: PropertySet, op?: ICombiningOp, seq?: number, collaborating?: boolean): PropertySet | undefined;
+    addProperties(oldProps: PropertySet, newProps: PropertySet, op?: ICombiningOp, seq?: number, collaborating?: boolean, rollback?: PropertiesRollback): PropertySet | undefined;
     // (undocumented)
     copyTo(oldProps: PropertySet, newProps: PropertySet | undefined, newManager: PropertiesManager): PropertySet | undefined;
     // (undocumented)
     hasPendingProperties(): boolean;
+}
+
+// @public (undocumented)
+export enum PropertiesRollback {
+    None = 0,
+    Rewrite = 2,
+    Rollback = 1
 }
 
 // Warning: (ae-internal-missing-underscore) The name "Property" should be prefixed with an underscore because the declaration is marked as @internal

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -837,6 +837,8 @@ export class List<T> {
     // (undocumented)
     next: List<T>;
     // (undocumented)
+    pop?(): T | undefined;
+    // (undocumented)
     prev: List<T>;
     // (undocumented)
     some(fn: (data: T, l: List<T>) => boolean, rev?: boolean): T[];
@@ -1430,6 +1432,8 @@ export interface SegmentGroup {
     // (undocumented)
     localSeq: number;
     // (undocumented)
+    previousProps?: PropertySet[];
+    // (undocumented)
     segments: ISegment[];
 }
 
@@ -1446,6 +1450,8 @@ export class SegmentGroupCollection {
     get empty(): boolean;
     // (undocumented)
     enqueue(segmentGroup: SegmentGroup): void;
+    // (undocumented)
+    pop?(): SegmentGroup | undefined;
     // (undocumented)
     get size(): number;
 }

--- a/packages/dds/merge-tree/src/collections/list.ts
+++ b/packages/dds/merge-tree/src/collections/list.ts
@@ -74,6 +74,11 @@ export class List<T> {
         return this.add(data);
     }
 
+    public pop?(): T | undefined {
+        const removedEntry = ListRemoveEntry(this.prev);
+        return removedEntry ? removedEntry.data : undefined;
+    }
+
     public walk(fn: (data: T, l: List<T>) => void): void {
         for (let entry = this.next; !(entry.isHead); entry = entry.next) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -235,6 +235,7 @@ export interface MergeTreeStats {
 
 export interface SegmentGroup {
     segments: ISegment[];
+    previousProps?: PropertySet[];
     localSeq: number;
 }
 

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -43,7 +43,7 @@ import {
     refGetTileLabels,
  } from "./referencePositions";
 import { SegmentGroupCollection } from "./segmentGroupCollection";
-import { PropertiesManager } from "./segmentPropertiesManager";
+import { PropertiesManager, PropertiesRollback } from "./segmentPropertiesManager";
 
 export interface IMergeNodeCommon {
     parent?: IMergeBlock;
@@ -116,6 +116,7 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
         op?: ICombiningOp,
         seq?: number,
         collabWindow?: CollaborationWindow,
+        rollback?: PropertiesRollback,
     ): PropertySet | undefined;
     clone(): ISegment;
     canAppend(segment: ISegment): boolean;
@@ -325,7 +326,8 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     public localSeq?: number;
     public localRemovedSeq?: number;
 
-    public addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number, collabWindow?: CollaborationWindow) {
+    public addProperties(newProps: PropertySet, op?: ICombiningOp, seq?: number,
+        collabWindow?: CollaborationWindow, rollback: PropertiesRollback = PropertiesRollback.None) {
         if (!this.propertyManager) {
             this.propertyManager = new PropertiesManager();
         }
@@ -338,6 +340,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
             op,
             seq,
             collabWindow && collabWindow.collaborating,
+            rollback,
         );
     }
 

--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -65,28 +65,34 @@ export function combine(combiningInfo: ICombiningOp, currentValue: any, newValue
 
 export function matchProperties(a: PropertySet | undefined, b: PropertySet | undefined) {
     if (a) {
-        // For now, straightforward; later use hashing
+        if (!b) {
+            return false;
+        } else {
+            // For now, straightforward; later use hashing
 
-        // eslint-disable-next-line no-restricted-syntax
-        for (const key in a) {
-            if (!b || b[key] === undefined) {
-                return false;
-            } else if (typeof b[key] === "object") {
-                if (!matchProperties(a[key], b[key])) {
+            // eslint-disable-next-line no-restricted-syntax
+            for (const key in a) {
+                if (b[key] === undefined) {
+                    return false;
+                } else if (typeof b[key] === "object") {
+                    if (!matchProperties(a[key], b[key])) {
+                        return false;
+                    }
+                } else if (b[key] !== a[key]) {
                     return false;
                 }
-            } else if (b[key] !== a[key]) {
-                return false;
+            }
+
+            // eslint-disable-next-line no-restricted-syntax
+            for (const key in b) {
+                if (a[key] === undefined) {
+                    return false;
+                }
             }
         }
-    }
-
-    if (b) {
-        // eslint-disable-next-line no-restricted-syntax
-        for (const key in b) {
-            if (!a || a[key] === undefined) {
-                return false;
-            }
+    } else {
+        if (b) {
+            return false;
         }
     }
 

--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -65,36 +65,31 @@ export function combine(combiningInfo: ICombiningOp, currentValue: any, newValue
 
 export function matchProperties(a: PropertySet | undefined, b: PropertySet | undefined) {
     if (a) {
-        if (!b) {
-            return false;
-        } else {
-            // For now, straightforward; later use hashing
+        // For now, straightforward; later use hashing
 
-            // eslint-disable-next-line no-restricted-syntax
-            for (const key in a) {
-                if (b[key] === undefined) {
-                    return false;
-                } else if (typeof b[key] === "object") {
-                    if (!matchProperties(a[key], b[key])) {
-                        return false;
-                    }
-                } else if (b[key] !== a[key]) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const key in a) {
+            if (!b || b[key] === undefined) {
+                return false;
+            } else if (typeof b[key] === "object") {
+                if (!matchProperties(a[key], b[key])) {
                     return false;
                 }
+            } else if (b[key] !== a[key]) {
+                return false;
             }
-
-            // eslint-disable-next-line no-restricted-syntax
-            for (const key in b) {
-                if (a[key] === undefined) {
-                    return false;
-                }
-            }
-        }
-    } else {
-        if (b) {
-            return false;
         }
     }
+
+    if (b) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const key in b) {
+            if (!a || a[key] === undefined) {
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -30,6 +30,10 @@ export class SegmentGroupCollection {
         return this.segmentGroups.dequeue();
     }
 
+    public pop?(): SegmentGroup | undefined {
+        return this.segmentGroups.pop ? this.segmentGroups.pop() : undefined;
+    }
+
     public clear() {
         this.segmentGroups.clear();
     }

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { UniversalSequenceNumber } from "../constants";
-import { reservedMarkerIdKey, SegmentGroup } from "../mergeTreeNodes";
+import { Marker, reservedMarkerIdKey, SegmentGroup } from "../mergeTreeNodes";
 import { MergeTreeDeltaType, ReferenceType } from "../ops";
 import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
@@ -62,6 +62,132 @@ describe("client.rollback", () => {
         const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
         const segment = segmentGroup.segments[0];
         client.rollback?.({ type: MergeTreeDeltaType.INSERT }, segmentGroup);
+
+        // do some work and move the client's min seq forward, so zamboni runs
+        for (const c of "hello world") {
+            client.applyMsg(
+                client.makeOpMessage(
+                    client.insertTextLocal(client.getLength(), c),
+                    client.getCurrentSeq() + 1,
+                    client.getCurrentSeq(),
+                    undefined,
+                    client.getCurrentSeq()));
+        }
+
+        assert.equal(segment.parent, undefined);
+    });
+    it("Should rollback annotate marker", async () => {
+        client.insertMarkerLocal(
+            0,
+            ReferenceType.Simple,
+            {
+                [reservedMarkerIdKey]: "markerId",
+            },
+        );
+        const marker = client.getMarkerFromId("markerId") as Marker;
+        client.annotateMarker(marker, { foo: "bar" }, undefined);
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        const properties = marker.getProperties();
+        assert.equal(properties?.foo, undefined);
+    });
+    it("Should rollback annotate marker overwriting property", async () => {
+        client.insertMarkerLocal(
+            0,
+            ReferenceType.Simple,
+            {
+                [reservedMarkerIdKey]: "markerId",
+                foo: "bar",
+            },
+        );
+        const marker = client.getMarkerFromId("markerId") as Marker;
+        client.annotateMarker(marker, { foo: "baz" }, undefined);
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        const properties = marker.getProperties();
+        assert.equal(properties?.foo, "bar");
+    });
+    it("Should rollback annotate marker removing property", async () => {
+        client.insertMarkerLocal(
+            0,
+            ReferenceType.Simple,
+            {
+                [reservedMarkerIdKey]: "markerId",
+                foo: "bar",
+            },
+        );
+        const marker = client.getMarkerFromId("markerId") as Marker;
+        client.annotateMarker(marker, { foo: null }, undefined);
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        const properties = marker.getProperties();
+        assert.equal(properties?.foo, "bar");
+    });
+    it("Should rollback annotate marker rewrite", async () => {
+        client.insertMarkerLocal(
+            0,
+            ReferenceType.Simple,
+            {
+                [reservedMarkerIdKey]: "markerId",
+                foo: "bar",
+            },
+        );
+        const marker = client.getMarkerFromId("markerId") as Marker;
+        client.annotateMarker(marker, { abc: "def" }, { name: "rewrite" });
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        const properties = marker.getProperties();
+        assert.equal(properties?.foo, "bar");
+        assert.equal(properties?.abc, undefined);
+    });
+    it("Should rollback annotate causes split string", async () => {
+        client.insertTextLocal(0, "abcdefg");
+        client.annotateRangeLocal(1, 3, { foo: "bar" }, undefined);
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        for (let i = 0; i < 4; i++) {
+            const props = client.getPropertiesAtPosition(i);
+            assert(props === undefined || props.foo === undefined);
+        }
+    });
+    it("Should rollback annotate over split string", async () => {
+        client.insertTextLocal(0, "abfg");
+        client.insertTextLocal(1, "cde");
+        client.annotateRangeLocal(1, 6, { foo: "bar" }, undefined);
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        for (let i = 0; i < 7; i++) {
+            const props = client.getPropertiesAtPosition(i);
+            assert(props === undefined || props.foo === undefined);
+        }
+    });
+    it("Should rollback annotate with same prop", async () => {
+        client.insertTextLocal(0, "abcde");
+        client.annotateRangeLocal(2, 3, { foo: "bar" }, undefined);
+        client.annotateRangeLocal(1, 4, { foo: "bar" }, undefined);
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        for (let i = 0; i < 5; i++) {
+            const props = client.getPropertiesAtPosition(i);
+            if (i === 2) {
+                assert.equal(props?.foo, "bar");
+            } else {
+                assert(props === undefined || props.foo === undefined);
+            }
+        }
+    });
+    it("Should zamboni rolled back annotated segment", async () => {
+        client.applyMsg(
+            client.makeOpMessage(
+                client.insertTextLocal(0, "abcde"),
+                client.getCurrentSeq() + 1,
+                client.getCurrentSeq(),
+                undefined,
+                client.getCurrentSeq()));
+        client.annotateRangeLocal(2, 3, { foo: "bar" }, undefined);
+        const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
+        const segment = segmentGroup.segments[0];
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, segmentGroup);
 
         // do some work and move the client's min seq forward, so zamboni runs
         for (const c of "hello world") {

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -180,7 +180,7 @@ describe("client.rollback", () => {
     it("Should zamboni rolled back annotated segment", async () => {
         client.applyMsg(
             client.makeOpMessage(
-                client.insertTextLocal(0, "abcde"),
+                client.insertTextLocal(0, "abcde", { color: "red" }),
                 client.getCurrentSeq() + 1,
                 client.getCurrentSeq(),
                 undefined,

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -141,6 +141,24 @@ describe("client.rollback", () => {
         assert.equal(properties?.foo, "bar");
         assert.equal(properties?.abc, undefined);
     });
+    it("Should rollback annotate rewrite with explicit null", async () => {
+        client.insertMarkerLocal(
+            0,
+            ReferenceType.Simple,
+            {
+                [reservedMarkerIdKey]: "markerId",
+                foo: "bar",
+            },
+        );
+        const marker = client.getMarkerFromId("markerId") as Marker;
+        client.annotateMarker(marker, { abc: "def", foo: null }, { name: "rewrite" });
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE, combiningOp: { name: "rewrite" } },
+            client.peekPendingSegmentGroups());
+
+        const properties = marker.getProperties();
+        assert.equal(properties?.foo, "bar");
+        assert.equal(properties?.abc, undefined);
+    });
     it("Should rollback annotate causes split string", async () => {
         client.insertTextLocal(0, "abcdefg");
         client.annotateRangeLocal(1, 3, { foo: "bar" }, undefined);

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -134,7 +134,8 @@ describe("client.rollback", () => {
         );
         const marker = client.getMarkerFromId("markerId") as Marker;
         client.annotateMarker(marker, { abc: "def" }, { name: "rewrite" });
-        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE, combiningOp: { name: "rewrite" } },
+            client.peekPendingSegmentGroups());
 
         const properties = marker.getProperties();
         assert.equal(properties?.foo, "bar");

--- a/packages/dds/merge-tree/src/test/properties.spec.ts
+++ b/packages/dds/merge-tree/src/test/properties.spec.ts
@@ -32,5 +32,17 @@ describe("Properties", () => {
         it("complex properties don't match", () => {
             assert(!matchProperties({ c: { a: "a" } }, { c: { a: "b" } }));
         });
+        it("undefined properties match", () => {
+            assert(matchProperties(undefined, undefined));
+        });
+        it("empty properties match", () => {
+            assert(matchProperties({}, {}));
+        });
+        it("undefined and empty properties match", () => {
+            assert(matchProperties(undefined, {}));
+        });
+        it("empty and undefined properties match", () => {
+            assert(matchProperties({}, undefined));
+        });
     });
 });

--- a/packages/dds/merge-tree/src/test/properties.spec.ts
+++ b/packages/dds/merge-tree/src/test/properties.spec.ts
@@ -38,11 +38,11 @@ describe("Properties", () => {
         it("empty properties match", () => {
             assert(matchProperties({}, {}));
         });
-        it("undefined and empty properties match", () => {
-            assert(matchProperties(undefined, {}));
+        it("undefined and empty properties don't match", () => {
+            assert(!matchProperties(undefined, {}));
         });
-        it("empty and undefined properties match", () => {
-            assert(matchProperties({}, undefined));
+        it("empty and undefined properties don't match", () => {
+            assert(!matchProperties({}, undefined));
         });
     });
 });


### PR DESCRIPTION
Local rollback to undo annotations on SharedString. This adds the previous values of properties to localOpMetadata (same data already generated for annotation event) and then restores them on rollback.