### PR TITLE
Only init SharedTree index when blob is present

### DIFF
--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -122,10 +122,12 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
     }
 
     public async load(services: IChannelStorageService, parse: SummaryElementParser): Promise<void> {
-        const treeBuffer = await services.readBlob(treeBlobKey);
-        const tree = parse(bufferToString(treeBuffer, "utf8")) as string;
-        const placeholderTree = JSON.parse(tree) as JsonableTree[];
-
-        initializeForest(this.forest, placeholderTree);
+        if (await services.contains(treeBlobKey)) {
+            const treeBuffer = await services.readBlob(treeBlobKey);
+            const treeBufferString = bufferToString(treeBuffer, "utf8");
+            const tree = parse(treeBufferString) as string;
+            const placeholderTree = JSON.parse(tree) as JsonableTree[];
+            initializeForest(this.forest, placeholderTree);
+        }
     }
 }

--- a/packages/dds/tree/src/feature-libraries/schemaIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaIndex.ts
@@ -103,9 +103,11 @@ export class SchemaIndex implements Index<unknown>, SummaryElement {
     }
 
     public async load(services: IChannelStorageService, parse: SummaryElementParser): Promise<void> {
-        // const schemaBuffer = await services.readBlob(schemaBlobKey);
-        // TODO: use schema to initialize this.schema
-        // const schema = parse(bufferToString(_schemaBuffer, "utf8")) as string;
-        throw new Error("Method not implemented.");
+        if (await services.contains(schemaBlobKey)) {
+            // const schemaBuffer = await services.readBlob(schemaBlobKey);
+            // TODO: use schema to initialize this.schema
+            // const schema = parse(bufferToString(_schemaBuffer, "utf8")) as string;
+            throw new Error("Method not implemented.");
+        }
     }
 }


### PR DESCRIPTION
SharedTree indexes currently unconditionally attempt to load blobs, but they should first check if the blobs are present.