### PR TITLE
Allow undefined for ConsensusRegisterCollection

### DIFF
--- a/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -297,7 +297,7 @@ describe("ConsensusRegisterCollection", () => {
             let testCollection2: IConsensusRegisterCollection;
 
             beforeEach(() => {
-                containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+                containerRuntimeFactory = new MockContainerRuntimeFactory();
                 testCollection1 = createConnectedCollection("collection1", containerRuntimeFactory);
                 testCollection2 = createConnectedCollection("collection2", containerRuntimeFactory);
             });


### PR DESCRIPTION
In my work on [AB#688](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/688) I found that we could not read or write `undefined` to the `ConsensusRegisterCollection`.

This change allows us to do so. This change can only be taken advantage of once all clients have this version or greater.