### PR TITLE
Minor formatting fix to articles

### DIFF
--- a/docs/content/docs/concepts/signals.md
+++ b/docs/content/docs/concepts/signals.md
@@ -18,12 +18,12 @@ By sending signals, you avoid the storage and sequencing of data that will not b
 Signals are the most appropriate data channel in many user presence scenarios, where each user has the responsibility of sharing their current presence state to other connected users. In these scenarios, current presence data is short-lived, past presence state is irrelevant, and the shared data is not persisted on disconnect.
 
 ## How can I use signals in Fluid?
-The [`Signaler`](https://github.com/microsoft/FluidFramework/tree/main/experimental/framework/data-objects/src/signaler) DataObject can be used to send communications via signals in a Fluid application. `Signaler` allows clients to send signals to other connected clients and add/remove listeners for specified signal types.
+The [Signaler](https://github.com/microsoft/FluidFramework/tree/main/experimental/framework/data-objects/src/signaler) DataObject can be used to send communications via signals in a Fluid application. `Signaler` allows clients to send signals to other connected clients and add/remove listeners for specified signal types.
 
 # Signaler
 
 ## Creation
-Just like with DDSes, you can include `Signaler` as a shared object you would like to load in your [`FluidContainer`](https://fluidframework.com/docs/build/containers/) schema.
+Just like with DDSes, you can include `Signaler` as a shared object you would like to load in your [FluidContainer](https://fluidframework.com/docs/build/containers/) schema.
 
 Here is a look at how you would go about loading `Signaler` as part of the initial objects of the container:
 

--- a/docs/content/docs/recipes/signals.md
+++ b/docs/content/docs/recipes/signals.md
@@ -341,6 +341,6 @@ function renderMousePresence(mouseTracker: MouseTracker, focusTracker: FocusTrac
 ```
 
 ## Next Steps
-- You can find the completed code for this example in the Fluid GitHub repository [here]((https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
+- You can find the completed code for this example in the Fluid GitHub repository [here](https://github.com/microsoft/FluidFramework/tree/main/examples/data-objects/presence-tracker).
 - Try extending the `PresenceTracker` to track some other form of presence using signals!
 


### PR DESCRIPTION
## Description
Once the articles went live on FF.com I noticed a formatting error that the website doesn't like:
![Web capture_1-8-2022_153657_fluidframework com](https://user-images.githubusercontent.com/106282179/182257110-c676c34c-aef2-4cc7-bc9b-337ad6ffa28e.jpeg)

I fixed this and also fixed one of the links where I had an extra parenthesis.

