### PR TITLE
Move schedule manager to its own file

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { EventEmitter } from "events";
 import { ITelemetryBaseLogger, ITelemetryGenericEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     FluidObject,
@@ -34,7 +33,6 @@ import {
     Trace,
     TypedEventEmitter,
     unreachableCase,
-    performance,
 } from "@fluidframework/common-utils";
 import {
     ChildLogger,
@@ -56,7 +54,6 @@ import {
     DataProcessingError,
     GenericError,
     UsageError,
-    extractSafePropertiesFromMessage,
 } from "@fluidframework/container-utils";
 import {
     IClientDetails,
@@ -112,10 +109,8 @@ import { ContainerFluidHandleContext } from "./containerHandleContext";
 import { FluidDataStoreRegistry } from "./dataStoreRegistry";
 import { Summarizer } from "./summarizer";
 import { SummaryManager } from "./summaryManager";
-import { DeltaScheduler } from "./deltaScheduler";
 import {
     ReportOpPerfTelemetry,
-    latencyThreshold,
     IPerfSignalReport,
 } from "./connectionTelemetry";
 import { IPendingLocalState, PendingStateManager } from "./pendingStateManager";
@@ -164,6 +159,7 @@ import {
 } from "./dataStore";
 import { BindBatchTracker } from "./batchTracker";
 import { ISerializedBaseSnapshotBlobs, SerializedSnapshotStorage } from "./serializedSnapshotStorage";
+import { ScheduleManager } from "./scheduleManager";
 
 export enum ContainerMessageType {
     // An op to be delivered to store
@@ -438,10 +434,6 @@ export interface IContainerRuntimeOptions {
     readonly enableOfflineLoad?: boolean;
 }
 
-type IRuntimeMessageMetadata = undefined | {
-    batch?: boolean;
-};
-
 /**
  * The summary tree returned by the root node. It adds state relevant to the root of the tree.
  */
@@ -557,281 +549,6 @@ export function unpackRuntimeMessage(message: ISequencedDocumentMessage) {
         // Nothing to do in such case.
     }
     return message;
-}
-
-/**
- * This class controls pausing and resuming of inbound queue to ensure that we never
- * start processing ops in a batch IF we do not have all ops in the batch.
- */
-class ScheduleManagerCore {
-    private pauseSequenceNumber: number | undefined;
-    private currentBatchClientId: string | undefined;
-    private localPaused = false;
-    private timePaused = 0;
-    private batchCount = 0;
-
-    constructor(
-        private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-        private readonly logger: ITelemetryLogger,
-    ) {
-        // Listen for delta manager sends and add batch metadata to messages
-        this.deltaManager.on("prepareSend", (messages: IDocumentMessage[]) => {
-            if (messages.length === 0) {
-                return;
-            }
-
-            // First message will have the batch flag set to true if doing a batched send
-            const firstMessageMetadata = messages[0].metadata as IRuntimeMessageMetadata;
-            if (!firstMessageMetadata?.batch) {
-                return;
-            }
-
-            // If the batch contains only a single op, clear the batch flag.
-            if (messages.length === 1) {
-                delete firstMessageMetadata.batch;
-                return;
-            }
-
-            // Set the batch flag to false on the last message to indicate the end of the send batch
-            const lastMessage = messages[messages.length - 1];
-            lastMessage.metadata = { ...lastMessage.metadata, batch: false };
-        });
-
-        // Listen for updates and peek at the inbound
-        this.deltaManager.inbound.on(
-            "push",
-            (message: ISequencedDocumentMessage) => {
-                this.trackPending(message);
-            });
-
-        // Start with baseline - empty inbound queue.
-        assert(!this.localPaused, 0x293 /* "initial state" */);
-
-        const allPending = this.deltaManager.inbound.toArray();
-        for (const pending of allPending) {
-            this.trackPending(pending);
-        }
-
-        // We are intentionally directly listening to the "op" to inspect system ops as well.
-        // If we do not observe system ops, we are likely to hit 0x296 assert when system ops
-        // precedes start of incomplete batch.
-        this.deltaManager.on("op", (message) => this.afterOpProcessing(message.sequenceNumber));
-    }
-
-    /**
-     * The only public function in this class - called when we processed an op,
-     * to make decision if op processing should be paused or not afer that.
-     */
-    public afterOpProcessing(sequenceNumber: number) {
-        assert(!this.localPaused, 0x294 /* "can't have op processing paused if we are processing an op" */);
-
-        // If the inbound queue is ever empty, nothing to do!
-        if (this.deltaManager.inbound.length === 0) {
-            assert(this.pauseSequenceNumber === undefined,
-                0x295 /* "there should be no pending batch if we have no ops" */);
-            return;
-        }
-
-        // The queue is
-        // 1. paused only when the next message to be processed is the beginning of a batch. Done in two places:
-        //    - here (processing ops until reaching start of incomplete batch)
-        //    - in trackPending(), when queue was empty and start of batch showed up.
-        // 2. resumed when batch end comes in (in trackPending())
-
-        // do we have incomplete batch to worry about?
-        if (this.pauseSequenceNumber !== undefined) {
-            assert(sequenceNumber < this.pauseSequenceNumber,
-                0x296 /* "we should never start processing incomplete batch!" */);
-            // If the next op is the start of incomplete batch, then we can't process it until it's fully in - pause!
-            if (sequenceNumber + 1 === this.pauseSequenceNumber) {
-                this.pauseQueue();
-            }
-        }
-    }
-
-    private pauseQueue() {
-        assert(!this.localPaused, 0x297 /* "always called from resumed state" */);
-        this.localPaused = true;
-        this.timePaused = performance.now();
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.deltaManager.inbound.pause();
-    }
-
-    private resumeQueue(startBatch: number, messageEndBatch: ISequencedDocumentMessage) {
-        const endBatch = messageEndBatch.sequenceNumber;
-        const duration = this.localPaused ? (performance.now() - this.timePaused) : undefined;
-
-        this.batchCount++;
-        if (this.batchCount % 1000 === 1) {
-            this.logger.sendTelemetryEvent({
-                eventName: "BatchStats",
-                sequenceNumber: endBatch,
-                length: endBatch - startBatch + 1,
-                msnDistance: endBatch - messageEndBatch.minimumSequenceNumber,
-                duration,
-                batchCount: this.batchCount,
-                interrupted: this.localPaused,
-            });
-        }
-
-        // Return early if no change in value
-        if (!this.localPaused) {
-            return;
-        }
-
-        this.localPaused = false;
-
-        // Random round number - we want to know when batch waiting paused op processing.
-        if (duration !== undefined && duration > latencyThreshold) {
-            this.logger.sendErrorEvent({
-                eventName: "MaxBatchWaitTimeExceeded",
-                duration,
-                sequenceNumber: endBatch,
-                length: endBatch - startBatch,
-            });
-        }
-        this.deltaManager.inbound.resume();
-    }
-
-    /**
-     * Called for each incoming op (i.e. inbound "push" notification)
-     */
-    private trackPending(message: ISequencedDocumentMessage) {
-        assert(this.deltaManager.inbound.length !== 0,
-            0x298 /* "we have something in the queue that generates this event" */);
-
-        assert((this.currentBatchClientId === undefined) === (this.pauseSequenceNumber === undefined),
-            0x299 /* "non-synchronized state" */);
-
-        const metadata = message.metadata as IRuntimeMessageMetadata;
-        const batchMetadata = metadata?.batch;
-
-        // Protocol messages are never part of a runtime batch of messages
-        if (!isUnpackedRuntimeMessage(message)) {
-            // Protocol messages should never show up in the middle of the batch!
-            assert(this.currentBatchClientId === undefined, 0x29a /* "System message in the middle of batch!" */);
-            assert(batchMetadata === undefined, 0x29b /* "system op in a batch?" */);
-            assert(!this.localPaused, 0x29c /* "we should be processing ops when there is no active batch" */);
-            return;
-        }
-
-        if (this.currentBatchClientId === undefined && batchMetadata === undefined) {
-            assert(!this.localPaused, 0x29d /* "we should be processing ops when there is no active batch" */);
-            return;
-        }
-
-        // If the client ID changes then we can move the pause point. If it stayed the same then we need to check.
-        // If batchMetadata is not undefined then if it's true we've begun a new batch - if false we've ended
-        // the previous one
-        if (this.currentBatchClientId !== undefined || batchMetadata === false) {
-            if (this.currentBatchClientId !== message.clientId) {
-                // "Batch not closed, yet message from another client!"
-                throw new DataCorruptionError(
-                    "OpBatchIncomplete",
-                    {
-                        runtimeVersion: pkgVersion,
-                        batchClientId: this.currentBatchClientId,
-                        ...extractSafePropertiesFromMessage(message),
-                    });
-            }
-        }
-
-        // The queue is
-        // 1. paused only when the next message to be processed is the beginning of a batch. Done in two places:
-        //    - in afterOpProcessing() - processing ops until reaching start of incomplete batch
-        //    - here (batchMetadata == false below), when queue was empty and start of batch showed up.
-        // 2. resumed when batch end comes in (batchMetadata === true case below)
-
-        if (batchMetadata) {
-            assert(this.currentBatchClientId === undefined, 0x29e /* "there can't be active batch" */);
-            assert(!this.localPaused, 0x29f /* "we should be processing ops when there is no active batch" */);
-            this.pauseSequenceNumber = message.sequenceNumber;
-            this.currentBatchClientId = message.clientId;
-            // Start of the batch
-            // Only pause processing if queue has no other ops!
-            // If there are any other ops in the queue, processing will be stopped when they are processed!
-            if (this.deltaManager.inbound.length === 1) {
-                this.pauseQueue();
-            }
-        } else if (batchMetadata === false) {
-            assert(this.pauseSequenceNumber !== undefined, 0x2a0 /* "batch presence was validated above" */);
-            // Batch is complete, we can process it!
-            this.resumeQueue(this.pauseSequenceNumber, message);
-            this.pauseSequenceNumber = undefined;
-            this.currentBatchClientId = undefined;
-        } else {
-            // Continuation of current batch. Do nothing
-            assert(this.currentBatchClientId !== undefined, 0x2a1 /* "logic error" */);
-        }
-    }
-}
-
-/**
- * This class has the following responsibilities:
- * 1. It tracks batches as we process ops and raises "batchBegin" and "batchEnd" events.
- *    As part of it, it validates batch correctness (i.e. no system ops in the middle of batch)
- * 2. It creates instance of ScheduleManagerCore that ensures we never start processing ops from batch
- *    unless all ops of the batch are in.
- */
-export class ScheduleManager {
-    private readonly deltaScheduler: DeltaScheduler;
-    private batchClientId: string | undefined;
-    private hitError = false;
-
-    constructor(
-        private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-        private readonly emitter: EventEmitter,
-        private readonly logger: ITelemetryLogger,
-    ) {
-        this.deltaScheduler = new DeltaScheduler(
-            this.deltaManager,
-            ChildLogger.create(this.logger, "DeltaScheduler"),
-        );
-        void new ScheduleManagerCore(deltaManager, logger);
-    }
-
-    public beforeOpProcessing(message: ISequencedDocumentMessage) {
-        if (this.batchClientId !== message.clientId) {
-            assert(this.batchClientId === undefined,
-                0x2a2 /* "Batch is interrupted by other client op. Should be caught by trackPending()" */);
-
-            // This could be the beginning of a new batch or an individual message.
-            this.emitter.emit("batchBegin", message);
-            this.deltaScheduler.batchBegin(message);
-
-            const batch = (message?.metadata as IRuntimeMessageMetadata)?.batch;
-            if (batch) {
-                this.batchClientId = message.clientId;
-            } else {
-                this.batchClientId = undefined;
-            }
-        }
-    }
-
-    public afterOpProcessing(error: any | undefined, message: ISequencedDocumentMessage) {
-        // If this is no longer true, we need to revisit what we do where we set this.hitError.
-        assert(!this.hitError, 0x2a3 /* "container should be closed on any error" */);
-
-        if (error) {
-            // We assume here that loader will close container and stop processing all future ops.
-            // This is implicit dependency. If this flow changes, this code might no longer be correct.
-            this.hitError = true;
-            this.batchClientId = undefined;
-            this.emitter.emit("batchEnd", error, message);
-            this.deltaScheduler.batchEnd(message);
-            return;
-        }
-
-        const batch = (message?.metadata as IRuntimeMessageMetadata)?.batch;
-        // If no batchClientId has been set then we're in an individual batch. Else, if we get
-        // batch end metadata, this is end of the current batch.
-        if (this.batchClientId === undefined || batch === false) {
-            this.batchClientId = undefined;
-            this.emitter.emit("batchEnd", undefined, message);
-            this.deltaScheduler.batchEnd(message);
-            return;
-        }
-    }
 }
 
 /**

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -18,7 +18,6 @@ export {
     isRuntimeMessage,
     RuntimeMessage,
     unpackRuntimeMessage,
-    ScheduleManager,
     agentSchedulerId,
     ContainerRuntime,
     RuntimeHeaders,
@@ -40,6 +39,7 @@ export {
     IPendingMessage,
     IPendingState,
 } from "./pendingStateManager";
+export { ScheduleManager } from "./scheduleManager";
 export { Summarizer } from "./summarizer";
 export {
     EnqueueSummarizeResult,

--- a/packages/runtime/container-runtime/src/scheduleManager.ts
+++ b/packages/runtime/container-runtime/src/scheduleManager.ts
@@ -7,7 +7,7 @@ import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
-import { assert } from "@fluidframework/common-utils";
+import { assert, performance } from "@fluidframework/common-utils";
 import { isUnpackedRuntimeMessage } from "@fluidframework/driver-utils";
 import { DataCorruptionError, extractSafePropertiesFromMessage } from "@fluidframework/container-utils";
 import { DeltaScheduler } from "./deltaScheduler";

--- a/packages/runtime/container-runtime/src/scheduleManager.ts
+++ b/packages/runtime/container-runtime/src/scheduleManager.ts
@@ -1,0 +1,294 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { EventEmitter } from "events";
+import { IDeltaManager } from "@fluidframework/container-definitions";
+import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
+import { assert } from "@fluidframework/common-utils";
+import { isUnpackedRuntimeMessage } from "@fluidframework/driver-utils";
+import { DataCorruptionError, extractSafePropertiesFromMessage } from "@fluidframework/container-utils";
+import { DeltaScheduler } from "./deltaScheduler";
+import { pkgVersion } from "./packageVersion";
+import { latencyThreshold } from "./connectionTelemetry";
+
+type IRuntimeMessageMetadata = undefined | {
+    batch?: boolean;
+};
+
+/**
+ * This class has the following responsibilities:
+ * 1. It tracks batches as we process ops and raises "batchBegin" and "batchEnd" events.
+ *    As part of it, it validates batch correctness (i.e. no system ops in the middle of batch)
+ * 2. It creates instance of ScheduleManagerCore that ensures we never start processing ops from batch
+ *    unless all ops of the batch are in.
+ */
+export class ScheduleManager {
+    private readonly deltaScheduler: DeltaScheduler;
+    private batchClientId: string | undefined;
+    private hitError = false;
+
+    constructor(
+        private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
+        private readonly emitter: EventEmitter,
+        private readonly logger: ITelemetryLogger,
+    ) {
+        this.deltaScheduler = new DeltaScheduler(
+            this.deltaManager,
+            ChildLogger.create(this.logger, "DeltaScheduler"),
+        );
+        void new ScheduleManagerCore(deltaManager, logger);
+    }
+
+    public beforeOpProcessing(message: ISequencedDocumentMessage) {
+        if (this.batchClientId !== message.clientId) {
+            assert(this.batchClientId === undefined,
+                0x2a2 /* "Batch is interrupted by other client op. Should be caught by trackPending()" */);
+
+            // This could be the beginning of a new batch or an individual message.
+            this.emitter.emit("batchBegin", message);
+            this.deltaScheduler.batchBegin(message);
+
+            const batch = (message?.metadata as IRuntimeMessageMetadata)?.batch;
+            if (batch) {
+                this.batchClientId = message.clientId;
+            } else {
+                this.batchClientId = undefined;
+            }
+        }
+    }
+
+    public afterOpProcessing(error: any | undefined, message: ISequencedDocumentMessage) {
+        // If this is no longer true, we need to revisit what we do where we set this.hitError.
+        assert(!this.hitError, 0x2a3 /* "container should be closed on any error" */);
+
+        if (error) {
+            // We assume here that loader will close container and stop processing all future ops.
+            // This is implicit dependency. If this flow changes, this code might no longer be correct.
+            this.hitError = true;
+            this.batchClientId = undefined;
+            this.emitter.emit("batchEnd", error, message);
+            this.deltaScheduler.batchEnd(message);
+            return;
+        }
+
+        const batch = (message?.metadata as IRuntimeMessageMetadata)?.batch;
+        // If no batchClientId has been set then we're in an individual batch. Else, if we get
+        // batch end metadata, this is end of the current batch.
+        if (this.batchClientId === undefined || batch === false) {
+            this.batchClientId = undefined;
+            this.emitter.emit("batchEnd", undefined, message);
+            this.deltaScheduler.batchEnd(message);
+            return;
+        }
+    }
+}
+
+/**
+ * This class controls pausing and resuming of inbound queue to ensure that we never
+ * start processing ops in a batch IF we do not have all ops in the batch.
+ */
+class ScheduleManagerCore {
+    private pauseSequenceNumber: number | undefined;
+    private currentBatchClientId: string | undefined;
+    private localPaused = false;
+    private timePaused = 0;
+    private batchCount = 0;
+
+    constructor(
+        private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
+        private readonly logger: ITelemetryLogger,
+    ) {
+        // Listen for delta manager sends and add batch metadata to messages
+        this.deltaManager.on("prepareSend", (messages: IDocumentMessage[]) => {
+            if (messages.length === 0) {
+                return;
+            }
+
+            // First message will have the batch flag set to true if doing a batched send
+            const firstMessageMetadata = messages[0].metadata as IRuntimeMessageMetadata;
+            if (!firstMessageMetadata?.batch) {
+                return;
+            }
+
+            // If the batch contains only a single op, clear the batch flag.
+            if (messages.length === 1) {
+                delete firstMessageMetadata.batch;
+                return;
+            }
+
+            // Set the batch flag to false on the last message to indicate the end of the send batch
+            const lastMessage = messages[messages.length - 1];
+            lastMessage.metadata = { ...lastMessage.metadata, batch: false };
+        });
+
+        // Listen for updates and peek at the inbound
+        this.deltaManager.inbound.on(
+            "push",
+            (message: ISequencedDocumentMessage) => {
+                this.trackPending(message);
+            });
+
+        // Start with baseline - empty inbound queue.
+        assert(!this.localPaused, 0x293 /* "initial state" */);
+
+        const allPending = this.deltaManager.inbound.toArray();
+        for (const pending of allPending) {
+            this.trackPending(pending);
+        }
+
+        // We are intentionally directly listening to the "op" to inspect system ops as well.
+        // If we do not observe system ops, we are likely to hit 0x296 assert when system ops
+        // precedes start of incomplete batch.
+        this.deltaManager.on("op", (message) => this.afterOpProcessing(message.sequenceNumber));
+    }
+
+    /**
+     * The only public function in this class - called when we processed an op,
+     * to make decision if op processing should be paused or not after that.
+     */
+    public afterOpProcessing(sequenceNumber: number) {
+        assert(!this.localPaused, 0x294 /* "can't have op processing paused if we are processing an op" */);
+
+        // If the inbound queue is ever empty, nothing to do!
+        if (this.deltaManager.inbound.length === 0) {
+            assert(this.pauseSequenceNumber === undefined,
+                0x295 /* "there should be no pending batch if we have no ops" */);
+            return;
+        }
+
+        // The queue is
+        // 1. paused only when the next message to be processed is the beginning of a batch. Done in two places:
+        //    - here (processing ops until reaching start of incomplete batch)
+        //    - in trackPending(), when queue was empty and start of batch showed up.
+        // 2. resumed when batch end comes in (in trackPending())
+
+        // do we have incomplete batch to worry about?
+        if (this.pauseSequenceNumber !== undefined) {
+            assert(sequenceNumber < this.pauseSequenceNumber,
+                0x296 /* "we should never start processing incomplete batch!" */);
+            // If the next op is the start of incomplete batch, then we can't process it until it's fully in - pause!
+            if (sequenceNumber + 1 === this.pauseSequenceNumber) {
+                this.pauseQueue();
+            }
+        }
+    }
+
+    private pauseQueue() {
+        assert(!this.localPaused, 0x297 /* "always called from resumed state" */);
+        this.localPaused = true;
+        this.timePaused = performance.now();
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.deltaManager.inbound.pause();
+    }
+
+    private resumeQueue(startBatch: number, messageEndBatch: ISequencedDocumentMessage) {
+        const endBatch = messageEndBatch.sequenceNumber;
+        const duration = this.localPaused ? (performance.now() - this.timePaused) : undefined;
+
+        this.batchCount++;
+        if (this.batchCount % 1000 === 1) {
+            this.logger.sendTelemetryEvent({
+                eventName: "BatchStats",
+                sequenceNumber: endBatch,
+                length: endBatch - startBatch + 1,
+                msnDistance: endBatch - messageEndBatch.minimumSequenceNumber,
+                duration,
+                batchCount: this.batchCount,
+                interrupted: this.localPaused,
+            });
+        }
+
+        // Return early if no change in value
+        if (!this.localPaused) {
+            return;
+        }
+
+        this.localPaused = false;
+
+        // Random round number - we want to know when batch waiting paused op processing.
+        if (duration !== undefined && duration > latencyThreshold) {
+            this.logger.sendErrorEvent({
+                eventName: "MaxBatchWaitTimeExceeded",
+                duration,
+                sequenceNumber: endBatch,
+                length: endBatch - startBatch,
+            });
+        }
+        this.deltaManager.inbound.resume();
+    }
+
+    /**
+     * Called for each incoming op (i.e. inbound "push" notification)
+     */
+    private trackPending(message: ISequencedDocumentMessage) {
+        assert(this.deltaManager.inbound.length !== 0,
+            0x298 /* "we have something in the queue that generates this event" */);
+
+        assert((this.currentBatchClientId === undefined) === (this.pauseSequenceNumber === undefined),
+            0x299 /* "non-synchronized state" */);
+
+        const metadata = message.metadata as IRuntimeMessageMetadata;
+        const batchMetadata = metadata?.batch;
+
+        // Protocol messages are never part of a runtime batch of messages
+        if (!isUnpackedRuntimeMessage(message)) {
+            // Protocol messages should never show up in the middle of the batch!
+            assert(this.currentBatchClientId === undefined, 0x29a /* "System message in the middle of batch!" */);
+            assert(batchMetadata === undefined, 0x29b /* "system op in a batch?" */);
+            assert(!this.localPaused, 0x29c /* "we should be processing ops when there is no active batch" */);
+            return;
+        }
+
+        if (this.currentBatchClientId === undefined && batchMetadata === undefined) {
+            assert(!this.localPaused, 0x29d /* "we should be processing ops when there is no active batch" */);
+            return;
+        }
+
+        // If the client ID changes then we can move the pause point. If it stayed the same then we need to check.
+        // If batchMetadata is not undefined then if it's true we've begun a new batch - if false we've ended
+        // the previous one
+        if (this.currentBatchClientId !== undefined || batchMetadata === false) {
+            if (this.currentBatchClientId !== message.clientId) {
+                // "Batch not closed, yet message from another client!"
+                throw new DataCorruptionError(
+                    "OpBatchIncomplete",
+                    {
+                        runtimeVersion: pkgVersion,
+                        batchClientId: this.currentBatchClientId,
+                        ...extractSafePropertiesFromMessage(message),
+                    });
+            }
+        }
+
+        // The queue is
+        // 1. paused only when the next message to be processed is the beginning of a batch. Done in two places:
+        //    - in afterOpProcessing() - processing ops until reaching start of incomplete batch
+        //    - here (batchMetadata == false below), when queue was empty and start of batch showed up.
+        // 2. resumed when batch end comes in (batchMetadata === true case below)
+
+        if (batchMetadata) {
+            assert(this.currentBatchClientId === undefined, 0x29e /* "there can't be active batch" */);
+            assert(!this.localPaused, 0x29f /* "we should be processing ops when there is no active batch" */);
+            this.pauseSequenceNumber = message.sequenceNumber;
+            this.currentBatchClientId = message.clientId;
+            // Start of the batch
+            // Only pause processing if queue has no other ops!
+            // If there are any other ops in the queue, processing will be stopped when they are processed!
+            if (this.deltaManager.inbound.length === 1) {
+                this.pauseQueue();
+            }
+        } else if (batchMetadata === false) {
+            assert(this.pauseSequenceNumber !== undefined, 0x2a0 /* "batch presence was validated above" */);
+            // Batch is complete, we can process it!
+            this.resumeQueue(this.pauseSequenceNumber, message);
+            this.pauseSequenceNumber = undefined;
+            this.currentBatchClientId = undefined;
+        } else {
+            // Continuation of current batch. Do nothing
+            assert(this.currentBatchClientId !== undefined, 0x2a1 /* "logic error" */);
+        }
+    }
+}

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { EventEmitter } from "events";
 import { createSandbox } from "sinon";
 import {
     AttachState,
@@ -15,18 +14,16 @@ import {
 import { GenericError, DataProcessingError } from "@fluidframework/container-utils";
 import {
     ISequencedDocumentMessage,
-    MessageType,
 } from "@fluidframework/protocol-definitions";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import {
     ConfigTypes,
-    DebugLogger,
     IConfigProviderBase,
     mixinMonitoringContext,
     MockLogger,
 } from "@fluidframework/telemetry-utils";
 import { MockDeltaManager, MockQuorumClients } from "@fluidframework/test-runtime-utils";
-import { ContainerMessageType, ContainerRuntime, ScheduleManager } from "../containerRuntime";
+import { ContainerMessageType, ContainerRuntime } from "../containerRuntime";
 import { PendingStateManager } from "../pendingStateManager";
 import { DataStores } from "../dataStores";
 
@@ -176,7 +173,7 @@ describe("Runtime", () => {
                 });
             }));
 
-            describe("orderSequentially with rollback", () =>
+        describe("orderSequentially with rollback", () =>
             [FlushMode.TurnBased, FlushMode.Immediate].forEach((flushMode: FlushMode) => {
                 describe(`orderSequentially with flush mode: ${FlushMode[flushMode]}`, () => {
                     let containerRuntime: ContainerRuntime;
@@ -229,7 +226,7 @@ describe("Runtime", () => {
                     });
 
                     it("No errors on successful callback with rollback set", () => {
-                        containerRuntime.orderSequentially(() => {});
+                        containerRuntime.orderSequentially(() => { });
 
                         assert.strictEqual(containerErrors.length, 0);
                     });
@@ -241,10 +238,12 @@ describe("Runtime", () => {
             const createMockContext =
                 (attachState: AttachState, addPendingMsg: boolean): Partial<IContainerContext> => {
                     const pendingState = {
-                        pending: { pendingStates: [{
-                            type: "attach",
-                            content: {},
-                        }] },
+                        pending: {
+                            pendingStates: [{
+                                type: "attach",
+                                content: {},
+                            }],
+                        },
                         savedOps: [],
                     };
 
@@ -312,337 +311,6 @@ describe("Runtime", () => {
             });
         });
 
-        describe("ScheduleManager", () => {
-            describe("Batch processing events", () => {
-                let batchBegin: number = 0;
-                let batchEnd: number = 0;
-                let sequenceNumber: number = 0;
-                let emitter: EventEmitter;
-                let deltaManager: MockDeltaManager;
-                let scheduleManager: ScheduleManager;
-
-                beforeEach(() => {
-                    emitter = new EventEmitter();
-                    deltaManager = new MockDeltaManager();
-                    deltaManager.inbound.processCallback = (message: ISequencedDocumentMessage) => {
-                        scheduleManager.beforeOpProcessing(message);
-                        scheduleManager.afterOpProcessing(undefined, message);
-                        deltaManager.emit("op", message);
-                    };
-                    scheduleManager = new ScheduleManager(
-                        deltaManager,
-                        emitter,
-                        DebugLogger.create("fluid:testScheduleManager"),
-                    );
-
-                    emitter.on("batchBegin", () => {
-                        // When we receive a "batchBegin" event, we should not have any outstanding
-                        // events, i.e., batchBegin and batchEnd should be equal.
-                        assert.strictEqual(batchBegin, batchEnd, "Received batchBegin before previous batchEnd");
-                        batchBegin++;
-                    });
-
-                    emitter.on("batchEnd", () => {
-                        batchEnd++;
-                        // Every "batchEnd" event should correspond to a "batchBegin" event, i.e.,
-                        // batchBegin and batchEnd should be equal.
-                        assert.strictEqual(batchBegin, batchEnd, "Received batchEnd without corresponding batchBegin");
-                    });
-                });
-
-                afterEach(() => {
-                    batchBegin = 0;
-                    batchEnd = 0;
-                    sequenceNumber = 0;
-                });
-
-                /**
-                 * Pushes single op to the inbound queue. Adds proper sequence numbers to them
-                 */
-                function pushOp(partialMessage: Partial<ISequencedDocumentMessage>) {
-                    sequenceNumber++;
-                    const message = { ...partialMessage, sequenceNumber };
-                    deltaManager.inbound.push(message as ISequencedDocumentMessage);
-                }
-
-                /**
-                 * awaits until all ops that could be processed are processed.
-                 */
-                async function processOps() {
-                    const inbound = deltaManager.inbound;
-                    while (!inbound.paused && inbound.length > 0) {
-                        await Promise.resolve();
-                    }
-                }
-
-                it("Single non-batch message", async () => {
-                    const clientId: string = "test-client";
-                    const message: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                    };
-
-                    // Send a non-batch message.
-                    pushOp(message);
-
-                    await processOps();
-
-                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
-                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin events");
-                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd events");
-                });
-
-                it("Multiple non-batch messages", async () => {
-                    const clientId: string = "test-client";
-                    const message: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                    };
-
-                    // Sent 5 non-batch messages.
-                    pushOp(message);
-                    pushOp(message);
-                    pushOp(message);
-                    pushOp(message);
-                    pushOp(message);
-
-                    await processOps();
-
-                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
-                    assert.strictEqual(5, batchBegin, "Did not receive correct batchBegin events");
-                    assert.strictEqual(5, batchEnd, "Did not receive correct batchEnd events");
-                });
-
-                it("Message with non batch-related metadata", async () => {
-                    const clientId: string = "test-client";
-                    const message: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                        metadata: { foo: 1 },
-                    };
-
-                    pushOp(message);
-                    await processOps();
-
-                    // We should have a "batchBegin" and a "batchEnd" event for the batch.
-                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
-                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
-                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
-                });
-
-                it("Messages in a single batch", async () => {
-                    const clientId: string = "test-client";
-                    const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                        metadata: { batch: true },
-                    };
-
-                    const batchMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                    };
-
-                    const batchEndMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                        metadata: { batch: false },
-                    };
-
-                    // Send a batch with 4 messages.
-                    pushOp(batchBeginMessage);
-                    pushOp(batchMessage);
-                    pushOp(batchMessage);
-
-                    await processOps();
-                    assert.strictEqual(deltaManager.inbound.length, 3, "Some of partial batch ops were processed");
-
-                    pushOp(batchEndMessage);
-                    await processOps();
-
-                    // We should have only received one "batchBegin" and one "batchEnd" event for the batch.
-                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
-                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
-                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
-                });
-
-                it("two batches", async () => {
-                    const clientId: string = "test-client";
-                    const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                        metadata: { batch: true },
-                    };
-
-                    const batchMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                    };
-
-                    const batchEndMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                        metadata: { batch: false },
-                    };
-
-                    // Pause to not allow ops to be processed while we accumulated them.
-                    await deltaManager.inbound.pause();
-
-                    // Send a batch with 4 messages.
-                    pushOp(batchBeginMessage);
-                    pushOp(batchMessage);
-                    pushOp(batchMessage);
-                    pushOp(batchEndMessage);
-
-                    // Add incomplete batch
-                    pushOp(batchBeginMessage);
-                    pushOp(batchMessage);
-                    pushOp(batchMessage);
-
-                    assert.strictEqual(deltaManager.inbound.length, 7, "none of the batched ops are processed yet");
-
-                    void deltaManager.inbound.resume();
-                    await processOps();
-
-                    assert.strictEqual(deltaManager.inbound.length, 3,
-                        "none of the second batch ops are processed yet");
-                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
-                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
-
-                    // End the batch - all ops should be processed.
-                    pushOp(batchEndMessage);
-                    await processOps();
-
-                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
-                    assert.strictEqual(2, batchBegin, "Did not receive correct batchBegin event for the batch");
-                    assert.strictEqual(2, batchEnd, "Did not receive correct batchEnd event for the batch");
-                });
-
-                it("non-batched ops followed by batch", async () => {
-                    const clientId: string = "test-client";
-                    const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                        metadata: { batch: true },
-                    };
-
-                    const batchMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                    };
-
-                    const batchEndMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId,
-                        type: MessageType.Operation,
-                        metadata: { batch: false },
-                    };
-
-                    // Pause to not allow ops to be processed while we accumulated them.
-                    await deltaManager.inbound.pause();
-
-                    // Send a batch with 2 messages.
-                    pushOp(batchMessage);
-                    pushOp(batchMessage);
-
-                    // Add incomplete batch
-                    pushOp(batchBeginMessage);
-                    pushOp(batchMessage);
-                    pushOp(batchMessage);
-
-                    await processOps();
-
-                    assert.strictEqual(deltaManager.inbound.length, 5, "none of the batched ops are processed yet");
-
-                    void deltaManager.inbound.resume();
-                    await processOps();
-
-                    assert.strictEqual(deltaManager.inbound.length, 3,
-                        "none of the second batch ops are processed yet");
-
-                    // End the batch - all ops should be processed.
-                    pushOp(batchEndMessage);
-                    await processOps();
-
-                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
-                    assert.strictEqual(3, batchBegin, "Did not receive correct batchBegin event for the batch");
-                    assert.strictEqual(3, batchEnd, "Did not receive correct batchEnd event for the batch");
-                });
-
-                function testWrongBatches() {
-                    const clientId1: string = "test-client-1";
-                    const clientId2: string = "test-client-2";
-
-                    const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId: clientId1,
-                        type: MessageType.Operation,
-                        metadata: { batch: true },
-                    };
-
-                    const batchMessage: Partial<ISequencedDocumentMessage> = {
-                        clientId: clientId1,
-                        type: MessageType.Operation,
-                    };
-
-                    const messagesToFail: Partial<ISequencedDocumentMessage>[] = [
-                        // System op from same client
-                        {
-                            clientId: clientId1,
-                            type: MessageType.NoOp,
-                        },
-
-                        // Batch messages interleaved with a batch begin message from same client
-                        batchBeginMessage,
-
-                        // Send a message from another client. This should result in a a violation!
-                        {
-                            clientId: clientId2,
-                            type: MessageType.Operation,
-                        },
-
-                        // Send a message from another client with non batch-related metadata. This should result
-                        // in a "batchEnd" event for the previous batch since the client id changes. Also, we
-                        // should get a "batchBegin" and a "batchEnd" event for the new client.
-                        {
-                            clientId: clientId2,
-                            type: MessageType.Operation,
-                            metadata: { foo: 1 },
-                        },
-
-                        // Send a batch from another client. This should result in a "batchEnd" event for the
-                        // previous batch since the client id changes. Also, we should get one "batchBegin" and
-                        // one "batchEnd" event for the batch from the new client.
-                        {
-                            clientId: clientId2,
-                            type: MessageType.Operation,
-                            metadata: { batch: true },
-                        },
-                    ];
-
-                    let counter = 0;
-                    for (const messageToFail of messagesToFail) {
-                        counter++;
-                        it(`Partial batch messages, case ${counter}`, async () => {
-                            // Send a batch with 3 messages from first client but don't send batch end message.
-                            pushOp(batchBeginMessage);
-                            pushOp(batchMessage);
-                            pushOp(batchMessage);
-
-                            await processOps();
-                            assert.strictEqual(deltaManager.inbound.length, 3,
-                                "Some of partial batch ops were processed");
-
-                            assert.throws(() => pushOp(messageToFail));
-
-                            assert.strictEqual(deltaManager.inbound.length, 4, "Some of batch ops were processed");
-                            assert.strictEqual(0, batchBegin, "Did not receive correct batchBegin event for the batch");
-                            assert.strictEqual(0, batchEnd, "Did not receive correct batchBegin event for the batch");
-                        });
-                    }
-                }
-
-                testWrongBatches();
-            });
-        });
         describe("Pending state progress tracking", () => {
             const maxReconnects = 15;
 

--- a/packages/runtime/container-runtime/src/test/scheduleManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/scheduleManager.spec.ts
@@ -1,0 +1,343 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { EventEmitter } from "events";
+import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
+import { DebugLogger } from "@fluidframework/telemetry-utils";
+import { ScheduleManager } from "../scheduleManager";
+
+describe("ScheduleManager", () => {
+    describe("Batch processing events", () => {
+        let batchBegin: number = 0;
+        let batchEnd: number = 0;
+        let sequenceNumber: number = 0;
+        let emitter: EventEmitter;
+        let deltaManager: MockDeltaManager;
+        let scheduleManager: ScheduleManager;
+
+        beforeEach(() => {
+            emitter = new EventEmitter();
+            deltaManager = new MockDeltaManager();
+            deltaManager.inbound.processCallback = (message: ISequencedDocumentMessage) => {
+                scheduleManager.beforeOpProcessing(message);
+                scheduleManager.afterOpProcessing(undefined, message);
+                deltaManager.emit("op", message);
+            };
+            scheduleManager = new ScheduleManager(
+                deltaManager,
+                emitter,
+                DebugLogger.create("fluid:testScheduleManager"),
+            );
+
+            emitter.on("batchBegin", () => {
+                // When we receive a "batchBegin" event, we should not have any outstanding
+                // events, i.e., batchBegin and batchEnd should be equal.
+                assert.strictEqual(batchBegin, batchEnd, "Received batchBegin before previous batchEnd");
+                batchBegin++;
+            });
+
+            emitter.on("batchEnd", () => {
+                batchEnd++;
+                // Every "batchEnd" event should correspond to a "batchBegin" event, i.e.,
+                // batchBegin and batchEnd should be equal.
+                assert.strictEqual(batchBegin, batchEnd, "Received batchEnd without corresponding batchBegin");
+            });
+        });
+
+        afterEach(() => {
+            batchBegin = 0;
+            batchEnd = 0;
+            sequenceNumber = 0;
+        });
+
+        /**
+         * Pushes single op to the inbound queue. Adds proper sequence numbers to them
+         */
+        function pushOp(partialMessage: Partial<ISequencedDocumentMessage>) {
+            sequenceNumber++;
+            const message = { ...partialMessage, sequenceNumber };
+            deltaManager.inbound.push(message as ISequencedDocumentMessage);
+        }
+
+        /**
+         * awaits until all ops that could be processed are processed.
+         */
+        async function processOps() {
+            const inbound = deltaManager.inbound;
+            while (!inbound.paused && inbound.length > 0) {
+                await Promise.resolve();
+            }
+        }
+
+        it("Single non-batch message", async () => {
+            const clientId: string = "test-client";
+            const message: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+            };
+
+            // Send a non-batch message.
+            pushOp(message);
+
+            await processOps();
+
+            assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
+            assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin events");
+            assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd events");
+        });
+
+        it("Multiple non-batch messages", async () => {
+            const clientId: string = "test-client";
+            const message: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+            };
+
+            // Sent 5 non-batch messages.
+            pushOp(message);
+            pushOp(message);
+            pushOp(message);
+            pushOp(message);
+            pushOp(message);
+
+            await processOps();
+
+            assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
+            assert.strictEqual(5, batchBegin, "Did not receive correct batchBegin events");
+            assert.strictEqual(5, batchEnd, "Did not receive correct batchEnd events");
+        });
+
+        it("Message with non batch-related metadata", async () => {
+            const clientId: string = "test-client";
+            const message: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+                metadata: { foo: 1 },
+            };
+
+            pushOp(message);
+            await processOps();
+
+            // We should have a "batchBegin" and a "batchEnd" event for the batch.
+            assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
+            assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
+            assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
+        });
+
+        it("Messages in a single batch", async () => {
+            const clientId: string = "test-client";
+            const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+                metadata: { batch: true },
+            };
+
+            const batchMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+            };
+
+            const batchEndMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+                metadata: { batch: false },
+            };
+
+            // Send a batch with 4 messages.
+            pushOp(batchBeginMessage);
+            pushOp(batchMessage);
+            pushOp(batchMessage);
+
+            await processOps();
+            assert.strictEqual(deltaManager.inbound.length, 3, "Some of partial batch ops were processed");
+
+            pushOp(batchEndMessage);
+            await processOps();
+
+            // We should have only received one "batchBegin" and one "batchEnd" event for the batch.
+            assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
+            assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
+            assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
+        });
+
+        it("two batches", async () => {
+            const clientId: string = "test-client";
+            const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+                metadata: { batch: true },
+            };
+
+            const batchMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+            };
+
+            const batchEndMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+                metadata: { batch: false },
+            };
+
+            // Pause to not allow ops to be processed while we accumulated them.
+            await deltaManager.inbound.pause();
+
+            // Send a batch with 4 messages.
+            pushOp(batchBeginMessage);
+            pushOp(batchMessage);
+            pushOp(batchMessage);
+            pushOp(batchEndMessage);
+
+            // Add incomplete batch
+            pushOp(batchBeginMessage);
+            pushOp(batchMessage);
+            pushOp(batchMessage);
+
+            assert.strictEqual(deltaManager.inbound.length, 7, "none of the batched ops are processed yet");
+
+            void deltaManager.inbound.resume();
+            await processOps();
+
+            assert.strictEqual(deltaManager.inbound.length, 3,
+                "none of the second batch ops are processed yet");
+            assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
+            assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
+
+            // End the batch - all ops should be processed.
+            pushOp(batchEndMessage);
+            await processOps();
+
+            assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
+            assert.strictEqual(2, batchBegin, "Did not receive correct batchBegin event for the batch");
+            assert.strictEqual(2, batchEnd, "Did not receive correct batchEnd event for the batch");
+        });
+
+        it("non-batched ops followed by batch", async () => {
+            const clientId: string = "test-client";
+            const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+                metadata: { batch: true },
+            };
+
+            const batchMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+            };
+
+            const batchEndMessage: Partial<ISequencedDocumentMessage> = {
+                clientId,
+                type: MessageType.Operation,
+                metadata: { batch: false },
+            };
+
+            // Pause to not allow ops to be processed while we accumulated them.
+            await deltaManager.inbound.pause();
+
+            // Send a batch with 2 messages.
+            pushOp(batchMessage);
+            pushOp(batchMessage);
+
+            // Add incomplete batch
+            pushOp(batchBeginMessage);
+            pushOp(batchMessage);
+            pushOp(batchMessage);
+
+            await processOps();
+
+            assert.strictEqual(deltaManager.inbound.length, 5, "none of the batched ops are processed yet");
+
+            void deltaManager.inbound.resume();
+            await processOps();
+
+            assert.strictEqual(deltaManager.inbound.length, 3,
+                "none of the second batch ops are processed yet");
+
+            // End the batch - all ops should be processed.
+            pushOp(batchEndMessage);
+            await processOps();
+
+            assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
+            assert.strictEqual(3, batchBegin, "Did not receive correct batchBegin event for the batch");
+            assert.strictEqual(3, batchEnd, "Did not receive correct batchEnd event for the batch");
+        });
+
+        function testWrongBatches() {
+            const clientId1: string = "test-client-1";
+            const clientId2: string = "test-client-2";
+
+            const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                clientId: clientId1,
+                type: MessageType.Operation,
+                metadata: { batch: true },
+            };
+
+            const batchMessage: Partial<ISequencedDocumentMessage> = {
+                clientId: clientId1,
+                type: MessageType.Operation,
+            };
+
+            const messagesToFail: Partial<ISequencedDocumentMessage>[] = [
+                // System op from same client
+                {
+                    clientId: clientId1,
+                    type: MessageType.NoOp,
+                },
+
+                // Batch messages interleaved with a batch begin message from same client
+                batchBeginMessage,
+
+                // Send a message from another client. This should result in a a violation!
+                {
+                    clientId: clientId2,
+                    type: MessageType.Operation,
+                },
+
+                // Send a message from another client with non batch-related metadata. This should result
+                // in a "batchEnd" event for the previous batch since the client id changes. Also, we
+                // should get a "batchBegin" and a "batchEnd" event for the new client.
+                {
+                    clientId: clientId2,
+                    type: MessageType.Operation,
+                    metadata: { foo: 1 },
+                },
+
+                // Send a batch from another client. This should result in a "batchEnd" event for the
+                // previous batch since the client id changes. Also, we should get one "batchBegin" and
+                // one "batchEnd" event for the batch from the new client.
+                {
+                    clientId: clientId2,
+                    type: MessageType.Operation,
+                    metadata: { batch: true },
+                },
+            ];
+
+            let counter = 0;
+            for (const messageToFail of messagesToFail) {
+                counter++;
+                it(`Partial batch messages, case ${counter}`, async () => {
+                    // Send a batch with 3 messages from first client but don't send batch end message.
+                    pushOp(batchBeginMessage);
+                    pushOp(batchMessage);
+                    pushOp(batchMessage);
+
+                    await processOps();
+                    assert.strictEqual(deltaManager.inbound.length, 3,
+                        "Some of partial batch ops were processed");
+
+                    assert.throws(() => pushOp(messageToFail));
+
+                    assert.strictEqual(deltaManager.inbound.length, 4, "Some of batch ops were processed");
+                    assert.strictEqual(0, batchBegin, "Did not receive correct batchBegin event for the batch");
+                    assert.strictEqual(0, batchEnd, "Did not receive correct batchBegin event for the batch");
+                });
+            }
+        }
+
+        testWrongBatches();
+    });
+});


### PR DESCRIPTION
## Description

This change doesn't affect any functionality, it just moves two classes outside of the `containerruntime.ts` file, which has gotten fairly large.

## Does this introduce a breaking change?

No