### PR TITLE
Add documentation for merge tree node state fields

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -448,21 +448,17 @@ export interface IMarkerModifiedAction {
     (marker: Marker): void;
 }
 
-// @public (undocumented)
+// @public
 export interface IMergeBlock extends IMergeNodeCommon {
     // (undocumented)
     assignChild(child: IMergeNode, index: number, updateOrdinal?: boolean): void;
-    // (undocumented)
     childCount: number;
-    // (undocumented)
     children: IMergeNode[];
     // (undocumented)
     hierBlock(): IHierBlock | undefined;
     // (undocumented)
     needsScour?: boolean;
     // Warning: (ae-forgotten-export) The symbol "PartialSequenceLengths" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     partialLengths?: PartialSequenceLengths;
     // (undocumented)
     setOrdinal(child: IMergeNode, index: number): void;
@@ -471,14 +467,12 @@ export interface IMergeBlock extends IMergeNodeCommon {
 // @public (undocumented)
 export type IMergeNode = IMergeBlock | ISegment;
 
-// @public (undocumented)
+// @public
 export interface IMergeNodeCommon {
     cachedLength: number;
-    // (undocumented)
     index: number;
     // (undocumented)
     isLeaf(): this is ISegment;
-    // (undocumented)
     ordinal: string;
     // (undocumented)
     parent?: IMergeBlock;
@@ -741,11 +735,9 @@ export interface IRelativePosition {
     offset?: number;
 }
 
-// @public (undocumented)
+// @public
 export interface IRemovalInfo {
-    // (undocumented)
     removedClientIds: number[];
-    // (undocumented)
     removedSeq: number;
 }
 
@@ -759,23 +751,16 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
     append(segment: ISegment): void;
     // (undocumented)
     canAppend(segment: ISegment): boolean;
-    // (undocumented)
     clientId: number;
     // (undocumented)
     clone(): ISegment;
-    // (undocumented)
     localRefs?: LocalReferenceCollection;
-    // (undocumented)
     localRemovedSeq?: number;
-    // (undocumented)
     localSeq?: number;
-    // (undocumented)
     properties?: PropertySet;
-    // (undocumented)
     propertyManager?: PropertiesManager;
     // (undocumented)
     readonly segmentGroups: SegmentGroupCollection;
-    // (undocumented)
     seq?: number;
     // (undocumented)
     splitAt(pos: number): ISegment | undefined;

--- a/packages/dds/merge-tree/README.md
+++ b/packages/dds/merge-tree/README.md
@@ -74,7 +74,7 @@ tombstoned the segment.
 For clients to be able to reason about which segment insertions/removals other clients have processed the
 MergeTree we do two things:
 
-1. The MergeTree tracks which client inserted/removed each segment and the seq# assigned by the Fluid service to the
+1. The MergeTree tracks which client inserted/removed each segment and the sequence number (abbreviated "seq") assigned by the Fluid service to the
    insertion/removal operation.
 2. When sending a MergeTree op, the client includes the last seq# it has processed from the Fluid service.  This number
    is known as an op's "reference sequence number" or "refSeq#"

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -69,7 +69,7 @@ export interface IMergeNodeCommon {
 export type IMergeNode = IMergeBlock | ISegment;
 
 /**
- * Internal node in a merge tree.
+ * Internal (i.e. non-leaf) node in a merge tree.
  */
 export interface IMergeBlock extends IMergeNodeCommon {
     needsScour?: boolean;
@@ -78,7 +78,9 @@ export interface IMergeBlock extends IMergeNodeCommon {
      */
     childCount: number;
     /**
-     * Array of child nodes. To avoid reallocation, this is always initialized to have maximum length as deemed by
+     * Array of child nodes.
+     *
+     * @remarks To avoid reallocation, this is always initialized to have maximum length as deemed by
      * the merge tree's branching factor. Use `childCount` to determine how many children this node actually has.
      */
     children: IMergeNode[];
@@ -109,7 +111,7 @@ export interface IHierBlock extends IMergeBlock {
 }
 
 /**
- * Contains removal information associated to an ISegment.
+ * Contains removal information associated to an {@link ISegment}.
  */
 export interface IRemovalInfo {
     /**
@@ -117,10 +119,10 @@ export interface IRemovalInfo {
      */
     removedSeq: number;
     /**
-     * List of client ids that have removed this segment.
+     * List of client IDs that have removed this segment.
      * The client that actually removed the segment (i.e. whose removal op was sequenced first) is stored as the first
      * client in this list. Other clients in the list have all issued concurrent ops to remove the segment.
-     * (When this list has length \> 1, this is referred to as the "overlapping remove" case)
+     * @remarks When this list has length \> 1, this is referred to as the "overlapping remove" case.
      */
     removedClientIds: number[];
 }
@@ -146,12 +148,12 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
      */
     propertyManager?: PropertiesManager;
     /**
-     * local seq at which this segment was inserted. If this is defined, `seq` will be UnassignedSequenceNumber.
+     * Local seq at which this segment was inserted. If this is defined, `seq` will be UnassignedSequenceNumber.
      * Once the segment is acked, this field is cleared.
      */
     localSeq?: number;
     /**
-     * local seq at which this segment was removed. If this is defined, `removedSeq` will initially be set to
+     * Local seq at which this segment was removed. If this is defined, `removedSeq` will initially be set to
      * UnassignedSequenceNumber. However, if another client concurrently removes the same segment, `removedSeq`
      * will be updated to the seq at which that client removed this segment.
      *
@@ -159,7 +161,7 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
      */
     localRemovedSeq?: number;
     /**
-     * seq at which this segment was inserted.
+     * Seq at which this segment was inserted.
      * If undefined, it is assumed the segment was inserted prior to the collab window's minimum sequence number.
      */
     seq?: number;

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -74,7 +74,7 @@ export type IMergeNode = IMergeBlock | ISegment;
 export interface IMergeBlock extends IMergeNodeCommon {
     needsScour?: boolean;
     /**
-     * Number of children of this node
+     * Number of direct children of this node
      */
     childCount: number;
     /**

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -45,24 +45,47 @@ import {
 import { SegmentGroupCollection } from "./segmentGroupCollection";
 import { PropertiesManager, PropertiesRollback } from "./segmentPropertiesManager";
 
+/**
+ * Common properties for a node in a merge tree.
+ */
 export interface IMergeNodeCommon {
     parent?: IMergeBlock;
     /**
      * The length of the contents of the node.
      */
     cachedLength: number;
+    /**
+     * The index of this node in its parent's list of children.
+     */
     index: number;
+    /**
+     * A string that can be used for comparing the location of this node to other `MergeNode`s in the same tree.
+     * `a.ordinal < b.ordinal` if and only if `a` comes before `b` in a pre-order traversal of the MergeTree.
+     */
     ordinal: string;
     isLeaf(): this is ISegment;
 }
 
 export type IMergeNode = IMergeBlock | ISegment;
 
-// Node with segments as children
+/**
+ * Internal node in a merge tree.
+ */
 export interface IMergeBlock extends IMergeNodeCommon {
     needsScour?: boolean;
+    /**
+     * Number of children of this node
+     */
     childCount: number;
+    /**
+     * Array of child nodes. To avoid reallocation, this is always initialized to have maximum length as deemed by
+     * the merge tree's branching factor. Use `childCount` to determine how many children this node actually has.
+     */
     children: IMergeNode[];
+    /**
+     * Supports querying the total length of all descendants of this IMergeBlock from the perspective of any
+     * (clientId, seq) within the collab window.
+     */
     partialLengths?: PartialSequenceLengths;
     hierBlock(): IHierBlock | undefined;
     assignChild(child: IMergeNode, index: number, updateOrdinal?: boolean): void;
@@ -85,10 +108,23 @@ export interface IHierBlock extends IMergeBlock {
     rangeStacks: RangeStackMap;
 }
 
+/**
+ * Contains removal information associated to an ISegment.
+ */
 export interface IRemovalInfo {
+    /**
+     * Seq at which this segment was removed.
+     */
     removedSeq: number;
+    /**
+     * List of client ids that have removed this segment.
+     * The client that actually removed the segment (i.e. whose removal op was sequenced first) is stored as the first
+     * client in this list. Other clients in the list have all issued concurrent ops to remove the segment.
+     * (When this list has length \> 1, this is referred to as the "overlapping remove" case)
+     */
     removedClientIds: number[];
 }
+
 export function toRemovalInfo(maybe: Partial<IRemovalInfo> | undefined): IRemovalInfo | undefined {
     if (maybe?.removedClientIds !== undefined && maybe?.removedSeq !== undefined) {
         return maybe as IRemovalInfo;
@@ -99,17 +135,45 @@ export function toRemovalInfo(maybe: Partial<IRemovalInfo> | undefined): IRemova
 
 /**
  * A segment representing a portion of the merge tree.
+ * Segments are leaf nodes of the merge tree and contain data.
  */
 export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
     readonly type: string;
     readonly segmentGroups: SegmentGroupCollection;
     readonly trackingCollection: TrackingGroupCollection;
+    /**
+     * Manages pending local state for properties on this segment.
+     */
     propertyManager?: PropertiesManager;
+    /**
+     * local seq at which this segment was inserted. If this is defined, `seq` will be UnassignedSequenceNumber.
+     * Once the segment is acked, this field is cleared.
+     */
     localSeq?: number;
+    /**
+     * local seq at which this segment was removed. If this is defined, `removedSeq` will initially be set to
+     * UnassignedSequenceNumber. However, if another client concurrently removes the same segment, `removedSeq`
+     * will be updated to the seq at which that client removed this segment.
+     *
+     * Like `localSeq`, this field is cleared once the local removal of the segment is acked.
+     */
     localRemovedSeq?: number;
-    seq?: number;  // If not present assumed to be previous to window min
+    /**
+     * seq at which this segment was inserted.
+     * If undefined, it is assumed the segment was inserted prior to the collab window's minimum sequence number.
+     */
+    seq?: number;
+    /**
+     * Short clientId for the client that inserted this segment.
+     */
     clientId: number;
+    /**
+     * Local references added to this segment.
+     */
     localRefs?: LocalReferenceCollection;
+    /**
+     * Properties that have been added to this segment via annotation.
+     */
     properties?: PropertySet;
     addProperties(
         newProps: PropertySet,

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -60,7 +60,7 @@ export interface IMergeNodeCommon {
     index: number;
     /**
      * A string that can be used for comparing the location of this node to other `MergeNode`s in the same tree.
-     * `a.ordinal < b.ordinal` if and only if `a` comes before `b` in a pre-order traversal of the MergeTree.
+     * `a.ordinal < b.ordinal` if and only if `a` comes before `b` in a pre-order traversal of the tree.
      */
     ordinal: string;
     isLeaf(): this is ISegment;
@@ -87,6 +87,10 @@ export interface IMergeBlock extends IMergeNodeCommon {
     /**
      * Supports querying the total length of all descendants of this IMergeBlock from the perspective of any
      * (clientId, seq) within the collab window.
+     *
+     * @remarks This is only optional for implementation reasons (internal nodes can be created/moved without
+     * immediately initializing the partial lengths). Aside from mid-update on tree operations, these lengths
+     * objects are always defined.
      */
     partialLengths?: PartialSequenceLengths;
     hierBlock(): IHierBlock | undefined;


### PR DESCRIPTION
Adds doc comments which describe the core state of merge tree nodes (internal and leaves).