### PR TITLE
Attempt to fix AB 218 - Files with lot of unsummarized Ops.

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -227,12 +227,11 @@ export class SummaryManager implements IDisposable {
                     this.state = SummaryManagerState.Starting;
                     summarizer.stop(shouldSummarizeState.stopReason);
                     return `early exit after starting summarizer ${shouldSummarizeState.stopReason}`;
-                } else {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "LastAttemptToSummarize",
-                        startWithInitialDelay,
-                    });
                 }
+                this.logger.sendTelemetryEvent({
+                    eventName: "LastAttemptToSummarize",
+                    startWithInitialDelay,
+                });
             }
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -14,6 +14,7 @@ import {
     SummarizerStopReason,
 } from "./summarizerTypes";
 import { SummaryCollection } from "./summaryCollection";
+import { Summarizer } from "./summarizer";
 
 const defaultInitialDelayMs = 5000;
 const defaultOpsToBypassInitialDelay = 4000;
@@ -198,8 +199,13 @@ export class SummaryManager implements IDisposable {
             // a summarizer to kick off lastSummary. Without that, we would not be able to summarize and get
             // document out of broken state if it has too many ops and ordering service keeps nacking main
             // container (and thus it goes into cycle of reconnects)
-            if (startWithInitialDelay && this.getShouldSummarizeState().shouldSummarize === false) {
-                return "early exit";
+            // If we can't run the LastSummary, simply return as to avoid paying the cost of launching
+            // the summarizer at all.
+            const shouldSummarizeStateEarlyStage = this.getShouldSummarizeState();
+            if (startWithInitialDelay &&
+                shouldSummarizeStateEarlyStage.shouldSummarize === false &&
+                !Summarizer.stopReasonCanRunLastSummary(shouldSummarizeStateEarlyStage.stopReason)) {
+                    return `early exit ${shouldSummarizeStateEarlyStage.stopReason}`;
             }
 
             // We transition to Running before requesting the summarizer, because after requesting we can't predict
@@ -213,11 +219,20 @@ export class SummaryManager implements IDisposable {
             this.summarizer = summarizer;
 
             // Re-validate that it need to be running. Due to asynchrony, it may be not the case anymore
+            // If we can't run the LastSummary, simply return as to avoid paying the cost of launching
+            // the summarizer at all.
             const shouldSummarizeState = this.getShouldSummarizeState();
             if (shouldSummarizeState.shouldSummarize === false) {
-                this.state = SummaryManagerState.Starting;
-                summarizer.stop(shouldSummarizeState.stopReason);
-                return "early exit after starting summarizer";
+                if (!Summarizer.stopReasonCanRunLastSummary(shouldSummarizeState.stopReason)) {
+                    this.state = SummaryManagerState.Starting;
+                    summarizer.stop(shouldSummarizeState.stopReason);
+                    return `early exit after starting summarizer ${shouldSummarizeState.stopReason}`;
+                } else {
+                    this.logger.sendTelemetryEvent({
+                        eventName: "LastAttemptToSummarize",
+                        startWithInitialDelay,
+                    });
+                }
             }
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
The problem happens when we generate thousands of ops in a short period of time and get throttled by the push service. The users keep sending ops and, in case we are eventually able to recover, after retrying to connect (respecting imposed delay by the service) and submitting the outstanding ops, we reach a point in which the Summarizer needs to generate a snapshot as the server is now throttling the clients due to the limit of unsummarized ops. 

At this point, the server starts to send the following error: **NACK (ThrottlingError): Submit a summary before inserting additional ops.**

From this moment on, the client goes into in a loop trying to launch a summarizer and immediately asking it to stop as the parent of the summarizer is getting disconnected/throttled after trying to send an op (probably join ?). 

 
## Description

Before this change, if the parent is not connected, we would immediately ask the summarizer to stop.  With these changes, we will only ask the summarizer to stop in case the last summary would not be generated ( stopReason !=="parentNotConnected" )

Notice that we considered removing the entire short-circuit unconditionally but decided not to as to preserve resources as launching the summarizer against a scenario that is guaranteed to NOT generate the last summary would be a waste of 
resources. 

I took the chance to add the stop reason for the scenario in which we return early. 

## Does this introduce a breaking change?
No.

## Any relevant information

I did run the stress tests under the debugger and, when the condition we care about was hit, we successfully summarized. 

As a side not from the impact of these changes, in the last 30 days: 
 - 231638 documents hit the  "early exit after starting summarizer" 
 - 17276 documents hit the "early exit".
