### PR TITLE
re-enabled test for bug 277 since all tests pass

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -95,11 +95,11 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
 
         if (container.getSpecifiedCodeDetails !== undefined) {
             assert.strictEqual(container.getSpecifiedCodeDetails()?.package, provider.defaultCodeDetails.package,
-            "Specified package should be same as provided");
+                "Specified package should be same as provided");
         }
         if (container.getLoadedCodeDetails !== undefined) {
             assert.strictEqual(container.getLoadedCodeDetails()?.package, provider.defaultCodeDetails.package,
-            "Loaded package should be same as provided");
+                "Loaded package should be same as provided");
         }
         assert.strictEqual((container as Container).clientDetails.capabilities.interactive, true,
             "Client details should be set with interactive as true");
@@ -319,7 +319,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         await defPromise.promise;
     });
 
-    it.skip("Fire dataStore attach ops during container attach", async () => {
+    it("Fire dataStore attach ops during container attach", async () => {
         const testDataStoreType = "default";
         const defPromise = new Deferred<void>();
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);


### PR DESCRIPTION
# [Work Item 277](https://dev.azure.com/fluidframework/internal/_workitems/edit/277)

## Description

> ODSP and tinylicious tests are working for detachedContainerTests.spec.ts: Fire dataStore attach ops during container attach. Enabling test.

## Testing

> -   This was tested on a local machine, as well as on code spaces

## Other information or known dependencies
[AB#277](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/277)
#9040