### PR TITLE
Move TelemetryNullLogger to telemetry-utils

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,8 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 - [Remove `type` field from `ShareLinkInfoType`](#Remove-type-field-from-ShareLinkInfoType)
 - [Remove `ShareLinkTypes` interface](#Remove-ShareLinkTypes-interface)
 - [Remove `enableShareLinkWithCreate` from `HostStoragePolicy`](#Remove-enableShareLinkWithCreate-from-HostStoragePolicy)
+- [Move `TelemetryNullLogger` and `BaseTelemetryNullLogger` to telemetry-utils package](#Move-`TelemetryNullLogger`-and-`BaseTelemetryNullLogger`-to-telemetry-utils-package)
+
 ### Remove `type` field from `ShareLinkInfoType`
 This field has been deprecated and will be removed in a future breaking change. You should be able to get the kind of sharing link from `shareLinkInfo.createLink.link` property bag.
 
@@ -39,9 +41,12 @@ This field has been deprecated and will be removed in a future breaking change. 
     ): 
 ```
 
-
 ### Remove `enableShareLinkWithCreate` from `HostStoragePolicy`
 `enableShareLinkWithCreate` feature gate has been deprecated and will be removed in a future breaking change. If you wish to enable creation of a sharing link along with the creation of Fluid file, you will need to provide `createShareLinkType:ISharingLinkKind` input to the `createOdspCreateContainerRequest` function and enable the feature using `enableSingleRequestForShareLinkWithCreate` in `HostStoragePolicy`
+
+### Move `TelemetryNullLogger` and `BaseTelemetryNullLogger` to telemetry-utils package
+The utility classes `TelemetryNullLogger` and `BaseTelemetryNullLogger` are deprecated in the `@fluidframework/common-utils` package and have been moved to the `@fluidframework/telemetry-utils` package.  Please update your imports to take these from the new location.
+
 # 2.0.0
 
 ## 2.0.0 Upcoming changes

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -24,6 +24,11 @@ import { TelemetryEventPropertyType } from '@fluidframework/common-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
+export class BaseTelemetryNullLogger implements ITelemetryBaseLogger {
+    send(event: ITelemetryBaseEvent): void;
+}
+
+// @public
 export class ChildLogger extends TelemetryLogger {
     // (undocumented)
     protected readonly baseLogger: ITelemetryBaseLogger;
@@ -288,6 +293,18 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     protected sendTelemetryEventCore(event: ITelemetryGenericEvent & {
         category: TelemetryEventCategory;
     }, error?: any): void;
+}
+
+// @public
+export class TelemetryNullLogger implements ITelemetryLogger {
+    // (undocumented)
+    send(event: ITelemetryBaseEvent): void;
+    // (undocumented)
+    sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void;
+    // (undocumented)
+    sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;
+    // (undocumented)
+    sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any): void;
 }
 
 // @public

--- a/common/lib/common-utils/api-report/common-utils.api.md
+++ b/common/lib/common-utils/api-report/common-utils.api.md
@@ -20,7 +20,7 @@ import { TransformedEvent } from '@fluidframework/common-definitions';
 // @public
 export function assert(condition: boolean, message: string | number): asserts condition;
 
-// @public
+// @public @deprecated
 export class BaseTelemetryNullLogger implements ITelemetryBaseLogger {
     send(event: ITelemetryBaseEvent): void;
 }
@@ -259,7 +259,7 @@ export function setLongTimeout(timeoutFn: () => void, timeoutMs: number, setTime
 // @public
 export function stringToBuffer(input: string, encoding: string): ArrayBufferLike;
 
-// @public
+// @public @deprecated
 export class TelemetryNullLogger implements ITelemetryLogger {
     // (undocumented)
     send(event: ITelemetryBaseEvent): void;

--- a/common/lib/common-utils/src/logger.ts
+++ b/common/lib/common-utils/src/logger.ts
@@ -15,6 +15,7 @@ import {
 /**
  * Null logger
  * It can be used in places where logger instance is required, but events should be not send over.
+ * @deprecated BaseTelemetryNullLogger has been moved to the \@fluidframework/telemetry-utils package.
  */
 export class BaseTelemetryNullLogger implements ITelemetryBaseLogger {
     /**
@@ -30,6 +31,7 @@ export class BaseTelemetryNullLogger implements ITelemetryBaseLogger {
 /**
  * Null logger
  * It can be used in places where logger instance is required, but events should be not send over.
+ * @deprecated TelemetryNullLogger has been moved to the \@fluidframework/telemetry-utils package.
  */
 export class TelemetryNullLogger implements ITelemetryLogger {
     public send(event: ITelemetryBaseEvent): void {}

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.33.1000";
+export const pkgVersion = "1.1.0";

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -25,11 +25,11 @@ import {
 } from '@fluidframework/test-utils';
 import { LocalServerTestDriver } from '@fluidframework/test-drivers';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
-import { TelemetryNullLogger } from '@fluidframework/common-utils';
 import type { IContainer, IHostLoader } from '@fluidframework/container-definitions';
 import type { IFluidCodeDetails, IFluidHandle, IRequestHeader } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
+import { TelemetryNullLogger } from '@fluidframework/telemetry-utils';
 import { IRequest } from '@fluidframework/core-interfaces';
 import {
 	AttributionId,

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -68,6 +68,7 @@
     "@fluidframework/server-services-client": "^0.1037.1000",
     "@fluidframework/server-services-core": "^0.1037.1000",
     "@fluidframework/server-test-utils": "^0.1037.1000",
+    "@fluidframework/telemetry-utils": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "jsrsasign": "^10.5.25",
     "uuid": "^8.3.1"
   },

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
 import {
     IClient,
@@ -11,6 +10,7 @@ import {
     IDocumentMessage,
     NackErrorType,
 } from "@fluidframework/protocol-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { LocalWebSocketServer } from "@fluidframework/server-local-server";
 import * as core from "@fluidframework/server-services-core";
 import type { Socket } from "socket.io-client";

--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -9,7 +9,7 @@ import * as socketStorage from "@fluidframework/routerlicious-driver";
 import { GitManager } from "@fluidframework/server-services-client";
 import { TestHistorian } from "@fluidframework/server-test-utils";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { LocalDeltaStorageService, LocalDocumentDeltaConnection } from ".";
 
 /**

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -5,9 +5,16 @@
 
 import { strict as assert } from "assert";
 import * as api from "@fluidframework/protocol-definitions";
-import { bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
-import { IFileEntry, IOdspResolvedUrl, ShareLinkTypes, ISharingLinkKind, SharingLinkRole,
-    SharingLinkScope } from "@fluidframework/odsp-driver-definitions";
+import { bufferToString } from "@fluidframework/common-utils";
+import {
+    IFileEntry,
+    IOdspResolvedUrl,
+    ShareLinkTypes,
+    ISharingLinkKind,
+    SharingLinkRole,
+    SharingLinkScope,
+} from "@fluidframework/odsp-driver-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { convertCreateNewSummaryTreeToTreeAndBlobs } from "../createNewUtils";
 import { createNewFluidFile } from "../createFile";
 import { EpochTracker } from "../epochTracker";

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -4,13 +4,13 @@
  */
 
 import { strict as assert } from "assert";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import {
     IOdspResolvedUrl,
     ICacheEntry,
     IEntry,
 } from "@fluidframework/odsp-driver-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { EpochTracker } from "../epochTracker";
 import { LocalPersistentCache } from "../odspCache";
 import { getHashedDocumentId } from "../odspPublicUtils";

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -5,9 +5,9 @@
 
 import { strict as assert } from "assert";
 import { stub } from "sinon";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { EpochTracker } from "../epochTracker";
 import { HostStoragePolicyInternal } from "../contracts";
 import * as fetchSnapshotImport from "../fetchSnapshot";

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import { strict as assert } from "assert";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import {
     IOdspResolvedUrl,
     ICacheEntry,
 } from "@fluidframework/odsp-driver-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { EpochTracker, defaultCacheExpiryTimeoutMs } from "../epochTracker";
 import {
     IOdspSnapshot,

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -11,9 +11,8 @@ import {
 } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { readAndParse, requestOps, emptyMessageStream } from "@fluidframework/driver-utils";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { PerformanceEvent } from "@fluidframework/telemetry-utils";
+import { PerformanceEvent, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { RestWrapper } from "@fluidframework/server-services-client";
 import { DocumentStorageService } from "./documentStorageService";
 

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -6,15 +6,19 @@
 /* eslint-disable max-len */
 
 import { strict as assert } from "assert";
-import { TelemetryNullLogger, Timer, TypedEventEmitter } from "@fluidframework/common-utils";
+
+import { ITelemetryProperties } from "@fluidframework/common-definitions";
+import { Timer, TypedEventEmitter } from "@fluidframework/common-utils";
+import { IConnectionDetails, IDeltaManager, IDeltaManagerEvents } from "@fluidframework/container-definitions";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import { IClient, IClientConfiguration, ITokenClaims } from "@fluidframework/protocol-definitions";
-import { IConnectionDetails, IDeltaManager, IDeltaManagerEvents } from "@fluidframework/container-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+
 import { SinonFakeTimers, useFakeTimers } from "sinon";
-import { ITelemetryProperties } from "@fluidframework/common-definitions";
+
+import { ICatchUpMonitor } from "../catchUpMonitor";
 import { ConnectionState } from "../connectionState";
 import { ConnectionStateHandler, IConnectionStateHandlerInputs } from "../connectionStateHandler";
-import { ICatchUpMonitor } from "../catchUpMonitor";
 
 class MockDeltaManagerForCatchingUp
     extends TypedEventEmitter<IDeltaManagerEvents>

--- a/packages/loader/driver-utils/src/test/blobAggregation.spec.ts
+++ b/packages/loader/driver-utils/src/test/blobAggregation.spec.ts
@@ -4,10 +4,11 @@
  */
 
 import { strict as assert } from "assert";
+import { bufferToString } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { TelemetryNullLogger, bufferToString } from "@fluidframework/common-utils";
 import { ISummaryTree, SummaryType, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { convertSummaryTreeToITree } from "@fluidframework/runtime-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { BlobAggregationStorage } from "../blobAggregationStorage";
 import { buildSnapshotTree } from "../buildSnapshotTree";
 

--- a/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
+++ b/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { runWithRetry } from "../runWithRetry";
 
 const _setTimeout = global.setTimeout;

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -5,12 +5,15 @@
 
 import { strict as assert } from "assert";
 import { v4 as uuid } from "uuid";
-import { Deferred, gitHashFile, IsoBuffer, TelemetryNullLogger, TypedEventEmitter } from "@fluidframework/common-utils";
-import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
-import { ISequencedDocumentMessage, SummaryType } from "@fluidframework/protocol-definitions";
+
+import { Deferred, gitHashFile, IsoBuffer, TypedEventEmitter } from "@fluidframework/common-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions";
+import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IDocumentStorageService } from "@fluidframework/driver-definitions";
+import { ISequencedDocumentMessage, SummaryType } from "@fluidframework/protocol-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+
 import { BlobManager, IBlobManagerLoadInfo, IBlobManagerRuntime } from "../blobManager";
 
 abstract class BaseMockBlobStorage implements Pick<IDocumentStorageService, "readBlob" | "createBlob"> {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -6,6 +6,10 @@
 /* eslint-disable max-len */
 
 import { strict as assert } from "assert";
+
+import { ITaggedTelemetryPropertyType } from "@fluidframework/common-definitions";
+import { stringToBuffer } from "@fluidframework/common-utils";
+import { ContainerErrorType } from "@fluidframework/container-definitions";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { BlobCacheStorageService } from "@fluidframework/driver-utils";
@@ -26,12 +30,10 @@ import {
     CreateSummarizerNodeSource,
     channelsTreeName,
 } from "@fluidframework/runtime-definitions";
-import { MockFluidDataStoreRuntime, validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { createRootSummarizerNodeWithGC, IRootSummarizerNodeWithGC } from "@fluidframework/runtime-utils";
-import { stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
-import { isFluidError } from "@fluidframework/telemetry-utils";
-import { ContainerErrorType } from "@fluidframework/container-definitions";
-import { ITaggedTelemetryPropertyType } from "@fluidframework/common-definitions";
+import { isFluidError, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import { MockFluidDataStoreRuntime, validateAssertionError } from "@fluidframework/test-runtime-utils";
+
 import {
     LocalFluidDataStoreContext,
     RemoteFluidDataStoreContext,

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
+
+import { FluidObject } from "@fluidframework/core-interfaces";
+import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
     IFluidDataStoreContext,
     IFluidDataStoreFactory,
@@ -13,11 +16,10 @@ import {
     CreateChildSummarizerNodeFn,
     CreateSummarizerNodeSource,
 } from "@fluidframework/runtime-definitions";
-import { FluidObject } from "@fluidframework/core-interfaces";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { createRootSummarizerNodeWithGC } from "@fluidframework/runtime-utils";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
+
 import { LocalFluidDataStoreContext } from "../dataStoreContext";
 import { ContainerRuntime } from "../containerRuntime";
 

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -4,7 +4,8 @@
  */
 
 import { strict as assert } from "assert";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
+
+import { ISequencedDocumentMessage, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import {
     channelsTreeName,
     CreateChildSummarizerNodeParam,
@@ -12,14 +13,15 @@ import {
     ISummarizerNode,
     ISummarizerNodeConfig,
 } from "@fluidframework/runtime-definitions";
-import { ISequencedDocumentMessage, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+
 import {
     createRootSummarizerNode,
     IRootSummarizerNode,
 } from "../summarizerNode";
-import { mergeStats } from "../summaryUtils";
 // eslint-disable-next-line import/no-internal-modules
 import { SummarizerNode } from "../summarizerNode/summarizerNode";
+import { mergeStats } from "../summaryUtils";
 
 describe("Runtime", () => {
     describe("Summarization", () => {

--- a/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { cloneGCData } from "@fluidframework/garbage-collector";
 import { SummaryType } from "@fluidframework/protocol-definitions";
 import {
@@ -15,7 +14,7 @@ import {
     ISummarizerNodeWithGC,
     SummarizeInternalFn,
 } from "@fluidframework/runtime-definitions";
-import { MockLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 // eslint-disable-next-line import/no-internal-modules
 import { createRootSummarizerNodeWithGC, IRootSummarizerNodeWithGC } from "../summarizerNode/summarizerNodeWithGc";
 import { mergeStats } from "../summaryUtils";

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -4,12 +4,15 @@
  */
 
 import { strict as assert } from "assert";
+
 import {
     ContainerRuntimeFactoryWithDefaultDataStore,
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { IContainer, IRuntimeFactory, LoaderHeader } from "@fluidframework/container-definitions";
+import { ILoaderProps } from "@fluidframework/container-loader";
 import {
     ContainerRuntime,
     IAckedSummary,
@@ -18,24 +21,23 @@ import {
     neverCancelledSummaryToken,
     SummaryCollection,
 } from "@fluidframework/container-runtime";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { SharedCounter } from "@fluidframework/counter";
 import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
+import { DriverHeader, ISummaryContext } from "@fluidframework/driver-definitions";
 import { SharedMatrix } from "@fluidframework/matrix";
+import { ISequencedDocumentMessage, ISummaryTree, MessageType } from "@fluidframework/protocol-definitions";
+import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ITestFluidObject,
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import {
+    ITestFluidObject,
     ITestObjectProvider,
     wrapDocumentServiceFactory,
     waitForContainerConnection,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
-import { ILoaderProps } from "@fluidframework/container-loader";
-import { DriverHeader, ISummaryContext } from "@fluidframework/driver-definitions";
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { ISequencedDocumentMessage, ISummaryTree, MessageType } from "@fluidframework/protocol-definitions";
 import { UndoRedoStackManager } from "@fluidframework/undo-redo";
-import { SharedCounter } from "@fluidframework/counter";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type ProviderPropertyKeys<T extends Object, TProp extends keyof T = keyof T> = string extends TProp

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -4,25 +4,26 @@
  */
 
 import assert from "assert";
+
 import {
     ContainerRuntimeFactoryWithDefaultDataStore,
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
-import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     DefaultSummaryConfiguration,
     IAckedSummary,
     IContainerRuntimeOptions,
     SummaryCollection,
-    ISummaryConfiguration } from "@fluidframework/container-runtime";
-import { MockLogger } from "@fluidframework/telemetry-utils";
+    ISummaryConfiguration,
+} from "@fluidframework/container-runtime";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { MockLogger, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
 
 class TestDataObject extends DataObject {
     public get _root() {

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -4,10 +4,27 @@
  */
 
 import { strict as assert } from "assert";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+
+import { SharedCell } from "@fluidframework/cell";
+import { Deferred } from "@fluidframework/common-utils";
 import { AttachState, IContainer } from "@fluidframework/container-definitions";
 import { ConnectionState, Container, Loader } from "@fluidframework/container-loader";
+import { ContainerMessageType } from "@fluidframework/container-runtime";
+import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { DataStoreMessageType } from "@fluidframework/datastore";
+import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { Ink, IColor } from "@fluidframework/ink";
+import { SharedMap, SharedDirectory } from "@fluidframework/map";
+import { SharedMatrix } from "@fluidframework/matrix";
+import { MergeTreeDeltaType } from "@fluidframework/merge-tree";
+import { ConsensusQueue } from "@fluidframework/ordered-collection";
+import { MessageType, ISummaryTree } from "@fluidframework/protocol-definitions";
+import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { SharedString } from "@fluidframework/sequence";
+import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import {
     ITestContainerConfig,
     DataObjectFactoryType,
@@ -19,22 +36,7 @@ import {
     TestFluidObjectFactory,
     ensureContainerConnected,
 } from "@fluidframework/test-utils";
-import { SharedMap, SharedDirectory } from "@fluidframework/map";
-import { Deferred, TelemetryNullLogger } from "@fluidframework/common-utils";
-import { SharedString } from "@fluidframework/sequence";
-import { Ink, IColor } from "@fluidframework/ink";
-import { SharedMatrix } from "@fluidframework/matrix";
-import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
-import { SharedCell } from "@fluidframework/cell";
-import { ConsensusQueue } from "@fluidframework/ordered-collection";
-import { MergeTreeDeltaType } from "@fluidframework/merge-tree";
-import { MessageType, ISummaryTree } from "@fluidframework/protocol-definitions";
-import { DataStoreMessageType } from "@fluidframework/datastore";
-import { ContainerMessageType } from "@fluidframework/container-runtime";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeFullCompat, describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
-import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
-import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 
 const detachedContainerRefSeqNumber = 0;
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -4,10 +4,14 @@
  */
 
 import { strict as assert } from "assert";
-import { stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
+
+import { stringToBuffer } from "@fluidframework/common-utils";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { ITestContainerConfig, ITestObjectProvider, waitForContainerConnection } from "@fluidframework/test-utils";
 import {
     describeFullCompat,
@@ -15,8 +19,7 @@ import {
     ITestDataObject,
     TestDataObjectType,
 } from "@fluidframework/test-version-utils";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { channelsTreeName } from "@fluidframework/runtime-definitions";
+
 import { defaultGCConfig } from "./gcTestConfigs";
 import { getGCStateFromSummary } from "./gcTestSummaryUtils";
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import { strict as assert } from "assert";
+
 import {
     ContainerRuntimeFactoryWithDefaultDataStore,
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -18,6 +18,7 @@ import { Marker, ReferenceType, reservedMarkerIdKey } from "@fluidframework/merg
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { SharedString } from "@fluidframework/sequence";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { ITestObjectProvider, waitForContainerConnection } from "@fluidframework/test-utils";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { UndoRedoStackManager } from "@fluidframework/undo-redo";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -4,9 +4,9 @@
  */
 
 import { strict as assert } from "assert";
+
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer, IRuntimeFactory, LoaderHeader } from "@fluidframework/container-definitions";
 import { ILoaderProps } from "@fluidframework/container-loader";
 import {
@@ -20,9 +20,12 @@ import {
     SummarizerStopReason,
     SummaryCollection,
 } from "@fluidframework/container-runtime";
+import { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader, ISummaryContext } from "@fluidframework/driver-definitions";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import {
     ITestFluidObject,
     ITestObjectProvider,
@@ -32,8 +35,6 @@ import {
     waitForContainerConnection,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
-import { IRequest } from "@fluidframework/core-interfaces";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 
 /**
   * Loads a summarizer client with the given version (if any) and returns its container runtime and summary collection.

--- a/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
@@ -4,8 +4,15 @@
  */
 
 import { strict as assert } from "assert";
+
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { IContainerLoadMode, LoaderHeader } from "@fluidframework/container-definitions";
+import { Container } from "@fluidframework/container-loader";
+import { SummaryCollection, DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
+import { IDocumentService, IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import { generatePairwiseOptions } from "@fluidframework/test-pairwise-generator";
 import {
     createLoader,
     ITestContainerConfig,
@@ -13,13 +20,7 @@ import {
     ITestObjectProvider,
     timeoutPromise,
 } from "@fluidframework/test-utils";
-import { Container } from "@fluidframework/container-loader";
-import { SummaryCollection, DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
-import { generatePairwiseOptions } from "@fluidframework/test-pairwise-generator";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
-import { IDocumentService, IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
-import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 
 const loadOptions: IContainerLoadMode[] =
     generatePairwiseOptions<IContainerLoadMode>({

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -3,18 +3,10 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable max-len */
-
 import { strict as assert } from "assert";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
-import {
-    ITestFluidObject,
-    ITestObjectProvider,
-    ITestContainerConfig,
-    DataObjectFactoryType,
-} from "@fluidframework/test-utils";
-import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
+
 import { ContainerErrorType, IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import {
     ContainerMessageType,
     ContainerRuntime,
@@ -22,12 +14,18 @@ import {
     SummaryCollection,
     DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
-import { Loader } from "@fluidframework/container-loader";
-import { UsageError } from "@fluidframework/container-utils";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { UsageError } from "@fluidframework/container-utils";
 import { IFluidRouter } from "@fluidframework/core-interfaces";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ConfigTypes, IConfigProviderBase, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import {
+    ITestFluidObject,
+    ITestObjectProvider,
+    ITestContainerConfig,
+    DataObjectFactoryType,
+} from "@fluidframework/test-utils";
+import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
 
 describeNoCompat("Named root data stores", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -4,23 +4,27 @@
  */
 
 import { strict as assert } from "assert";
-import { bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
+
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { bufferToString } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
+import { ConnectionState } from "@fluidframework/container-loader";
 import {
     ContainerRuntime,
     Summarizer,
     ISummarizer,
     ISummarizeResults,
-    ISummaryRuntimeOptions, DefaultSummaryConfiguration, SummaryCollection } from "@fluidframework/container-runtime";
+    ISummaryRuntimeOptions,
+    DefaultSummaryConfiguration,
+    SummaryCollection,
+} from "@fluidframework/container-runtime";
+import { ISummaryContext } from "@fluidframework/driver-definitions";
 import { ISummaryBlob, ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { describeNoCompat, ITestDataObject, TestDataObjectType } from "@fluidframework/test-version-utils";
+import { MockLogger, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
-import { ConnectionState } from "@fluidframework/container-loader";
-import { MockLogger } from "@fluidframework/telemetry-utils";
-import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import { ISummaryContext } from "@fluidframework/driver-definitions";
+import { describeNoCompat, ITestDataObject, TestDataObjectType } from "@fluidframework/test-version-utils";
 
 const defaultDataStoreId = "default";
 const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));

--- a/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
@@ -9,21 +9,20 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { IContainer } from "@fluidframework/container-definitions";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
 import {
     IContainerRuntimeOptions,
     SummaryCollection,
     ISummaryConfiguration,
     DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime";
-import { MockLogger } from "@fluidframework/telemetry-utils";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
+import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { MockLogger, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
 
 class TestDataObject extends DataObject {
     public get _root() {

--- a/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
@@ -5,16 +5,19 @@
 
 import fs from "fs";
 import util from "util";
-import { bufferToString, stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
+
+import { bufferToString, stringToBuffer } from "@fluidframework/common-utils";
 import {
     IDocumentService,
     IDocumentStorageService,
 } from "@fluidframework/driver-definitions";
+import { BlobAggregationStorage } from "@fluidframework/driver-utils";
 import {
     ISnapshotTree,
     IVersion,
 } from "@fluidframework/protocol-definitions";
-import { BlobAggregationStorage } from "@fluidframework/driver-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+
 import { formatNumber } from "./fluidAnalyzeMessages";
 import {
     dumpSnapshotStats,

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -79,6 +79,7 @@
     "@fluidframework/runtime-utils": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "@fluidframework/server-local-server": "^0.1037.1000",
     "@fluidframework/server-services-client": "^0.1037.1000",
+    "@fluidframework/telemetry-utils": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "@fluidframework/tool-utils": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "@fluidframework/view-adapters": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -6,7 +6,7 @@
 import sillyname from "sillyname";
 import { v4 as uuid } from "uuid";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
-import { assert, BaseTelemetryNullLogger, Deferred } from "@fluidframework/common-utils";
+import { assert, Deferred } from "@fluidframework/common-utils";
 import {
     AttachState,
     IFluidCodeResolver,
@@ -23,6 +23,7 @@ import { Loader } from "@fluidframework/container-loader";
 import { prefetchLatestSnapshot } from "@fluidframework/odsp-driver";
 import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
+import { BaseTelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { IFluidMountableView } from "@fluidframework/view-interfaces";
 import {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -15,7 +15,7 @@ import {
     ITaggedTelemetryPropertyType,
     TelemetryEventCategory,
 } from "@fluidframework/common-definitions";
-import { BaseTelemetryNullLogger, performance } from "@fluidframework/common-utils";
+import { performance } from "@fluidframework/common-utils";
 import {
     CachedConfigProvider,
     loggerIsMonitoringContext,
@@ -528,7 +528,7 @@ export class PerformanceEvent {
  * Logger that is useful for UT
  * It can be used in places where logger instance is required, but events should be not send over.
  */
- export class TelemetryUTLogger implements ITelemetryLogger {
+export class TelemetryUTLogger implements ITelemetryLogger {
     public send(event: ITelemetryBaseEvent): void {
     }
     public sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any) {
@@ -560,4 +560,30 @@ export class PerformanceEvent {
         console.error(error);
         throw error;
     }
+}
+
+/**
+ * Null logger
+ * It can be used in places where logger instance is required, but events should be not send over.
+ */
+export class BaseTelemetryNullLogger implements ITelemetryBaseLogger {
+    /**
+     * Send an event with the logger
+     *
+     * @param event - the event to send
+     */
+    public send(event: ITelemetryBaseEvent): void {
+        return;
+    }
+}
+
+/**
+ * Null logger
+ * It can be used in places where logger instance is required, but events should be not send over.
+ */
+export class TelemetryNullLogger implements ITelemetryLogger {
+    public send(event: ITelemetryBaseEvent): void {}
+    public sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any): void {}
+    public sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void {}
+    public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {}
 }


### PR DESCRIPTION
Doesn't seem to make sense for this single logger to live in common-utils -- moving this will make it easier to find and consolidate related code, and I think it aligns with the similar movement in #9016.  This change would also update all existing imports in our repo in preparation for the eventual removal.