### PR TITLE
Fix contentType header parsing in fetch snapshot

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -252,16 +252,13 @@ async function fetchLatestSnapshotCore(
                 });
 
                 let parsedSnapshotContents: IOdspResponse<ISnapshotContents> | undefined;
-                const splittedContentType = contentType?.split(";");
                 let contentTypeToRead: string | undefined;
-                if (splittedContentType !== undefined) {
-                    for (let type in splittedContentType) {
-                        if (type === "application/json" || type === "application/ms-fluid") {
-                            contentTypeToRead = type;
-                            break;
-                        }
-                    }
+                if (contentType?.indexOf("application/ms-fluid") !== -1) {
+                    contentTypeToRead = "application/ms-fluid";
+                } else if (contentType?.indexOf("application/json") !== -1) {
+                    contentTypeToRead = "application/json";
                 }
+
                 try {
                     switch (contentTypeToRead) {
                         case "application/json": {
@@ -558,9 +555,6 @@ export async function downloadSnapshot(
     };
     // Decide what snapshot format to fetch as per the feature gate.
     switch (snapshotFormatFetchType) {
-        case SnapshotFormatSupportType.JsonAndBinary:
-            headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
-            break;
         case SnapshotFormatSupportType.Binary:
             headers.accept = `application/ms-fluid; v=${currentReadVersion}`;
             break;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -252,9 +252,18 @@ async function fetchLatestSnapshotCore(
                 });
 
                 let parsedSnapshotContents: IOdspResponse<ISnapshotContents> | undefined;
-
+                const splittedContentType = contentType?.split(";");
+                let contentTypeToRead: string | undefined;
+                if (splittedContentType !== undefined) {
+                    for (let type in splittedContentType) {
+                        if (type === "application/json" || type === "application/ms-fluid") {
+                            contentTypeToRead = type;
+                            break;
+                        }
+                    }
+                }
                 try {
-                    switch (contentType) {
+                    switch (contentTypeToRead) {
                         case "application/json": {
                             const text = await odspResponse.content.text();
                             propsToLog.bodySize = text.length;
@@ -556,7 +565,8 @@ export async function downloadSnapshot(
             headers.accept = `application/ms-fluid; v=${currentReadVersion}`;
             break;
         default:
-            headers.accept = "application/json";
+            // By default ask both versions and let the server decide the format.
+            headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
     }
 
     const odspResponse = await (epochTracker?.fetch(url, fetchOptions, "treesLatest", true, scenarioName) ??


### PR DESCRIPTION
## Description

1.) Fix contentType header parsing in fetch snapshot.
2.) By default, accept both json and binary format in trees/latest call if not value is provided by feature gate.

