### PR TITLE
Tree: Fix siblings on cursor.up()

### DIFF
--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -402,7 +402,8 @@ class Cursor implements ITreeSubscriptionCursor {
         assert(this.indexStack.length === length, "Unexpected indexStack.length");
         assert(this.keyStack.length === length - 1, "Unexpected keyStack.length");
 
-        // Already at the root
+        // If parentStack (which includes the current node) contains only one item,
+        // then the current node is the root, and we can not navigate up.
         if (length === 1) {
             return TreeNavigationResult.NotFound;
         }
@@ -413,6 +414,9 @@ class Cursor implements ITreeSubscriptionCursor {
         this.keyStack.pop();
         // TODO: maybe compute siblings lazily or store in stack? Store instead of keyStack?
         if (length === 2) {
+            // Before navigation, cursor was one below the root (height 2), so now it's at the root.
+            // At the root it cannot get the sibling list by looking at the parent (since there is none),
+            // so get it from the forest directly.
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.siblings = this.forest.getRoot(this.root!);
         } else {

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -122,7 +122,8 @@ export class TextCursor implements ITreeCursor {
         assert(this.indexStack.length === length, "Unexpected indexStack.length");
         assert(this.keyStack.length === length - 1, "Unexpected keyStack.length");
 
-        // Already at the root
+        // If parentStack (which includes the current node) contains only one item,
+        // then the current node is the root, and we can not navigate up.
         if (length === 1) {
             return TreeNavigationResult.NotFound;
         }
@@ -133,6 +134,9 @@ export class TextCursor implements ITreeCursor {
         this.keyStack.pop();
         // TODO: maybe compute siblings lazily or store in stack? Store instead of keyStack?
         if (length === 2) {
+            // Before navigation, cursor was one below the root (height 2), so now it's at the root.
+            // At the root it cannot get the sibling list by looking at the parent (since there is none),
+            // so use the saved root array.
             this.siblings = this.root;
         } else {
             const newParent = this.parentStack[this.parentStack.length - 2];

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -49,7 +49,7 @@ import {
  */
 export class TextCursor implements ITreeCursor {
     // Ancestors traversed to visit this node (including this node and the root).
-    private readonly parentStack: JsonableTree[] = [];
+    private readonly nodeStack: JsonableTree[] = [];
     // Keys traversed to visit this node
     private readonly keyStack: FieldKey[] = [];
     // Indices traversed to visit this node
@@ -62,11 +62,11 @@ export class TextCursor implements ITreeCursor {
         this.root = [root];
         this.indexStack.push(0);
         this.siblings = this.root;
-        this.parentStack.push(root);
+        this.nodeStack.push(root);
     }
 
     getNode(): JsonableTree {
-        return this.parentStack[this.parentStack.length - 1];
+        return this.nodeStack[this.nodeStack.length - 1];
     }
 
     getFields(): Readonly<FieldMap<JsonableTree>> {
@@ -96,7 +96,7 @@ export class TextCursor implements ITreeCursor {
         const siblings = this.getField(key);
         const child = siblings[index];
         if (child !== undefined) {
-            this.parentStack.push(child);
+            this.nodeStack.push(child);
             this.indexStack.push(index);
             this.keyStack.push(key);
             this.siblings = siblings;
@@ -110,7 +110,7 @@ export class TextCursor implements ITreeCursor {
         const child = this.siblings[index];
         if (child !== undefined) {
             this.indexStack[this.indexStack.length - 1] = index;
-            this.parentStack[this.parentStack.length - 1] = child;
+            this.nodeStack[this.nodeStack.length - 1] = child;
             return { result: TreeNavigationResult.Ok, moved: offset };
         }
         // TODO: Maybe truncate move, and move to end?
@@ -118,18 +118,18 @@ export class TextCursor implements ITreeCursor {
     }
 
     up(): TreeNavigationResult {
-        const length = this.parentStack.length;
+        const length = this.nodeStack.length;
         assert(this.indexStack.length === length, "Unexpected indexStack.length");
         assert(this.keyStack.length === length - 1, "Unexpected keyStack.length");
 
-        // If parentStack (which includes the current node) contains only one item,
+        // If nodeStack (which includes the current node) contains only one item,
         // then the current node is the root, and we can not navigate up.
         if (length === 1) {
             return TreeNavigationResult.NotFound;
         }
 
-        assert(length > 1, "Unexpected parentStack.length");
-        this.parentStack.pop();
+        assert(length > 1, "Unexpected nodeStack.length");
+        this.nodeStack.pop();
         this.indexStack.pop();
         this.keyStack.pop();
         // TODO: maybe compute siblings lazily or store in stack? Store instead of keyStack?
@@ -139,7 +139,7 @@ export class TextCursor implements ITreeCursor {
             // so use the saved root array.
             this.siblings = this.root;
         } else {
-            const newParent = this.parentStack[this.parentStack.length - 2];
+            const newParent = this.nodeStack[this.nodeStack.length - 2];
             const key = this.keyStack[this.keyStack.length - 1];
             this.siblings = getGenericTreeField(newParent, key, false);
         }

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -48,7 +48,7 @@ import {
  * Maybe do a refactoring to deduplicate this.
  */
 export class TextCursor implements ITreeCursor {
-    // Ancestors traversed to visit this node (including this node).
+    // Ancestors traversed to visit this node (including this node and the root).
     private readonly parentStack: JsonableTree[] = [];
     // Keys traversed to visit this node
     private readonly keyStack: FieldKey[] = [];
@@ -122,17 +122,20 @@ export class TextCursor implements ITreeCursor {
         assert(this.indexStack.length === length, "Unexpected indexStack.length");
         assert(this.keyStack.length === length - 1, "Unexpected keyStack.length");
 
-        if (length === 0) {
+        // Already at the root
+        if (length === 1) {
             return TreeNavigationResult.NotFound;
         }
+
+        assert(length > 1, "Unexpected parentStack.length");
         this.parentStack.pop();
         this.indexStack.pop();
         this.keyStack.pop();
         // TODO: maybe compute siblings lazily or store in stack? Store instead of keyStack?
-        if (length === 1) {
+        if (length === 2) {
             this.siblings = this.root;
         } else {
-            const newParent = this.parentStack[this.parentStack.length - 1];
+            const newParent = this.parentStack[this.parentStack.length - 2];
             const key = this.keyStack[this.keyStack.length - 1];
             this.siblings = getGenericTreeField(newParent, key, false);
         }

--- a/packages/dds/tree/src/test/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/treeTextCursor.spec.ts
@@ -4,60 +4,95 @@
  */
 
 import { strict as assert } from "assert";
+import { ObjectForest } from "../feature-libraries";
 
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { jsonableTreeFromCursor, TextCursor } from "../feature-libraries/treeTextCursor";
+import { ITreeCursor, TreeNavigationResult } from "../forest";
 
-import { PlaceholderTree } from "../tree";
+import { JsonableTree } from "../tree";
 import { brand } from "../util";
 
-const testCases: [string, PlaceholderTree][] = [
-	["minimal", { type: brand("Foo") }],
-	["value", { type: brand("Foo"), value: "test" }],
-	["nested", { type: brand("Foo"), fields: { x: [{ type: brand("Bar") }, { type: brand("Foo"), value: 6 }] } }],
-	["multiple fields", {
-		type: brand("Foo"),
-		fields: {
-			a: [{ type: brand("Bar") }],
-			b: [{ type: brand("Baz") }],
-		},
-	}],
-	["double nested", {
-		type: brand("Foo"),
-		fields: {
-			b: [{
-				type: brand("Bar"),
-				fields: { c: [{ type: brand("Baz") }] },
-			}],
-		},
-	}],
-	["complex", {
-		type: brand("Foo"),
-		fields: {
-			a: [{ type: brand("Bar") }],
-			b: [{
-				type: brand("Bar"),
-				fields: {
-					c: [{ type: brand("Bar"), value: 6 }],
-				},
-			}],
-		},
-	}],
+const testCases: [string, JsonableTree][] = [
+    ["minimal", { type: brand("Foo") }],
+    ["value", { type: brand("Foo"), value: "test" }],
+    ["nested", { type: brand("Foo"), fields: { x: [{ type: brand("Bar") }, { type: brand("Foo"), value: 6 }] } }],
+    ["multiple fields", {
+        type: brand("Foo"),
+        fields: {
+            a: [{ type: brand("Bar") }],
+            b: [{ type: brand("Baz") }],
+        },
+    }],
+    ["double nested", {
+        type: brand("Foo"),
+        fields: {
+            b: [{
+                type: brand("Bar"),
+                fields: { c: [{ type: brand("Baz") }] },
+            }],
+        },
+    }],
+    ["complex", {
+        type: brand("Foo"),
+        fields: {
+            a: [{ type: brand("Bar") }],
+            b: [{
+                type: brand("Bar"),
+                fields: {
+                    c: [{ type: brand("Bar"), value: 6 }],
+                },
+            }],
+        },
+    }],
+    ["siblings restored on up", {
+        type: brand("Foo"),
+        fields: {
+            X: [
+                {
+                    type: brand("a"),
+                    // Inner node so that when navigating up from it,
+                    // The cursor's siblings value needs to be restored.
+                    fields: { q: [{ type: brand("b") }] },
+                },
+                { type: brand("c") },
+            ],
+        },
+    }],
 ];
 
-describe("textTreeFormat", () => {
-	describe("round trip", () => {
-		for (const [name, data] of testCases) {
-			it(name, () => {
-				const cursor = new TextCursor(data);
-				const clone = jsonableTreeFromCursor(cursor);
-				assert.deepEqual(clone, data);
-				// Check objects are actually json compatible
-				const text = JSON.stringify(clone);
-				const parsed = JSON.parse(text);
-				assert.deepEqual(parsed, data);
-			});
-		}
-	});
+function testCursor(suiteName: string, factory: (data: JsonableTree) => ITreeCursor): void {
+    describe(suiteName, () => {
+        describe("round trip", () => {
+            for (const [name, data] of testCases) {
+                it(name, () => {
+                    const cursor = factory(data);
+                    const clone = jsonableTreeFromCursor(cursor);
+                    assert.deepEqual(clone, data);
+                    // Check objects are actually json compatible
+                    const text = JSON.stringify(clone);
+                    const parsed = JSON.parse(text);
+                    assert.deepEqual(parsed, data);
+                });
+            }
+        });
+
+        it("up from root", () => {
+            const cursor = new TextCursor({ type: brand("Foo") });
+            assert.equal(cursor.up(), TreeNavigationResult.NotFound);
+        });
+    });
+}
+
+// Tests for TextCursor and jsonableTreeFromCursor.
+testCursor("textTreeFormat", (data): ITreeCursor => new TextCursor(data));
+
+// TODO: put these in a better place / unify with object forest tests.
+testCursor("object-forest cursor", (data): ITreeCursor => {
+    const forest = new ObjectForest();
+    const insert = forest.add([new TextCursor(data)]);
+    const cursor = forest.allocateCursor();
+    assert.equal(forest.tryGet(forest.root(insert), cursor), TreeNavigationResult.Ok);
+    return cursor;
 });


### PR DESCRIPTION
## Description

More cursor fixes in `up`, and more test coverage for it.