### PR TITLE
Skip StayOnRemove references in addBefore/AfterTombstones

### DIFF
--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -414,7 +414,9 @@ export class LocalReferenceCollection {
         for (const iterable of refs) {
             for (const lref of iterable) {
                 assertLocalReferences(lref);
-                if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
+                if (refTypeIncludesFlag(lref, ReferenceType.StayOnRemove)) {
+                    continue;
+                } else if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
                     lref.callbacks?.beforeSlide?.();
                     beforeRefs.unshift(lref);
                     lref.link(this.segment, 0, beforeRefs.next);
@@ -442,7 +444,9 @@ export class LocalReferenceCollection {
         for (const iterable of refs) {
             for (const lref of iterable) {
                 assertLocalReferences(lref);
-                if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
+                if (refTypeIncludesFlag(lref, ReferenceType.StayOnRemove)) {
+                    continue;
+                } else if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
                     lref.callbacks?.beforeSlide?.();
                     afterRefs.enqueue(lref);
                     lref.link(this.segment, lastOffset, afterRefs.prev);

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -141,6 +141,35 @@ describe("SharedString interval collections", () => {
             ]);
         });
 
+        describe("remain consistent on double-delete", () => {
+            let collection: IntervalCollection<SequenceInterval>;
+            let collection2: IntervalCollection<SequenceInterval>;
+            beforeEach(() => {
+                sharedString.insertText(0, "01234");
+                collection = sharedString.getIntervalCollection("test");
+                collection2 = sharedString.getIntervalCollection("test");
+                containerRuntimeFactory.processAllMessages();
+            });
+
+            it("causing references to slide forward", () => {
+                sharedString2.removeRange(2, 3);
+                collection.add(2, 2, IntervalType.SlideOnRemove);
+                sharedString.removeRange(2, 4);
+                containerRuntimeFactory.processAllMessages();
+                assertIntervals(sharedString, collection, [{ start: 2, end: 2 }]);
+                assertIntervals(sharedString2, collection2, [{ start: 2, end: 2 }]);
+            });
+
+            it("causing references to slide backward", () => {
+                sharedString2.removeRange(2, 3);
+                collection.add(2, 2, IntervalType.SlideOnRemove);
+                sharedString.removeRange(2, 5);
+                containerRuntimeFactory.processAllMessages();
+                assertIntervals(sharedString, collection, [{ start: 1, end: 1 }]);
+                assertIntervals(sharedString2, collection2, [{ start: 1, end: 1 }]);
+            });
+        });
+
         it("errors creating invalid intervals", () => {
             const collection1 = sharedString.getIntervalCollection("test");
             containerRuntimeFactory.processAllMessages();


### PR DESCRIPTION
#11142 refactored some LocalReference-related code, but altered the treatment of StayOnRemove references on removed segments. These refs should remain on removed segments, but previous code ended up unlinking them. This presented issues for eventual consistency of intervals.