### PR TITLE
Remove it.only from test

### DIFF
--- a/experimental/dds/tree/src/test/Checkout.tests.ts
+++ b/experimental/dds/tree/src/test/Checkout.tests.ts
@@ -167,7 +167,7 @@ export function checkoutTests(
 			checkout.closeEdit();
 		});
 
-		it.only('emits error telemetry on attempted close of malformed edits', async () => {
+		it('emits error telemetry on attempted close of malformed edits', async () => {
 			const events: ITelemetryBaseEvent[] = [];
 			const { checkout } = await setUpTestTreeCheckout({
 				logger: { send: (event) => event.eventName.includes('Checkout') && events.push(event) },


### PR DESCRIPTION
## Description

Change `it.only()` to `it()` for recent test in experimental tree.

## Reviewer Guidance

@Abe27342 just double checking that the `it.only()` wasn't intended for long-term?
