### PR TITLE
update interface `ISummarizerInternalsProvider.refreshLatestSummaryAck`

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,8 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 - [Remove `type` field from `ShareLinkInfoType`](#Remove-type-field-from-ShareLinkInfoType)
 - [Remove `ShareLinkTypes` interface](#Remove-ShareLinkTypes-interface)
 - [Remove `enableShareLinkWithCreate` from `HostStoragePolicy`](#Remove-enableShareLinkWithCreate-from-HostStoragePolicy)
+- [Signature from  `ISummarizerInternalsProvider.refreshLatestSummaryAck` interface has changed](#Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface)
+
 ### Remove `type` field from `ShareLinkInfoType`
 This field has been deprecated and will be removed in a future breaking change. You should be able to get the kind of sharing link from `shareLinkInfo.createLink.link` property bag.
 
@@ -36,12 +38,25 @@ This field has been deprecated and will be removed in a future breaking change. 
         fileName: string,
 -       createShareLinkType?: ShareLinkTypes,
 +       createShareLinkType?: ShareLinkTypes | ISharingLinkKind,
-    ): 
+    ):
 ```
 
 
 ### Remove `enableShareLinkWithCreate` from `HostStoragePolicy`
 `enableShareLinkWithCreate` feature gate has been deprecated and will be removed in a future breaking change. If you wish to enable creation of a sharing link along with the creation of Fluid file, you will need to provide `createShareLinkType:ISharingLinkKind` input to the `createOdspCreateContainerRequest` function and enable the feature using `enableSingleRequestForShareLinkWithCreate` in `HostStoragePolicy`
+
+### Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface
+`ISummarizerInternalsProvider.refreshLatestSummaryAck` interface has been updated to now accept `IRefreshSummaryOptions` property instead.
+```diff
+    async refreshLatestSummaryAck(
+-       proposalHandle: string | undefined,
+-       ackHandle: string,
+-       summaryRefSeq: number,
+-       summaryLogger: ITelemetryLogger,
++       options: IRefreshSummaryAckOptions,
+    ):
+```
+
 # 2.0.0
 
 ## 2.0.0 Upcoming changes

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -46,7 +46,7 @@ This field has been deprecated and will be removed in a future breaking change. 
 `enableShareLinkWithCreate` feature gate has been deprecated and will be removed in a future breaking change. If you wish to enable creation of a sharing link along with the creation of Fluid file, you will need to provide `createShareLinkType:ISharingLinkKind` input to the `createOdspCreateContainerRequest` function and enable the feature using `enableSingleRequestForShareLinkWithCreate` in `HostStoragePolicy`
 
 ### Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface
-`ISummarizerInternalsProvider.refreshLatestSummaryAck` interface has been updated to now accept `IRefreshSummaryOptions` property instead.
+`ISummarizerInternalsProvider.refreshLatestSummaryAck` interface has been updated to now accept `IRefreshSummaryAckOptions` property instead.
 ```diff
     async refreshLatestSummaryAck(
 -       proposalHandle: string | undefined,

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -154,7 +154,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     process(messageArg: ISequencedDocumentMessage, local: boolean): void;
     // (undocumented)
     processSignal(message: ISignalMessage, local: boolean): void;
-    refreshLatestSummaryAck(proposalHandle: string | undefined, ackHandle: string, summaryRefSeq: number, summaryLogger: ITelemetryLogger): Promise<void>;
+    refreshLatestSummaryAck(options: IRefreshSummaryAckOptions): Promise<void>;
     request(request: IRequest): Promise<IResponse>;
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
@@ -449,6 +449,14 @@ export interface IProvideSummarizer {
 }
 
 // @public
+export interface IRefreshSummaryAckOptions {
+    readonly ackHandle: string;
+    readonly proposalHandle: string | undefined;
+    readonly summaryLogger: ITelemetryLogger;
+    readonly summaryRefSeq: number;
+}
+
+// @public
 export interface IRootSummaryTreeWithStats extends ISummaryTreeWithStats {
     gcStats?: IGCStats;
 }
@@ -505,7 +513,7 @@ export interface ISummarizerEvents extends IEvent {
 
 // @public (undocumented)
 export interface ISummarizerInternalsProvider {
-    refreshLatestSummaryAck(proposalHandle: string, ackHandle: string, summaryRefSeq: number, summaryLogger: ITelemetryLogger): Promise<void>;
+    refreshLatestSummaryAck(options: IRefreshSummaryAckOptions): Promise<void>;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
 }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -147,6 +147,7 @@ import {
     ISummarizerInternalsProvider,
     ISummarizerOptions,
     ISummarizerRuntime,
+    IRefreshSummaryAckOptions,
 } from "./summarizerTypes";
 import { formExponentialFn, Throttler } from "./throttler";
 import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
@@ -3087,12 +3088,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     /** Implementation of ISummarizerInternalsProvider.refreshLatestSummaryAck */
-    public async refreshLatestSummaryAck(
-        proposalHandle: string | undefined,
-        ackHandle: string,
-        summaryRefSeq: number,
-        summaryLogger: ITelemetryLogger,
-    ) {
+    public async refreshLatestSummaryAck(options: IRefreshSummaryAckOptions) {
+        const { proposalHandle, ackHandle, summaryRefSeq, summaryLogger } = options;
         const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
         const { snapshotTree } = await this.fetchSnapshotFromStorage(
             ackHandle,

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -54,6 +54,7 @@ export {
     INackSummaryResult,
     IOnDemandSummarizeOptions,
     IProvideSummarizer,
+    IRefreshSummaryAckOptions,
     ISubmitSummaryOpResult,
     ISubmitSummaryOptions,
     ISummarizeOptions,

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -382,11 +382,11 @@ export class Summarizer extends EventEmitter implements ISummarizer {
                 // executing the refreshLatestSummaryAck.
                 // https://dev.azure.com/fluidframework/internal/_workitems/edit/779
                 await this.runningSummarizer.lockedRefreshSummaryAckAction(async () =>
-                    this.internalsProvider.refreshLatestSummaryAck(
-                        summaryOpHandle,
-                        summaryAckHandle,
-                        refSequenceNumber,
-                        summaryLogger,
+                    this.internalsProvider.refreshLatestSummaryAck({
+                        proposalHandle: summaryOpHandle,
+                        ackHandle: summaryAckHandle,
+                        summaryRefSeq: refSequenceNumber,
+                        summaryLogger },
                     ).catch(async (error) => {
                         // If the error is 404, so maybe the fetched version no longer exists on server. We just
                         // ignore this error in that case, as that means we will have another summaryAck for the

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -61,12 +61,7 @@ export interface ISummarizerInternalsProvider {
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
 
     /** Callback whenever a new SummaryAck is received, to update internal tracking state */
-    refreshLatestSummaryAck(
-        proposalHandle: string,
-        ackHandle: string,
-        summaryRefSeq: number,
-        summaryLogger: ITelemetryLogger,
-    ): Promise<void>;
+    refreshLatestSummaryAck(options: IRefreshSummaryAckOptions): Promise<void>;
 }
 
 /**
@@ -112,6 +107,20 @@ export interface ISummarizeOptions {
     readonly fullTree?: boolean;
     /** True to ask the server what the latest summary is first; defaults to false */
     readonly refreshLatestAck?: boolean;
+}
+
+/**
+ * Data required to update internal tracking state after receiving a Summary Ack.
+ */
+ export interface IRefreshSummaryAckOptions {
+    /** Handle from the ack's summary op. */
+    readonly proposalHandle: string | undefined;
+    /** Handle from the summary ack just received */
+    readonly ackHandle: string;
+    /** Reference sequence number from the ack's summary op */
+    readonly summaryRefSeq: number;
+    /** Telemetry logger to which telemetry events will be forwarded. */
+    readonly summaryLogger: ITelemetryLogger;
 }
 
 export interface ISubmitSummaryOptions extends ISummarizeOptions {

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -144,11 +144,11 @@ async function submitAndAckSummary(
     const ackedSummary = await summarizerClient.summaryCollection.waitSummaryAck(summarySequenceNumber);
     // Update the container runtime with the given ack. We have to do this manually because there is no summarizer
     // client in these tests that takes care of this.
-    await summarizerClient.containerRuntime.refreshLatestSummaryAck(
-        ackedSummary.summaryOp.contents.handle,
-        ackedSummary.summaryAck.contents.handle,
-        ackedSummary.summaryOp.referenceSequenceNumber,
-        logger,
+    await summarizerClient.containerRuntime.refreshLatestSummaryAck({
+        proposalHandle: ackedSummary.summaryOp.contents.handle,
+        ackHandle: ackedSummary.summaryAck.contents.handle,
+        summaryRefSeq: ackedSummary.summaryOp.referenceSequenceNumber,
+        summaryLogger: logger },
     );
     return { ackedSummary, summarySequenceNumber };
 }
@@ -362,11 +362,11 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
             // Wait for the above summary to be ack'd.
             const ackedSummary = await summarizerClient.summaryCollection.waitSummaryAck(summarySequenceNumber);
             // The assert 0x1a6 should not be hit anymore.
-            await summarizerClient.containerRuntime.refreshLatestSummaryAck(
-                ackedSummary.summaryOp.contents.handle,
-                ackedSummary.summaryAck.contents.handle,
-                ackedSummary.summaryOp.referenceSequenceNumber,
-                logger,
+            await summarizerClient.containerRuntime.refreshLatestSummaryAck({
+                proposalHandle: ackedSummary.summaryOp.contents.handle,
+                ackHandle: ackedSummary.summaryAck.contents.handle,
+                summaryRefSeq: ackedSummary.summaryOp.referenceSequenceNumber,
+                summaryLogger: logger },
             );
         });
 
@@ -402,11 +402,11 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
             const ackedSummary = await summarizerClient2.summaryCollection.waitSummaryAck(summarySequenceNumber);
 
             // The assert 0x1a6 should be hit now.
-            await summarizerClient2.containerRuntime.refreshLatestSummaryAck(
-                ackedSummary.summaryOp.contents.handle,
-                ackedSummary.summaryAck.contents.handle,
-                ackedSummary.summaryOp.referenceSequenceNumber,
-                logger,
+            await summarizerClient2.containerRuntime.refreshLatestSummaryAck({
+                proposalHandle: ackedSummary.summaryOp.contents.handle,
+                ackHandle: ackedSummary.summaryAck.contents.handle,
+                summaryRefSeq: ackedSummary.summaryOp.referenceSequenceNumber,
+                summaryLogger: logger },
             );
         });
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -154,12 +154,11 @@ async function submitAndAckSummary(
     const ackedSummary = await summarizerClient.summaryCollection.waitSummaryAck(summarySequenceNumber);
     // Update the container runtime with the given ack. We have to do this manually because there is no summarizer
     // client in these tests that takes care of this.
-    await summarizerClient.containerRuntime.refreshLatestSummaryAck(
-        ackedSummary.summaryOp.contents.handle,
-        ackedSummary.summaryAck.contents.handle,
-        ackedSummary.summaryOp.referenceSequenceNumber,
-        logger,
-    );
+    await summarizerClient.containerRuntime.refreshLatestSummaryAck({
+        proposalHandle: ackedSummary.summaryOp.contents.handle,
+        ackHandle: ackedSummary.summaryAck.contents.handle,
+        summaryRefSeq: ackedSummary.summaryOp.referenceSequenceNumber,
+        summaryLogger: logger });
     return { ackedSummary, summarySequenceNumber };
 }
 


### PR DESCRIPTION
update interface `ISummarizerInternalsProvider.refreshLatestSummaryAck`  to accept `IRefreshSummaryAckOptions` property instead of the previous arguments.
```diff
    async refreshLatestSummaryAck(
-       proposalHandle: string | undefined,
-       ackHandle: string,
-       summaryRefSeq: number,
-       summaryLogger: ITelemetryLogger,
+       options: IRefreshSummaryAckOptions,
    ):

## Does this introduce a breaking change?
yes

