### PR TITLE
Removed IGarbageCollectionSummaryDetails and getInitialGCSummaryDetails 

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -40,7 +40,7 @@ export const blobCountPropertyName = "BlobCount";
 export const channelsTreeName = ".channels";
 
 // @public (undocumented)
-export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>, getInitialGCSummaryDetailsFn: () => Promise<IGarbageCollectionSummaryDetails>) => ISummarizerNodeWithGC;
+export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>, getBaseGCDetailsFn: () => Promise<IGarbageCollectionDetailsBase>) => ISummarizerNodeWithGC;
 
 // @public (undocumented)
 export type CreateChildSummarizerNodeParam = {
@@ -166,13 +166,11 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getAudience(): IAudience;
-    getBaseGCDetails?(): Promise<IGarbageCollectionDetailsBase>;
+    getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     // (undocumented)
     getCreateChildSummarizerNodeFn(
     id: string,
     createParam: CreateChildSummarizerNodeParam): CreateChildSummarizerNodeFn;
-    // @deprecated (undocumented)
-    getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
     getQuorum(): IQuorumClients;
     // (undocumented)
     readonly id: string;
@@ -249,9 +247,6 @@ export interface IGarbageCollectionState {
         [id: string]: IGarbageCollectionNodeData;
     };
 }
-
-// @public @deprecated (undocumented)
-export type IGarbageCollectionSummaryDetails = IGarbageCollectionDetailsBase;
 
 // @public
 export interface IInboundSignalMessage extends ISignalMessage {
@@ -337,14 +332,12 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     summarizeInternalFn: SummarizeInternalFn,
     id: string,
     createParam: CreateChildSummarizerNodeParam,
-    config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>, getInitialGCSummaryDetailsFn?: () => Promise<IGarbageCollectionSummaryDetails>): ISummarizerNodeWithGC;
+    config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>, getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>): ISummarizerNodeWithGC;
     deleteChild(id: string): void;
-    getBaseGCDetails?(): IGarbageCollectionDetailsBase;
+    getBaseGCDetails(): IGarbageCollectionDetailsBase;
     // (undocumented)
     getChild(id: string): ISummarizerNodeWithGC | undefined;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    // @deprecated (undocumented)
-    getGCSummaryDetails(): IGarbageCollectionSummaryDetails;
     isReferenced(): boolean;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
 }

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -33,7 +33,6 @@ import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IGarbageCollectionDetailsBase } from '@fluidframework/runtime-definitions';
-import { IGarbageCollectionSummaryDetails } from '@fluidframework/runtime-definitions';
 import { ILoader } from '@fluidframework/container-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
@@ -299,8 +298,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     // (undocumented)
     getCreateChildSummarizerNodeFn(id: string, createParam: CreateChildSummarizerNodeParam): CreateChildSummarizerNodeFn;
-    // (undocumented)
-    getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
     // (undocumented)
     getQuorum(): IQuorumClients;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -50,7 +50,6 @@ import {
     IFluidDataStoreRegistry,
     IGarbageCollectionData,
     IGarbageCollectionDetailsBase,
-    IGarbageCollectionSummaryDetails,
     IInboundSignalMessage,
     IProvideFluidDataStoreFactory,
     ISummarizeInternalResult,
@@ -484,7 +483,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
         // Add GC data to the summary if it's not written at the root.
         if (!this.writeGCDataAtRoot) {
-            addBlobToSummary(summarizeResult, gcBlobKey, JSON.stringify(this.summarizerNode.getGCSummaryDetails()));
+            addBlobToSummary(summarizeResult, gcBlobKey, JSON.stringify(this.summarizerNode.getBaseGCDetails()));
         }
 
         // If we are not referenced, mark the summary tree as unreferenced. Also, update unreferenced blob
@@ -720,11 +719,6 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         this._isInMemoryRoot = true;
     }
 
-    /**
-     * @deprecated - Renamed to getBaseGCDetails().
-     */
-    public abstract getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
-
     public abstract getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
 
     public reSubmit(contents: any, localOpMetadata: unknown) {
@@ -862,13 +856,6 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
         return this.initialSnapshotDetailsP;
     }
 
-    /**
-     * @deprecated - Renamed to getBaseGCDetails.
-     */
-    public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
-        return this.getBaseGCDetails();
-    }
-
     public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
         return this.baseGCDetailsP;
     }
@@ -977,14 +964,6 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
             isRootDataStore,
             snapshot,
         };
-    }
-
-    /**
-     * @deprecated - Renamed to getBaseGCDetails.
-     */
-    public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
-        // Local data store does not have initial summary.
-        return {};
     }
 
     public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -199,8 +199,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         const tree = dataStoreContext.baseSnapshot;
 
         this.channelsBaseGCDetails = new LazyPromise(async () => {
-            const baseGCDetails = await
-                (this.dataStoreContext.getBaseGCDetails?.() ?? this.dataStoreContext.getInitialGCSummaryDetails());
+            const baseGCDetails = await this.dataStoreContext.getBaseGCDetails();
             return unpackChildNodesGCDetails(baseGCDetails);
         });
 

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -74,6 +74,14 @@
       },
       "InterfaceDeclaration_IContainerRuntimeBase": {
         "backCompat": false
+      },
+      "RemovedTypeAliasDeclaration_IGarbageCollectionSummaryDetails": {
+        "backCompat": false,
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_ISummarizerNodeWithGC": {
+        "backCompat": false,
+        "forwardCompat": false
       }
     }
   }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -31,7 +31,6 @@ import { IProvideFluidDataStoreRegistry } from "./dataStoreRegistry";
 import {
     IGarbageCollectionData,
     IGarbageCollectionDetailsBase,
-    IGarbageCollectionSummaryDetails,
 } from "./garbageCollection";
 import { IInboundSignalMessage } from "./protocol";
 import {
@@ -294,7 +293,7 @@ export interface IFluidDataStoreChannel extends
 export type CreateChildSummarizerNodeFn = (
     summarizeInternal: SummarizeInternalFn,
     getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-    getInitialGCSummaryDetailsFn: () => Promise<IGarbageCollectionSummaryDetails>,
+    getBaseGCDetailsFn: () => Promise<IGarbageCollectionDetailsBase>,
 ) => ISummarizerNodeWithGC;
 
 export interface IFluidDataStoreContextEvents extends IEvent {
@@ -409,15 +408,10 @@ export interface IFluidDataStoreContext extends
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 
     /**
-     * @deprecated - Renamed to getBaseGCDetails.
-     */
-    getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
-
-    /**
      * Returns the GC details in the initial summary of this data store. This is used to initialize the data store
      * and its children with the GC details from the previous summary.
      */
-    getBaseGCDetails?(): Promise<IGarbageCollectionDetailsBase>;
+    getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
 
     /**
      * Called when a new outbound reference is added to another node. This is used by garbage collection to identify

--- a/packages/runtime/runtime-definitions/src/garbageCollection.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollection.ts
@@ -26,8 +26,3 @@ export interface IGarbageCollectionDetailsBase {
     /** If this node is unreferenced, the time when it was marked as such. */
     unrefTimestamp?: number;
 }
-
-/**
- * @deprecated - Kept for back-compat. This has been renamed to {@link IGarbageCollectionDetailsBase}.
- */
-export type IGarbageCollectionSummaryDetails = IGarbageCollectionDetailsBase;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -14,7 +14,6 @@ import {
 import {
     IGarbageCollectionData,
     IGarbageCollectionDetailsBase,
-    IGarbageCollectionSummaryDetails,
 } from "./garbageCollection";
 
 /**
@@ -234,7 +233,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
         /** Optional configuration affecting summarize behavior */
         config?: ISummarizerNodeConfigWithGC,
         getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-        getInitialGCSummaryDetailsFn?: () => Promise<IGarbageCollectionSummaryDetails>,
+        getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
     ): ISummarizerNodeWithGC;
 
     /**
@@ -265,14 +264,8 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
      */
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
 
-    /**
-     * @deprecated - Renamed to getBaseGCDetails.
-     * Returns the GC details that may be added to this node's summary.
-     */
-    getGCSummaryDetails(): IGarbageCollectionSummaryDetails;
-
     /** Returns the GC details to be added to this node's summary and is used to initialize new nodes' GC state. */
-    getBaseGCDetails?(): IGarbageCollectionDetailsBase;
+    getBaseGCDetails(): IGarbageCollectionDetailsBase;
 }
 
 export const channelsTreeName = ".channels";

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.ts
@@ -648,26 +648,14 @@ use_old_InterfaceDeclaration_IGarbageCollectionState(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IGarbageCollectionSummaryDetails": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_IGarbageCollectionSummaryDetails": {"forwardCompat": false}
 */
-declare function get_old_TypeAliasDeclaration_IGarbageCollectionSummaryDetails():
-    TypeOnly<old.IGarbageCollectionSummaryDetails>;
-declare function use_current_TypeAliasDeclaration_IGarbageCollectionSummaryDetails(
-    use: TypeOnly<current.IGarbageCollectionSummaryDetails>);
-use_current_TypeAliasDeclaration_IGarbageCollectionSummaryDetails(
-    get_old_TypeAliasDeclaration_IGarbageCollectionSummaryDetails());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IGarbageCollectionSummaryDetails": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_IGarbageCollectionSummaryDetails": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_IGarbageCollectionSummaryDetails():
-    TypeOnly<current.IGarbageCollectionSummaryDetails>;
-declare function use_old_TypeAliasDeclaration_IGarbageCollectionSummaryDetails(
-    use: TypeOnly<old.IGarbageCollectionSummaryDetails>);
-use_old_TypeAliasDeclaration_IGarbageCollectionSummaryDetails(
-    get_current_TypeAliasDeclaration_IGarbageCollectionSummaryDetails());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -919,6 +907,7 @@ declare function get_old_InterfaceDeclaration_ISummarizerNodeWithGC():
 declare function use_current_InterfaceDeclaration_ISummarizerNodeWithGC(
     use: TypeOnly<current.ISummarizerNodeWithGC>);
 use_current_InterfaceDeclaration_ISummarizerNodeWithGC(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISummarizerNodeWithGC());
 
 /*
@@ -931,6 +920,7 @@ declare function get_current_InterfaceDeclaration_ISummarizerNodeWithGC():
 declare function use_old_InterfaceDeclaration_ISummarizerNodeWithGC(
     use: TypeOnly<old.ISummarizerNodeWithGC>);
 use_old_InterfaceDeclaration_ISummarizerNodeWithGC(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummarizerNodeWithGC());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -96,6 +96,11 @@
   },
   "typeValidation": {
     "version": "2.0.0",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_IRootSummarizerNodeWithGC": {
+        "backCompat": false,
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -12,7 +12,6 @@ import {
     gcBlobKey,
     IGarbageCollectionData,
     IGarbageCollectionDetailsBase,
-    IGarbageCollectionSummaryDetails,
     ISummarizeInternalResult,
     ISummarizeResult,
     ISummarizerNodeConfigWithGC,
@@ -118,13 +117,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         this.baseGCDetailsP = new LazyPromise(async () => {
             return (await getBaseGCDetailsFn?.()) ?? { usedRoutes: [] };
         });
-    }
-
-    /**
-     * @deprecated - Renamed to getBaseGCDetails.
-     */
-    public getGCSummaryDetails(): IGarbageCollectionSummaryDetails {
-        return this.getBaseGCDetails();
     }
 
     // Returns the GC details to be added to this node's summary and is used to initialize new nodes' GC state.

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.ts
@@ -479,6 +479,7 @@ declare function get_old_InterfaceDeclaration_IRootSummarizerNodeWithGC():
 declare function use_current_InterfaceDeclaration_IRootSummarizerNodeWithGC(
     use: TypeOnly<current.IRootSummarizerNodeWithGC>);
 use_current_InterfaceDeclaration_IRootSummarizerNodeWithGC(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRootSummarizerNodeWithGC());
 
 /*
@@ -491,6 +492,7 @@ declare function get_current_InterfaceDeclaration_IRootSummarizerNodeWithGC():
 declare function use_old_InterfaceDeclaration_IRootSummarizerNodeWithGC(
     use: TypeOnly<old.IRootSummarizerNodeWithGC>);
 use_old_InterfaceDeclaration_IRootSummarizerNodeWithGC(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IRootSummarizerNodeWithGC());
 
 /*

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -31,7 +31,6 @@ import {
     IFluidDataStoreContext,
     IFluidDataStoreRegistry,
     IGarbageCollectionDetailsBase,
-    IGarbageCollectionSummaryDetails,
 } from "@fluidframework/runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
@@ -121,10 +120,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     }
 
     public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
-        throw new Error("Method not implemented.");
-    }
-
-    public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
         throw new Error("Method not implemented.");
     }
 


### PR DESCRIPTION
## Description
[AB#396](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/396)
IGarbageCollectionSummaryDetails and getInitialGCSummaryDetails were deprecated and renamed few months back via https://github.com/microsoft/FluidFramework/pull/8611. This change removes these deprecated interface / method.

## Does this introduce a breaking change?
No