### PR TITLE
Publish test file artifacts for DDS packages with fuzz tests

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -27,6 +27,7 @@
     "format": "npm run prettier:fix",
     "lint": "npm run prettier && npm run eslint",
     "lint:fix": "npm run prettier:fix && npm run eslint:fix",
+    "postpack": "cd dist && tar -cvf ../experimental-tree.test-files.tar ./test",
     "perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit -r node_modules/@fluidframework/mocha-test-setup --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
     "perf:measure": "npm run perf -- --fgrep @Measurement",
     "prettier": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -29,6 +29,7 @@
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "postpack": "cd dist && tar -cvf ../merge-tree.test-files.tar ./test",
     "test": "npm run test:mocha",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup -r source-map-support/register --unhandled-rejections=strict",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -30,6 +30,7 @@
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "postpack": "cd dist && tar -cvf ../sequence.test-files.tar ./test",
     "test": "npm run test:mocha",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "test:mocha": "mocha --recursive dist/test/**/*.spec.js -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",


### PR DESCRIPTION
This causes the tests for `merge-tree`, `sequence`, and the legacy tree DDS to be published as a build artifact in the CI build. It's a change ahead of adding a pipeline for consuming those packages using `include-test-real-service.yml` template (probably to-be-renamed since it's a generic template for running a package with published tests in a potentially different config).

This is the same pattern that azure-client uses: see [this commit](https://github.com/microsoft/FluidFramework/commit/98c2ec6351281c0780591845cd1955682b4e6289).

Reviewer can validate this is working as intended by looking at the published artifacts on the PR client build--e.g. [here is a previous one](https://dev.azure.com/fluidframework/public/_build/results?buildId=84621&view=artifacts&pathAsName=false&type=publishedArtifacts)