### PR TITLE
Fix minSeq calculation in test mocks

### DIFF
--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -211,7 +211,7 @@ export class MockContainerRuntimeFactory {
     public getMinSeq(): number {
         let minSeq: number | undefined;
         for (const [, clientSeq] of this.minSeq) {
-            if (!minSeq) {
+            if (minSeq === undefined) {
                 minSeq = clientSeq;
             } else {
                 minSeq = Math.min(minSeq, clientSeq);


### PR DESCRIPTION
Previous computation could fail in some cases due to falsiness of 0. For example if the client tracking iterator returned `0` then `5` in order, previous logic would yield 5 when minSeq should actually be 0.

I noticed this issue while working on some merge-tree refactors.