### PR TITLE
Update markdown-magic template for "Getting Started" formatting

### DIFF
--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -19,11 +19,12 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
-   `npm run build:fast -- --nolint @fluid-example/app-integration-external-controller`
+    - For an even faster build, you can add the package name to the build command, like this:
+      `npm run build:fast -- --nolint @fluid-example/app-integration-external-controller`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (azure/packages/external-controller) and open <http://localhost:8080> in a web browser to see the app running.
- <!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing
 

--- a/docs/md-magic.config.js
+++ b/docs/md-magic.config.js
@@ -54,7 +54,7 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run \`npm install\` and \`npm run build:fast -- --nolint\` from the \`FluidFramework\` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       \`npm run build:fast -- --nolint ${getPackageName(path)}\``;
 
     const tinyliciousStep = `1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).`;
@@ -66,7 +66,7 @@ You can run this example using the following steps:
         finalStep,
     ].filter(item => item !== undefined);
 
-    return steps.join("\n");
+    return `${steps.join("\n")}\n`;
 }
 
 const fetchFunc = async (content, options) => {

--- a/examples/apps/collaborative-textarea/README.md
+++ b/examples/apps/collaborative-textarea/README.md
@@ -12,10 +12,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/collaborative-textarea`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/apps/collaborative-textarea) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/apps/contact-collection/README.md
+++ b/examples/apps/contact-collection/README.md
@@ -27,10 +27,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/contact-collection`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/apps/contact-collection) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/apps/spaces/README.md
+++ b/examples/apps/spaces/README.md
@@ -11,10 +11,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/spaces`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/apps/spaces) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Components

--- a/examples/apps/view-framework-sampler/README.md
+++ b/examples/apps/view-framework-sampler/README.md
@@ -11,10 +11,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/view-framework-sampler`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/apps/view-framework-sampler) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/data-objects/canvas/README.md
+++ b/examples/data-objects/canvas/README.md
@@ -11,9 +11,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/canvas`
 1. Run `npm run start` from this directory (examples/data-objects/canvas) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data model

--- a/examples/data-objects/clicker/README.md
+++ b/examples/data-objects/clicker/README.md
@@ -18,9 +18,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/clicker`
 1. Run `npm run start` from this directory (examples/data-objects/clicker) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/data-objects/codemirror/README.md
+++ b/examples/data-objects/codemirror/README.md
@@ -12,9 +12,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/codemirror`
 1. Run `npm run start` from this directory (examples/data-objects/codemirror) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data model

--- a/examples/data-objects/diceroller/README.md
+++ b/examples/data-objects/diceroller/README.md
@@ -13,9 +13,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/diceroller`
 1. Run `npm run start` from this directory (examples/data-objects/diceroller) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/data-objects/monaco/README.md
+++ b/examples/data-objects/monaco/README.md
@@ -12,9 +12,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/monaco`
 1. Run `npm run start` from this directory (examples/data-objects/monaco) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data model

--- a/examples/data-objects/multiview/container/README.md
+++ b/examples/data-objects/multiview/container/README.md
@@ -11,7 +11,8 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/multiview-container`
 1. Run `npm run start` from this directory (examples/data-objects/multiview/container) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/examples/data-objects/presence-tracker/README.md
+++ b/examples/data-objects/presence-tracker/README.md
@@ -15,8 +15,9 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/presence-tracker`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/data-objects/presence-tracker) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/examples/data-objects/prosemirror/README.md
+++ b/examples/data-objects/prosemirror/README.md
@@ -12,9 +12,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/prosemirror`
 1. Run `npm run start` from this directory (examples/data-objects/prosemirror) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data model

--- a/examples/data-objects/shared-text/README.md
+++ b/examples/data-objects/shared-text/README.md
@@ -15,7 +15,8 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/shared-text`
 1. Run `npm run start` from this directory (examples/data-objects/shared-text) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/examples/data-objects/smde/README.md
+++ b/examples/data-objects/smde/README.md
@@ -12,9 +12,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/smde`
 1. Run `npm run start` from this directory (examples/data-objects/smde) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data model

--- a/examples/data-objects/table-view/README.md
+++ b/examples/data-objects/table-view/README.md
@@ -13,9 +13,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/table-view`
 1. Run `npm run start` from this directory (examples/data-objects/table-view) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data model

--- a/examples/data-objects/task-selection/README.md
+++ b/examples/data-objects/task-selection/README.md
@@ -11,10 +11,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/task-selection`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/data-objects/task-selection) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/data-objects/todo/README.md
+++ b/examples/data-objects/todo/README.md
@@ -13,9 +13,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/todo`
 1. Run `npm run start` from this directory (examples/data-objects/todo) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Todo Fluid objects

--- a/examples/data-objects/vltava/README.md
+++ b/examples/data-objects/vltava/README.md
@@ -17,9 +17,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/vltava`
 1. Run `npm run start` from this directory (examples/data-objects/vltava) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Components

--- a/examples/data-objects/webflow/README.md
+++ b/examples/data-objects/webflow/README.md
@@ -11,9 +11,10 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/webflow`
 1. Run `npm run start` from this directory (examples/data-objects/webflow) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data Objects

--- a/examples/hosts/app-integration/container-views/README.md
+++ b/examples/hosts/app-integration/container-views/README.md
@@ -13,10 +13,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-container-views`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/hosts/app-integration/container-views) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/hosts/app-integration/external-views/README.md
+++ b/examples/hosts/app-integration/external-views/README.md
@@ -13,10 +13,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-external-views`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/hosts/app-integration/external-views) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/hosts/app-integration/schema-upgrade/README.md
+++ b/examples/hosts/app-integration/schema-upgrade/README.md
@@ -17,10 +17,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-schema-upgrade`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/hosts/app-integration/schema-upgrade) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Testing

--- a/examples/hosts/hosts-sample/README.md
+++ b/examples/hosts/hosts-sample/README.md
@@ -14,10 +14,11 @@ To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' 
 You can run this example using the following steps:
 
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
-   a. For an even faster build, you can add the package name to the build command, like this:
+    - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-internal/hosts-sample`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/hosts/hosts-sample) and open <http://localhost:8080> in a web browser to see the app running.
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Using Example


### PR DESCRIPTION
Updates formatting of generated content to be better github-markdown compliant, and makes spacing between comments consistent.