### PR TITLE
Simplify state machine of pending summary state after summary is submitted

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -225,15 +225,18 @@ export class SummarizerNode implements IRootSummarizerNode {
                 return { latestSummaryUpdated: true, wasSummaryTracked: true };
             }
 
+            const props = {
+                summaryRefSeq,
+                pendingSize: this.pendingSummaries.size,
+                pendingHandle: this.pendingSummaries.size > 0 ? this.pendingSummaries.keys[0] : undefined,
+                pendingSeqNumber: this.pendingSummaries.size > 0 ?
+                    this.pendingSummaries.values[0].referenceSequenceNumber : undefined,
+            };
             this.defaultLogger.sendTelemetryEvent({
                 eventName: "PendingSummaryNotFound",
                 proposalHandle,
-                summaryRefSeq,
-                length: this.pendingSummaries.size,
-                pendingSummaryHandle: this.pendingSummaries.size > 0 ? this.pendingSummaries.keys[0] : undefined,
                 referenceSequenceNumber: this.referenceSequenceNumber,
-                pendingSummarySequenceNumber: this.pendingSummaries.size > 0 ?
-                    this.pendingSummaries.values[0].referenceSequenceNumber : undefined,
+                details: JSON.stringify(props),
             });
         }
 

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -224,6 +224,14 @@ export class SummarizerNode implements IRootSummarizerNode {
                 this.refreshLatestSummaryFromPending(proposalHandle, maybeSummaryNode.referenceSequenceNumber);
                 return { latestSummaryUpdated: true, wasSummaryTracked: true };
             }
+
+            this.defaultLogger.sendTelemetryEvent({
+                eventName: "PendingSummaryNotFound",
+                proposalHandle,
+                summaryRefSeq,
+                size: this.pendingSummaries.size,
+                haveHandle: this.pendingSummaries.size > 0 ? this.pendingSummaries.keys[0] : undefined,
+            });
         }
 
         // If we have seen a summary same or later as the current one, ignore it.

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -229,8 +229,11 @@ export class SummarizerNode implements IRootSummarizerNode {
                 eventName: "PendingSummaryNotFound",
                 proposalHandle,
                 summaryRefSeq,
-                size: this.pendingSummaries.size,
-                haveHandle: this.pendingSummaries.size > 0 ? this.pendingSummaries.keys[0] : undefined,
+                length: this.pendingSummaries.size,
+                pendingSummaryHandle: this.pendingSummaries.size > 0 ? this.pendingSummaries.keys[0] : undefined,
+                referenceSequenceNumber: this.referenceSequenceNumber,
+                pendingSummarySequenceNumber: this.pendingSummaries.size > 0 ?
+                    this.pendingSummaries.values[0].referenceSequenceNumber : undefined,
             });
         }
 


### PR DESCRIPTION
The initial goal for this task was to simplify the state machine of the pending summary state after a summary is submitted. 

In order to better understand how often the scenario happens, we are simply adding a telemetry event that will be logged whenever the proposal handle is not on the pendingsummaries list. 

Addressing part of [#AB444](https://dev.azure.com/fluidframework/internal/_workitems/edit/444)

Note: this will also help understand a problem on FRS in which the pendingsummaries list never seems to have the proposal handle.