### PR TITLE
Demote `fluid:telemetry:Batching:Length` from error to performance

### DIFF
--- a/packages/runtime/container-runtime/src/batchTracker.ts
+++ b/packages/runtime/container-runtime/src/batchTracker.ts
@@ -37,7 +37,7 @@ export class BatchTracker {
 
             const length = message.sequenceNumber - this.startBatchSequenceNumber + 1;
             if (length >= batchLengthThreshold) {
-                this.logger.sendErrorEvent({
+                this.logger.sendPerformanceEvent({
                     eventName: "LengthTooBig",
                     length,
                     threshold: batchLengthThreshold,

--- a/packages/runtime/container-runtime/src/test/batchTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/batchTracker.spec.ts
@@ -39,7 +39,7 @@ describe("Runtime", () => {
                 batchEndSequenceNumber: 5,
                 duration: 10,
                 batchError: false,
-                category: "error",
+                category: "performance",
             }, {
                 eventName: "Batching:LengthTooBig",
                 length: 8,
@@ -47,7 +47,7 @@ describe("Runtime", () => {
                 batchEndSequenceNumber: 8,
                 duration: 20,
                 batchError: true,
-                category: "error",
+                category: "performance",
             },
         ]);
     });


### PR DESCRIPTION
See 292 in ADO.

This error doesn't tell us much so it shouldn't be an error. We can keep it in order to be able to confirm/correlate other indicators about the size of the payloads, etc.. during an OCE investigation, as the sampling mechanism would only record 1 out of 1000 batches..