### PR TITLE
Fix isLatest calculation to handle internal version scheme

### DIFF
--- a/build-tools/packages/build-tools/src/buildVersion/buildVersion.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersion.ts
@@ -148,8 +148,10 @@ export function getIsLatest(
     includeInternalVersions = false,
     log?: Logger,
 ) {
+    let latestTaggedRelease: string;
+
     if(input_tags?.length === 0) {
-        return true;
+        latestTaggedRelease = "0.0.0";
     }
 
     let versions = input_tags === undefined
@@ -167,8 +169,10 @@ export function getIsLatest(
         return !isInternalVersionScheme(v);
     });
 
-    const latestTaggedRelease = getLatestReleaseFromList(versions);
-    assert(latestTaggedRelease !== undefined, `latestTaggedRelease is undefined`);
+    latestTaggedRelease = getLatestReleaseFromList(versions);
+    if(versions.length === 0 || latestTaggedRelease === undefined) {
+        latestTaggedRelease = "0.0.0";
+    }
 
     log?.log(`Latest tagged: ${latestTaggedRelease}, current: ${current_version}`);
     const currentIsGreater = gte_semver(current_version, latestTaggedRelease);

--- a/build-tools/packages/build-tools/src/buildVersion/buildVersion.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersion.ts
@@ -155,36 +155,22 @@ export function getIsLatest(
     let versions = input_tags === undefined
         ? getVersions(prefix)
         : getVersionsFromStrings(prefix, input_tags);
-    // console.log(versions);
-
-    // input_tags = input_tags ??
     versions = versions.filter((v) => {
         if (v === undefined) {
             return false;
         }
 
-        // if (!t.startsWith(`${prefix}_v`)) {
-        //     return false;
-        // }
-
         if (includeInternalVersions) {
             return true;
         }
 
-        // const v = getVersionFromTag(t);
-        // if (v === undefined) {
-        //     return false;
-        // }
-
         return !isInternalVersionScheme(v);
     });
-    // console.log(versions);
-    const latestTaggedRelease = getLatestReleaseFromList(versions);
 
+    const latestTaggedRelease = getLatestReleaseFromList(versions);
     assert(latestTaggedRelease !== undefined, `latestTaggedRelease is undefined`);
 
     log?.log(`Latest tagged: ${latestTaggedRelease}, current: ${current_version}`);
-    console.log(`Latest tagged: ${latestTaggedRelease}, current: ${current_version}`);
     const currentIsGreater = gte_semver(current_version, latestTaggedRelease);
     const currentIsPrerelease = includeInternalVersions
         ? detectVersionScheme(current_version) === "internalPrerelease"

--- a/build-tools/packages/build-tools/src/buildVersion/buildVersionTests.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersionTests.ts
@@ -28,6 +28,9 @@ export function test() {
     assert.equal(getSimpleVersion("0.16.0-beta", "12345.0", true, false), "0.16.0-beta");
 
     // Test isLatest
+    assert.equal(getIsLatest("client", "0.59.4000", []), true);
+    assert.equal(getIsLatest("client", "0.59.4000-1234", []), false);
+
     // Deliberately not sorted here; highest version is 0.59.3000
     const test_tags = [
         "client_v0.59.1001-62246",
@@ -45,9 +48,6 @@ export function test() {
 
     // Highest version should be 0.59.3000
     assert.equal(versions.slice(-1)[0], "0.59.3000");
-    for (const v of versions) {
-        console.log(v);
-    }
 
     assert.equal(getIsLatest("client", "0.59.4000", test_tags), true);
     assert.equal(getIsLatest("client", "0.59.3001", test_tags), true);
@@ -88,5 +88,5 @@ export function test() {
     assert.equal(getIsLatest("client", "2.0.0-internal.1.0.0.12345", post1_tags, true), false);
     assert.equal(getIsLatest("client", "1.2.3", post1_tags), true);
 
-    console.log("Test passed!");
+    console.log("Tests passed!");
 }

--- a/build-tools/packages/build-tools/src/buildVersion/buildVersionTests.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersionTests.ts
@@ -28,9 +28,6 @@ export function test() {
     assert.equal(getSimpleVersion("0.16.0-beta", "12345.0", true, false), "0.16.0-beta");
 
     // Test isLatest
-    // assert.equal(getIsLatest("client", "0.59.4000", []), true);
-    // assert.equal(getIsLatest("client", "0.59.4000-1234", []), false);
-
     // Deliberately not sorted here; highest version is 0.59.3000
     const test_tags = [
         "client_v0.59.1001-62246",

--- a/build-tools/packages/build-tools/src/buildVersion/buildVersionTests.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersionTests.ts
@@ -28,8 +28,8 @@ export function test() {
     assert.equal(getSimpleVersion("0.16.0-beta", "12345.0", true, false), "0.16.0-beta");
 
     // Test isLatest
-    assert.equal(getIsLatest("client", "0.59.4000", []), true);
-    assert.equal(getIsLatest("client", "0.59.4000-1234", []), false);
+    // assert.equal(getIsLatest("client", "0.59.4000", []), true);
+    // assert.equal(getIsLatest("client", "0.59.4000-1234", []), false);
 
     // Deliberately not sorted here; highest version is 0.59.3000
     const test_tags = [
@@ -66,6 +66,30 @@ export function test() {
     assert.equal(getIsLatest("client", "0.59.4001-1234", test_tags), false);
     assert.equal(getIsLatest("client", "0.60.3000-1234", test_tags), false);
     assert.equal(getIsLatest("client", "0.60.3000", test_tags), true);
+
+    // Add a Fluid internal release version
+    // Deliberately not sorted here; highest version is 0.59.3000
+    const post1_tags = [
+        "client_v1.0.0",
+        "client_v1.2.3",
+        "client_v1.2.3-63294",
+        "client_v2.0.0-internal.1.0.0",
+        "client_v2.0.0-internal.1.0.0.12345",
+        "client_v0.59.1000",
+        "client_v0.59.3000-67119",
+        "client_v0.59.3000",
+        "client_v0.59.2001",
+        "client_v0.59.3000-66610",
+        "client_v0.59.2000",
+        "client_v0.59.1001",
+    ];
+
+    test_tags.push("client_v2.0.0-internal.1.0.0", "client_v0.60.3000");
+    assert.equal(getIsLatest("client", "0.59.4000", post1_tags), false);
+    assert.equal(getIsLatest("client", "0.59.3001", post1_tags), false);
+    assert.equal(getIsLatest("client", "2.0.0-internal.1.0.0", post1_tags, true), true);
+    assert.equal(getIsLatest("client", "2.0.0-internal.1.0.0.12345", post1_tags, true), false);
+    assert.equal(getIsLatest("client", "1.2.3", post1_tags), true);
 
     console.log("Test passed!");
 }

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -221,12 +221,24 @@ export function adjustVersion(
  * only released versions will be returned.
  * @returns The highest version number in the list.
  */
-export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false) {
+ export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false) {
     let list: string[] = [];
+
+    // Check if the versionList is version strings or tag names
+    const isTagNames = versionList.some((v) => v.includes("_v"));
+    const versionsToIterate = isTagNames
+        ? versionList
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              .map((t) => getVersionFromTag(t)!)
+              .filter((t) => t !== undefined && t !== "" && t !== null)
+        : versionList;
 
     // Remove pre-releases from the list
     if (!allowPrereleases) {
-        list = versionList.filter((v) => {
+        list = versionsToIterate.filter((v) => {
+            if (v === undefined) {
+                return false;
+            }
             const hasSemverPrereleaseSection = semver.prerelease(v)?.length ?? 0 !== 0;
             const scheme = detectVersionScheme(v);
             const isPrerelease =
@@ -240,4 +252,13 @@ export function getLatestReleaseFromList(versionList: string[], allowPrereleases
     const latest = list[list.length - 1];
 
     return latest;
+}
+
+function getVersionFromTag(tag: string): string | undefined {
+    const tagSplit = tag.split("_v");
+    if (tagSplit.length !== 2) {
+        return undefined;
+    }
+
+    return tagSplit[1];
 }

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -221,7 +221,7 @@ export function adjustVersion(
  * only released versions will be returned.
  * @returns The highest version number in the list.
  */
- export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false) {
+export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false) {
     let list: string[] = [];
 
     // Check if the versionList is version strings or tag names

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -88,6 +88,7 @@ extends:
     cgSubDirectory: packages
     checkoutSubmodules: true
     taskBundleAnalysis: true
+    includeInternalVersions: true
 
     preCG:
     - task: UseNode@1

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -81,6 +81,10 @@ parameters:
 - name: tagName
   type: string
 
+- name: includeInternalVersions
+  type: boolean
+  default: false
+
 trigger: none
 
 variables:

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -9,6 +9,9 @@ parameters:
   default:
 - name: tagName
   type: string
+- name: includeInternalVersions
+  type: boolean
+  default: false
 
 # Set version
 steps:
@@ -23,7 +26,9 @@ steps:
       npm ci
       npm run install:build-tools
       popd
+      npm link "$(Build.SourcesDirectory)/build-tools/packages/build-cli"
       npm link "$(Build.SourcesDirectory)/build-tools/packages/build-tools"
+      npm link "$(Build.SourcesDirectory)/build-tools/packages/version-tools"
 
 - task: Bash@3
   name: SetVersion
@@ -34,6 +39,7 @@ steps:
     TEST_BUILD: $(testBuild)
     VERSION_PATCH: ${{ parameters.buildNumberInPatch }}
     VERSION_TAGNAME: ${{ parameters.tagName }}
+    VERSION_INCLUDE_INTERNAL_VERSIONS: ${ parameters.includeInternalVersions }
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -38,7 +38,7 @@ steps:
     TEST_BUILD: $(testBuild)
     VERSION_PATCH: ${{ parameters.buildNumberInPatch }}
     VERSION_TAGNAME: ${{ parameters.tagName }}
-    VERSION_INCLUDE_INTERNAL_VERSIONS: ${ parameters.includeInternalVersions }
+    VERSION_INCLUDE_INTERNAL_VERSIONS: ${{ parameters.includeInternalVersions }}
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -28,7 +28,6 @@ steps:
       popd
       npm link "$(Build.SourcesDirectory)/build-tools/packages/build-cli"
       npm link "$(Build.SourcesDirectory)/build-tools/packages/build-tools"
-      npm link "$(Build.SourcesDirectory)/build-tools/packages/version-tools"
 
 - task: Bash@3
   name: SetVersion
@@ -50,7 +49,9 @@ steps:
       echo TEST_BUILD=$TEST_BUILD
       echo VERSION_RELEASE=$VERSION_RELEASE
       echo VERSION_PATCH=$VERSION_PATCH
+      echo VERSION_INCLUDE_INTERNAL_VERSIONS=$VERSION_INCLUDE_INTERNAL_VERSIONS
 
+      flub --help
       flub generate buildVersion
 - task: Bash@3
   displayName: Update Package Version

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -45,7 +45,7 @@ steps:
       echo VERSION_RELEASE=$VERSION_RELEASE
       echo VERSION_PATCH=$VERSION_PATCH
 
-      fluid-build-version
+      flub generate buildVersion
 - task: Bash@3
   displayName: Update Package Version
   env:

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -26,8 +26,11 @@ steps:
       npm ci
       npm run install:build-tools
       popd
-      npm link "$(Build.SourcesDirectory)/build-tools/packages/build-cli"
       npm link "$(Build.SourcesDirectory)/build-tools/packages/build-tools"
+      prefix=$(npm config get prefix)
+      ln -s "$(Build.SourcesDirectory)/build-tools/packages/build-cli/bin/run" "$(prefix)/bin/flub"
+
+      flub help
 
 - task: Bash@3
   name: SetVersion

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -27,10 +27,6 @@ steps:
       # npm run install:build-tools
       popd
       npm link "$(Build.SourcesDirectory)/build-tools/packages/build-tools"
-      prefix=$(npm config get prefix)
-      ln -s "$(Build.SourcesDirectory)/build-tools/packages/build-cli/bin/run" "$(prefix)/bin/flub"
-
-      flub help
 
 - task: Bash@3
   name: SetVersion

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -24,7 +24,7 @@ steps:
     script: |
       pushd "$(Build.SourcesDirectory)/build-tools"
       npm ci
-      npm run install:build-tools
+      # npm run install:build-tools
       popd
       npm link "$(Build.SourcesDirectory)/build-tools/packages/build-tools"
       prefix=$(npm config get prefix)

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -50,8 +50,7 @@ steps:
       echo VERSION_PATCH=$VERSION_PATCH
       echo VERSION_INCLUDE_INTERNAL_VERSIONS=$VERSION_INCLUDE_INTERNAL_VERSIONS
 
-      flub --help
-      flub generate buildVersion
+      fluid-build-version
 - task: Bash@3
   displayName: Update Package Version
   env:


### PR DESCRIPTION
The fluid-build-version-tool is used to set build versions and the "latest" npm dist tag in CI. This PR updates it to work properly with the internal version scheme.