### PR TITLE
Bugfix for clearing segment on detached localRefs

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -25,6 +25,7 @@ import {
     UniversalSequenceNumber,
 } from "./constants";
 import {
+    assertLocalReferences,
      LocalReferenceCollection,
      LocalReferencePosition,
 } from "./localReference";
@@ -875,7 +876,8 @@ export class MergeTree {
         } else {
             for (const ref of refsToSlide) {
                 ref.callbacks?.beforeSlide?.();
-                segment.localRefs.removeLocalRef(ref);
+                assertLocalReferences(ref);
+                ref.link(undefined, 0, undefined);
                 ref.callbacks?.afterSlide?.();
             }
         }

--- a/packages/dds/merge-tree/src/test/client.localReference.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReference.spec.ts
@@ -283,6 +283,7 @@ describe("MergeTree.Client", () => {
         client2.applyMsg(remove);
 
         assert.equal(client1.localReferencePositionToPosition(c1LocalRef), DetachedReferencePosition);
+        assert.equal(c1LocalRef.getSegment(), undefined);
     });
 
     it("References can have offsets on removed segment", () => {

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -367,7 +367,7 @@ describe("SharedString interval collections", () => {
             const assertAllIntervals = (expected: readonly { start: number; end: number; }[]) => {
                 assertIntervals(sharedString, collection1, expected, false);
                 assertIntervals(sharedString2, collection2, expected, false);
-            }
+            };
 
             sharedString.insertText(0, "ABCD");
             const interval = collection1.add(1, 3, IntervalType.SlideOnRemove);
@@ -377,7 +377,8 @@ describe("SharedString interval collections", () => {
 
             assertAllIntervals([{ start: -1, end: -1 }]);
 
-            collection2.change(interval.getIntervalId()!, undefined, 2);
+            const id = interval.getIntervalId() ?? assert.fail("expected interval to have id");
+            collection2.change(id, undefined, 2);
             containerRuntimeFactory.processAllMessages();
 
             assertAllIntervals([{ start: -1, end: 2 }]);

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -361,6 +361,28 @@ describe("SharedString interval collections", () => {
             ], false);
         });
 
+        it("remains consistent after changing only one end of a detached interval", () => {
+            const collection1 = sharedString.getIntervalCollection("test");
+            const collection2 = sharedString2.getIntervalCollection("test");
+            const assertAllIntervals = (expected: readonly { start: number; end: number; }[]) => {
+                assertIntervals(sharedString, collection1, expected, false);
+                assertIntervals(sharedString2, collection2, expected, false);
+            }
+
+            sharedString.insertText(0, "ABCD");
+            const interval = collection1.add(1, 3, IntervalType.SlideOnRemove);
+            sharedString.removeRange(0, 4);
+            sharedString.insertText(0, "012");
+            containerRuntimeFactory.processAllMessages();
+
+            assertAllIntervals([{ start: -1, end: -1 }]);
+
+            collection2.change(interval.getIntervalId()!, undefined, 2);
+            containerRuntimeFactory.processAllMessages();
+
+            assertAllIntervals([{ start: -1, end: 2 }]);
+        });
+
         it("can slide intervals on remove ack", () => {
             const collection1 = sharedString.getIntervalCollection("test");
             sharedString.insertText(0, "ABCD");


### PR DESCRIPTION
This wipes the `segment` field on `slideReferences` when there's no segment to slide to.

For references that aren't SlideOnRemove or StayOnRemove, this behavior is more consistent with the detach behavior in addBeforeTombstones/addAfterTombstones (there, we also fully unlink, which removes the segment).

For SlideOnRemove references, this behavior is more consistent between the local behavior and what a remote client might see, since the reference should slide to a detached position. Leaving the segment intact can present issues if the segment then slides again. I wrote a test in the sequence package to demonstrate the issue, but the added assert in the existing merge-tree test covers the code change.