### PR TITLE
Tree: add support for Path based Anchors in object forest

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -225,7 +225,7 @@ export interface IForestSubscription extends Dependee {
     // (undocumented)
     readonly rootField: DetachedField;
     readonly schema: SchemaRepository & Dependee;
-    tryGet(destination: Anchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): TreeNavigationResult;
+    tryMoveCursorTo(destination: Anchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): TreeNavigationResult;
 }
 
 // @public

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -14,6 +14,7 @@ export type Anchor = Brand<number, "rebaser.Anchor">;
 export class AnchorSet {
     // (undocumented)
     forget(anchor: Anchor): void;
+    isEmpty(): boolean;
     locate(anchor: Anchor): UpPath | undefined;
     moveChildren(count: number, src: undefined | {
         path: UpPath;
@@ -197,13 +198,7 @@ export interface FieldSchema {
 export type FinalFromChangeRebaser<TChangeRebaser extends ChangeRebaser<any, any, any>> = TChangeRebaser extends ChangeRebaser<any, infer TFinal, any> ? TFinal : never;
 
 // @public
-export interface ForestAnchor {
-    free(): void;
-    readonly state: ITreeSubscriptionCursorState;
-}
-
-// @public
-export type ForestLocation = ITreeSubscriptionCursor | ForestAnchor;
+export type ForestLocation = ITreeSubscriptionCursor | Anchor;
 
 // @public
 export interface GenericTreeNode<TChild> extends NodeData {
@@ -226,11 +221,11 @@ export interface IEditableForest extends IForestSubscription {
 // @public
 export interface IForestSubscription extends Dependee {
     allocateCursor(): ITreeSubscriptionCursor;
-    root(range: DetachedField): ForestAnchor;
+    root(range: DetachedField): Anchor;
     // (undocumented)
     readonly rootField: DetachedField;
     readonly schema: SchemaRepository & Dependee;
-    tryGet(destination: ForestAnchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): TreeNavigationResult;
+    tryGet(destination: Anchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): TreeNavigationResult;
 }
 
 // @public
@@ -290,7 +285,7 @@ export interface ITreeCursor<TResult = TreeNavigationResult> {
 
 // @public
 export interface ITreeSubscriptionCursor extends ITreeCursor {
-    buildAnchor(): ForestAnchor;
+    buildAnchor(): Anchor;
     clear(): void;
     // (undocumented)
     fork(observer?: ObservingDependent): ITreeSubscriptionCursor;

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -81,7 +81,7 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
         // (since we don't save them, and they should not exist outside transactions).
         const rootAnchor = this.forest.root(this.forest.rootField);
         const roots: JsonableTree[] = [];
-        let result = this.forest.tryGet(rootAnchor, this.cursor);
+        let result = this.forest.tryMoveCursorTo(rootAnchor, this.cursor);
         while (result === TreeNavigationResult.Ok) {
             roots.push(jsonableTreeFromCursor(this.cursor));
             result = this.cursor.seek(1);

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -220,7 +220,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         if (path === undefined) {
             return TreeNavigationResult.NotFound;
         }
-       this.getAtPath(path, cursorToMove, observer);
+        this.getAtPath(path, cursorToMove, observer);
         return TreeNavigationResult.Ok;
     }
 

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -124,7 +124,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
                 assert(currentField !== undefined, "must be in field to enterNode");
                 let result: TreeNavigationResult;
                 if (currentNode.state === ITreeSubscriptionCursorState.Cleared) {
-                    result = this.tryGet(this.root(currentField as unknown as DetachedField), currentNode);
+                    result = this.tryMoveCursorTo(this.root(currentField as unknown as DetachedField), currentNode);
                 } else {
                     result = currentNode.down(currentField, index);
                 }
@@ -213,14 +213,14 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         this.invalidateDependents();
     }
 
-    tryGet(
+    tryMoveCursorTo(
         destination: Anchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent,
     ): TreeNavigationResult {
         const path = this.anchors.locate(destination);
         if (path === undefined) {
             return TreeNavigationResult.NotFound;
         }
-        this.getAtPath(path, cursorToMove, observer);
+        this.moveCursorToPath(path, cursorToMove, observer);
         return TreeNavigationResult.Ok;
     }
 
@@ -229,7 +229,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
      * This is NOT a relative move: current position is discarded.
      * Path must point to existing node.
      */
-    getAtPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): void {
+    moveCursorToPath(destination: UpPath, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): void {
         assert(cursorToMove instanceof Cursor, 0x337 /* ObjectForest must only be given its own Cursor type */);
         assert(cursorToMove.forest === this, 0x338 /* ObjectForest must only be given its own Cursor */);
 
@@ -341,7 +341,7 @@ class Cursor implements ITreeSubscriptionCursor {
     fork(observer?: ObservingDependent): ITreeSubscriptionCursor {
         const other = this.forest.allocateCursor();
         const path = this.getPath();
-        this.forest.getAtPath(path, other, observer);
+        this.forest.moveCursorToPath(path, other, observer);
         return other;
     }
 

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -4,8 +4,8 @@
  */
 
 import { StoredSchemaRepository } from "../schema";
-import { AnchorSet, FieldKey, DetachedField, Delta, JsonableTree, detachedFieldAsKey } from "../tree";
-import { IForestSubscription, ITreeSubscriptionCursor, ForestAnchor } from "./forest";
+import { AnchorSet, FieldKey, DetachedField, Delta, JsonableTree, detachedFieldAsKey, Anchor } from "../tree";
+import { IForestSubscription, ITreeSubscriptionCursor } from "./forest";
 
 /**
  * Editing APIs.
@@ -43,7 +43,7 @@ export function initializeForest(forest: IEditableForest, content: JsonableTree[
 /**
  * Ways to refer to a node in an IEditableForest.
  */
- export type ForestLocation = ITreeSubscriptionCursor | ForestAnchor;
+ export type ForestLocation = ITreeSubscriptionCursor | Anchor;
 
 export interface TreeLocation {
     readonly range: FieldLocation | DetachedField;

--- a/packages/dds/tree/src/forest/forest.ts
+++ b/packages/dds/tree/src/forest/forest.ts
@@ -5,7 +5,7 @@
 
 import { Dependee, ObservingDependent } from "../dependency-tracking";
 import { SchemaRepository } from "../schema";
-import { DetachedField } from "../tree";
+import { Anchor, DetachedField } from "../tree";
 import { ITreeCursor, TreeNavigationResult } from "./cursor";
 
 /**
@@ -47,7 +47,7 @@ export interface IForestSubscription extends Dependee {
     /**
      * Anchor at the beginning of a root field.
      */
-    root(range: DetachedField): ForestAnchor;
+    root(range: DetachedField): Anchor;
 
     /**
      * If observer is provided, it will be invalidated if the value returned from this changes
@@ -57,7 +57,7 @@ export interface IForestSubscription extends Dependee {
      * Must provide a `cursorToMove` from this subscription (acquired via `allocateCursor`).
      */
     tryGet(
-        destination: ForestAnchor,
+        destination: Anchor,
         cursorToMove: ITreeSubscriptionCursor,
         observer?: ObservingDependent
     ): TreeNavigationResult;
@@ -102,7 +102,7 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
      * Construct an `Anchor` which the IForestSubscription will keep rebased to `current`.
      * Note that maintaining an Anchor has cost: free them to stop incurring that cost.
      */
-    buildAnchor(): ForestAnchor;
+    buildAnchor(): Anchor;
 
     /**
      * Current state.
@@ -114,27 +114,6 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
      */
     // TODO: maybe support this.
     // getParentInfo(id: NodeId): TreeLocation;
-}
-
-/**
- * Pointer to a location in a Forest which IForestSubscription will keep rebased onto `current`.
- *
- * TODO:Performance:
- * An implementation might prefer to de-duplicate
- * Anchors and thus use a ref count instead of allocating an object for each one.
- * This could be enabled by removing "state".
- */
-export interface ForestAnchor {
-    /**
-     * Release any resources this Anchor is holding onto.
-     * After doing this, further use of this object other than reading `state` is forbidden (undefined behavior).
-     */
-    free(): void;
-
-    /**
-     * Current state.
-     */
-    readonly state: ITreeSubscriptionCursorState;
 }
 
 export enum ITreeSubscriptionCursorState {

--- a/packages/dds/tree/src/forest/forest.ts
+++ b/packages/dds/tree/src/forest/forest.ts
@@ -56,7 +56,7 @@ export interface IForestSubscription extends Dependee {
      * It is an error not to free `cursorToMove` before the next edit.
      * Must provide a `cursorToMove` from this subscription (acquired via `allocateCursor`).
      */
-    tryGet(
+    tryMoveCursorTo(
         destination: Anchor,
         cursorToMove: ITreeSubscriptionCursor,
         observer?: ObservingDependent

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -21,7 +21,6 @@ export { ITreeCursor, TreeNavigationResult, IEditableForest,
     FieldLocation,
     ForestLocation,
     ITreeSubscriptionCursor,
-    ForestAnchor,
     ITreeSubscriptionCursorState,
     SynchronousNavigationResult,
 } from "./forest";

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -77,7 +77,7 @@ function bench(name: string, getJson: () => any) {
             const forest = buildForest();
             initializeForest(forest, [encodedTree]);
             const cursor = forest.allocateCursor();
-            assert.equal(forest.tryGet(forest.root(forest.rootField), cursor), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(forest.root(forest.rootField), cursor), TreeNavigationResult.Ok);
             return cursor;
         }],
     ];

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -14,10 +14,11 @@ import {
     isNeverField, FieldKind,
 } from "../schema";
 import { IEditableForest, initializeForest, TreeNavigationResult } from "../forest";
-import { JsonCursor, cursorToJsonObject, jsonTypeSchema, jsonNumber } from "../domains";
+import { JsonCursor, cursorToJsonObject, jsonTypeSchema, jsonNumber, jsonObject } from "../domains";
 import { recordDependency } from "../dependency-tracking";
-import { Delta, detachedFieldAsKey, JsonableTree } from "../tree";
+import { clonePath, Delta, detachedFieldAsKey, JsonableTree, UpPath } from "../tree";
 import { jsonableTreeFromCursor } from "..";
+import { brand } from "../util";
 import { MockDependent } from "./utils";
 
 /**
@@ -118,6 +119,79 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
             assert.equal(forest.tryGet(anchor, reader), TreeNavigationResult.Ok);
             assert.equal(reader.value, 2);
             assert.equal(reader.seek(1), TreeNavigationResult.NotFound);
+        });
+
+        it("anchors creation and use", () => {
+            const forest = factory();
+            const dependent = new MockDependent("dependent");
+            recordDependency(dependent, forest);
+
+            const content: JsonableTree[] = [
+                { type: jsonObject.name, fields: { data: [
+                    { type: jsonNumber.name, value: 1 }, { type: jsonNumber.name, value: 2 }],
+                } },
+            ];
+            initializeForest(forest, content);
+
+            const rootAnchor = forest.root(forest.rootField);
+
+            const cursor = forest.allocateCursor();
+            assert.equal(forest.tryGet(rootAnchor, cursor), TreeNavigationResult.Ok);
+            const parentAnchor = cursor.buildAnchor();
+            assert.equal(cursor.down(brand("data"), 0), TreeNavigationResult.Ok);
+            assert.equal(cursor.value, 1);
+            const childAnchor1 = cursor.buildAnchor();
+            assert.equal(cursor.seek(1), TreeNavigationResult.Ok);
+            const childAnchor2 = cursor.buildAnchor();
+            assert.equal(cursor.up(), TreeNavigationResult.Ok);
+            const parentAnchor2 = cursor.buildAnchor();
+
+            const rootPath = clonePath(forest.anchors.locate(rootAnchor));
+            const parentPath = clonePath(forest.anchors.locate(parentAnchor));
+            const childPath1 = clonePath(forest.anchors.locate(childAnchor1));
+            const childPath2 = clonePath(forest.anchors.locate(childAnchor2));
+            const parentPath2 = clonePath(forest.anchors.locate(parentAnchor2));
+
+            const expectedParent: UpPath = {
+                parent: undefined,
+                parentField: detachedFieldAsKey(forest.rootField),
+                parentIndex: 0,
+            };
+
+            assert.deepStrictEqual(rootPath, expectedParent);
+            assert.deepStrictEqual(parentPath, expectedParent);
+            assert.deepStrictEqual(parentPath2, expectedParent);
+
+            const expectedChild1: UpPath = {
+                parent: expectedParent,
+                parentField: brand("data"),
+                parentIndex: 0,
+            };
+
+            const expectedChild2: UpPath = {
+                parent: expectedParent,
+                parentField: brand("data"),
+                parentIndex: 1,
+            };
+
+            assert.deepStrictEqual(childPath1, expectedChild1);
+            assert.deepStrictEqual(childPath2, expectedChild2);
+
+            assert.equal(forest.tryGet(parentAnchor, cursor), TreeNavigationResult.Ok);
+            assert.equal(cursor.value, undefined);
+            assert.equal(forest.tryGet(childAnchor1, cursor), TreeNavigationResult.Ok);
+            assert.equal(cursor.value, 1);
+            assert.equal(forest.tryGet(childAnchor2, cursor), TreeNavigationResult.Ok);
+            assert.equal(cursor.value, 2);
+
+            // Cleanup is not required for this test (since anchor set will go out of scope here),
+            // But make sure it works:
+            forest.anchors.forget(rootAnchor);
+            forest.anchors.forget(parentAnchor);
+            forest.anchors.forget(childAnchor1);
+            forest.anchors.forget(childAnchor2);
+            forest.anchors.forget(parentAnchor2);
+            assert(forest.anchors.isEmpty());
         });
 
         // TODO: test more kinds of deltas, including moves.

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -55,7 +55,8 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
                     initializeForest(forest, content);
 
                     const reader = forest.allocateCursor();
-                    assert.equal(forest.tryGet(forest.root(forest.rootField), reader), TreeNavigationResult.Ok);
+                    assert.equal(
+                        forest.tryMoveCursorTo(forest.root(forest.rootField), reader), TreeNavigationResult.Ok);
 
                     // copy data from reader into json object and compare to data.
                     const copy = cursorToJsonObject(reader);
@@ -78,7 +79,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
             forest.applyDelta(delta);
 
             const reader = forest.allocateCursor();
-            assert.equal(forest.tryGet(anchor, reader), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(anchor, reader), TreeNavigationResult.Ok);
 
             assert.equal(reader.value, 2);
         });
@@ -96,7 +97,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
             forest.applyDelta(delta);
 
             const reader = forest.allocateCursor();
-            assert.equal(forest.tryGet(anchor, reader), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(anchor, reader), TreeNavigationResult.Ok);
 
             assert.equal(reader.value, undefined);
         });
@@ -116,7 +117,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
 
             // Inspect resulting tree: should just have `2`.
             const reader = forest.allocateCursor();
-            assert.equal(forest.tryGet(anchor, reader), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(anchor, reader), TreeNavigationResult.Ok);
             assert.equal(reader.value, 2);
             assert.equal(reader.seek(1), TreeNavigationResult.NotFound);
         });
@@ -136,7 +137,7 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
             const rootAnchor = forest.root(forest.rootField);
 
             const cursor = forest.allocateCursor();
-            assert.equal(forest.tryGet(rootAnchor, cursor), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(rootAnchor, cursor), TreeNavigationResult.Ok);
             const parentAnchor = cursor.buildAnchor();
             assert.equal(cursor.down(brand("data"), 0), TreeNavigationResult.Ok);
             assert.equal(cursor.value, 1);
@@ -177,11 +178,11 @@ function testForest(suiteName: string, factory: () => IEditableForest): void {
             assert.deepStrictEqual(childPath1, expectedChild1);
             assert.deepStrictEqual(childPath2, expectedChild2);
 
-            assert.equal(forest.tryGet(parentAnchor, cursor), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(parentAnchor, cursor), TreeNavigationResult.Ok);
             assert.equal(cursor.value, undefined);
-            assert.equal(forest.tryGet(childAnchor1, cursor), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(childAnchor1, cursor), TreeNavigationResult.Ok);
             assert.equal(cursor.value, 1);
-            assert.equal(forest.tryGet(childAnchor2, cursor), TreeNavigationResult.Ok);
+            assert.equal(forest.tryMoveCursorTo(childAnchor2, cursor), TreeNavigationResult.Ok);
             assert.equal(cursor.value, 2);
 
             // Cleanup is not required for this test (since anchor set will go out of scope here),

--- a/packages/dds/tree/src/test/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/treeTextCursor.spec.ts
@@ -93,6 +93,6 @@ testCursor("object-forest cursor", (data): ITreeCursor => {
     const forest = new ObjectForest();
     initializeForest(forest, [data]);
     const cursor = forest.allocateCursor();
-    assert.equal(forest.tryGet(forest.root(forest.rootField), cursor), TreeNavigationResult.Ok);
+    assert.equal(forest.tryMoveCursorTo(forest.root(forest.rootField), cursor), TreeNavigationResult.Ok);
     return cursor;
 });

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -38,6 +38,17 @@ export class AnchorSet {
     private readonly anchorToPath: Map<Anchor, PathNode> = new Map();
 
     /**
+     * Check if there are currently no anchors tracked.
+     * Mainly for testing anchor cleanup.
+     */
+    public isEmpty(): boolean {
+        return this.root.children.size === 0;
+    }
+
+    /**
+     * Get the current location of an Anchor.
+     * The returned value should not be used after an edit has occurred.
+     *
      * TODO: support extra/custom return types for specific/custom anchor types:
      * for now caller must rely on data in anchor + returned node location
      * (not ideal for anchors for places or ranges instead of nodes).

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -14,6 +14,7 @@ export {
     Value,
     TreeValue,
     detachedFieldAsKey,
+    keyAsDetachedField,
 } from "./types";
 
 export * from "./pathTree";

--- a/packages/dds/tree/src/tree/pathTree.ts
+++ b/packages/dds/tree/src/tree/pathTree.ts
@@ -32,3 +32,26 @@ export interface UpPath {
      */
      readonly parentIndex: number; // TODO: field index branded type?
 }
+
+/**
+ * @returns a deep copy of the provided path as simple javascript objects.
+ * This is safe to hold onto and use deep object comparisons on.
+ */
+export function clonePath(path: UpPath): UpPath;
+
+/**
+ * @returns a deep copy of the provided path as simple javascript objects.
+ * This is safe to hold onto and use deep object comparisons on.
+ */
+export function clonePath(path: UpPath | undefined): UpPath | undefined;
+
+export function clonePath(path: UpPath | undefined): UpPath | undefined {
+    if (path === undefined) {
+        return undefined;
+    }
+    return {
+        parent: clonePath(path.parent),
+        parentField: path.parentField,
+        parentIndex: path.parentIndex,
+    };
+}

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -71,7 +71,7 @@ export function detachedFieldAsKey(field: DetachedField): LocalFieldKey {
  * Thus must only be used on {@link LocalFieldKey}s which were produced via {@link detachedFieldAsKey},
  * and with the same scope (ex: forest) as the detachedFieldAsKey was originally from.
  */
-export function keyAsDetachedField(key: DetachedField): DetachedField {
+export function keyAsDetachedField(key: FieldKey): DetachedField {
     return brand(extractFromOpaque(key));
 }
 


### PR DESCRIPTION
## Description

Replace the hacky untested object anchors in object-forest with proper path based one.

Unify forest anchor types with tree anchor types.

Add test for anchors.