### PR TITLE
[r11s] Preventing empty properties in http metrics

### DIFF
--- a/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
@@ -45,10 +45,10 @@ export function jsonMorganLoggerMiddleware(
                 additionalProperties = computeAdditionalProperties(tokens, req, res);
             }
             const properties = {
-                [HttpProperties.method]: tokens.method(req, res),
+                [HttpProperties.method]: tokens.method(req, res) ?? "METHOD_UNAVAILABLE",
                 [HttpProperties.pathCategory]: `${req.baseUrl}${req.route?.path ?? "PATH_UNAVAILABLE"}`,
                 [HttpProperties.url]: tokens.url(req, res),
-                [HttpProperties.status]: tokens.status(req, res),
+                [HttpProperties.status]: tokens.status(req, res) ?? "STATUS_UNAVAILABLE",
                 [HttpProperties.requestContentLength]: tokens.req(req, res, "content-length"),
                 [HttpProperties.responseContentLength]: tokens.res(req, res, "content-length"),
                 [HttpProperties.responseTime]: tokens["response-time"](req, res),

--- a/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
@@ -45,10 +45,10 @@ export function jsonMorganLoggerMiddleware(
                 additionalProperties = computeAdditionalProperties(tokens, req, res);
             }
             const properties = {
-                [HttpProperties.method]: tokens.method(req, res) ?? "METHOD_UNAVAILABLE",
+                [HttpProperties.method]: tokens.method(req, res) || "METHOD_UNAVAILABLE",
                 [HttpProperties.pathCategory]: `${req.baseUrl}${req.route?.path ?? "PATH_UNAVAILABLE"}`,
                 [HttpProperties.url]: tokens.url(req, res),
-                [HttpProperties.status]: tokens.status(req, res) ?? "STATUS_UNAVAILABLE",
+                [HttpProperties.status]: tokens.status(req, res) || "STATUS_UNAVAILABLE",
                 [HttpProperties.requestContentLength]: tokens.req(req, res, "content-length"),
                 [HttpProperties.responseContentLength]: tokens.res(req, res, "content-length"),
                 [HttpProperties.responseTime]: tokens["response-time"](req, res),


### PR DESCRIPTION
## Description

When `express` services cannot process an HTTP request before the connection is closed or terminated, some properties used in our `morgan` middleware become empty (see https://github.com/expressjs/morgan/issues/121). As a result, we noticed that our metric processing infrastructure in Fluid Relay was "ignoring" the HTTP metrics/data points that had those empty fields. This PR implements a simple fix to this issue, doing something similar to what had been done originally for `pathCategory`: adding a specific, explicit string indicating the field is empty/unavailable.

## Does this introduce a breaking change?

No.

## Any relevant logs or outputs

Validated that the fix makes it possible for our metrics to be processed correctly.
![Screen Shot 2022-08-09 at 11 44 51 PM](https://user-images.githubusercontent.com/41453887/183833331-95715215-bff2-4342-a9ef-110c691272ac.png)
