### PR TITLE
Improve comment in SummaryManager.getShouldSummarizeState()

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -747,7 +747,11 @@ export type SummarizerStopReason =
 * client to no longer be elected as responsible for summaries. Then it
 * tries to stop its spawned summarizer client.
 */
-| "parentShouldNotSummarize"
+| "notElectedParent"
+/**
+* We are not already running the summarizer and we are not the current elected client id.
+*/
+| "notElectedClient"
 /** Summarizer client was disconnected */
 | "summarizerClientDisconnected" | "summarizerException";
 

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -162,6 +162,10 @@
       },
       "InterfaceDeclaration_IConnectableRuntime": {
         "backCompat": false
+      },
+      "TypeAliasDeclaration_SummarizerStopReason": {
+        "forwardCompat": false,
+        "backCompat": false
       }
     }
   }

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -286,7 +286,11 @@ export type SummarizerStopReason =
      * client to no longer be elected as responsible for summaries. Then it
      * tries to stop its spawned summarizer client.
      */
-    | "parentShouldNotSummarize"
+    | "notElectedParent"
+    /**
+     * We are not already running the summarizer and we are not the current elected client id.
+     */
+    | "notElectedClient"
     /** Summarizer client was disconnected */
     | "summarizerClientDisconnected"
     /* running summarizer threw an exception */

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -142,17 +142,22 @@ export class SummaryManager implements IDisposable {
         // only transition to Stopping when the electedParentId changes. Stopping the summarizer without
         // changing the electedParent will just cause us to transition to Starting again.
 
-        // Conditions for returning notElectedParent/notElectedClient and not running the last summary:
-        // a) New Parent has been elected and it is not the current client, or
-        // b) We are not already running the summarizer and we are not the current elected client id.
+        // New Parent has been elected and it is not the current client, or
         if (this.connectedState.clientId !== this.clientElection.electedParentId) {
             return { shouldSummarize: false, stopReason: "notElectedParent" };
-        } else if (this.state !== SummaryManagerState.Running &&
+        }
+
+        // We are not already running the summarizer and we are not the current elected client id.
+        if (this.state !== SummaryManagerState.Running &&
                 this.connectedState.clientId !== this.clientElection.electedClientId) {
             return { shouldSummarize: false, stopReason: "notElectedClient" };
-        } else if (!this.connectedState.connected) {
+        }
+
+        if (!this.connectedState.connected) {
             return { shouldSummarize: false, stopReason: "parentNotConnected" };
-        } else if (this.disposed) {
+        }
+
+        if (this.disposed) {
             assert(false, 0x260 /* "Disposed should mean disconnected!" */);
         } else {
             return { shouldSummarize: true };

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { SummarizerStopReason } from "@fluidframework/container-runtime-previous";
+import { SummarizerStopReason } from "../summarizerTypes";
 import { Summarizer } from "../summarizer";
 
 describe("Runtime", () => {
@@ -13,7 +13,8 @@ describe("Runtime", () => {
             it("Should not run last summary when reason is not parentNotConnected", () => {
                 const stopReasons: SummarizerStopReason[] = [
                     "failToSummarize",
-                    "parentShouldNotSummarize",
+                    "notElectedParent",
+                    "notElectedClient",
                     "summarizerClientDisconnected",
                     "summarizerException",
                 ];

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -1681,6 +1681,7 @@ declare function get_old_TypeAliasDeclaration_SummarizerStopReason():
 declare function use_current_TypeAliasDeclaration_SummarizerStopReason(
     use: TypeOnly<current.SummarizerStopReason>);
 use_current_TypeAliasDeclaration_SummarizerStopReason(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_SummarizerStopReason());
 
 /*
@@ -1693,6 +1694,7 @@ declare function get_current_TypeAliasDeclaration_SummarizerStopReason():
 declare function use_old_TypeAliasDeclaration_SummarizerStopReason(
     use: TypeOnly<old.SummarizerStopReason>);
 use_old_TypeAliasDeclaration_SummarizerStopReason(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_SummarizerStopReason());
 
 /*


### PR DESCRIPTION
Fix for [AB427](https://dev.azure.com/fluidframework/internal/_workitems/edit/427)
Adding 2 new Summary Reasons to getShouldSummarizeState: notElectedParent and notElectedClient
to replace the original parentShouldNotSummarize one. 

## Description
Instead of parentShouldNotSummarize, we will be using 
- **notElectedParent** - to indicate there was an election and a new client has been elected  
- **notElectedClient** - to indicate that we are not the current elected client and we are not running the (last) summary 

Concepts: 
electedClient - is the non-interactive summarizer client if one exists. If not, then electedClient is equal to
electedParent. If electedParent === electedClient, this is the signal for electedParent to spawn a new
electedClient. 

electedParent - is the interactive client that has been elected to spawn a summarizer.


## Does this introduce a breaking change?

yes as we remove the parentShouldNotSummarize reason. 

## Other information or known dependencies

I talked to Andrei and as the use of the getShouldSummarizeState is restricted to the containerRuntime, I believe there will be no  backward compatibility issue. 