### PR TITLE
Polyfill buffer package to fix compiling issues

### DIFF
--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/view-interfaces": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
     "@fluidframework/web-code-loader": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
     "axios": "^0.26.0",
-    "buffer": "6.0.3",
+    "buffer": "^6.0.3",
     "express": "^4.16.3",
     "nconf": "^0.11.4",
     "sillyname": "^0.1.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -85,6 +85,7 @@
     "@fluidframework/view-interfaces": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
     "@fluidframework/web-code-loader": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
     "axios": "^0.26.0",
+    "buffer": "6.0.3",
     "express": "^4.16.3",
     "nconf": "^0.11.4",
     "sillyname": "^0.1.0",

--- a/packages/tools/webpack-fluid-loader/webpack.config.js
+++ b/packages/tools/webpack-fluid-loader/webpack.config.js
@@ -33,7 +33,8 @@ module.exports = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
     fallback:{
-        "url": require.resolve("url")
+        "url": require.resolve("url"),
+        "buffer": require.resolve("buffer")
     }
   },
   // Some of Fluid's dependencies depend on things like global and process.env.NODE_ENV being defined. This won't be set in Webpack 5 by default, so we are setting it with the define plugin.


### PR DESCRIPTION
# Work Item

## Description

This bug fix is to polyfill the ```buffer``` package. This bug causes compiling any project that uses these libraries to fail. Upgrading to webpack 5 removed the automatic NodeJS polyfills.

## Exception or Error
```
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "buffer": require.resolve("buffer/") }'
        - install 'buffer'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "buffer": false }
```

## Steps to Reproduce Bug and Validate Solution

Follow any documentation to get started with fluid-framework. Preferably with React or Angular but it should be the same for all JavaScript client side projects

## Testing

We were able to import the packages ```fluid-framework``` and ```@fluidframework/tinylicious-client``` with my local changes into a new React project we created in ```FluidFramework/examples/apps/```, build and test successfully. We were unable to reproduce the errors since they were always compiling in this directory. I will validate the pre-release package for testing.

## Other information or known dependencies
[AB#1230](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1230)
[AB#1219](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1219)