### PR TITLE
Fix wrongly annotated error as ServiceReadonlyErrorTooManyRetries

### DIFF
--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -43,7 +43,9 @@ export async function runWithRetry<T>(
 
             const coherencyError = error?.[Odsp409Error] === true;
             const serviceReadonlyError = error?.errorType === OdspErrorType.serviceReadOnly;
-            // Retry for retriable 409 coherency errors or serviceReadOnly errors.
+            // Retry for retriable 409 coherency errors or serviceReadOnly errors. These errors are always retriable
+            // unless someone specifically set canRetry = false on the error like in fetchSnapshot() flow. So in
+            // that case don't retry.
             if (!((coherencyError || serviceReadonlyError) && canRetry)) {
                 throw error;
             }

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -44,7 +44,7 @@ export async function runWithRetry<T>(
             const coherencyError = error?.[Odsp409Error] === true;
             const serviceReadonlyError = error?.errorType === OdspErrorType.serviceReadOnly;
             // Retry for retriable 409 coherency errors or serviceReadOnly errors.
-            if (!(coherencyError || serviceReadonlyError || canRetry)) {
+            if (!((coherencyError || serviceReadonlyError) && canRetry)) {
                 throw error;
             }
 
@@ -55,7 +55,7 @@ export async function runWithRetry<T>(
                 logger.sendErrorEvent(
                     {
                         eventName: coherencyError ? "CoherencyErrorTooManyRetries" :
-                            serviceReadonlyError ? "ServiceReadonlyErrorTooManyRetries" : "TooManyRetries",
+                            "ServiceReadonlyErrorTooManyRetries",
                         callName,
                         attempts,
                         duration: performance.now() - start, // record total wait time.


### PR DESCRIPTION
## Description

Errors seems to be wrongly annotated as ServiceReadonlyErrorTooManyRetries, so added a proper check to classify.