### PR TITLE
Tree: Fix bug in TextCursor

### DIFF
--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -410,7 +410,8 @@ class Cursor implements ITreeSubscriptionCursor {
             this.siblings = this.forest.getRoot(this.root!);
         } else {
             const newParent = this.parentStack[this.parentStack.length - 1];
-            this.siblings = getGenericTreeField(newParent, this.keyStack[this.keyStack.length - 1], false);
+            const key = this.keyStack[this.keyStack.length - 1];
+            this.siblings = getGenericTreeField(newParent, key, false);
         }
         return TreeNavigationResult.Ok;
     }

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -17,7 +17,6 @@ import { TreeNavigationResult } from "../forest";
 import { JsonCursor, cursorToJsonObject, jsonTypeSchema } from "../domains";
 import { recordDependency } from "../dependency-tracking";
 import { MockDependent } from "./utils";
-
 /**
  * Generic forest test suite
  */
@@ -32,7 +31,7 @@ function testForest(suiteName: string, factory: () => ObjectForest): void {
                 ["primitive", 5],
                 ["array", [1, 2, 3]],
                 ["object", { blah: "test" }],
-                ["nested objects", { blah: { foo: 5 }, baz: [{}, {}] }],
+                ["nested objects", { blah: { foo: 5 }, baz: [{}, { foo: 3 }] }],
             ];
             for (const [name, data] of testCases) {
                 it(name, () => {

--- a/packages/dds/tree/src/test/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/treeTextCursor.spec.ts
@@ -16,6 +16,34 @@ const testCases: [string, PlaceholderTree][] = [
 	["minimal", { type: brand("Foo") }],
 	["value", { type: brand("Foo"), value: "test" }],
 	["nested", { type: brand("Foo"), fields: { x: [{ type: brand("Bar") }, { type: brand("Foo"), value: 6 }] } }],
+	["multiple fields", {
+		type: brand("Foo"),
+		fields: {
+			a: [{ type: brand("Bar") }],
+			b: [{ type: brand("Baz") }],
+		},
+	}],
+	["double nested", {
+		type: brand("Foo"),
+		fields: {
+			b: [{
+				type: brand("Bar"),
+				fields: { c: [{ type: brand("Baz") }] },
+			}],
+		},
+	}],
+	["complex", {
+		type: brand("Foo"),
+		fields: {
+			a: [{ type: brand("Bar") }],
+			b: [{
+				type: brand("Bar"),
+				fields: {
+					c: [{ type: brand("Bar"), value: 6 }],
+				},
+			}],
+		},
+	}],
 ];
 
 describe("textTreeFormat", () => {


### PR DESCRIPTION
## Description

Bug fix and improved tests for TextCursor.

Improved readability for code in TextCursor and related code in ObjectForest.

I think the bug was a mistake with regard to operator associativity. This was not confirmed as rewriting the code to be more readable fixed the issue.

From the new tests `double nested` and `complex` failed before the fix.

## Other information or known dependencies

Based on bug an initial workaround and test from https://github.com/microsoft/FluidFramework/pull/11287
