### PR TITLE
Adding lock file for buffer polyfill in server-lambdas

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -6046,6 +6046,22 @@
 			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"dev": true
 		},
+		"buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			},
+			"dependencies": {
+				"ieee754": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+				}
+			}
+		},
 		"buffer-alloc": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",


### PR DESCRIPTION
# Work Item

## Description

This bug fix is to polyfill the ```buffer``` package. This bug causes compiling any project that uses these libraries to fail. Upgrading to webpack 5 removed the automatic NodeJS polyfills. sha.js uses buffer as a dependency. This package is used within ```@fluidframework/server-lambdas```

## Exception or Error
```
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "buffer": require.resolve("buffer/") }'
        - install 'buffer'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "buffer": false }
```

## Steps to Reproduce Bug and Validate Solution

Follow any documentation to get started with fluid-framework. Preferably with React or Angular but it should be the same for all JavaScript client side projects

## Testing

We were able to import the packages ```fluid-framework``` and ```@fluidframework/tinylicious-client``` with my local changes into a new React project we created in ```FluidFramework/examples/apps/```, build and test successfully. We were unable to reproduce the errors since they were always compiling in this directory. I will validate the pre-release package for testing.

## Other information or known dependencies
[AB#1230](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1230)
[AB#1219](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1219)
https://github.com/microsoft/FluidFramework/pull/11271