### PR TITLE
Tree: more consistent type branding and simplify object-forest's Cursor

### DIFF
--- a/packages/dds/tree/src/changeset/toDelta.ts
+++ b/packages/dds/tree/src/changeset/toDelta.ts
@@ -216,7 +216,7 @@ function applyOrCollectModifications(
         const protoFields = node.fields ?? {};
         const modifyFields = modify.fields;
         for (const key of Object.keys(modifyFields)) {
-            const brandedKey = brand<FieldKey>(key);
+            const brandedKey: FieldKey = brand(key);
             const outNodes = protoFields[key] ?? fail(ERR_MOD_ON_MISSING_FIELD);
             const outMarks = new OffsetListFactory<InsertedFieldsMark>();
             let index = 0;
@@ -377,7 +377,7 @@ function convertFieldMarks<TMarks>(fields: T.FieldMarks): Delta.FieldMarks<TMark
     const outFields: Delta.FieldMarks<TMarks> = new Map();
     for (const key of Object.keys(fields)) {
         const marks = convertMarkList<TMarks>(fields[key]);
-        const brandedKey = brand<FieldKey>(key);
+        const brandedKey: FieldKey = brand(key);
         outFields.set(brandedKey, marks);
     }
     return outFields;

--- a/packages/dds/tree/src/domains/json/jsonDomainSchema.ts
+++ b/packages/dds/tree/src/domains/json/jsonDomainSchema.ts
@@ -16,12 +16,12 @@ import {
     ValueSchema,
     FieldSchema,
     TreeSchemaIdentifier,
-    LocalFieldKey,
     NamedTreeSchema,
     emptyField,
     emptyMap,
     emptySet,
 } from "../../schema";
+import { brand } from "../../util";
 
 export const jsonTypeSchema: Map<TreeSchemaIdentifier, NamedTreeSchema> = new Map();
 
@@ -30,7 +30,7 @@ const jsonTypes: Set<TreeSchemaIdentifier> = new Set();
 const json: NamedTreeSchema[] = [];
 
 export const jsonObject: NamedTreeSchema = {
-    name: "Json.Object" as TreeSchemaIdentifier,
+    name: brand("Json.Object"),
     localFields: emptyMap,
     globalFields: emptySet,
     extraLocalFields: emptyField,
@@ -39,13 +39,13 @@ export const jsonObject: NamedTreeSchema = {
 };
 
 export const jsonArray: NamedTreeSchema = {
-    name: "Json.Array" as TreeSchemaIdentifier,
+    name: brand("Json.Array"),
     globalFields: emptySet,
     extraLocalFields: emptyField,
     extraGlobalFields: false,
     localFields: new Map([
         [
-            "items" as LocalFieldKey,
+            brand("items"),
             { kind: FieldKind.Sequence, types: jsonTypes },
         ],
     ]),
@@ -53,7 +53,7 @@ export const jsonArray: NamedTreeSchema = {
 };
 
 export const jsonNumber: NamedTreeSchema = {
-    name: "Json.Number" as TreeSchemaIdentifier,
+    name: brand("Json.Number"),
     localFields: emptyMap,
     globalFields: emptySet,
     extraLocalFields: emptyField,
@@ -62,7 +62,7 @@ export const jsonNumber: NamedTreeSchema = {
 };
 
 export const jsonString: NamedTreeSchema = {
-    name: "Json.String" as TreeSchemaIdentifier,
+    name: brand("Json.String"),
     localFields: emptyMap,
     globalFields: emptySet,
     extraLocalFields: emptyField,
@@ -71,7 +71,7 @@ export const jsonString: NamedTreeSchema = {
 };
 
 export const jsonNull: NamedTreeSchema = {
-    name: "Json.Null" as TreeSchemaIdentifier,
+    name: brand("Json.Null"),
     localFields: emptyMap,
     globalFields: emptySet,
     extraLocalFields: emptyField,
@@ -80,7 +80,7 @@ export const jsonNull: NamedTreeSchema = {
 };
 
 export const jsonBoolean: NamedTreeSchema = {
-    name: "Json.Boolean" as TreeSchemaIdentifier,
+    name: brand("Json.Boolean"),
     localFields: emptyMap,
     globalFields: emptySet,
     extraLocalFields: emptyField,

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -414,7 +414,7 @@ class Cursor implements ITreeSubscriptionCursor {
 
         let path: UpPath | undefined;
         const length = this.indexStack.length;
-        assert(this.indexStack.length === length, "Unexpected indexStack.length");
+        assert(this.siblingStack.length === length, "Unexpected siblingStack.length");
         assert(this.keyStack.length === length + 1, "Unexpected keyStack.length");
         for (let height = 0; height < length; height++) {
             path = {

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -340,7 +340,7 @@ class Cursor implements ITreeSubscriptionCursor {
     private readonly siblingStack: JsonableTree[][] = [];
     // Keys traversed to visit this node, including detached field at the beginning
     private readonly keyStack: FieldKey[] = [];
-    // Indices traversed to visit this node: does not include currently level (which is stored in `index`).
+    // Indices traversed to visit this node: does not include current level (which is stored in `index`).
     private readonly indexStack: number[] = [];
 
     private siblings?: JsonableTree[];

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -462,7 +462,7 @@ class Cursor implements ITreeSubscriptionCursor {
     up(): TreeNavigationResult {
         const index = this.indexStack.pop();
         if (index === undefined) {
-            // At root already (and made not changes to current location)
+            // At root already (and made no changes to current location)
             return TreeNavigationResult.NotFound;
         }
 

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -336,9 +336,9 @@ class Cursor implements ITreeSubscriptionCursor {
 
     observer?: ObservingDependent | undefined;
 
-    // Siblings of node stack: does not include currently level (which is stored in `siblings`).
+    // Siblings of into which indexStack indexes: does not include currently level (which is stored in `siblings`).
     private readonly siblingStack: JsonableTree[][] = [];
-    // Keys traversed to visit this node, including detached field at the beginning
+    // Keys traversed to visit this node, including detached field at the beginning.
     private readonly keyStack: FieldKey[] = [];
     // Indices traversed to visit this node: does not include current level (which is stored in `index`).
     private readonly indexStack: number[] = [];
@@ -346,9 +346,11 @@ class Cursor implements ITreeSubscriptionCursor {
     private siblings?: JsonableTree[];
     private index: number = -1;
 
+    // TODO: tests for clear when not at root.
     public clear(): void {
         assert(this.state !== ITreeSubscriptionCursorState.Freed, 0x33b /* Cursor must not be freed */);
         this.state = ITreeSubscriptionCursorState.Cleared;
+        this.keyStack.length = 1;
         this.siblingStack.length = 0;
         this.indexStack.length = 0;
         this.siblings = undefined;

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -336,12 +336,12 @@ class Cursor implements ITreeSubscriptionCursor {
 
     observer?: ObservingDependent | undefined;
 
-    // Siblings of into which indexStack indexes: does not include currently level (which is stored in `siblings`).
+    // Indices traversed to visit this node: does not include current level (which is stored in `index`).
+    private readonly indexStack: number[] = [];
+    // Siblings into which indexStack indexes: does not include current level (which is stored in `siblings`).
     private readonly siblingStack: JsonableTree[][] = [];
     // Keys traversed to visit this node, including detached field at the beginning.
     private readonly keyStack: FieldKey[] = [];
-    // Indices traversed to visit this node: does not include current level (which is stored in `index`).
-    private readonly indexStack: number[] = [];
 
     private siblings?: JsonableTree[];
     private index: number = -1;

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -4,8 +4,7 @@
  */
 
 import { StoredSchemaRepository } from "../schema";
-import { AnchorSet, FieldKey, DetachedField, Delta, JsonableTree } from "../tree";
-import { brand } from "../util";
+import { AnchorSet, FieldKey, DetachedField, Delta, JsonableTree, detachedFieldAsKey } from "../tree";
 import { IForestSubscription, ITreeSubscriptionCursor, ForestAnchor } from "./forest";
 
 /**
@@ -35,8 +34,7 @@ export interface IEditableForest extends IForestSubscription {
 export function initializeForest(forest: IEditableForest, content: JsonableTree[]): void {
     // TODO: maybe assert forest is empty?
     const insert: Delta.Insert = { type: Delta.MarkType.Insert, content };
-    // TODO: make type-safe
-    const rootField = brand<FieldKey>(forest.rootField as unknown as string);
+    const rootField = detachedFieldAsKey(forest.rootField);
     forest.applyDelta(new Map([[rootField, [insert]]]));
 }
 

--- a/packages/dds/tree/src/schema/Builders.ts
+++ b/packages/dds/tree/src/schema/Builders.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { brandOpaque } from "../util";
+import { brand, brandOpaque } from "../util";
 import {
     FieldSchema, GlobalFieldKey, LocalFieldKey, FieldKind, TreeSchema, TreeSchemaIdentifier, ValueSchema,
 } from "./Schema";
@@ -29,7 +29,7 @@ export const emptyMap: ReadonlyMap<never, never> = new Map<never, never>();
  * LocalFieldKey to use for when there is a collection of items under a tree node
  * that makes up the logical primary significant of that tree.
  */
-export const itemsKey = "items" as LocalFieldKey;
+export const itemsKey: LocalFieldKey = brand("items");
 
 /**
  * GlobalFieldKey to use for the root of documents.
@@ -71,7 +71,7 @@ export function treeSchema(data: TreeSchemaBuilder): TreeSchema {
     // eslint-disable-next-line no-restricted-syntax
     for (const key in local) {
         if (Object.prototype.hasOwnProperty.call(local, key)) {
-            localFields.set(key as LocalFieldKey, local[key]);
+            localFields.set(brand(key), local[key]);
         }
     }
 

--- a/packages/dds/tree/src/test/changeset/toDelta.spec.ts
+++ b/packages/dds/tree/src/test/changeset/toDelta.spec.ts
@@ -25,11 +25,11 @@ function toTreeDelta(list: T.MarkList): Delta.MarkList<Delta.OuterMark> {
     return fullDelta.get(rootKey) ?? assert.fail("Expected changes under the root");
 }
 
-const type = brand<TreeSchemaIdentifier>("Node");
-const rootKey = brand<FieldKey>("root");
-const detachedKey = brand<FieldKey>("detached");
-const fooKey = brand<FieldKey>("foo");
-const barKey = brand<FieldKey>("bar");
+const type: TreeSchemaIdentifier = brand("Node");
+const rootKey: FieldKey = brand("root");
+const detachedKey: FieldKey = brand("detached");
+const fooKey: FieldKey = brand("foo");
+const barKey: FieldKey = brand("bar");
 const content: ProtoNode[] = [{
     type,
     value: 42,

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -9,6 +9,7 @@ import { FieldKey } from "../../../tree";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor";
+import { brand } from "../../../util";
 
 describe("JsonCursor", () => {
     // This tests that test data roundtrips via extract.
@@ -79,7 +80,7 @@ describe("JsonCursor", () => {
     describe("seek()", () => {
         describe("with map-like node", () => {
             const tests: [string, FieldKey][] = [
-                ["non-empty", "key" as const as FieldKey],
+                ["non-empty", brand("key")],
                 ["empty", EmptyKey],
             ];
 
@@ -140,8 +141,8 @@ describe("JsonCursor", () => {
     });
 
     describe("TreeNavigationResult", () => {
-        const notFoundKey = "notFound" as FieldKey;
-        const foundKey = "found" as FieldKey;
+        const notFoundKey: FieldKey = brand("notFound");
+        const foundKey: FieldKey = brand("found");
 
         function expectFound(cursor: ITreeCursor, key: FieldKey, index = 0) {
             assert(0 <= index && index < cursor.length(key),

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -16,9 +16,8 @@ import {
 import { IEditableForest, initializeForest, TreeNavigationResult } from "../forest";
 import { JsonCursor, cursorToJsonObject, jsonTypeSchema, jsonNumber } from "../domains";
 import { recordDependency } from "../dependency-tracking";
-import { Delta, FieldKey, JsonableTree } from "../tree";
+import { Delta, detachedFieldAsKey, JsonableTree } from "../tree";
 import { jsonableTreeFromCursor } from "..";
-import { brand } from "../util";
 import { MockDependent } from "./utils";
 
 /**
@@ -73,7 +72,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
 
             const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: 2 };
             // TODO: make type-safe
-            const rootField = brand<FieldKey>(forest.rootField as unknown as string);
+            const rootField = detachedFieldAsKey(forest.rootField);
             const delta: Delta.Root = new Map([[rootField, [setValue]]]);
             forest.applyDelta(delta);
 
@@ -91,7 +90,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
 
             const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: undefined };
             // TODO: make type-safe
-            const rootField = brand<FieldKey>(forest.rootField as unknown as string);
+            const rootField = detachedFieldAsKey(forest.rootField);
             const delta: Delta.Root = new Map([[rootField, [setValue]]]);
             forest.applyDelta(delta);
 
@@ -109,7 +108,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
 
             // TODO: does does this select what to delete?
             const mark: Delta.Delete = { type: Delta.MarkType.Delete, count: 1 };
-            const rootField = brand<FieldKey>(forest.rootField as unknown as string);
+            const rootField = detachedFieldAsKey(forest.rootField);
             const delta: Delta.Root = new Map([[rootField, [0, mark]]]);
             // TODO: make type-safe
             forest.applyDelta(delta);
@@ -132,7 +131,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
                 const content: JsonableTree[] = [{ type: jsonNumber.name, value: 1 }];
                 const insert: Delta.Insert = { type: Delta.MarkType.Insert, content };
                 // TODO: make type-safe
-                const rootField = brand<FieldKey>(forest.rootField as unknown as string);
+                const rootField = detachedFieldAsKey(forest.rootField);
                 const delta: Delta.Root = new Map([[rootField, [insert]]]);
 
                 assert.deepEqual(dependent.tokens, []);

--- a/packages/dds/tree/src/test/schema/StoredSchemaRepository.spec.ts
+++ b/packages/dds/tree/src/test/schema/StoredSchemaRepository.spec.ts
@@ -16,6 +16,7 @@ import {
 	FieldSchema,
 	GlobalFieldKey, FieldKind, TreeSchema, TreeSchemaIdentifier, ValueSchema,
 } from "../../schema";
+import { brand } from "../../util";
 
 // Allow importing specific example files:
 /* eslint-disable-next-line import/no-internal-modules */
@@ -43,11 +44,11 @@ class ViewSchemaRepository extends StoredSchemaRepository {
 
 describe("StoredSchemaRepository", () => {
 	// Define some schema and identifiers for them for use in these examples:
-	const canvasIdentifier = "86432448-8454-4c86-a39c-699afbbdb753" as TreeSchemaIdentifier;
-	const textIdentifier = "3034e643-0ff3-44a9-8b7e-aea31fe635c8" as TreeSchemaIdentifier;
-	const positionedCanvasItemIdentifier = "d1810094-0990-410e-9704-b17a94b1ad85" as TreeSchemaIdentifier;
-	const pointIdentifier = "a68c1750-9fba-4b6e-8643-9d830e271c05" as TreeSchemaIdentifier;
-	const numberIdentifier = "08b4087a-da53-45d1-86cd-15a2948077bf" as TreeSchemaIdentifier;
+	const canvasIdentifier: TreeSchemaIdentifier = brand("86432448-8454-4c86-a39c-699afbbdb753");
+	const textIdentifier: TreeSchemaIdentifier = brand("3034e643-0ff3-44a9-8b7e-aea31fe635c8");
+	const positionedCanvasItemIdentifier: TreeSchemaIdentifier = brand("d1810094-0990-410e-9704-b17a94b1ad85");
+	const pointIdentifier: TreeSchemaIdentifier = brand("a68c1750-9fba-4b6e-8643-9d830e271c05");
+	const numberIdentifier: TreeSchemaIdentifier = brand("08b4087a-da53-45d1-86cd-15a2948077bf");
 
 	const canvas = treeSchema({ localFields: { items: fieldSchema(FieldKind.Sequence, [numberIdentifier]) } });
 	const number = treeSchema({ value: ValueSchema.Number });
@@ -184,7 +185,7 @@ describe("StoredSchemaRepository", () => {
 			assert(compatNew.write === Compatibility.Compatible);
 
 			// Now lets imagine some time passes, and the developers want to add a second content type:
-			const counterIdentifier = "0d8da0ca-b3ba-4025-93a3-b8f181379e3b" as TreeSchemaIdentifier;
+			const counterIdentifier: TreeSchemaIdentifier = brand("0d8da0ca-b3ba-4025-93a3-b8f181379e3b");
 			const counter = treeSchema({
 				localFields: {
 					count: fieldSchema(FieldKind.Value, [numberIdentifier]),
@@ -294,7 +295,7 @@ describe("StoredSchemaRepository", () => {
 		// In this version of the app,
 		// we decided that text should be organized into a hierarchy of formatting ranges.
 		// We are doing this schema change in an incompatible way, and thus introducing a new identifier:
-		const formattedTextIdentifier = "2cbc277e-8820-41ef-a3f4-0a00de8ef934" as TreeSchemaIdentifier;
+		const formattedTextIdentifier: TreeSchemaIdentifier = brand("2cbc277e-8820-41ef-a3f4-0a00de8ef934");
 		const formattedText = treeSchema({
 			localFields: {
 				content: fieldSchema(FieldKind.Sequence, [formattedTextIdentifier, codePoint.name]),

--- a/packages/dds/tree/src/test/schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/schema/comparison.spec.ts
@@ -21,11 +21,11 @@ import {
 	ValueSchema,
 	emptyField, emptyMap, emptySet, fieldSchema, anyField, anyTree, neverField, neverTree, StoredSchemaRepository,
 } from "../../schema";
-import { brandOpaque } from "../../util";
+import { brand, brandOpaque } from "../../util";
 
 describe("Schema Comparison", () => {
 	const neverTree2: TreeSchema = {
-		localFields: new Map([["x" as LocalFieldKey, neverField]]),
+		localFields: new Map([[brand("x"), neverField]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
 		extraGlobalFields: true,
@@ -33,7 +33,7 @@ describe("Schema Comparison", () => {
 	};
 
 	const emptyTree: NamedTreeSchema = {
-		name: "empty" as TreeSchemaIdentifier,
+		name: brand("empty"),
 		localFields: emptyMap,
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
@@ -42,8 +42,8 @@ describe("Schema Comparison", () => {
 	};
 
 	const emptyLocalFieldTree: NamedTreeSchema = {
-		name: "emptyLocalFieldTree" as TreeSchemaIdentifier,
-		localFields: new Map([["x" as LocalFieldKey, emptyField]]),
+		name: brand("emptyLocalFieldTree"),
+		localFields: new Map([[brand("x"), emptyField]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
 		extraGlobalFields: false,
@@ -51,8 +51,8 @@ describe("Schema Comparison", () => {
 	};
 
 	const optionalLocalFieldTree: NamedTreeSchema = {
-		name: "optionalLocalFieldTree" as TreeSchemaIdentifier,
-		localFields: new Map([["x" as LocalFieldKey, fieldSchema(FieldKind.Optional, [emptyTree.name])]]),
+		name: brand("optionalLocalFieldTree"),
+		localFields: new Map([[brand("x"), fieldSchema(FieldKind.Optional, [emptyTree.name])]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
 		extraGlobalFields: false,
@@ -60,8 +60,8 @@ describe("Schema Comparison", () => {
 	};
 
 	const valueLocalFieldTree: NamedTreeSchema = {
-		name: "valueLocalFieldTree" as TreeSchemaIdentifier,
-		localFields: new Map([["x" as LocalFieldKey, fieldSchema(FieldKind.Value, [emptyTree.name])]]),
+		name: brand("valueLocalFieldTree"),
+		localFields: new Map([[brand("x"), fieldSchema(FieldKind.Value, [emptyTree.name])]]),
 		globalFields: emptySet,
 		extraLocalFields: emptyField,
 		extraGlobalFields: false,
@@ -71,18 +71,18 @@ describe("Schema Comparison", () => {
 	it("isNeverField", () => {
 		const repo = new StoredSchemaRepository();
 		assert(isNeverField(repo, neverField));
-		repo.tryUpdateTreeSchema("never" as TreeSchemaIdentifier, neverTree);
+		repo.tryUpdateTreeSchema(brand("never"), neverTree);
 		const neverField2: FieldSchema = {
 			kind: FieldKind.Value,
-			types: new Set(["never" as TreeSchemaIdentifier]),
+			types: new Set([brand("never")]),
 		};
 		assert(isNeverField(repo, neverField2));
 		assert.equal(isNeverField(repo, emptyField), false);
 		assert.equal(isNeverField(repo, anyField), false);
-		repo.tryUpdateTreeSchema("empty" as TreeSchemaIdentifier, emptyTree);
+		repo.tryUpdateTreeSchema(brand("empty"), emptyTree);
 		assert.equal(isNeverField(repo, {
 			kind: FieldKind.Value,
-			types: new Set(["empty" as TreeSchemaIdentifier]),
+			types: new Set([brand("empty")]),
 		}), false);
 	});
 
@@ -135,10 +135,10 @@ describe("Schema Comparison", () => {
 
 	it("allowsFieldSuperset", () => {
 		const repo = new StoredSchemaRepository();
-		repo.tryUpdateTreeSchema("never" as TreeSchemaIdentifier, neverTree);
+		repo.tryUpdateTreeSchema(brand("never"), neverTree);
 		const neverField2: FieldSchema = {
 			kind: FieldKind.Value,
-			types: new Set(["never" as TreeSchemaIdentifier]),
+			types: new Set([brand("never")]),
 		};
 		const compare = (a: FieldSchema, b: FieldSchema): boolean => allowsFieldSuperset(repo, a, b);
 		testOrder(compare, [neverField, emptyField, anyField]);

--- a/packages/dds/tree/src/test/schema/examples/SchemaExamples.ts
+++ b/packages/dds/tree/src/test/schema/examples/SchemaExamples.ts
@@ -16,15 +16,15 @@
     FieldKind,
     ValueSchema,
     TreeSchemaIdentifier,
-    LocalFieldKey,
     NamedTreeSchema,
     emptyField,
     emptyMap,
     emptySet,
 } from "../../../schema";
+import { brand } from "../../../util";
 
 export const codePoint: NamedTreeSchema = {
-    name: "Primitive.CodePoint" as TreeSchemaIdentifier,
+    name: brand("Primitive.CodePoint"),
     localFields: emptyMap,
     globalFields: emptySet,
     extraLocalFields: emptyField,
@@ -41,7 +41,7 @@ export const string: TreeSchema = {
     extraGlobalFields: false,
     localFields: new Map([
         [
-            "children" as LocalFieldKey,
+            brand("children"),
             { kind: FieldKind.Sequence, types: new Set([codePoint.name]) },
         ],
     ]),

--- a/packages/dds/tree/src/test/tree/visit.spec.ts
+++ b/packages/dds/tree/src/test/tree/visit.spec.ts
@@ -53,8 +53,8 @@ function testTreeVisit(marks: Delta.MarkList, expected: Readonly<VisitScript>): 
     testVisit(new Map([[rootKey, marks]]), [["enterField", rootKey], ...expected, ["exitField", rootKey]]);
 }
 
-const rootKey = brand<FieldKey>("root");
-const fooKey = brand<FieldKey>("foo");
+const rootKey: FieldKey = brand("root");
+const fooKey: FieldKey = brand("foo");
 const nodeX = { type: jsonString.name, value: "X" };
 const content = [nodeX];
 

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -61,7 +61,7 @@ export class AnchorSet {
      */
     public track(path: UpPath): Anchor {
         const foundPath = this.trackInner(path);
-        const anchor = brand<Anchor>(this.anchorCounter++);
+        const anchor: Anchor = brand(this.anchorCounter++);
         this.anchorToPath.set(anchor, foundPath);
         return anchor;
     }

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -13,6 +13,7 @@ export {
     RootField,
     Value,
     TreeValue,
+    detachedFieldAsKey,
 } from "./types";
 
 export * from "./pathTree";

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -5,7 +5,7 @@
 
 import { Serializable } from "@fluidframework/datastore-definitions";
 import { GlobalFieldKey, LocalFieldKey, TreeSchemaIdentifier } from "../schema";
-import { Brand, Opaque } from "../util";
+import { brand, Brand, extractFromOpaque, Opaque } from "../util";
 
 export type FieldKey = LocalFieldKey | GlobalFieldKey;
 export type TreeType = TreeSchemaIdentifier;
@@ -14,7 +14,7 @@ export type TreeType = TreeSchemaIdentifier;
  * The empty key ("") is used for unnamed relationships, such as the indexer
  * of an explicit array node.
  */
-export const EmptyKey = "" as const as FieldKey;
+export const EmptyKey: FieldKey = brand("");
 
 /**
  * Location of a tree relative to is parent container (which can be a tree or forest).
@@ -55,6 +55,25 @@ export type ChildCollection = FieldKey | RootField;
  * to simplify the APIs and implementation.
  */
 export interface DetachedField extends Opaque<Brand<string, "tree.DetachedField">> {}
+
+/**
+ * Some code abstracts the root as a node with detached fields as its fields.
+ * This maps detached field to field keys for thus use.
+ *
+ * @returns `field` as a {@link LocalFieldKey} usable on a special root node serving as a parent of detached fields.
+ */
+export function detachedFieldAsKey(field: DetachedField): LocalFieldKey {
+    return brand(extractFromOpaque(field));
+}
+
+/**
+ * The inverse of {@link detachedFieldAsKey}.
+ * Thus must only be used on {@link LocalFieldKey}s which were produced via {@link detachedFieldAsKey},
+ * and with the same scope (ex: forest) as the detachedFieldAsKey was originally from.
+ */
+export function keyAsDetachedField(key: DetachedField): DetachedField {
+    return brand(extractFromOpaque(key));
+}
 
 /**
  * TODO: integrate this into Schema. Decide how to persist them (need stable Id?). Maybe allow updating field kinds?.


### PR DESCRIPTION
## Description

Use type branding more consistently.
Remove use of `as` with branded types.
Add conversion functions for DetachedField and LocalFieldKey.
Simplify object-forest's Cursor.