### PR TITLE
Remove flushMode tracking from PendingStateManager

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1372,7 +1372,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 rollback: this.rollback.bind(this),
                 orderSequentially: this.orderSequentially.bind(this),
             },
-            this.flushMode,
             pendingRuntimeState?.pending);
 
         this.context.quorum.on("removeMember", (clientId: string) => {
@@ -2052,7 +2051,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // Note that this should happen before the `this.needsFlush` check below because in the scenario where we are
         // not connected, `this.needsFlush` will be false but the PendingStateManager might have pending messages and
         // hence needs to track this.
-        this.pendingStateManager.onFlush(isImmediateBatch);
+        if (this.flushMode !== FlushMode.Immediate || isImmediateBatch) {
+            this.pendingStateManager.onFlush();
+        }
 
         // If flush has already been called then exit early
         if (!this.needsFlush) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2047,11 +2047,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             return;
         }
 
-        // Let the PendingStateManager know that there was an attempt to flush messages.
-        // Note that this should happen before the `this.needsFlush` check below because in the scenario where we are
-        // not connected, `this.needsFlush` will be false but the PendingStateManager might have pending messages and
-        // hence needs to track this.
+        // ! TODO: This condition should be removed once "flush" becomes private
+        // See https://dev.azure.com/fluidframework/internal/_workitems/edit/1076
         if (this.flushMode !== FlushMode.Immediate || isImmediateBatch) {
+            // Let the PendingStateManager know that there was an attempt to flush messages.
+            // Note that this should happen before the `this.needsFlush` check below because in the scenario where we
+            // are not connected, `this.needsFlush` will be false but the PendingStateManager might have pending
+            // messages and hence needs to track this.
             this.pendingStateManager.onFlush();
         }
 

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import assert from "assert";
-import { FlushMode } from "@fluidframework/runtime-definitions";
 import { PendingStateManager } from "../pendingStateManager";
 import { ContainerMessageType } from "..";
 
@@ -35,7 +34,7 @@ describe("Pending State Manager Rollback", () => {
                 }
             },
             orderSequentially: () => {},
-        }, FlushMode.Immediate, undefined);
+        }, undefined);
     });
 
     it("should do nothing when rolling back empty pending stack", () => {


### PR DESCRIPTION
[AB#1107](https://dev.azure.com/fluidframework/internal/_workitems/edit/1107)

For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

## Description

The `PendingStateManager` should just track batches and ops and not care about the `flushMode` of the container runtime.
See https://github.com/microsoft/FluidFramework/pull/10930#discussion_r912239281.