### PR TITLE
Update spec.selector in r11s deployment manifests

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/alfred-deployment.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       app: {{ template "routerlicious.name" . }}
+      component: "{{ .Values.alfred.name }}"
+      release: {{ .Release.Name }}
   replicas: {{ .Values.alfred.replicas }}
   template:
     metadata:

--- a/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/foreman-deployment.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       app: {{ template "routerlicious.name" . }}
+      component: "{{ .Values.foreman.name }}"
+      release: {{ .Release.Name }}
   replicas: {{ .Values.foreman.replicas }}
   template:
     metadata:

--- a/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/riddler-deployment.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       app: {{ template "routerlicious.name" . }}
+      component: "{{ .Values.riddler.name }}"
+      release: {{ .Release.Name }}
   replicas: {{ .Values.riddler.replicas }}
   template:
     metadata:

--- a/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scribe-deployment.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       app: {{ template "routerlicious.name" . }}
+      component: "{{ .Values.scribe.name }}"
+      release: {{ .Release.Name }}
   replicas: {{ .Values.scribe.replicas }}
   template:
     metadata:

--- a/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/scriptorium-deployment.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       app: {{ template "routerlicious.name" . }}
+      component: "{{ .Values.scriptorium.name }}"
+      release: {{ .Release.Name }}
   replicas: {{ .Values.scriptorium.replicas }}
   template:
     metadata:


### PR DESCRIPTION
## Description

Updates k8s Deployment manifests for Routerlicious so `spec.selector.matchLabels` matches *all* the label values in `spec.template.metadata.labels` instead of just one of them.

K8 documentation is a bit confusing around this topic, it says that if several Deployments have overlapping `spec.selector`s, they might start to compete to manage the same pods and cause unexpected issues. However, it seems that only applies to pods created manually (with labels that match the selectors for more than one deployment/replicaSet). Pods that are created by Deployments (or technically, by the ReplicaSets created by Deployments) also have `metadata.ownerReferences` values which Deployments/ReplicaSets also leverage to know exactly which pods they should try to manage. For pods that have a value there, that dictates who should manage it; for pods with no value there, then the label selectors come into play and Deployments/ReplicaSets could start competing.

Since we (should) only have pods created by the Deployments themselves, the label selectors (`spec.selector.matchLabels`) don't really matter right now, but I wanted to update them to match the labels that the pods for each Deployment end up getting (`spec.template.metadata.labels`) so we further minimize the risk of weird things happening where these charts are deployed.
