### PR TITLE
Force passing access token via authorization header when calling GetSharingInformation

### DIFF
--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -57,7 +57,7 @@ export interface ICollabSessionOptions {
      */
     unauthenticatedUserDisplayName?: string;
     /**
-     * @deprecated - Due to security reasons we will passing the token via Authorization header only.
+     * @deprecated - Due to security reasons we will be passing the token via Authorization header only.
      * Value indicating session preference to always pass access token via Authorization header.
      * Default behavior is to pass access token via query parameter unless overall href string
      * length exceeds 2048 characters. Using query param is performance optimization which results

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -29,17 +29,13 @@ const fileLinkCache = new Map<string, Promise<string>>();
  * throttling error. In future, we are thinking of app allowing to pass some cancel token, with which
  * we would be able to stop retrying.
  * @param getToken - used to fetch access tokens needed to execute operation
- * @param siteUrl - url of the site that contains the file
- * @param driveId - drive where file is stored
- * @param itemId - file id
- * @param identityType - type of client account
+ * @param odspUrlParts - object describing file storage identity
  * @param logger - used to log results of operation, including any error
  * @returns Promise which resolves to file link url when successful; otherwise, undefined.
  */
 export async function getFileLink(
     getToken: TokenFetcher<OdspResourceTokenFetchOptions>,
     odspUrlParts: IOdspUrlParts,
-    identityType: IdentityType,
     logger: ITelemetryLogger,
 ): Promise<string> {
     const cacheKey = `${odspUrlParts.siteUrl}_${odspUrlParts.driveId}_${odspUrlParts.itemId}`;
@@ -52,7 +48,7 @@ export async function getFileLink(
         let fileLinkCore: string;
         try {
             fileLinkCore = await runWithRetry(
-                async () => getFileLinkCore(getToken, odspUrlParts, identityType, logger),
+                async () => getFileLinkCore(getToken, odspUrlParts, logger),
                 "getFileLinkCore",
                 logger,
             );
@@ -78,10 +74,9 @@ export async function getFileLink(
 async function getFileLinkCore(
     getToken: TokenFetcher<OdspResourceTokenFetchOptions>,
     odspUrlParts: IOdspUrlParts,
-    identityType: IdentityType,
     logger: ITelemetryLogger,
 ): Promise<string> {
-    const fileItem = await getFileItemLite(getToken, odspUrlParts, logger, identityType === "Consumer");
+    const fileItem = await getFileItemLite(getToken, odspUrlParts, logger, true);
 
     // ODSP link requires extra call to return link that is resistant to file being renamed or moved to different folder
     return PerformanceEvent.timedExecAsync(
@@ -107,7 +102,7 @@ async function getFileLinkCore(
                         encodeURIComponent(`'${fileItem.webDavUrl}'`)
                     }`,
                     storageToken,
-                    false,
+                    true,
                 );
                 const requestInit = {
                     method: "POST",

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -8,12 +8,7 @@ import { assert } from "@fluidframework/common-utils";
 import { canRetryOnError, NonRetryableError } from "@fluidframework/driver-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
-import {
-    IOdspUrlParts,
-    OdspResourceTokenFetchOptions,
-    IdentityType,
-    TokenFetcher,
-} from "@fluidframework/odsp-driver-definitions";
+import { IOdspUrlParts, OdspResourceTokenFetchOptions, TokenFetcher } from "@fluidframework/odsp-driver-definitions";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { fetchHelper, getWithRetryForTokenRefresh, toInstrumentedOdspTokenFetcher } from "./odspUtils";
 import { pkgVersion as driverVersion } from "./packageVersion";

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -171,9 +171,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
             return cachedLinkPromise;
         }
         const newLinkPromise = getFileLink(
-            this.shareLinkFetcherProps.tokenFetcher,
-            resolvedUrl,
-            this.logger,
+            this.shareLinkFetcherProps.tokenFetcher, resolvedUrl, this.logger,
         ).catch((error) => {
             // This should imply that error is a non-retriable error.
             this.logger.sendErrorEvent({ eventName: "FluidFileUrlError" }, error);

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -173,7 +173,6 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         const newLinkPromise = getFileLink(
             this.shareLinkFetcherProps.tokenFetcher,
             resolvedUrl,
-            this.shareLinkFetcherProps.identityType,
             this.logger,
         ).catch((error) => {
             // This should imply that error is a non-retriable error.

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -20,7 +20,7 @@ describe("getFileLink", () => {
 
     it("should return share link with existing access", async () => {
         const result = await mockFetchMultiple(
-            async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId4" }, "Enterprise", logger),
+            async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId4" }, logger),
             [
                 async () => okResponse({}, fileItemResponse),
                 async () => okResponse({}, { d: { directUrl: "sharelink" } }),
@@ -32,7 +32,7 @@ describe("getFileLink", () => {
 
     it("should reject if file web dav url is missing", async () => {
         await assert.rejects(mockFetchMultiple(
-            async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId5" }, "Enterprise", logger),
+            async () => getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId5" }, logger),
             [
                 async () => okResponse({}, {}),
                 // We retry once on malformed response from server, so need a second response mocked.
@@ -43,7 +43,7 @@ describe("getFileLink", () => {
 
     it("should reject if file item is not found", async () => {
         await assert.rejects(mockFetchSingle(async () => {
-            return getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId6" }, "Enterprise", logger);
+            return getFileLink(storageTokenFetcher, { siteUrl, driveId, itemId: "itemId6" }, logger);
             },
             notFound,
         ), "File link should reject when not found");


### PR DESCRIPTION
## Description

> A concise description of the changes (bug or feature) and their impact/motivation.
> If this description is short enough to be used as the title, delete this section and just use the title.

This PR fixes the issue that repros only for Consumer user on Converged stack. The root of the problem is in how we pass access token when calling GetSharingInformation API. Currently we are allowing perf optimization which uses access_token query param for that. This method is not supported on Converged stack and as a result the function fails with 401 error.

The fix is to force passing access token via Authorization error. This is in line with our desire to deprecate use of access_token everywhere (controlled via host policy right now)

> For bug fixes, also include specifics of how to reproduce it / confirm it is fixed.

This has been validated by composing GetSharingInformation call that conforms to above logic and verifying that it succeeds against Consumer on Converged stack

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

## Reviewer Guidance

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.

## Does this introduce a breaking change?

No breaking change

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
> If there are no breaking changes, delete this section.

## Any relevant logs or outputs

> -   Use this section to provide either screenshots or output of logs as code snippets

## Other information or known dependencies

> -   Any other information or known dependencies that is important to this PR.
> -   Links to internal bug/work tracker items.
> -   TODO that are to be done after this PR.
