### PR TITLE
Splitting FRS test variants.

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -90,15 +90,15 @@ stages:
         timeoutInMinutes: 360
         continueOnError: true
         testCommand: test:realsvc:frs:report
-        # splitTestVariants:
-        #   - name: Non-compat
-        #     flags: --compatVersion=0
-        #   - name: N-1
-        #     flags: --compatVersion=-1
-        #   - name: N-2
-        #     flags: --compatVersion=-2
-        #   - name: LTS
-        #     flags: --compatVersion=LTS
+        splitTestVariants:
+          - name: Non-compat
+            flags: --compatVersion=0
+          - name: N-1
+            flags: --compatVersion=-1
+          - name: N-2
+            flags: --compatVersion=-2
+          - name: LTS
+            flags: --compatVersion=LTS
         env:
           fluid__test__driver__frs: $(automation-fluid-test-driver-frs)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
Re-enable splitTestVariants for real service e2e FRS test to improve test time and make compat test results more observable. Given we are running against canary, I'm assuming some of the older issues we were facing are not applicable any further.

https://github.com/microsoft/FluidFramework/issues/8451



