### PR TITLE
Tree: split schema and forest indexes

### DIFF
--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -22,8 +22,6 @@ import { jsonableTreeFromCursor } from "./treeTextCursor";
 
 /** The storage key for the blob in the summary containing tree data */
 const treeBlobKey = "ForestTree";
-/** The storage key for the blob in the summary containing schema data */
-const schemaBlobKey = "ForestSchema";
 
 /**
  * Index which provides an editable forest for the current state for the document.
@@ -43,7 +41,6 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
 
     // Note that if invalidation happens when these promises are running, you may get stale results.
     private readonly treeBlob: ICachedValue<Promise<IFluidHandle<ArrayBufferLike>>>;
-    private readonly schemaBlob: ICachedValue<Promise<IFluidHandle<ArrayBufferLike>>>;
 
     public constructor(private readonly runtime: IFluidDataStoreRuntime, private readonly forest: IEditableForest) {
         this.cursor = this.forest.allocateCursor();
@@ -55,13 +52,6 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
             // For now we are not chunking the data, and instead put it in a single blob:
             // TODO: use lower level API to avoid blob manager?
             return this.runtime.uploadBlob(IsoBuffer.from(treeText));
-        });
-        this.schemaBlob = cachedValue(async (observer) => {
-            recordDependency(observer, this.forest.schema);
-            const schemaText = this.getSchemaString();
-
-            // For now we are not chunking the the schema, but still put it in a reusable blob:
-            return this.runtime.uploadBlob(IsoBuffer.from(schemaText));
         });
     }
 
@@ -92,25 +82,13 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
         return JSON.stringify(roots);
     }
 
-    /**
-     * Synchronous monolithic summarization of schema content.
-     *
-     * TODO: when perf matters, this should be replaced with a chunked async version using a binary format.
-     *
-     * @returns a snapshot of the forest schema as a string.
-     */
-     private getSchemaString(): string {
-        const { treeSchema, globalFieldSchema } = this.forest.schema;
-        return `TODO: actual format ${treeSchema}, ${globalFieldSchema}`;
-    }
-
     public getAttachSummary(
         stringify: SummaryElementStringifier,
         fullTree?: boolean,
         trackState?: boolean,
         telemetryContext?: ITelemetryContext,
     ): ISummaryTreeWithStats {
-        return this.summarizeCore(stringify, this.getSchemaString(), this.getTreeString());
+        return this.summarizeCore(stringify, this.getTreeString());
     }
 
     public async summarize(
@@ -119,18 +97,15 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
         trackState?: boolean,
         telemetryContext?: ITelemetryContext,
     ): Promise<ISummaryTreeWithStats> {
-        const [schemaBlobHandle, treeBlobHandle] = await Promise.all([this.schemaBlob.get(), this.treeBlob.get()]);
-        return this.summarizeCore(stringify, schemaBlobHandle, treeBlobHandle);
+        const treeBlobHandle = await this.treeBlob.get();
+        return this.summarizeCore(stringify, treeBlobHandle);
     }
 
     private summarizeCore(
         stringify: SummaryElementStringifier,
-        schema: string | IFluidHandle<ArrayBufferLike>,
         tree: string | IFluidHandle<ArrayBufferLike>,
     ): ISummaryTreeWithStats {
         const builder = new SummaryTreeBuilder();
-        const serializedSchemaBlobHandle = stringify(schema);
-        builder.addBlob(schemaBlobKey, serializedSchemaBlobHandle);
         const serializedTreeBlobHandle = stringify(tree);
         builder.addBlob(treeBlobKey, serializedTreeBlobHandle);
         return builder.getSummaryTree();
@@ -147,17 +122,10 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
     }
 
     public async load(services: IChannelStorageService, parse: SummaryElementParser): Promise<void> {
-        const [_schemaBuffer, treeBuffer] = await Promise.all([
-            services.readBlob(schemaBlobKey),
-            services.readBlob(treeBlobKey),
-        ]);
+        const treeBuffer = await services.readBlob(treeBlobKey);
         const tree = parse(bufferToString(treeBuffer, "utf8")) as string;
         const placeholderTree = JSON.parse(tree) as JsonableTree[];
 
         initializeForest(this.forest, placeholderTree);
-
-        // TODO: use schema to initialize forest.schema
-        // const schema = parse(bufferToString(_schemaBuffer, "utf8")) as string;
-        throw new Error("Method not implemented.");
     }
 }

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -6,5 +6,6 @@
 export * from "./object-forest";
 export * from "./defaultRebaser";
 export * from "./forestIndex";
+export * from "./schemaIndex";
 export * from "./treeTextCursor";
 export * from "./sequence-change-family";

--- a/packages/dds/tree/src/feature-libraries/schemaIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaIndex.ts
@@ -1,0 +1,111 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IsoBuffer } from "@fluidframework/common-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/datastore-definitions";
+import {
+    ITelemetryContext,
+    ISummaryTreeWithStats,
+    IGarbageCollectionData,
+} from "@fluidframework/runtime-definitions";
+import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
+import { Index, SummaryElement, SummaryElementParser, SummaryElementStringifier } from "../shared-tree-core";
+import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
+import { Delta } from "../tree";
+import { StoredSchemaRepository } from "../schema-stored";
+
+/** The storage key for the blob in the summary containing schema data */
+const schemaBlobKey = "SchemaBlob";
+
+/**
+ * Index which tracks stored schema for the current state for the document.
+ *
+ * Maintains the schema in memory.
+ *
+ * Used to capture snapshots of schema for summaries, as well as for anything else needing access to stored schema.
+ */
+export class SchemaIndex implements Index<unknown>, SummaryElement {
+    public readonly key = "Schema";
+
+    public readonly summaryElement?: SummaryElement = this;
+
+    private readonly schemaBlob: ICachedValue<Promise<IFluidHandle<ArrayBufferLike>>>;
+
+    public constructor(
+        private readonly runtime: IFluidDataStoreRuntime,
+        private readonly schema: StoredSchemaRepository) {
+        this.schemaBlob = cachedValue(async (observer) => {
+            recordDependency(observer, this.schema);
+            const schemaText = this.getSchemaString();
+
+            // For now we are not chunking the the schema, but still put it in a reusable blob:
+            return this.runtime.uploadBlob(IsoBuffer.from(schemaText));
+        });
+    }
+
+    newLocalState(changeDelta: Delta.Root): void {
+        // TODO: apply schema changes.
+        // Extend delta to include them, or maybe have some higher level edit type that includes them and deltas?
+    }
+
+    /**
+     * Synchronous monolithic summarization of schema content.
+     *
+     * TODO: when perf matters, this should be replaced with a chunked async version using a binary format.
+     *
+     * @returns a snapshot of the forest schema as a string.
+     */
+     private getSchemaString(): string {
+        const { treeSchema, globalFieldSchema } = this.schema;
+        return `TODO: actual format ${treeSchema}, ${globalFieldSchema}`;
+    }
+
+    public getAttachSummary(
+        stringify: SummaryElementStringifier,
+        fullTree?: boolean,
+        trackState?: boolean,
+        telemetryContext?: ITelemetryContext,
+    ): ISummaryTreeWithStats {
+        return this.summarizeCore(stringify, this.getSchemaString());
+    }
+
+    public async summarize(
+        stringify: SummaryElementStringifier,
+        fullTree?: boolean,
+        trackState?: boolean,
+        telemetryContext?: ITelemetryContext,
+    ): Promise<ISummaryTreeWithStats> {
+        const schemaBlobHandle = await this.schemaBlob.get();
+        return this.summarizeCore(stringify, schemaBlobHandle);
+    }
+
+    private summarizeCore(
+        stringify: SummaryElementStringifier,
+        schema: string | IFluidHandle<ArrayBufferLike>,
+    ): ISummaryTreeWithStats {
+        const builder = new SummaryTreeBuilder();
+        const serializedSchemaBlobHandle = stringify(schema);
+        builder.addBlob(schemaBlobKey, serializedSchemaBlobHandle);
+        return builder.getSummaryTree();
+    }
+
+    public getGCData(fullGC?: boolean): IGarbageCollectionData {
+        // TODO: Properly implement garbage collection. Right now, garbage collection is performed automatically
+        // by the code in SharedObject (from which SharedTreeCore extends). The `runtime.uploadBlob` API delegates
+        // to the `BlobManager`, which automatically populates the summary with ISummaryAttachment entries for each
+        // blob.
+        return {
+            gcNodes: {},
+        };
+    }
+
+    public async load(services: IChannelStorageService, parse: SummaryElementParser): Promise<void> {
+        // const schemaBuffer = await services.readBlob(schemaBlobKey);
+        // TODO: use schema to initialize this.schema
+        // const schema = parse(bufferToString(_schemaBuffer, "utf8")) as string;
+        throw new Error("Method not implemented.");
+    }
+}

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -4,7 +4,7 @@
  */
 
 import { IChannelAttributes, IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { DefaultChangeSet, DefaultRebaser, ForestIndex, ObjectForest } from "../feature-libraries";
+import { DefaultChangeSet, DefaultRebaser, ForestIndex, ObjectForest, SchemaIndex } from "../feature-libraries";
 import { Index, SharedTreeCore } from "../shared-tree-core";
 import { AnchorSet } from "../tree";
 
@@ -22,9 +22,12 @@ export class SharedTree extends SharedTreeCore<DefaultRebaser> {
         telemetryContextPrefix: string) {
             const anchors = new AnchorSet();
             const forest = new ObjectForest(anchors);
-            const index: Index<DefaultChangeSet> = new ForestIndex(runtime, forest);
+            const indexes: Index<DefaultChangeSet>[] = [
+                new SchemaIndex(runtime, forest.schema),
+                new ForestIndex(runtime, forest),
+            ];
             super(
-                [index],
+                indexes,
                 new DefaultRebaser(), anchors, id, runtime, attributes, telemetryContextPrefix,
                 );
 


### PR DESCRIPTION
## Description

The storing of schema and the storing of tree data are rather separate this with different tradeoffs.

Coupling them in a single index likely overcomplicates things like changing the storage format of one of them, or running an application which only stores on of them (ex: an application with a single hard coded schema).

This change splits them apart, storing them separately in different indexes.

## Reviewer Guidance

I'd like opinions on if this separation seems like a good idea as well as the actual code.