### PR TITLE
Enabling last skipped stashed ops tests

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -113,6 +113,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     private previouslyProcessedMessage: ISequencedDocumentMessage | undefined;
 
     // The sequence number we initially loaded from
+    // In case of reading from a snapshot or pending state, its value will be equel to
+    // the last message that got serialized.
     private initSequenceNumber: number = 0;
 
     private readonly _inbound: DeltaQueue<ISequencedDocumentMessage>;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -113,7 +113,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     private previouslyProcessedMessage: ISequencedDocumentMessage | undefined;
 
     // The sequence number we initially loaded from
-    // In case of reading from a snapshot or pending state, its value will be equel to
+    // In case of reading from a snapshot or pending state, its value will be equal to
     // the last message that got serialized.
     private initSequenceNumber: number = 0;
 

--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -366,7 +366,7 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
             // from. i.e. initialSequenceNumber > summarySequenceNumber.
             // We really don't care about it for now, since it is older than
             // the one we loaded from.
-            if (seq >= this.deltaManager.initialSequenceNumber) {
+            if (seq > this.deltaManager.initialSequenceNumber) {
                 // Potential causes for it to be later than our initialSequenceNumber
                 // are that the summaryOp was nacked then acked, double-acked, or
                 // the summarySequenceNumber is incorrect.

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -876,7 +876,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
     });
 
     // TODO: https://github.com/microsoft/FluidFramework/issues/10729
-    it.skip("works with summary while offline", async function() {
+    it("works with summary while offline", async function() {
         map1.set("test op 1", "test op 1");
         await waitForSummary();
 
@@ -898,7 +898,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
     });
 
     // TODO: https://github.com/microsoft/FluidFramework/issues/10729
-    it.skip("can stash between summary op and ack", async function() {
+    it("can stash between summary op and ack", async function() {
         map1.set("test op 1", "test op 1");
         const container = await provider.loadTestContainer(testContainerConfig);
         const pendingOps = await new Promise<string>((resolve, reject) => container.on("op", (op) => {


### PR DESCRIPTION
[AZ776](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Curtis/internal/CY22Q3/2022.08/Team%20Curtis%20-%202022.08?workitem=776).

## Description

> The condition to check whether or not we are facing a potencial issue after seeing a summaryAck without its summary was wrong because the initialSequenceNumber in deltaManager after a pending state or snapshot is equal to the last sequence number of the last message serialized, and if the last message was a summary then both variables (this.deltaManager.initialSequenceNumber and summarySequenceNumber) will be the same. Removing the equal to handle that case.

