### PR TITLE
IntervalCollection fuzz: allow insert at end of string

### DIFF
--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -150,18 +150,18 @@ function makeOperationGenerator(optionsParam?: OperationGenerationConfig): Gener
     }
 
     // All subsequent helper functions are generators; note that they don't actually apply any operations.
-    function position({ random, sharedString }: ClientOpState): number {
+    function startPosition({ random, sharedString }: ClientOpState): number {
         return random.integer(0, Math.max(0, sharedString.getLength() - 1));
     }
 
     function exclusiveRange(state: ClientOpState): RangeSpec {
-        const start = position(state);
+        const start = startPosition(state);
         const end = state.random.integer(start + 1, state.sharedString.getLength());
         return { start, end };
     }
 
     function inclusiveRange(state: ClientOpState): RangeSpec {
-        const start = position(state);
+        const start = startPosition(state);
         const end = state.random.integer(start, Math.max(start, state.sharedString.getLength() - 1));
         return { start, end };
     }
@@ -201,7 +201,7 @@ function makeOperationGenerator(optionsParam?: OperationGenerationConfig): Gener
         const { random, sharedString } = state;
         return {
             type: "addText",
-            index: position(state),
+            index: random.integer(0, sharedString.getLength()),
             content: random.string(random.integer(0, options.maxInsertLength)),
             stringId: sharedString.id,
         };


### PR DESCRIPTION
insertion at the end of the string is allowed, but ranges' (inclusive and exclusive) start positions must be less than the length. This adjusts op generation to reflect that.