### PR TITLE
Add entire x-fluid-telemetry to our telemetry 

### DIFF
--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -59,6 +59,7 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: { get: (id: string
     // Ex. x-fluid-telemetry:Origin=c
     const fluidTelemetry = headers.get("x-fluid-telemetry");
     if (fluidTelemetry !== undefined && fluidTelemetry !== null) {
+        additionalProps.xFluidTelemetry = fluidTelemetry;
         const keyValueMap = fluidTelemetry.split(",").map((keyValuePair) => keyValuePair.split("="));
         for (const [key, value] of keyValueMap) {
             if ("Origin" === key.trim()) {


### PR DESCRIPTION
Hammond Pang, from ODSP , asked us to add the x-fluid-telemetry to our telemetry. 

## Does this introduce a breaking change?
No

## Any relevant logs or outputs
xFluidTelemtry will have "origin=g,compression=pre,...." 

From Hammond: "... it would be really nice if we can just pass information about the request using this header for the client to log.... 
An example would be that we're starting to move towards pre-computed pre-gzipped responses, we would possibly want to return origin=g,compression=pre,...." 