### PR TITLE
docs: Update README

### DIFF
--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -23,7 +23,7 @@ You can run this example using the following steps:
    `npm run build:fast -- --nolint @fluid-example/app-integration-external-controller`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (azure/packages/external-controller) and open <http://localhost:8080> in a web browser to see the app running.
-<!-- AUTO-GENERATED-CONTENT:END -->
+ <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing
 

--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -23,7 +23,7 @@ You can run this example using the following steps:
    `npm run build:fast -- --nolint @fluid-example/app-integration-external-controller`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (azure/packages/external-controller) and open <http://localhost:8080> in a web browser to see the app running.
- <!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing
 

--- a/common/build/eslint-config-fluid/README.md
+++ b/common/build/eslint-config-fluid/README.md
@@ -34,6 +34,11 @@ a diff to review as part of a PR -- just like we do with API reports for code ch
 | Script                     | Description                                                                                                   |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `cleanup-printed-configs`  | Clean up the printed configs. Removes the `parser` property and sorts the JSON.                               |
+| `format`                   | `npm run prettier:fix`                                                                                        |
+| `lint`                     | `npm run prettier`                                                                                            |
+| `lint:fix`                 | `npm run prettier:fix`                                                                                        |
+| `prettier`                 | `prettier --check .`                                                                                          |
+| `prettier:fix`             | `prettier --write .`                                                                                          |
 | `print-config`             | Print all the eslint configs.                                                                                 |
 | `print-config:default`     | Print the eslint config for regular TypeScript files (`eslint --config index.js --print-config src/file.ts`). |
 | `print-config:minimal`     | `eslint --config ./minimal.js --print-config ./src/file.ts > ./printed-configs/minimal.json`                  |


### PR DESCRIPTION
Run the docs build to update auto-generated contents in package README. The contents were out of date with recent formatting script changes.