### PR TITLE
Tree: Split out TreeTypeSet

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -195,7 +195,7 @@ type FieldMarks<TMark> = FieldMap_2<MarkList<TMark>>;
 export interface FieldSchema {
     // (undocumented)
     readonly kind: FieldKind;
-    readonly types?: ReadonlySet<TreeSchemaIdentifier>;
+    readonly types?: TreeTypeSet;
 }
 
 // @public (undocumented)
@@ -667,6 +667,9 @@ export type TreeSchemaIdentifier = Brand<string, "tree.TreeSchemaIdentifier">;
 
 // @public (undocumented)
 export type TreeType = TreeSchemaIdentifier;
+
+// @public
+export type TreeTypeSet = ReadonlySet<TreeSchemaIdentifier> | undefined;
 
 // @public
 export interface TreeValue extends Serializable {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -30,7 +30,7 @@ export {
     FieldSchema, ValueSchema, TreeSchema, FieldKind,
     emptyField, neverTree,
     SchemaRepository, StoredSchemaRepository,
-    rootFieldKey,
+    rootFieldKey, TreeTypeSet,
 } from "./schema-stored";
 
 export {

--- a/packages/dds/tree/src/schema-stored/comparison.ts
+++ b/packages/dds/tree/src/schema-stored/comparison.ts
@@ -131,7 +131,7 @@ export function allowsFieldSuperset(
     if (original.kind === FieldKind.Forbidden) {
         return true;
     }
-    return allowsTypesSuperset(original.types, superset.types);
+    return allowsTreeSchemaIdentifierSuperset(original.types, superset.types);
 }
 
 /**
@@ -139,7 +139,7 @@ export function allowsFieldSuperset(
  *
  * This does not require a strict (aka proper) superset: equivalent schema will return true.
  */
-export function allowsTypesSuperset(
+export function allowsTreeSchemaIdentifierSuperset(
     original: TreeTypeSet,
     superset: TreeTypeSet,
 ): boolean {

--- a/packages/dds/tree/src/schema-stored/comparison.ts
+++ b/packages/dds/tree/src/schema-stored/comparison.ts
@@ -10,6 +10,7 @@ import {
     ValueSchema,
     FieldSchema,
     FieldKind,
+    TreeTypeSet,
 } from "./schema";
 import { emptyField } from "./builders";
 
@@ -130,14 +131,26 @@ export function allowsFieldSuperset(
     if (original.kind === FieldKind.Forbidden) {
         return true;
     }
-    if (superset.types === undefined) {
+    return allowsTypesSuperset(original.types, superset.types);
+}
+
+/**
+ * @returns true iff `superset` is a superset of `original`.
+ *
+ * This does not require a strict (aka proper) superset: equivalent schema will return true.
+ */
+export function allowsTypesSuperset(
+    original: TreeTypeSet,
+    superset: TreeTypeSet,
+): boolean {
+    if (superset === undefined) {
         return true;
     }
-    if (original.types === undefined) {
+    if (original === undefined) {
         return false;
     }
-    for (const originalType of original.types) {
-        if (!superset.types.has(originalType)) {
+    for (const originalType of original) {
+        if (!superset.has(originalType)) {
             return false;
         }
     }

--- a/packages/dds/tree/src/schema-stored/index.ts
+++ b/packages/dds/tree/src/schema-stored/index.ts
@@ -6,7 +6,7 @@
 export {
     FieldSchema, FieldKind, ValueSchema, GlobalFieldKey, TreeSchema,
     TreeSchemaIdentifier, LocalFieldKey, NamedTreeSchema, SchemaRepository,
-    Named,
+    Named, TreeTypeSet,
 } from "./schema";
 export { anyField, anyTree, neverField, neverTree } from "./specialSchema";
 export { StoredSchemaRepository } from "./storedSchemaRepository";

--- a/packages/dds/tree/src/schema-stored/index.ts
+++ b/packages/dds/tree/src/schema-stored/index.ts
@@ -11,4 +11,4 @@ export {
 export { anyField, anyTree, neverField, neverTree } from "./specialSchema";
 export { StoredSchemaRepository } from "./storedSchemaRepository";
 export { treeSchema, fieldSchema, emptyField, rootFieldKey, emptyMap, emptySet, TreeSchemaBuilder } from "./builders";
-export { isNeverField, isNeverTree, allowsRepoSuperset } from "./comparison";
+export { isNeverField, isNeverTree, allowsRepoSuperset, allowsTreeSchemaIdentifierSuperset } from "./comparison";

--- a/packages/dds/tree/src/schema-stored/schema.ts
+++ b/packages/dds/tree/src/schema-stored/schema.ts
@@ -130,31 +130,38 @@ export enum ValueSchema {
     Serializable,
 }
 
+/**
+ * Set of allowed tree types.
+ * Providing multiple values here allows polymorphism, tagged union style.
+ *
+ * If not specified, types are unconstrained
+ * (equivalent to the set containing every TreeSchemaIdentifier defined in the document).
+ *
+ * Note that even when unconstrained, children must still be in-schema for their own type.
+ *
+ * In the future, this could be extended to allow inlining a TreeSchema here
+ * (or some similar structural schema system).
+ * For structural types which could go here, there are a few interesting options:
+ * - Allow replacing the whole set with a structural type for terminal / non-tree data,
+ * and use this as a replacement for values on the tree nodes.
+ * - Allow expression structural constraints for child trees, for example requiring specific traits
+ * (ex: via TreeSchema), instead of by type.
+ * There are two ways this could work:
+ *      - Constrain the child nodes based on their shape:
+ * this makes schema safe editing difficult because nodes would incur extra editing constraints to prevent them
+ * from going out of schema based on their location in such a field.
+ *      - Constrain the types allowed based on which types guarantee their data will always meet the constraints.
+ * Care would need to be taken to make sure this is sound for the schema updating mechanisms.
+ */
+export type TreeTypeSet = ReadonlySet<TreeSchemaIdentifier> | undefined;
+
 export interface FieldSchema {
     readonly kind: FieldKind;
     /**
      * The set of allowed child types.
-     * Providing multiple values here allows polymorphism, tagged union style.
-     *
-     * If not specified, child types are unconstrained
-     * (equivalent to the set containing every TreeSchemaIdentifier defined in the document).
-     * Note that even when unconstrained, children must still be in-schema for their own type.
-     *
-     * In the future, this could be extended to allow inlining a TreeSchema here
-     * (or some similar structural schema system).
-     * For structural types which could go here, there are a few interesting options:
-     * - Allow replacing the whole set with a structural type for terminal / non-tree data,
-     * and use this as a replacement for values on the tree nodes.
-     * - Allow expression structural constraints for child trees, for example requiring specific traits
-     * (ex: via TreeSchema), instead of by type.
-     * There are two ways this could work:
-     *      - Constrain the child nodes based on their shape:
-     * this makes schema safe editing difficult because nodes would incur extra editing constraints to prevent them
-     * from going out of schema based on their location in such a field.
-     *      - Constrain the types allowed based on which types guarantee their data will always meet the constraints.
-     * Care would need to be taken to make sure this is sound for the schema updating mechanisms.
+     * If not specified, types are unconstrained.
      */
-    readonly types?: ReadonlySet<TreeSchemaIdentifier>;
+    readonly types?: TreeTypeSet;
 }
 
 export interface TreeSchema {

--- a/packages/dds/tree/src/test/schema-stored/comparison.spec.ts
+++ b/packages/dds/tree/src/test/schema-stored/comparison.spec.ts
@@ -6,7 +6,8 @@
 import { strict as assert } from "assert";
 
 import {
-	allowsFieldSuperset, allowsTreeSuperset, allowsTypesSuperset, allowsValueSuperset, isNeverField, isNeverTree,
+	allowsFieldSuperset, allowsTreeSuperset, allowsTreeSchemaIdentifierSuperset,
+	allowsValueSuperset, isNeverField, isNeverTree,
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 } from "../../schema-stored/comparison";
@@ -134,13 +135,13 @@ describe("Schema Comparison", () => {
 
 	it("allowsTypesSuperset", () => {
 		testOrder(
-			allowsTypesSuperset,
+			allowsTreeSchemaIdentifierSuperset,
 			[new Set(), new Set([brand("1")]), new Set([brand("1"), brand("2")]), undefined],
 		);
 		const neverSet: TreeTypeSet = new Set();
 		const neverSet2: TreeTypeSet = new Set();
 		testPartialOrder(
-			allowsTypesSuperset,
+			allowsTreeSchemaIdentifierSuperset,
 			[
 				neverSet,
 				neverSet2,

--- a/packages/dds/tree/src/test/schema-stored/comparison.spec.ts
+++ b/packages/dds/tree/src/test/schema-stored/comparison.spec.ts
@@ -6,19 +6,18 @@
 import { strict as assert } from "assert";
 
 import {
-	allowsFieldSuperset, allowsTreeSuperset, allowsValueSuperset, isNeverField, isNeverTree,
+	allowsFieldSuperset, allowsTreeSuperset, allowsTypesSuperset, allowsValueSuperset, isNeverField, isNeverTree,
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 } from "../../schema-stored/comparison";
 import {
 	FieldSchema,
 	GlobalFieldKey,
-	LocalFieldKey,
 	FieldKind,
 	NamedTreeSchema,
 	TreeSchema,
-	TreeSchemaIdentifier,
 	ValueSchema,
+	TreeTypeSet,
 	emptyField, emptyMap, emptySet, fieldSchema, anyField, anyTree, neverField, neverTree, StoredSchemaRepository,
 } from "../../schema-stored";
 import { brand, brandOpaque } from "../../util";
@@ -133,6 +132,27 @@ describe("Schema Comparison", () => {
 		);
 	});
 
+	it("allowsTypesSuperset", () => {
+		testOrder(
+			allowsTypesSuperset,
+			[new Set(), new Set([brand("1")]), new Set([brand("1"), brand("2")]), undefined],
+		);
+		const neverSet: TreeTypeSet = new Set();
+		const neverSet2: TreeTypeSet = new Set();
+		testPartialOrder(
+			allowsTypesSuperset,
+			[
+				neverSet,
+				neverSet2,
+				new Set([brand("1")]),
+				new Set([brand("2")]),
+				new Set([brand("1"), brand("2")]),
+				undefined,
+			],
+			[[neverSet, neverSet2]],
+		);
+	});
+
 	it("allowsFieldSuperset", () => {
 		const repo = new StoredSchemaRepository();
 		repo.tryUpdateTreeSchema(brand("never"), neverTree);
@@ -200,7 +220,7 @@ function testPartialOrder<T>(
 	// Antisymmetry: if a ≤ b and b ≤ a then a = b
 	// Transitivity: if a ≤ b  and  b ≤ c  then  a ≤ c
 
-	// This can is brute forced in O(n^3) time below:
+	// This is brute forced in O(n^3) time below:
 	// Violations:
 	const reflexivity: T[] = [];
 	const antisymmetry: [boolean, T, T][] = [];


### PR DESCRIPTION
Split out TreeTypeSet type and comparison function.

FieldKinds will need to interact with these (as the inputs when defining FieldSchema), so separating it makes the FieldKinds work a bit cleaner.