### PR TITLE
Update jsprim and json-schema dependency

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -9316,9 +9316,9 @@
             "dev": true
         },
         "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
             "dev": true
         },
         "json-schema-traverse": {
@@ -9396,14 +9396,14 @@
             }
         },
         "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
             "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
+                "json-schema": "0.4.0",
                 "verror": "1.10.0"
             }
         },

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1909,6 +1909,11 @@
 						"argparse": "^2.0.1"
 					}
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"minimatch": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2303,32 +2308,32 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.2.tgz",
-			"integrity": "sha512-qsYPUYMkBsVHY5X2g0nzmSL+3A7rl+NUEr7VIjOfZ6dlqMrwm5uKYOzgtVlokwBxpmLBn2kpN7kMTwWgyfO7eQ==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.3.tgz",
+			"integrity": "sha512-Z2y77VMxxKqoX7XZEbzN6UTKaZvrqD2BW73T+7DLrqo/9rTi6IykVJS3SgsjW3bKuSnYpTgm9m7npL4o7+LA/A==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.2",
+				"@fluidframework/aqueduct": "^1.2.3",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/local-driver": "^1.2.2",
-				"@fluidframework/odsp-doclib-utils": "^1.2.2",
-				"@fluidframework/odsp-driver": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/local-driver": "^1.2.3",
+				"@fluidframework/odsp-doclib-utils": "^1.2.3",
+				"@fluidframework/odsp-driver": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/test-runtime-utils": "^1.2.2",
-				"@fluidframework/tool-utils": "^1.2.2",
-				"@fluidframework/view-adapters": "^1.2.2",
-				"@fluidframework/view-interfaces": "^1.2.2",
-				"@fluidframework/web-code-loader": "^1.2.2",
+				"@fluidframework/test-runtime-utils": "^1.2.3",
+				"@fluidframework/tool-utils": "^1.2.3",
+				"@fluidframework/view-adapters": "^1.2.3",
+				"@fluidframework/view-interfaces": "^1.2.3",
+				"@fluidframework/web-code-loader": "^1.2.3",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
 				"nconf": "^0.11.4",
@@ -2524,20 +2529,20 @@
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.2.2.tgz",
-			"integrity": "sha512-iRRuRM1gnjGJ7YoUqPf5N/RIMl6U892tq3a4iFrEz3Y43ZAOFdD/wKPVCNAIjw/a/bPfNSbHI81cvtbcswwfCQ==",
+			"version": "npm:@fluidframework/agent-scheduler@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.2.3.tgz",
+			"integrity": "sha512-3gGLn7/CjtqXWdu/ikkVRFr0UhADY8iH8uB2nYBgFi+iiowfmq1g1V54uZo2xpLC3qXOWQmdT2a305K+YlDKJg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
-				"@fluidframework/register-collection": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
+				"@fluidframework/register-collection": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2562,25 +2567,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.2.tgz",
-			"integrity": "sha512-ioDJLk6clNMSbACdC1cl1ujnnyrtO2pUpmaJcGXoNUHruUFeAL4crcSbQ8a6IAtbu0SsoxBxY1yPZSEFRtNUcw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.3.tgz",
+			"integrity": "sha512-byK4ph6AhxP90X73H5ER9Lo6kK8oreFgOh+4WBunzeG17k7rYNOYRS6nA2yOHcaOlh4aNIdTsvi6KdU8KWzpxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
-				"@fluidframework/request-handler": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/synthesize": "^1.2.2",
-				"@fluidframework/view-interfaces": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
+				"@fluidframework/request-handler": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/synthesize": "^1.2.3",
+				"@fluidframework/view-interfaces": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2605,25 +2610,25 @@
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.2.tgz",
-			"integrity": "sha512-ioDJLk6clNMSbACdC1cl1ujnnyrtO2pUpmaJcGXoNUHruUFeAL4crcSbQ8a6IAtbu0SsoxBxY1yPZSEFRtNUcw==",
+			"version": "npm:@fluidframework/aqueduct@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.3.tgz",
+			"integrity": "sha512-byK4ph6AhxP90X73H5ER9Lo6kK8oreFgOh+4WBunzeG17k7rYNOYRS6nA2yOHcaOlh4aNIdTsvi6KdU8KWzpxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
-				"@fluidframework/request-handler": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/synthesize": "^1.2.2",
-				"@fluidframework/view-interfaces": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
+				"@fluidframework/request-handler": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/synthesize": "^1.2.3",
+				"@fluidframework/view-interfaces": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2754,17 +2759,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.2.tgz",
-			"integrity": "sha512-52NxCVz8Eys833hBuS3YIaCPNPdfuJwUv6ajxzpGQLjODFXlKJCA2daKJDZcObsOz4ECHXzVs5NmAcCK1uswWA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.3.tgz",
+			"integrity": "sha512-ihhw3Ac0dRFJKpy6EdpHUEWFpQ8/MJQNaizuMTB8ST03KzvdRDwRDOIgv6tYBVMtP+l9sMZojKbBcWjMacYbIQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2796,17 +2801,17 @@
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.2.tgz",
-			"integrity": "sha512-52NxCVz8Eys833hBuS3YIaCPNPdfuJwUv6ajxzpGQLjODFXlKJCA2daKJDZcObsOz4ECHXzVs5NmAcCK1uswWA==",
+			"version": "npm:@fluidframework/cell@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.3.tgz",
+			"integrity": "sha512-ihhw3Ac0dRFJKpy6EdpHUEWFpQ8/MJQNaizuMTB8ST03KzvdRDwRDOIgv6tYBVMtP+l9sMZojKbBcWjMacYbIQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2864,13 +2869,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.2.tgz",
-			"integrity": "sha512-AgIfFFbjZu/vwcDOiD253pu1HOLBwrg3AVcEIp0tXfkAKe4De5aYkPsZ1dq1fVWsd4/VR38n6vNdPQYB+QJSJg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.3.tgz",
+			"integrity": "sha512-US496kfpqsrbSzMg2D890Tx7wjQoJkQcYA/8WX1Fq2Zwx9ZJAcKa8IIaHCCWzytLrOLvNy1eXba12OyFpr2Mjg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -2885,13 +2890,13 @@
 			}
 		},
 		"@fluidframework/container-definitions-previous": {
-			"version": "npm:@fluidframework/container-definitions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.2.tgz",
-			"integrity": "sha512-AgIfFFbjZu/vwcDOiD253pu1HOLBwrg3AVcEIp0tXfkAKe4De5aYkPsZ1dq1fVWsd4/VR38n6vNdPQYB+QJSJg==",
+			"version": "npm:@fluidframework/container-definitions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.3.tgz",
+			"integrity": "sha512-US496kfpqsrbSzMg2D890Tx7wjQoJkQcYA/8WX1Fq2Zwx9ZJAcKa8IIaHCCWzytLrOLvNy1eXba12OyFpr2Mjg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -2906,20 +2911,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.2.tgz",
-			"integrity": "sha512-NEBj6IZQMXiurwWdRr/4z5oxHAVGwrLxK7Anru3WsJi17D9e/WJfY23qsCedVbVAU5EbhoQ3LAAzcwlAa4WCYQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.3.tgz",
+			"integrity": "sha512-JiyzVcvRprLPcgrslbX2k8QyD0vN7r+FXNEnr5kZSoI+dBzrlrsc1sYjg3f7S1DRCmp/iJNLLB+GfVUOEy8Zzg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2971,20 +2976,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.2.tgz",
-			"integrity": "sha512-NEBj6IZQMXiurwWdRr/4z5oxHAVGwrLxK7Anru3WsJi17D9e/WJfY23qsCedVbVAU5EbhoQ3LAAzcwlAa4WCYQ==",
+			"version": "npm:@fluidframework/container-loader@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.3.tgz",
+			"integrity": "sha512-JiyzVcvRprLPcgrslbX2k8QyD0vN7r+FXNEnr5kZSoI+dBzrlrsc1sYjg3f7S1DRCmp/iJNLLB+GfVUOEy8Zzg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -3036,25 +3041,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.2.tgz",
-			"integrity": "sha512-wlB7wVVYU/If+rGX3Cr6wN8oI0edUcezVAVnx08H6/fcoSjBQG9VziypazQVHuHrbjLSmGS18SVn5lBYB5plDQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.3.tgz",
+			"integrity": "sha512-H8UgrrGWC8aQ9cmdl4lbKlBy/qdMxZzFiIoSFv9+7xv8RN4eTQky0Z3SO/nP6ODsIKgNFaquPGtVU4Oq9zFFpA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/garbage-collector": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/garbage-collector": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -3104,16 +3109,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.2.tgz",
-			"integrity": "sha512-0GA6FlDV87dPRL515hJfIUFf2eANSeVJfWyJHsXwe+QFUEknadpnfaOJDBwO0MG92/IG2sJJvr3X4aXRZ0q2fA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.3.tgz",
+			"integrity": "sha512-5gk/hDzqlTB1S2WNgylJkwXbBHNPuTVrf4dgpyqIpIXDsfA2MUkRC2s8VM0tI0IXuuatso74oJA516ZLvZLjqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3128,16 +3133,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.2.tgz",
-			"integrity": "sha512-0GA6FlDV87dPRL515hJfIUFf2eANSeVJfWyJHsXwe+QFUEknadpnfaOJDBwO0MG92/IG2sJJvr3X4aXRZ0q2fA==",
+			"version": "npm:@fluidframework/container-runtime-definitions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.3.tgz",
+			"integrity": "sha512-5gk/hDzqlTB1S2WNgylJkwXbBHNPuTVrf4dgpyqIpIXDsfA2MUkRC2s8VM0tI0IXuuatso74oJA516ZLvZLjqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3152,25 +3157,25 @@
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.2.tgz",
-			"integrity": "sha512-wlB7wVVYU/If+rGX3Cr6wN8oI0edUcezVAVnx08H6/fcoSjBQG9VziypazQVHuHrbjLSmGS18SVn5lBYB5plDQ==",
+			"version": "npm:@fluidframework/container-runtime@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.3.tgz",
+			"integrity": "sha512-H8UgrrGWC8aQ9cmdl4lbKlBy/qdMxZzFiIoSFv9+7xv8RN4eTQky0Z3SO/nP6ODsIKgNFaquPGtVU4Oq9zFFpA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/garbage-collector": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/garbage-collector": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -3220,15 +3225,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.2.tgz",
-			"integrity": "sha512-17oz+f3H4JGKU+E7qY6gzdNKAr2mNXZAFiXhvTErfi91SuftKY71c+a+J1MACngZdJzolws7BCt2w07+gjXLDw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.3.tgz",
+			"integrity": "sha512-11NIwB8iRLXVatUXGc2i22Ulp2HZ5BqAEoJI2A7DPpqfjlMHlc/kPvEfoJiLKBC1JzsHasa20qsBUc7fjMAxSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3260,15 +3265,15 @@
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.2.tgz",
-			"integrity": "sha512-17oz+f3H4JGKU+E7qY6gzdNKAr2mNXZAFiXhvTErfi91SuftKY71c+a+J1MACngZdJzolws7BCt2w07+gjXLDw==",
+			"version": "npm:@fluidframework/container-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.3.tgz",
+			"integrity": "sha512-11NIwB8iRLXVatUXGc2i22Ulp2HZ5BqAEoJI2A7DPpqfjlMHlc/kPvEfoJiLKBC1JzsHasa20qsBUc7fjMAxSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3300,27 +3305,27 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.2.tgz",
-			"integrity": "sha512-LSsJksyj7go20lmCJPgepj3hEOi5S62OHChy9ZkhH6U9e/bteBtz8vrNGS/IXiCpK2zxPsr7HEa9PdVsw6etlQ=="
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.3.tgz",
+			"integrity": "sha512-4Z0/6O2iVIFuY40HABCP+N5lV1Ga3leCZP1KCSDeEhzGIpCEU04XtEMYCjCEc4O4FGII/kvCGuum/UaQDNCanQ=="
 		},
 		"@fluidframework/core-interfaces-previous": {
-			"version": "npm:@fluidframework/core-interfaces@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.2.tgz",
-			"integrity": "sha512-LSsJksyj7go20lmCJPgepj3hEOi5S62OHChy9ZkhH6U9e/bteBtz8vrNGS/IXiCpK2zxPsr7HEa9PdVsw6etlQ=="
+			"version": "npm:@fluidframework/core-interfaces@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.3.tgz",
+			"integrity": "sha512-4Z0/6O2iVIFuY40HABCP+N5lV1Ga3leCZP1KCSDeEhzGIpCEU04XtEMYCjCEc4O4FGII/kvCGuum/UaQDNCanQ=="
 		},
 		"@fluidframework/counter": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.2.tgz",
-			"integrity": "sha512-CRwh5myCbwuby/r/eAf+tjeVdiLPRsNpM4WXi9hWMLqN83PrMdn/2eHHprOHvrIz2OAcxhrJ7UGijZyEA4O1ew==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.3.tgz",
+			"integrity": "sha512-IqelbLfnQeD6nV8A+dcblNdcvqhlRXeHIE/dA7/Rqh6pASFoTxF9VHkKiJwM/FdXVOj6t2MAz/AZ2kluTguXcg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3352,17 +3357,17 @@
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.2.tgz",
-			"integrity": "sha512-CRwh5myCbwuby/r/eAf+tjeVdiLPRsNpM4WXi9hWMLqN83PrMdn/2eHHprOHvrIz2OAcxhrJ7UGijZyEA4O1ew==",
+			"version": "npm:@fluidframework/counter@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.3.tgz",
+			"integrity": "sha512-IqelbLfnQeD6nV8A+dcblNdcvqhlRXeHIE/dA7/Rqh6pASFoTxF9VHkKiJwM/FdXVOj6t2MAz/AZ2kluTguXcg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3394,21 +3399,21 @@
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.2.2.tgz",
-			"integrity": "sha512-Ot1W63BlCqLJyh2oGg8Ylqu7qfwm8UMeNAG+5Kn5cKnFLmQfDbUaYRUNsrzsDsurFyfsVbzJR52YE0mxhMd3yQ==",
+			"version": "npm:@fluidframework/data-object-base@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.2.3.tgz",
+			"integrity": "sha512-VKa0zTZA6Y+a0XCjVeMbs1PjwJJ+pima5U31nHKa0mJynAJ0YW/dFENqBVjYx9R0iS3mt4mV1Z5IUGEYJCoJdw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/request-handler": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/request-handler": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3432,24 +3437,24 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.2.tgz",
-			"integrity": "sha512-0v0BtnW4SGU2kDVWC1HRoFAS0h1c93ANgz+1PVkVkVGJNnFWUM/G1nSk44mUfpfbwwolG2a9HK+Eznt/MdZPQQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.3.tgz",
+			"integrity": "sha512-5TBLWKLsPqn4SqifiCokPYJw2+hc3keS5+KoeCMwXAPKH3AyWplXZY3/FXKnuhurin/UAtaVD7hR2sFEpN13wg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/garbage-collector": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/garbage-collector": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3499,16 +3504,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.2.tgz",
-			"integrity": "sha512-4JCUGn9OrNid3UpOOUpNRCEqr5s6xvJA6QAoAShXnry9+vmKC2llo1XrRIkNTyW3q6NBOhE39/rLqvceUgny6w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.3.tgz",
+			"integrity": "sha512-FusXiXPeF8Ae8dsY7EvFf801HU+k3m1nLXJkYLuEf2S5UE3GuSz7Pf9JDFSJozgK+wkkCM4y1+AhuOgMFZemuA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3541,16 +3546,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.2.tgz",
-			"integrity": "sha512-4JCUGn9OrNid3UpOOUpNRCEqr5s6xvJA6QAoAShXnry9+vmKC2llo1XrRIkNTyW3q6NBOhE39/rLqvceUgny6w==",
+			"version": "npm:@fluidframework/datastore-definitions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.3.tgz",
+			"integrity": "sha512-FusXiXPeF8Ae8dsY7EvFf801HU+k3m1nLXJkYLuEf2S5UE3GuSz7Pf9JDFSJozgK+wkkCM4y1+AhuOgMFZemuA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3583,24 +3588,24 @@
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.2.tgz",
-			"integrity": "sha512-0v0BtnW4SGU2kDVWC1HRoFAS0h1c93ANgz+1PVkVkVGJNnFWUM/G1nSk44mUfpfbwwolG2a9HK+Eznt/MdZPQQ==",
+			"version": "npm:@fluidframework/datastore@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.3.tgz",
+			"integrity": "sha512-5TBLWKLsPqn4SqifiCokPYJw2+hc3keS5+KoeCMwXAPKH3AyWplXZY3/FXKnuhurin/UAtaVD7hR2sFEpN13wg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/garbage-collector": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/garbage-collector": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3650,15 +3655,15 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.2.tgz",
-			"integrity": "sha512-KtRfhmVj9w3gH0C3fA2YJlNdLVBR9F/twB2wqMml6gP41yZvrcz6OvXr43m83My7aYZW7Q1ZR5UDwSuSsTd+yg==",
+			"version": "npm:@fluidframework/dds-interceptions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.3.tgz",
+			"integrity": "sha512-CI5/5HPtsi/kwy5dCErYuyzTsFKxGkN9Etbigllikvzf9PQH0tGdKopXjxNhYmkt6Xr8wII7MBCX6Utm6JkeYQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^1.2.2",
-				"@fluidframework/merge-tree": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/sequence": "^1.2.2"
+				"@fluidframework/map": "^1.2.3",
+				"@fluidframework/merge-tree": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/sequence": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3682,15 +3687,15 @@
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.2.2.tgz",
-			"integrity": "sha512-5c6soQF234i/ucM6F6BrfWWu7G6DASA4vubKc8sUVPW/58vk87mBcb9JZk0zgLHOzArdoPsT1WC7h6r3p54xDw==",
+			"version": "npm:@fluidframework/debugger@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.2.3.tgz",
+			"integrity": "sha512-6IboDkugAne4+mvlu/1rHlqO9eHVhOOQgGg9SfUpeKCEFgzo7icwR1/wycFxyxFioqqcO1HMJMQvUyxr1OkFwQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.2.2",
+				"@fluidframework/replay-driver": "^1.2.3",
 				"jsonschema": "^1.2.6"
 			},
 			"dependencies": {
@@ -3723,16 +3728,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.2.tgz",
-			"integrity": "sha512-DYSGM4IdwCc/VuEnTUNjRLWyHKI3mjUTMqKw7BhQroOh2olyM4r0lL+acSPjnH6VQjYJpDjcFO3A9SFZ5N5zwQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.3.tgz",
+			"integrity": "sha512-Exln7DkNB2369/DJPCX4nW3vgJ82PQMe0MF/YfJciVlXj62lFjJDv4Lc5Pn0NNr+VMgZjxVpb3c5dIYCQ432BA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3764,16 +3769,16 @@
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.2.tgz",
-			"integrity": "sha512-DYSGM4IdwCc/VuEnTUNjRLWyHKI3mjUTMqKw7BhQroOh2olyM4r0lL+acSPjnH6VQjYJpDjcFO3A9SFZ5N5zwQ==",
+			"version": "npm:@fluidframework/driver-base@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.3.tgz",
+			"integrity": "sha512-Exln7DkNB2369/DJPCX4nW3vgJ82PQMe0MF/YfJciVlXj62lFjJDv4Lc5Pn0NNr+VMgZjxVpb3c5dIYCQ432BA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3805,12 +3810,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.2.tgz",
-			"integrity": "sha512-3tEZY0Tri3cWH67m8+dtZDPdVT3MNxYJ1y6GywrY4xJFJVd1isJrIyWb8lljbSQPjNDR9tnG17p3uq1MxjRosw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.3.tgz",
+			"integrity": "sha512-talJDyezDaXo2De0JWsFXqOiyCnSaU51zV6zKNig6V9uk/wd57wrF455HLtKSGCjt4VHvr0R0EdHMoN+LckDyw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -3825,12 +3830,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions-previous": {
-			"version": "npm:@fluidframework/driver-definitions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.2.tgz",
-			"integrity": "sha512-3tEZY0Tri3cWH67m8+dtZDPdVT3MNxYJ1y6GywrY4xJFJVd1isJrIyWb8lljbSQPjNDR9tnG17p3uq1MxjRosw==",
+			"version": "npm:@fluidframework/driver-definitions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.3.tgz",
+			"integrity": "sha512-talJDyezDaXo2De0JWsFXqOiyCnSaU51zV6zKNig6V9uk/wd57wrF455HLtKSGCjt4VHvr0R0EdHMoN+LckDyw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -3845,18 +3850,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.2.tgz",
-			"integrity": "sha512-7akTLrrvRSZmJKTBcJREqgmglWI9KV4d6lf3JrCzqPPkQBr6TkApmSf3J+8/xEsp5516MLdT0zDTMAxrNp7UOg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.3.tgz",
+			"integrity": "sha512-5hoMEsd7ZG9waw2aVgzmEMEntlWy0tR1iQRNYpV72FkmtJ7RQgtYi1dJA59AC/T6c/qrLOhETXtxQtIrJvlX7w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3906,18 +3911,18 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.2.tgz",
-			"integrity": "sha512-7akTLrrvRSZmJKTBcJREqgmglWI9KV4d6lf3JrCzqPPkQBr6TkApmSf3J+8/xEsp5516MLdT0zDTMAxrNp7UOg==",
+			"version": "npm:@fluidframework/driver-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.3.tgz",
+			"integrity": "sha512-5hoMEsd7ZG9waw2aVgzmEMEntlWy0tR1iQRNYpV72FkmtJ7RQgtYi1dJA59AC/T6c/qrLOhETXtxQtIrJvlX7w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3967,13 +3972,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.2.tgz",
-			"integrity": "sha512-WqXHVqJvHtaf0sMjoKjA4efx85LW3lxaGwmUDcZZ02dbsLOZee/l/CgR8pLJ5wY03CoQBNFYUCS++b3hYegIBQ==",
+			"version": "npm:@fluidframework/driver-web-cache@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.3.tgz",
+			"integrity": "sha512-SMW1DRQwRWTI+gUztA//EEEtpvW67rSajdqrQ3jQeSxybSeUiRs+4h6rdahzLu4wA9H1EYTaf5YVQCehrL1UPQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3997,16 +4002,16 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.2.2.tgz",
-			"integrity": "sha512-y+OxxXXujv7kG5gGbE91m/4zVE65gg9vS+dHMoT0zFpytxQrmEJjemxpnAvHivHdfyClL9rNjfeI9TJVRP2JYQ==",
+			"version": "npm:@fluidframework/file-driver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.2.3.tgz",
+			"integrity": "sha512-+dlKA1uwNvZRXRJB7Ff930hrNQkeZyzBdfOPAeEftzLoZAMamt2tbZxoLEKyKgDGZeJmHtdP/QAOyuKxnZFl0w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.2.2"
+				"@fluidframework/replay-driver": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4038,22 +4043,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.2.tgz",
-			"integrity": "sha512-qJ1juVJ/oHqsHmCba/nqUv0JalXj/a3heQVJRBsLPSBkEf+Ss7FqfJeBCwkxvpkVczWXQnKu0UVbBDbAk0E0nA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.3.tgz",
+			"integrity": "sha512-34Z6Zlxty2ndSe2VgrFpTCEdDnTPx/KjhBlMGlWz9XqcUOM+mM1vIc3Sb5iqP0hNF6qAo5mOzFTiDiDNb+BohA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.2",
+				"@fluidframework/aqueduct": "^1.2.3",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2"
+				"@fluidframework/request-handler": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4085,22 +4090,22 @@
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.2.tgz",
-			"integrity": "sha512-qJ1juVJ/oHqsHmCba/nqUv0JalXj/a3heQVJRBsLPSBkEf+Ss7FqfJeBCwkxvpkVczWXQnKu0UVbBDbAk0E0nA==",
+			"version": "npm:@fluidframework/fluid-static@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.3.tgz",
+			"integrity": "sha512-34Z6Zlxty2ndSe2VgrFpTCEdDnTPx/KjhBlMGlWz9XqcUOM+mM1vIc3Sb5iqP0hNF6qAo5mOzFTiDiDNb+BohA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.2",
+				"@fluidframework/aqueduct": "^1.2.3",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2"
+				"@fluidframework/request-handler": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4132,13 +4137,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.2.tgz",
-			"integrity": "sha512-Drgs1Ql5n/SDu0VEhYodTsmG3I0S/+hfAjUNJDMR658gHlDURHfS29/IL0WEUH3LqhNBQQKlnDrX2/LjVBXC4A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.3.tgz",
+			"integrity": "sha512-q81AksgXWbI6JOGPf4nWot4TpJFoA6+vGn/avYFXfBDf68DX4heeo7ad6ow7x+AkJpqwGulObCqLwqaHRtB1Pw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4162,13 +4167,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.2.tgz",
-			"integrity": "sha512-Drgs1Ql5n/SDu0VEhYodTsmG3I0S/+hfAjUNJDMR658gHlDURHfS29/IL0WEUH3LqhNBQQKlnDrX2/LjVBXC4A==",
+			"version": "npm:@fluidframework/garbage-collector@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.3.tgz",
+			"integrity": "sha512-q81AksgXWbI6JOGPf4nWot4TpJFoA6+vGn/avYFXfBDf68DX4heeo7ad6ow7x+AkJpqwGulObCqLwqaHRtB1Pw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4197,17 +4202,17 @@
 			"integrity": "sha512-b12BJjSMrZFgJ/1rC+DkLwQZsQPcuwElc/4VTM3f/tS3dIrmbeRdz3vhdenM0WllGrw5ZdbqxYcvoQ52Xk7ZQw=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.2.2.tgz",
-			"integrity": "sha512-9+7GargBy3QE6DiL8M5ITsosxloGTph4KbDbcWq4fm07IgPsvCSIIfGKWA0Ae3z1vHdsvu6itvLEZhbyuVYeZQ==",
+			"version": "npm:@fluidframework/iframe-driver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.2.3.tgz",
+			"integrity": "sha512-umR6aMT/HOjmJymLkuxp/k+kznIYAYaQjZ8xzVYh5JZgYgaRAm2rdfdcWAoZPAURn0+2iL5QwEfT16o1TrzSbA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"comlink": "^4.3.0"
 			},
 			"dependencies": {
@@ -4240,17 +4245,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.2.tgz",
-			"integrity": "sha512-2uZsBY789adZFVLPcDKQBXZ3SuKEgwjXF+5XaDoyBldjk39e6K+NIA7YUbv1RES5i3eSQn5iBpEOlL1+67kDYg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.3.tgz",
+			"integrity": "sha512-A0JidV69aSfKpQMfnnO07uTBVmmcnYbd/wVXTC3A3J+n6vgwEtT8X4n3SZZmnSBodAwnlrua7Hg8ABtG5bLY0Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4283,17 +4288,17 @@
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.2.tgz",
-			"integrity": "sha512-2uZsBY789adZFVLPcDKQBXZ3SuKEgwjXF+5XaDoyBldjk39e6K+NIA7YUbv1RES5i3eSQn5iBpEOlL1+67kDYg==",
+			"version": "npm:@fluidframework/ink@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.3.tgz",
+			"integrity": "sha512-A0JidV69aSfKpQMfnnO07uTBVmmcnYbd/wVXTC3A3J+n6vgwEtT8X4n3SZZmnSBodAwnlrua7Hg8ABtG5bLY0Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4326,18 +4331,18 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.2.tgz",
-			"integrity": "sha512-9vgh2vhdoRtO7eFpwumLgIEi751VbxPMtKzJPUUkSK+7rWAoAMpCy8Ws1JwZSXNxm/SEI8WfhRcECT9Sop+N7Q==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.3.tgz",
+			"integrity": "sha512-Psf8++4nK24vZUEnvMP55XNWr5vMZSxDhiAwgAEj9toRtU49Hyt44RE0zKX04N/xooR9A74dRM2WyvzlHj4oow==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-base": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-base": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -4531,18 +4536,18 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.2.tgz",
-			"integrity": "sha512-9vgh2vhdoRtO7eFpwumLgIEi751VbxPMtKzJPUUkSK+7rWAoAMpCy8Ws1JwZSXNxm/SEI8WfhRcECT9Sop+N7Q==",
+			"version": "npm:@fluidframework/local-driver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.3.tgz",
+			"integrity": "sha512-Psf8++4nK24vZUEnvMP55XNWr5vMZSxDhiAwgAEj9toRtU49Hyt44RE0zKX04N/xooR9A74dRM2WyvzlHj4oow==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-base": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-base": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -4736,20 +4741,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.2.tgz",
-			"integrity": "sha512-84F1XSHr1q9Hm1iVELv59Stm2k6Zs+eCDOyJX7hNecVPqN3m5ZjKa52YPxHOPo82dlckdiNYZ1pFHGyZP0Ovyg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.3.tgz",
+			"integrity": "sha512-S67/gB4o9bYA+YxuwUQ0PAY3lre/cDCxgZD+ApwG30dvizJ1eHLHuxZ1ME+X98pfdL9n7GFj5aqNJgcZ5q4nWA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4782,20 +4787,20 @@
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.2.tgz",
-			"integrity": "sha512-84F1XSHr1q9Hm1iVELv59Stm2k6Zs+eCDOyJX7hNecVPqN3m5ZjKa52YPxHOPo82dlckdiNYZ1pFHGyZP0Ovyg==",
+			"version": "npm:@fluidframework/map@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.3.tgz",
+			"integrity": "sha512-S67/gB4o9bYA+YxuwUQ0PAY3lre/cDCxgZD+ApwG30dvizJ1eHLHuxZ1ME+X98pfdL9n7GFj5aqNJgcZ5q4nWA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4828,21 +4833,21 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.2.tgz",
-			"integrity": "sha512-a0hcBzcKT1qfxtHk2eLc4RAY08cDr2TX5cFHx8AOi0DmOef0Cx7hbe67/CCLPXtssEe52eYokwos38rjkb1IWQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.3.tgz",
+			"integrity": "sha512-uR7PL21Msuy3Mtt9UueYJBJOC4dlHQVtutrZugTO2tNjC6mTX+8Tkz4+98q/Uw7/GQpgEH0Y+B5aElFmABDo2A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/merge-tree": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/merge-tree": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4892,21 +4897,21 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.2.tgz",
-			"integrity": "sha512-a0hcBzcKT1qfxtHk2eLc4RAY08cDr2TX5cFHx8AOi0DmOef0Cx7hbe67/CCLPXtssEe52eYokwos38rjkb1IWQ==",
+			"version": "npm:@fluidframework/matrix@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.3.tgz",
+			"integrity": "sha512-uR7PL21Msuy3Mtt9UueYJBJOC4dlHQVtutrZugTO2tNjC6mTX+8Tkz4+98q/Uw7/GQpgEH0Y+B5aElFmABDo2A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/merge-tree": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/merge-tree": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4956,21 +4961,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.2.tgz",
-			"integrity": "sha512-vwD61h9kvquj6vD4qLFfyCZEtIlYYkmimUdm4c/tBQ9JRZk/7e5jZ8JxaVrJLY1Tn5FZDZsiv3CM8MhKl7rMJA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.3.tgz",
+			"integrity": "sha512-gqENntU+dJawH2eDgQ62hb5+Zo7Yq9zdaIPxdq0k/9hvHxwNwVtAb6fABxc0ZaR/IFbdvuu2vzutCrCxPq4HcA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5002,21 +5007,21 @@
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.2.tgz",
-			"integrity": "sha512-vwD61h9kvquj6vD4qLFfyCZEtIlYYkmimUdm4c/tBQ9JRZk/7e5jZ8JxaVrJLY1Tn5FZDZsiv3CM8MhKl7rMJA==",
+			"version": "npm:@fluidframework/merge-tree@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.3.tgz",
+			"integrity": "sha512-gqENntU+dJawH2eDgQ62hb5+Zo7Yq9zdaIPxdq0k/9hvHxwNwVtAb6fABxc0ZaR/IFbdvuu2vzutCrCxPq4HcA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5048,36 +5053,36 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.2.tgz",
-			"integrity": "sha512-czSIZ5i68u1ccMgpKlxKq/i3vDBWQdFaY3SW2QrraxrivIuH2Qn2z1ehzQPQfk3nZGiwtG/M1q9AY5g0iT7+1w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.3.tgz",
+			"integrity": "sha512-eHEsjIEvEAb8nXBr0uG6pwVyO4fRfwKH5gR43T7WnEQe6uiFUz0zf5rsMlVKezMDjHKuXb+aoP5dZchwI+2ZZw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.2.2",
+				"@fluidframework/test-driver-definitions": "^1.2.3",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.2.tgz",
-			"integrity": "sha512-czSIZ5i68u1ccMgpKlxKq/i3vDBWQdFaY3SW2QrraxrivIuH2Qn2z1ehzQPQfk3nZGiwtG/M1q9AY5g0iT7+1w==",
+			"version": "npm:@fluidframework/mocha-test-setup@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.3.tgz",
+			"integrity": "sha512-eHEsjIEvEAb8nXBr0uG6pwVyO4fRfwKH5gR43T7WnEQe6uiFUz0zf5rsMlVKezMDjHKuXb+aoP5dZchwI+2ZZw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.2.2",
+				"@fluidframework/test-driver-definitions": "^1.2.3",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.2.tgz",
-			"integrity": "sha512-xUzn8NyWTzutDu1o8Qvcg8fWSj2hvoNUx5HfeWki7paOlB6HhRKmcRp3+uMIHEqpQQjPGLTYJx9VQQ1tv4omMA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.3.tgz",
+			"integrity": "sha512-H2fUjG23k9lGJcshyBl9gcw9cCMv8PBr8eQhW1ok0gtz63sCN3MRLqRhmAwWiRk6KtcM1dPAj9kzhcTAyWyQ0A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -5102,16 +5107,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.2.tgz",
-			"integrity": "sha512-xUzn8NyWTzutDu1o8Qvcg8fWSj2hvoNUx5HfeWki7paOlB6HhRKmcRp3+uMIHEqpQQjPGLTYJx9VQQ1tv4omMA==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.3.tgz",
+			"integrity": "sha512-H2fUjG23k9lGJcshyBl9gcw9cCMv8PBr8eQhW1ok0gtz63sCN3MRLqRhmAwWiRk6KtcM1dPAj9kzhcTAyWyQ0A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -5136,22 +5141,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.2.tgz",
-			"integrity": "sha512-yUBGPB2SHJy1Zyk+MnsDzXLhoFj3GG4Ogt5dqBI3FSStORQdRBjjtAzT6u+GQnqVmjeoprh3VYd0/B3Qqq/Zmg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.3.tgz",
+			"integrity": "sha512-JMQiDq4OPZxolcQSHWdco37ptjmLcjWbVW6HxQciJwRfTpJUP7ruynT2XfdXoTZZVRazh0k1jPMcBmQLARDA6A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-base": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-base": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/odsp-doclib-utils": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -5203,38 +5208,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.2.tgz",
-			"integrity": "sha512-BMo66EiBCJgjCaWalRlvyxROWELfn1dN4eVmpS7ZhOGnPvdffMfOhlsQUSEKdjUY8R6PRBvFwD9cMju1ZPqc0g==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.3.tgz",
+			"integrity": "sha512-eWO3G9sefDN28qHg/AMW6+mplGJ8KwCl2p4/oPkBq6Y0gDyI2KLouuTE9yQDIEI7+qSwi1J2xXkSIhAGevOS0w==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.2"
+				"@fluidframework/driver-definitions": "^1.2.3"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.2.tgz",
-			"integrity": "sha512-BMo66EiBCJgjCaWalRlvyxROWELfn1dN4eVmpS7ZhOGnPvdffMfOhlsQUSEKdjUY8R6PRBvFwD9cMju1ZPqc0g==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.3.tgz",
+			"integrity": "sha512-eWO3G9sefDN28qHg/AMW6+mplGJ8KwCl2p4/oPkBq6Y0gDyI2KLouuTE9yQDIEI7+qSwi1J2xXkSIhAGevOS0w==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.2"
+				"@fluidframework/driver-definitions": "^1.2.3"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.2.tgz",
-			"integrity": "sha512-yUBGPB2SHJy1Zyk+MnsDzXLhoFj3GG4Ogt5dqBI3FSStORQdRBjjtAzT6u+GQnqVmjeoprh3VYd0/B3Qqq/Zmg==",
+			"version": "npm:@fluidframework/odsp-driver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.3.tgz",
+			"integrity": "sha512-JMQiDq4OPZxolcQSHWdco37ptjmLcjWbVW6HxQciJwRfTpJUP7ruynT2XfdXoTZZVRazh0k1jPMcBmQLARDA6A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-base": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-base": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
+				"@fluidframework/odsp-doclib-utils": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -5286,39 +5291,39 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.2.tgz",
-			"integrity": "sha512-oR/LTKcQiRfG6XWpp5+sGmuZt/8R6cR0wt9I4xWGMrgM2kTHzpH0H7p0LiNrH4FrcWXcSaeCSSPWVp9tkSEM5A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.3.tgz",
+			"integrity": "sha512-7Lg+JqofhOG5x7++ovLU+jszUlj93xNrs+JTKF8k6ea9Knvn8GkDvDEbQfbyzbreX1ykHasePEF3dMR66wGF+w==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/odsp-driver": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2"
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/odsp-driver": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.2.tgz",
-			"integrity": "sha512-oR/LTKcQiRfG6XWpp5+sGmuZt/8R6cR0wt9I4xWGMrgM2kTHzpH0H7p0LiNrH4FrcWXcSaeCSSPWVp9tkSEM5A==",
+			"version": "npm:@fluidframework/odsp-urlresolver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.3.tgz",
+			"integrity": "sha512-7Lg+JqofhOG5x7++ovLU+jszUlj93xNrs+JTKF8k6ea9Knvn8GkDvDEbQfbyzbreX1ykHasePEF3dMR66wGF+w==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/odsp-driver": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2"
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/odsp-driver": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.2.tgz",
-			"integrity": "sha512-XYPcw03IJQm72ub7Or4gOCt9aGJR6Wb/RUt4CQLF8W5lFAXaeOYzKB/u4dMbFmMf3T66kZ6rvF+8aA7GOdTT7w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.3.tgz",
+			"integrity": "sha512-VDGGTyrdU+Po2qaW0t3RxfMuwQ6cGmVh7093O6FWwQIlsICmvbJbQAQDOiQW4jchlKtppkNrPNRPDSi8BzntRQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -5351,17 +5356,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.2.tgz",
-			"integrity": "sha512-XYPcw03IJQm72ub7Or4gOCt9aGJR6Wb/RUt4CQLF8W5lFAXaeOYzKB/u4dMbFmMf3T66kZ6rvF+8aA7GOdTT7w==",
+			"version": "npm:@fluidframework/ordered-collection@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.3.tgz",
+			"integrity": "sha512-VDGGTyrdU+Po2qaW0t3RxfMuwQ6cGmVh7093O6FWwQIlsICmvbJbQAQDOiQW4jchlKtppkNrPNRPDSi8BzntRQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -5413,17 +5418,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.2.tgz",
-			"integrity": "sha512-RiiD15O4mixkerHptociuOa+wqOA+hp6pkM3eMhkHqKO0g1JYOrUfK6g4hiPnibwP8fZAK1r8oZpDugzyTgZ3Q==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.3.tgz",
+			"integrity": "sha512-kqUMupu5QL9wjERGi5+5xMYywo29cg7VshM3k03P+5hIZNkC78l1ZUJgrbi57RdS6BTTU3iklyZRupkCKJ47Cw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5471,17 +5476,17 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.2.tgz",
-			"integrity": "sha512-RiiD15O4mixkerHptociuOa+wqOA+hp6pkM3eMhkHqKO0g1JYOrUfK6g4hiPnibwP8fZAK1r8oZpDugzyTgZ3Q==",
+			"version": "npm:@fluidframework/register-collection@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.3.tgz",
+			"integrity": "sha512-kqUMupu5QL9wjERGi5+5xMYywo29cg7VshM3k03P+5hIZNkC78l1ZUJgrbi57RdS6BTTU3iklyZRupkCKJ47Cw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5529,16 +5534,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.2.tgz",
-			"integrity": "sha512-VRm7JjHGpL58g6ZnJbP6lKUNrV82pL85kNpAM495A55fwLYCC0Q5lynIFpzgqxhy4S/pJi7hQT/kUO4URyEwVw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.3.tgz",
+			"integrity": "sha512-ksX3gShzNr6D7jB5qmue+jc7CATDIJ4q8Z/g+W8cgFtRtZXTviy6u0klybSZTtmrIcaOjGteDNxkxzL0Q3DO4w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5570,16 +5575,16 @@
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.2.tgz",
-			"integrity": "sha512-VRm7JjHGpL58g6ZnJbP6lKUNrV82pL85kNpAM495A55fwLYCC0Q5lynIFpzgqxhy4S/pJi7hQT/kUO4URyEwVw==",
+			"version": "npm:@fluidframework/replay-driver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.3.tgz",
+			"integrity": "sha512-ksX3gShzNr6D7jB5qmue+jc7CATDIJ4q8Z/g+W8cgFtRtZXTviy6u0klybSZTtmrIcaOjGteDNxkxzL0Q3DO4w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5611,15 +5616,15 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.2.tgz",
-			"integrity": "sha512-rDgY7E0A3bgOOOSVDCPgRQx+WhWQXGel9jtVflvjox5gwFZcew2HJvaIhNbpIADSoM8g35J41VyM9tvXd8kPXQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.3.tgz",
+			"integrity": "sha512-ztmnAscDmoK5TJiC7wwSrnsBChCA4g8UQcPo9h/r2vpMebuSpND/mAKEzzAc97qqTRzUB+e2CY2O/BxCKJ5BAg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2"
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5643,15 +5648,15 @@
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.2.tgz",
-			"integrity": "sha512-rDgY7E0A3bgOOOSVDCPgRQx+WhWQXGel9jtVflvjox5gwFZcew2HJvaIhNbpIADSoM8g35J41VyM9tvXd8kPXQ==",
+			"version": "npm:@fluidframework/request-handler@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.3.tgz",
+			"integrity": "sha512-ztmnAscDmoK5TJiC7wwSrnsBChCA4g8UQcPo9h/r2vpMebuSpND/mAKEzzAc97qqTRzUB+e2CY2O/BxCKJ5BAg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2"
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5675,20 +5680,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.2.tgz",
-			"integrity": "sha512-TRJNVG/L0JAthm4i/kpCdziLreRe6wFQZjzsuQrp4J5knfdo2/Dg/tB5AzvJONv5m3iMgA1SPrOFrj324lSseQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.3.tgz",
+			"integrity": "sha512-wLpr8jgBlfYZaXOZS8n3mdnaPbk4im20WTJBf5J6XAHHgD1pvKgFnhBnKjmt9CilvhCpHSkwVEzCFtU3wMws7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-base": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -5767,20 +5772,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.2.tgz",
-			"integrity": "sha512-TRJNVG/L0JAthm4i/kpCdziLreRe6wFQZjzsuQrp4J5knfdo2/Dg/tB5AzvJONv5m3iMgA1SPrOFrj324lSseQ==",
+			"version": "npm:@fluidframework/routerlicious-driver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.3.tgz",
+			"integrity": "sha512-wLpr8jgBlfYZaXOZS8n3mdnaPbk4im20WTJBf5J6XAHHgD1pvKgFnhBnKjmt9CilvhCpHSkwVEzCFtU3wMws7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-base": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -5859,13 +5864,13 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.2.tgz",
-			"integrity": "sha512-b2TOwMPve46llFVXUFrsbmfPJb4Sik7d1Id4LqnMe68c1veWTWWlq7LXycO7VgG5e6KUn39t6CBtsiixa+8iFw==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.3.tgz",
+			"integrity": "sha512-Tqx2AaXb78KragJUAYn/lSfI0sB+VqEa6DA50HgoWlr1k/GKUBt4AJAhRgabxMkjmqCtUETv5J/BEJKlovzl7g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"nconf": "^0.11.4"
 			},
@@ -5899,15 +5904,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.2.tgz",
-			"integrity": "sha512-dlbwCKNSp7kEjpvEuZSnVUshbcFuu0BMZZOGqGqWwvh1ataw59IIYRX02auKe5O4r4xZ/PYVE9UnGreNshqj8A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.3.tgz",
+			"integrity": "sha512-oClpTEb90zMzD2d5ZyoXaZy0XOFmwL/E7xoDP7ut2Aa4AVZ2OOre9xMj+/p+TGle9NkMNNZ/Qclx8zJZyw1UEw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -5941,15 +5946,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.2.tgz",
-			"integrity": "sha512-dlbwCKNSp7kEjpvEuZSnVUshbcFuu0BMZZOGqGqWwvh1ataw59IIYRX02auKe5O4r4xZ/PYVE9UnGreNshqj8A==",
+			"version": "npm:@fluidframework/runtime-definitions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.3.tgz",
+			"integrity": "sha512-oClpTEb90zMzD2d5ZyoXaZy0XOFmwL/E7xoDP7ut2Aa4AVZ2OOre9xMj+/p+TGle9NkMNNZ/Qclx8zJZyw1UEw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -5983,21 +5988,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.2.tgz",
-			"integrity": "sha512-DT36SnJEShWR9lgEmTUzvkMMm0oLll2hmNelRxiortSl67Qjky8ujxlsYCnQCZpwPXJSJZkzACbDO9w2+ejdKQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.3.tgz",
+			"integrity": "sha512-VHWGY53oOjBLDPeIU6lH7WMyEWFgioG3j8hgyX0ngNVlHFnNCmpY3zZ0BAPGDIxAjlHTQSzcueOzLf9ewvdp/A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/garbage-collector": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/garbage-collector": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -6045,21 +6050,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.2.tgz",
-			"integrity": "sha512-DT36SnJEShWR9lgEmTUzvkMMm0oLll2hmNelRxiortSl67Qjky8ujxlsYCnQCZpwPXJSJZkzACbDO9w2+ejdKQ==",
+			"version": "npm:@fluidframework/runtime-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.3.tgz",
+			"integrity": "sha512-VHWGY53oOjBLDPeIU6lH7WMyEWFgioG3j8hgyX0ngNVlHFnNCmpY3zZ0BAPGDIxAjlHTQSzcueOzLf9ewvdp/A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/garbage-collector": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/garbage-collector": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -6107,21 +6112,21 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.2.tgz",
-			"integrity": "sha512-j4I+9qgDMtFgMH1uP9Qv2LTFkAK1rxAd7e11kDJ5E/B2NQwFOfUOTtUDPYGe0q2HJMMqo6fSWYfZDAEB20LfEw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.3.tgz",
+			"integrity": "sha512-us4iTzV/HSSCHt5ifvzCOM6sbGO1OfPrdh+yqwi1KUPLn/FZtC/Ut2AqcyXY6p8lTJwSntKH6uVlaYb3/hYluw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/merge-tree": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/merge-tree": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6154,21 +6159,21 @@
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.2.tgz",
-			"integrity": "sha512-j4I+9qgDMtFgMH1uP9Qv2LTFkAK1rxAd7e11kDJ5E/B2NQwFOfUOTtUDPYGe0q2HJMMqo6fSWYfZDAEB20LfEw==",
+			"version": "npm:@fluidframework/sequence@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.3.tgz",
+			"integrity": "sha512-us4iTzV/HSSCHt5ifvzCOM6sbGO1OfPrdh+yqwi1KUPLn/FZtC/Ut2AqcyXY6p8lTJwSntKH6uVlaYb3/hYluw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/merge-tree": "^1.2.2",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/merge-tree": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7470,22 +7475,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.2.tgz",
-			"integrity": "sha512-uRTmx2/88Pq2pl2/Wb9CBi9LxTW5TCez0oeZL1Zn0xxIIX0437t390+rm/7lsjasEubuSBV0VC39UKp1deI/TA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.3.tgz",
+			"integrity": "sha512-gN6TR/bvnlCCNg1HRsc4C16zqpGWTmbodE+VJKtsxvaPmse3AcLnhB/7bqOEdUshaSNLYrZMrs7dr5ay58OlmQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7518,22 +7523,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.2.tgz",
-			"integrity": "sha512-uRTmx2/88Pq2pl2/Wb9CBi9LxTW5TCez0oeZL1Zn0xxIIX0437t390+rm/7lsjasEubuSBV0VC39UKp1deI/TA==",
+			"version": "npm:@fluidframework/shared-object-base@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.3.tgz",
+			"integrity": "sha512-gN6TR/bvnlCCNg1HRsc4C16zqpGWTmbodE+VJKtsxvaPmse3AcLnhB/7bqOEdUshaSNLYrZMrs7dr5ay58OlmQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/container-utils": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/container-utils": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7566,17 +7571,17 @@
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.2.tgz",
-			"integrity": "sha512-r8qPHUF1Upc0l1LWt45qkGkl5FVHx2mQVfnRLzWjhsybamwwTwM2o5z+Tk0lt5WTr+X+74D026cTP+y6e5sTeQ==",
+			"version": "npm:@fluidframework/shared-summary-block@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.3.tgz",
+			"integrity": "sha512-/C/ZsqgnkpBtZIWTsPHXGjv0yncXOE8iMUAQOTqa4ajP3WWYKlZmiJ94D3eNw6h7A4Mn6mt97eufMzaP6y9cIQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/shared-object-base": "^1.2.2"
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/shared-object-base": "^1.2.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -7608,19 +7613,19 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.2.tgz",
-			"integrity": "sha512-4ajrHGcq3fxnczjFNM5tdF5i+gzz7Nco7UnOR5Q9b7122nxMBQhBBGC086VpdJvUCQLBDTM9nLNuUaTx+JveCQ=="
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.3.tgz",
+			"integrity": "sha512-IvvCf0U0ftp30NmxUwPK3QzNf6v9kGkT9jxzzSjp3Nv9BAJLo3Pl5+XWYZodSlIyvEwapmFQYNEASHnIZMiVSw=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.2.tgz",
-			"integrity": "sha512-4ajrHGcq3fxnczjFNM5tdF5i+gzz7Nco7UnOR5Q9b7122nxMBQhBBGC086VpdJvUCQLBDTM9nLNuUaTx+JveCQ=="
+			"version": "npm:@fluidframework/synthesize@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.3.tgz",
+			"integrity": "sha512-IvvCf0U0ftp30NmxUwPK3QzNf6v9kGkT9jxzzSjp3Nv9BAJLo3Pl5+XWYZodSlIyvEwapmFQYNEASHnIZMiVSw=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.2.tgz",
-			"integrity": "sha512-7EWIhEL7BTCkpumPG0F8bjPOyN5hyu0MV9SRO7K668FSBvTv+isAuUY2mPhtdddx+nexXXWqXYyGYRUcIdlf4A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.3.tgz",
+			"integrity": "sha512-CVqp+MV/L3UJ+le3WPKv7ePfeLNFy21sFZ+D0nVQ6r591WZapAKGqaFAaxPIFirXf/7/lkqoTP89j5VubsDHKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -7650,9 +7655,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.2.tgz",
-			"integrity": "sha512-7EWIhEL7BTCkpumPG0F8bjPOyN5hyu0MV9SRO7K668FSBvTv+isAuUY2mPhtdddx+nexXXWqXYyGYRUcIdlf4A==",
+			"version": "npm:@fluidframework/telemetry-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.3.tgz",
+			"integrity": "sha512-CVqp+MV/L3UJ+le3WPKv7ePfeLNFy21sFZ+D0nVQ6r591WZapAKGqaFAaxPIFirXf/7/lkqoTP89j5VubsDHKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -7682,12 +7687,12 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.2.tgz",
-			"integrity": "sha512-R/LmVrL67pcyaZoNoHU/JLDINxlODz6787kQQgQjBV4pBYfrx1wszEtzVSUFhkoNkF970iSlhdQOrk/vWtFe+A==",
+			"version": "npm:@fluidframework/test-client-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.3.tgz",
+			"integrity": "sha512-JE8HPvnL+OhbyV0de5sXOYra7Xc+7Tt8tNVjS4Y8H2T1edDcqtJVHCr4G0cPT45iSDrtFnmcSII/CXj6HG8Ejg==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/test-runtime-utils": "^1.2.2",
+				"@fluidframework/test-runtime-utils": "^1.2.3",
 				"sillyname": "^0.1.0"
 			},
 			"dependencies": {
@@ -7702,13 +7707,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.2.tgz",
-			"integrity": "sha512-e/LPVQWab4Td97g0wEzmqV3WUYU7LnontXQ5vK4RcH8gWIjQ+Oh+2sfL9lxPVKzUGwUVwa18R745mYEi9uhi9w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.3.tgz",
+			"integrity": "sha512-ah7d9mnwTNAjMGbs7BhNOAFqcLKf8tkIZUYc4fH6R7VKK0aUiWXBNnajIGWH1tC/mi3L82axDylqyDEJo2Xc2w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			},
@@ -7724,13 +7729,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "npm:@fluidframework/test-driver-definitions@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.2.tgz",
-			"integrity": "sha512-e/LPVQWab4Td97g0wEzmqV3WUYU7LnontXQ5vK4RcH8gWIjQ+Oh+2sfL9lxPVKzUGwUVwa18R745mYEi9uhi9w==",
+			"version": "npm:@fluidframework/test-driver-definitions@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.3.tgz",
+			"integrity": "sha512-ah7d9mnwTNAjMGbs7BhNOAFqcLKf8tkIZUYc4fH6R7VKK0aUiWXBNnajIGWH1tC/mi3L82axDylqyDEJo2Xc2w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			},
@@ -7746,27 +7751,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.2.tgz",
-			"integrity": "sha512-8h6cF+uyEdt2CNrQjrc4EferQFDkTaAER4h79gHFjRtkRPeQhGU1PaP7RmycCgrfPSo0z/8Qk7rejnhYmhbgMA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.3.tgz",
+			"integrity": "sha512-RqEP+U9AMs3X7cFav4dcQzxhRSRGVLPR1o/G5jFnO/9sn8Q+t2gZ39E+0NbUjq7mJNLvdYw0+86I3At4KE2YFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/local-driver": "^1.2.2",
-				"@fluidframework/odsp-doclib-utils": "^1.2.2",
-				"@fluidframework/odsp-driver": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
-				"@fluidframework/odsp-urlresolver": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/local-driver": "^1.2.3",
+				"@fluidframework/odsp-doclib-utils": "^1.2.3",
+				"@fluidframework/odsp-driver": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
+				"@fluidframework/odsp-urlresolver": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.2",
-				"@fluidframework/test-pairwise-generator": "^1.2.2",
-				"@fluidframework/test-runtime-utils": "^1.2.2",
-				"@fluidframework/tinylicious-driver": "^1.2.2",
-				"@fluidframework/tool-utils": "^1.2.2",
+				"@fluidframework/test-driver-definitions": "^1.2.3",
+				"@fluidframework/test-pairwise-generator": "^1.2.3",
+				"@fluidframework/test-runtime-utils": "^1.2.3",
+				"@fluidframework/tinylicious-driver": "^1.2.3",
+				"@fluidframework/tool-utils": "^1.2.3",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -7957,27 +7962,27 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.2.tgz",
-			"integrity": "sha512-8h6cF+uyEdt2CNrQjrc4EferQFDkTaAER4h79gHFjRtkRPeQhGU1PaP7RmycCgrfPSo0z/8Qk7rejnhYmhbgMA==",
+			"version": "npm:@fluidframework/test-drivers@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.3.tgz",
+			"integrity": "sha512-RqEP+U9AMs3X7cFav4dcQzxhRSRGVLPR1o/G5jFnO/9sn8Q+t2gZ39E+0NbUjq7mJNLvdYw0+86I3At4KE2YFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/local-driver": "^1.2.2",
-				"@fluidframework/odsp-doclib-utils": "^1.2.2",
-				"@fluidframework/odsp-driver": "^1.2.2",
-				"@fluidframework/odsp-driver-definitions": "^1.2.2",
-				"@fluidframework/odsp-urlresolver": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/local-driver": "^1.2.3",
+				"@fluidframework/odsp-doclib-utils": "^1.2.3",
+				"@fluidframework/odsp-driver": "^1.2.3",
+				"@fluidframework/odsp-driver-definitions": "^1.2.3",
+				"@fluidframework/odsp-urlresolver": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.2",
-				"@fluidframework/test-pairwise-generator": "^1.2.2",
-				"@fluidframework/test-runtime-utils": "^1.2.2",
-				"@fluidframework/tinylicious-driver": "^1.2.2",
-				"@fluidframework/tool-utils": "^1.2.2",
+				"@fluidframework/test-driver-definitions": "^1.2.3",
+				"@fluidframework/test-pairwise-generator": "^1.2.3",
+				"@fluidframework/test-runtime-utils": "^1.2.3",
+				"@fluidframework/tinylicious-driver": "^1.2.3",
+				"@fluidframework/tool-utils": "^1.2.3",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -8168,14 +8173,14 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.2.tgz",
-			"integrity": "sha512-EgeYldMi5PXVLVy1UGY0h2abJygCTPIala1XSjbTr3yHBBh+auKf37LQaRB4FliIikcWrKcfK8yvIgbck44GPw==",
+			"version": "npm:@fluidframework/test-loader-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.3.tgz",
+			"integrity": "sha512-NAHIeUVvJNKUCRJu/WPmyNoHsKB5i7du3e3gfzboIMOqJrKXCNqlmwYqRC6ixm3JrZCnHTRnQ087RUH5zCDnIQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -8208,9 +8213,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.2.tgz",
-			"integrity": "sha512-lg39KINpZfx2VAmKh8rL2Mcz5X+OFq5torMT2RaMlMs9ccS+wsrg0jPNC6FxtKwwHI/CbAqpHmcb85amiZNbpw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.3.tgz",
+			"integrity": "sha512-Tmavs8wAGK9UK5N8uZezE1FIxQV89rMGH1AjsrU1ai+cK4HWcVGcEMlCZVJEE1cY+vR36FMFt2zdEM228Q6D8A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
@@ -8237,9 +8242,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.2.tgz",
-			"integrity": "sha512-lg39KINpZfx2VAmKh8rL2Mcz5X+OFq5torMT2RaMlMs9ccS+wsrg0jPNC6FxtKwwHI/CbAqpHmcb85amiZNbpw==",
+			"version": "npm:@fluidframework/test-pairwise-generator@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.3.tgz",
+			"integrity": "sha512-Tmavs8wAGK9UK5N8uZezE1FIxQV89rMGH1AjsrU1ai+cK4HWcVGcEMlCZVJEE1cY+vR36FMFt2zdEM228Q6D8A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
@@ -8266,22 +8271,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.2.tgz",
-			"integrity": "sha512-+jyqdp9qtlu/jgu+6N2FqNZfvwA0rQDozI3sv4b8O9xPvl7X1CZ+idhYxpJR176TGfdUIGw5+vh8mduilSeU0g==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.3.tgz",
+			"integrity": "sha512-mzP/QT548dxtfgfg3I2tB9ZDT7zMaL5wSO2YThjD3g9hn5kEY9dfEvGqcrADa8NtbjujWJWF+g1Vd4v7jk4VMw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8316,22 +8321,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.2.tgz",
-			"integrity": "sha512-+jyqdp9qtlu/jgu+6N2FqNZfvwA0rQDozI3sv4b8O9xPvl7X1CZ+idhYxpJR176TGfdUIGw5+vh8mduilSeU0g==",
+			"version": "npm:@fluidframework/test-runtime-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.3.tgz",
+			"integrity": "sha512-mzP/QT548dxtfgfg3I2tB9ZDT7zMaL5wSO2YThjD3g9hn5kEY9dfEvGqcrADa8NtbjujWJWF+g1Vd4v7jk4VMw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8372,32 +8377,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.2.tgz",
-			"integrity": "sha512-DtzmQ4I194Ha93BIvc8yoU3DIACjD205fBtoMRST7blnu8sSGUjIgKkGlwJlsK63MDxPggGvNPV96KCPSm6NsA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.3.tgz",
+			"integrity": "sha512-jmJptledRjBg8y8haGQJroYBSLVHLYcSD6ZMpycPLgvF32HJUbL9xVLxXRIs0OMH3CQr6jJRbfWoZKkVNO6qew==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.2",
+				"@fluidframework/aqueduct": "^1.2.3",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/local-driver": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/local-driver": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.2",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
-				"@fluidframework/test-driver-definitions": "^1.2.2",
-				"@fluidframework/test-runtime-utils": "^1.2.2",
+				"@fluidframework/request-handler": "^1.2.3",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
+				"@fluidframework/test-driver-definitions": "^1.2.3",
+				"@fluidframework/test-runtime-utils": "^1.2.3",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -8431,32 +8436,32 @@
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.2.tgz",
-			"integrity": "sha512-DtzmQ4I194Ha93BIvc8yoU3DIACjD205fBtoMRST7blnu8sSGUjIgKkGlwJlsK63MDxPggGvNPV96KCPSm6NsA==",
+			"version": "npm:@fluidframework/test-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.3.tgz",
+			"integrity": "sha512-jmJptledRjBg8y8haGQJroYBSLVHLYcSD6ZMpycPLgvF32HJUbL9xVLxXRIs0OMH3CQr6jJRbfWoZKkVNO6qew==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.2",
+				"@fluidframework/aqueduct": "^1.2.3",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/container-runtime-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/datastore": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/local-driver": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/container-runtime-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/datastore": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/local-driver": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.2",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/telemetry-utils": "^1.2.2",
-				"@fluidframework/test-driver-definitions": "^1.2.2",
-				"@fluidframework/test-runtime-utils": "^1.2.2",
+				"@fluidframework/request-handler": "^1.2.3",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/telemetry-utils": "^1.2.3",
+				"@fluidframework/test-driver-definitions": "^1.2.3",
+				"@fluidframework/test-runtime-utils": "^1.2.3",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -8490,34 +8495,34 @@
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.2.tgz",
-			"integrity": "sha512-RdQ7u1MsdffEdA3TGbTJ3NCAA6g2JJCoj2asWbiGLGCh6aqUrndXrX+cB0rtDk/EED1nlWlOIdyPSO58n/HF5A==",
+			"version": "npm:@fluidframework/test-version-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.3.tgz",
+			"integrity": "sha512-jMCZxc/7uvdk94Acs0ojSQEv9hJ3a5YCUtQcT5kuVxYRUuih/ckGJQV9Vl87NUCPtqBI1y6H6Ac9fx2kFjcerw==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.2",
-				"@fluidframework/cell": "^1.2.2",
+				"@fluidframework/aqueduct": "^1.2.3",
+				"@fluidframework/cell": "^1.2.3",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/container-runtime": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/counter": "^1.2.2",
-				"@fluidframework/datastore-definitions": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/ink": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
-				"@fluidframework/matrix": "^1.2.2",
-				"@fluidframework/mocha-test-setup": "^1.2.2",
-				"@fluidframework/ordered-collection": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/container-runtime": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/counter": "^1.2.3",
+				"@fluidframework/datastore-definitions": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/ink": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
+				"@fluidframework/matrix": "^1.2.3",
+				"@fluidframework/mocha-test-setup": "^1.2.3",
+				"@fluidframework/ordered-collection": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/register-collection": "^1.2.2",
-				"@fluidframework/runtime-definitions": "^1.2.2",
-				"@fluidframework/sequence": "^1.2.2",
-				"@fluidframework/test-driver-definitions": "^1.2.2",
-				"@fluidframework/test-drivers": "^1.2.2",
-				"@fluidframework/test-utils": "^1.2.2",
+				"@fluidframework/register-collection": "^1.2.3",
+				"@fluidframework/runtime-definitions": "^1.2.3",
+				"@fluidframework/sequence": "^1.2.3",
+				"@fluidframework/test-driver-definitions": "^1.2.3",
+				"@fluidframework/test-drivers": "^1.2.3",
+				"@fluidframework/test-utils": "^1.2.3",
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
@@ -8552,22 +8557,22 @@
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.2.tgz",
-			"integrity": "sha512-SOLFn0rI9lRHbiIaZq9Q2PO57oQviZxE/aKzObLG6fjBNIbbW/ebrbKmNx+nXadB0Ao7OcJ2f9Ps5e9MhdJt/Q==",
+			"version": "npm:@fluidframework/tinylicious-client@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.3.tgz",
+			"integrity": "sha512-hkO7hPxN8xvLLyWujYIrwm53jK2sj1Tswwf/dLvd+oKqAVEerjf/FZkmqe7A0pWw+YGwCrFm+od+imxDxj0n+Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
-				"@fluidframework/fluid-static": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
+				"@fluidframework/fluid-static": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
-				"@fluidframework/runtime-utils": "^1.2.2",
-				"@fluidframework/tinylicious-driver": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
+				"@fluidframework/runtime-utils": "^1.2.3",
+				"@fluidframework/tinylicious-driver": "^1.2.3",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -8600,15 +8605,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.2.tgz",
-			"integrity": "sha512-3YigUpJ/Vl5+aTPNJ6XaJX3YdW0wGE81uMhMDOjUGK8SIxBWW1TZSNXPKlm58M2rhKCKrvVklCQWaFlez65jgQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.3.tgz",
+			"integrity": "sha512-x0fswxF2bwJ5nOTBZZiNve5jW05nizpYAgG1UU1HrHve5uihCqF7c4PmqQ9aWSbONpv4+YFScnIiHoC9srCILg==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8684,15 +8689,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.2.tgz",
-			"integrity": "sha512-3YigUpJ/Vl5+aTPNJ6XaJX3YdW0wGE81uMhMDOjUGK8SIxBWW1TZSNXPKlm58M2rhKCKrvVklCQWaFlez65jgQ==",
+			"version": "npm:@fluidframework/tinylicious-driver@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.3.tgz",
+			"integrity": "sha512-x0fswxF2bwJ5nOTBZZiNve5jW05nizpYAgG1UU1HrHve5uihCqF7c4PmqQ9aWSbONpv4+YFScnIiHoC9srCILg==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/driver-definitions": "^1.2.2",
-				"@fluidframework/driver-utils": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/driver-definitions": "^1.2.3",
+				"@fluidframework/driver-utils": "^1.2.3",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.2",
+				"@fluidframework/routerlicious-driver": "^1.2.3",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8768,12 +8773,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.2.tgz",
-			"integrity": "sha512-Jyvqx691Z/pKi26UPk1WjUDwQMc0tJ6jit2dz8WysUXhWpkha4cwYXHPrmPTfBO2VHKGqjjN2MjzomdijPmkBg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.3.tgz",
+			"integrity": "sha512-IkbIdeeo63f6frFq3H/50T8545E7/x2Nn8Vy3AdFJYtBr3dqD5lf+y5dAYpCvD5VzQ30/ry8rCx2X6JdF4XjlQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.2",
+				"@fluidframework/odsp-doclib-utils": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -8827,12 +8832,12 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.2.tgz",
-			"integrity": "sha512-Jyvqx691Z/pKi26UPk1WjUDwQMc0tJ6jit2dz8WysUXhWpkha4cwYXHPrmPTfBO2VHKGqjjN2MjzomdijPmkBg==",
+			"version": "npm:@fluidframework/tool-utils@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.3.tgz",
+			"integrity": "sha512-IkbIdeeo63f6frFq3H/50T8545E7/x2Nn8Vy3AdFJYtBr3dqD5lf+y5dAYpCvD5VzQ30/ry8rCx2X6JdF4XjlQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.2",
+				"@fluidframework/odsp-doclib-utils": "^1.2.3",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -8886,71 +8891,71 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.2.tgz",
-			"integrity": "sha512-0F5bXT23ZQfnD5JUYq+14i9ECvykDBRd1Px+wlrdM/LCYWu5gF64r73icM2Iwo0B6AVsrZh2TrC+qHCKzQ8r2g==",
+			"version": "npm:@fluidframework/undo-redo@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.3.tgz",
+			"integrity": "sha512-zzi3uptvA6RnBPzPg2tJEZwJfLpB+4fNTpN4wnZ4jdAXT1jgDpnJqnGzudD5ZIbUKsihOKNvjIT4wdaJNSootQ==",
 			"requires": {
-				"@fluidframework/map": "^1.2.2",
-				"@fluidframework/matrix": "^1.2.2",
-				"@fluidframework/merge-tree": "^1.2.2",
-				"@fluidframework/sequence": "^1.2.2"
+				"@fluidframework/map": "^1.2.3",
+				"@fluidframework/matrix": "^1.2.3",
+				"@fluidframework/merge-tree": "^1.2.3",
+				"@fluidframework/sequence": "^1.2.3"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.2.tgz",
-			"integrity": "sha512-IsxVRVrIgP0w7JIJVn5VPwwtINhX/ZTCb2/h7BP2dXZRQpUHyvLM+mTkKMOAUf2TCaI4lh0RPk24Rbt9mauMjg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.3.tgz",
+			"integrity": "sha512-hqPLh0vu1HS6qk4jdAHKjIIIo4Q6hIpuCq+GvU+lA7hv+ug6uw5yDdxI1xvitnzu5R3Paa1pRwAuI07i5pWreQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/view-interfaces": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/view-interfaces": "^1.2.3",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.2.tgz",
-			"integrity": "sha512-IsxVRVrIgP0w7JIJVn5VPwwtINhX/ZTCb2/h7BP2dXZRQpUHyvLM+mTkKMOAUf2TCaI4lh0RPk24Rbt9mauMjg==",
+			"version": "npm:@fluidframework/view-adapters@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.3.tgz",
+			"integrity": "sha512-hqPLh0vu1HS6qk4jdAHKjIIIo4Q6hIpuCq+GvU+lA7hv+ug6uw5yDdxI1xvitnzu5R3Paa1pRwAuI07i5pWreQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2",
-				"@fluidframework/view-interfaces": "^1.2.2",
+				"@fluidframework/core-interfaces": "^1.2.3",
+				"@fluidframework/view-interfaces": "^1.2.3",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.2.tgz",
-			"integrity": "sha512-U0U4gObYIUmDHc8k/S2VuxI/BSHXCAD55Nc6MPOz17CP+XReOd8e0lrXF9aQoEV7m6xFXxUdXZhdipmiU8vsTA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.3.tgz",
+			"integrity": "sha512-zsw4SbeiHIQRTIurdXihiktRNTetIs/c4CY5qEm6bDZFdGYTvvese72hrzE0kVxaWUj30EHrLddEacvB2QWkHA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2"
+				"@fluidframework/core-interfaces": "^1.2.3"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.2.tgz",
-			"integrity": "sha512-U0U4gObYIUmDHc8k/S2VuxI/BSHXCAD55Nc6MPOz17CP+XReOd8e0lrXF9aQoEV7m6xFXxUdXZhdipmiU8vsTA==",
+			"version": "npm:@fluidframework/view-interfaces@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.3.tgz",
+			"integrity": "sha512-zsw4SbeiHIQRTIurdXihiktRNTetIs/c4CY5qEm6bDZFdGYTvvese72hrzE0kVxaWUj30EHrLddEacvB2QWkHA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.2"
+				"@fluidframework/core-interfaces": "^1.2.3"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.2.tgz",
-			"integrity": "sha512-+uE553TVW1ZoSRwMUosxb07x0Zk9yAKkJdwO8gQMY/Kkcg8hxjYR7wsTNwGdAQStzQxu/bfJDgbobmahZene6g==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.3.tgz",
+			"integrity": "sha512-e7i4a+4Tw4YCQQdhyYV0m8sMkveMyaiREdv5ObxxxkF5/FyUEQ0Wn2qNW6N/wuGGsf7ZCWwjDo+whisFueQmhQ==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@1.2.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.2.tgz",
-			"integrity": "sha512-+uE553TVW1ZoSRwMUosxb07x0Zk9yAKkJdwO8gQMY/Kkcg8hxjYR7wsTNwGdAQStzQxu/bfJDgbobmahZene6g==",
+			"version": "npm:@fluidframework/web-code-loader@1.2.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.3.tgz",
+			"integrity": "sha512-e7i4a+4Tw4YCQQdhyYV0m8sMkveMyaiREdv5ObxxxkF5/FyUEQ0Wn2qNW6N/wuGGsf7ZCWwjDo+whisFueQmhQ==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/core-interfaces": "^1.2.2",
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/core-interfaces": "^1.2.3",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
@@ -16764,6 +16769,12 @@
 						"uri-js": "^4.2.2"
 					}
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
+				},
 				"resolve": {
 					"version": "1.17.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -16816,6 +16827,12 @@
 						"uri-js": "^4.2.2"
 					}
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
+				},
 				"resolve": {
 					"version": "1.19.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
@@ -16864,6 +16881,11 @@
 						"json-schema-traverse": "^0.4.1",
 						"uri-js": "^4.2.2"
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"resolve": {
 					"version": "1.19.0",
@@ -19702,6 +19724,11 @@
 					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
 					"integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw=="
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -20730,6 +20757,11 @@
 							}
 						}
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"locate-path": {
 					"version": "5.0.0",
@@ -21796,6 +21828,11 @@
 						}
 					}
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -22374,6 +22411,11 @@
 							}
 						}
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"locate-path": {
 					"version": "5.0.0",
@@ -23092,6 +23134,11 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
 					"integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw=="
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"locate-path": {
 					"version": "5.0.0",
@@ -24052,6 +24099,11 @@
 						}
 					}
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -25004,6 +25056,11 @@
 						}
 					}
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -25570,6 +25627,11 @@
 							}
 						}
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"locate-path": {
 					"version": "5.0.0",
@@ -27785,13 +27847,6 @@
 				"json-schema-traverse": "^1.0.0",
 				"require-from-string": "^2.0.2",
 				"uri-js": "^4.2.2"
-			},
-			"dependencies": {
-				"json-schema-traverse": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-				}
 			}
 		},
 		"ajv-errors": {
@@ -27817,11 +27872,6 @@
 						"require-from-string": "^2.0.2",
 						"uri-js": "^4.2.2"
 					}
-				},
-				"json-schema-traverse": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 				}
 			}
 		},
@@ -29511,6 +29561,11 @@
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"loader-utils": {
 					"version": "2.0.2",
@@ -35601,6 +35656,11 @@
 						"argparse": "^2.0.1"
 					}
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"path-key": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -36771,6 +36831,11 @@
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"schema-utils": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -37004,15 +37069,15 @@
 			"integrity": "sha512-OapHwT5Ug1c3iiv8JNrwh/3XGjP45l/2iwfl25chePrvCgl0786ZvsJK+hxCCaUZjPm1lHdh5LHZhmKRxunziA=="
 		},
 		"fluid-framework-previous": {
-			"version": "npm:fluid-framework@1.2.2",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.2.tgz",
-			"integrity": "sha512-1N7hGFrxflAP5ghPEus1o3mSy4sf3N/IbbF7C5KStxVI/+v0FzVSPUDA45TkiYD8f0JnK+NYfrYLII+PBBWHgw==",
+			"version": "npm:fluid-framework@1.2.3",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.3.tgz",
+			"integrity": "sha512-FXEGFkmFzVzxqEO2XPW6J8MGHQpQ8BaibygVudy/3Wg5g7YL5+Ejm5EgQraTZUIAynXGv4IOXbhlTxBPv8AZxQ==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.2",
-				"@fluidframework/container-loader": "^1.2.2",
-				"@fluidframework/fluid-static": "^1.2.2",
-				"@fluidframework/map": "^1.2.2",
-				"@fluidframework/sequence": "^1.2.2"
+				"@fluidframework/container-definitions": "^1.2.3",
+				"@fluidframework/container-loader": "^1.2.3",
+				"@fluidframework/fluid-static": "^1.2.3",
+				"@fluidframework/map": "^1.2.3",
+				"@fluidframework/sequence": "^1.2.3"
 			}
 		},
 		"flush-write-stream": {
@@ -37210,6 +37275,11 @@
 						"path-type": "^4.0.0",
 						"yaml": "^1.7.2"
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"parse-json": {
 					"version": "5.2.0",
@@ -38383,6 +38453,11 @@
 						"json-schema-traverse": "^0.4.1",
 						"uri-js": "^4.2.2"
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				}
 			}
 		},
@@ -42269,14 +42344,14 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -42407,13 +42482,13 @@
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},
@@ -47405,6 +47480,12 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
 					"integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+					"dev": true
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
 				},
 				"locate-path": {
@@ -53582,6 +53663,11 @@
 					"version": "3.5.2",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				}
 			}
 		},
@@ -55730,6 +55816,11 @@
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"loader-utils": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
@@ -56695,6 +56786,11 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
 					"integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw=="
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"schema-utils": {
 					"version": "1.0.0",
@@ -58346,6 +58442,11 @@
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
 				"mime": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -59452,11 +59553,6 @@
 					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
 					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
 				},
-				"json-schema-traverse": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-				},
 				"mime-db": {
 					"version": "1.52.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -59580,11 +59676,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
 					"integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
-				},
-				"json-schema-traverse": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 				},
 				"readdirp": {
 					"version": "3.6.0",

--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -10215,9 +10215,9 @@
 			"dev": true
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -10287,13 +10287,13 @@
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -9192,9 +9192,9 @@
 			"dev": true
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -9231,14 +9231,14 @@
 			"dev": true
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -10720,9 +10720,9 @@
 			"dev": true
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -10804,14 +10804,14 @@
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -9530,9 +9530,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -9617,14 +9617,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -11094,9 +11094,9 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -11174,13 +11174,13 @@
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},

--- a/tools/getkeys/package-lock.json
+++ b/tools/getkeys/package-lock.json
@@ -573,9 +573,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -588,13 +588,13 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },


### PR DESCRIPTION
Task 1181, updating jsprim to 1.4.2 and json-schema to 0.4.0 to resolve [this alert](https://nvd.nist.gov/vuln/detail/CVE-2021-3918)

Packages updated:
- .\
- .\azure
- .\build-tools
- .\common\lib\common-utils
- .\server\gitrest
- .\server\historian
- .\server\routerlicious
- .\tools\getkeys