### PR TITLE
toDelta: basic move support

### DIFF
--- a/packages/dds/tree/src/changeset/toDelta.ts
+++ b/packages/dds/tree/src/changeset/toDelta.ts
@@ -4,7 +4,7 @@
  */
 
 import { unreachableCase } from "@fluidframework/common-utils";
-import { brand, clone, fail, OffsetListFactory } from "../util";
+import { brand, brandOpaque, clone, fail, OffsetListFactory } from "../util";
 import { FieldKey, Value, Delta } from "../tree";
 import { ProtoNode, Transposed as T } from "./format";
 
@@ -55,7 +55,14 @@ function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
                         }
                         break;
                     }
-                    case "MoveIn":
+                    case "MoveIn": {
+                        const moveMark: Delta.MoveIn = {
+                            type: Delta.MarkType.MoveIn,
+                            moveId: brandOpaque<Delta.MoveId>(attach.id),
+                        };
+                        out.pushContent(moveMark);
+                        break;
+                    }
                     case "MMoveIn":
                         fail(ERR_NOT_IMPLEMENTED);
                     case "Bounce":
@@ -103,7 +110,15 @@ function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
                     }
                     break;
                 }
-                case "MoveOut":
+                case "MoveOut": {
+                    const moveMark: Delta.MoveOut = {
+                        type: Delta.MarkType.MoveOut,
+                        moveId: brandOpaque<Delta.MoveId>(mark.id),
+                        count: mark.count,
+                    };
+                    out.pushContent(moveMark);
+                    break;
+                }
                 case "MMoveOut":
                 case "Revive":
                 case "MRevive":


### PR DESCRIPTION
Adds support for moves that do not include nested modifications in the Changeset => Delta conversion