### PR TITLE
Fix for reporting correct bundle size 

### DIFF
--- a/build-tools/packages/build-tools/src/bundleSizeAnalysis/dangerfile.ts
+++ b/build-tools/packages/build-tools/src/bundleSizeAnalysis/dangerfile.ts
@@ -41,6 +41,9 @@ const localReportPath = "./artifacts/bundleAnalysis";
         undefined,
         ADOSizeComparator.naiveFallbackCommitGenerator,
     );
+    const branchName = process.env["TARGET_BRANCH_NAME"] === "" || process.env["TARGET_BRANCH_NAME"] === undefined
+        ? "main" : process.env["TARGET_BRANCH_NAME"];
+    console.log(`Branch name: ${branchName}`);
     const result: BundleComparisonResult = await sizeComparator.createSizeComparisonMessage(false);
 
     // Post a message only if there was an error (result.comparison is undefined) or if

--- a/build-tools/packages/build-tools/src/bundleSizeAnalysis/dangerfile.ts
+++ b/build-tools/packages/build-tools/src/bundleSizeAnalysis/dangerfile.ts
@@ -41,9 +41,6 @@ const localReportPath = "./artifacts/bundleAnalysis";
         undefined,
         ADOSizeComparator.naiveFallbackCommitGenerator,
     );
-    const branchName = process.env["TARGET_BRANCH_NAME"] === "" || process.env["TARGET_BRANCH_NAME"] === undefined
-        ? "main" : process.env["TARGET_BRANCH_NAME"];
-    console.log(`Branch name: ${branchName}`);
     const result: BundleComparisonResult = await sizeComparator.createSizeComparisonMessage(false);
 
     // Post a message only if there was an error (result.comparison is undefined) or if

--- a/tools/bundle-size-tools/src/ADO/AdoSizeComparator.ts
+++ b/tools/bundle-size-tools/src/ADO/AdoSizeComparator.ts
@@ -97,7 +97,7 @@ export class ADOSizeComparator {
 
       if (baselineBuild === undefined) {
         baselineCommit = fallbackGen?.next().value;
-        console.log(`Trying backup baseline commit ${baselineCommit}`);
+        console.log(`Trying backup baseline commit when baseline build is undefined ${baselineCommit}`);
         continue;
       }
 
@@ -143,7 +143,7 @@ export class ADOSizeComparator {
       // Successful baseline build does not have the needed build artifacts
       if (baselineZip === undefined) {
         baselineCommit = this.getFallbackCommit?.(baselineCommit).next().value;
-        console.log(`Trying backup baseline commit ${baselineCommit}`);
+        console.log(`Trying backup baseline commit when successful baseline build does not have the needed build artifacts ${baselineCommit}`);
         continue;
       }
 

--- a/tools/bundle-size-tools/src/ADO/AdoSizeComparator.ts
+++ b/tools/bundle-size-tools/src/ADO/AdoSizeComparator.ts
@@ -79,8 +79,8 @@ export class ADOSizeComparator {
    * @returns The size comparison result with formatted message and raw data.  In case
    * of failure, the message contains the error message and the raw data will be undefined.
    */
-  public async createSizeComparisonMessage(tagWaiting: boolean): Promise<BundleComparisonResult> {
-    let baselineCommit: string | undefined = getBaselineCommit();
+  public async createSizeComparisonMessage(tagWaiting: boolean, branchName?: string): Promise<BundleComparisonResult> {
+    let baselineCommit: string | undefined = getBaselineCommit(branchName);
     console.log(`The baseline commit for this PR is ${baselineCommit}`);
 
     // Some circumstances may want us to try a fallback, such as when a commit does
@@ -153,7 +153,7 @@ export class ADOSizeComparator {
 
     // Unable to find a usable baseline
     if (baselineCommit === undefined || baselineZip === undefined) {
-      const message = `Could not find a usable baseline build with search starting at CI ${getBaselineCommit()}`;
+      const message = `Could not find a usable baseline build with search starting at CI ${getBaselineCommit(branchName)}`;
       console.log(message);
       return { message, comparison: undefined };
     }

--- a/tools/bundle-size-tools/src/ADO/AdoSizeComparator.ts
+++ b/tools/bundle-size-tools/src/ADO/AdoSizeComparator.ts
@@ -79,8 +79,8 @@ export class ADOSizeComparator {
    * @returns The size comparison result with formatted message and raw data.  In case
    * of failure, the message contains the error message and the raw data will be undefined.
    */
-  public async createSizeComparisonMessage(tagWaiting: boolean, branchName?: string): Promise<BundleComparisonResult> {
-    let baselineCommit: string | undefined = getBaselineCommit(branchName);
+  public async createSizeComparisonMessage(tagWaiting: boolean): Promise<BundleComparisonResult> {
+    let baselineCommit: string | undefined = getBaselineCommit();
     console.log(`The baseline commit for this PR is ${baselineCommit}`);
 
     // Some circumstances may want us to try a fallback, such as when a commit does
@@ -153,7 +153,7 @@ export class ADOSizeComparator {
 
     // Unable to find a usable baseline
     if (baselineCommit === undefined || baselineZip === undefined) {
-      const message = `Could not find a usable baseline build with search starting at CI ${getBaselineCommit(branchName)}`;
+      const message = `Could not find a usable baseline build with search starting at CI ${getBaselineCommit()}`;
       console.log(message);
       return { message, comparison: undefined };
     }

--- a/tools/bundle-size-tools/src/utilities/gitCommands.ts
+++ b/tools/bundle-size-tools/src/utilities/gitCommands.ts
@@ -8,8 +8,8 @@ import { execSync } from 'child_process';
 /**
  * Gets the commit in main that the current branch is based on.
  */
-export function getBaselineCommit(branchName?: string): string {
-  return execSync(`git merge-base origin/${branchName} HEAD`).toString().trim();
+export function getBaselineCommit(): string {
+  return execSync(`git merge-base origin/${process.env.TARGET_BRANCH_NAME} HEAD`).toString().trim();
 }
 
 export function getPriorCommit(baseCommit: string): string {

--- a/tools/bundle-size-tools/src/utilities/gitCommands.ts
+++ b/tools/bundle-size-tools/src/utilities/gitCommands.ts
@@ -8,8 +8,8 @@ import { execSync } from 'child_process';
 /**
  * Gets the commit in main that the current branch is based on.
  */
-export function getBaselineCommit(): string {
-  return execSync('git merge-base origin/main HEAD').toString().trim();
+export function getBaselineCommit(branchName?: string): string {
+  return execSync(`git merge-base origin/${branchName} HEAD`).toString().trim();
 }
 
 export function getPriorCommit(baseCommit: string): string {

--- a/tools/bundle-size-tools/src/utilities/gitCommands.ts
+++ b/tools/bundle-size-tools/src/utilities/gitCommands.ts
@@ -6,7 +6,7 @@
 import { execSync } from 'child_process';
 
 /**
- * Gets the commit in main that the current branch is based on.
+ * Gets the commit in the target branch that the current branch is based on.
  */
 export function getBaselineCommit(): string {
   return execSync(`git merge-base origin/${process.env.TARGET_BRANCH_NAME} HEAD`).toString().trim();

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -148,8 +148,7 @@ stages:
                 publish=${{ variables.publish }}
                 canRelease=${{ variables.canRelease }}
                 publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
-                branchName = ${{ variables['Build.SourceBranch'] }}
-                branchNameSource = ${{ variables['Build.SourceBranchName'] }}
+                targetbranchName = ${{ variables['System.PullRequest.TargetBranch	'] }}
 
                 release=$(release)"
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -360,14 +360,13 @@ stages:
             env:
               ADO_API_TOKEN: $(System.AccessToken)
               DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
-              TARGET_BRANCH_NAME: ${{ variables['Build.SourceBranch'] }}
+              TARGET_BRANCH_NAME: $(System.PullRequest.TargetBranch)
             inputs:
               command: 'custom'
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run bundle-analysis:run'
               script: |
-                echo ${{ variables['Build.SourceBranch'] }}
-                echo ${{ variables['Build.SourceBranchName'] }}
+                echo $(System.PullRequest.TargetBranch)
 
         # Docs
         - ${{ if ne(parameters.taskBuildDocs, false) }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -359,6 +359,7 @@ stages:
             env:
               ADO_API_TOKEN: $(System.AccessToken)
               DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
+              TARGET_BRANCH_NAME: ${{ variables['Build.SourceBranch'] }}
             inputs:
               command: 'custom'
               workingDir: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -148,7 +148,7 @@ stages:
                 publish=${{ variables.publish }}
                 canRelease=${{ variables.canRelease }}
                 publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
-                targetbranchName = $(System.PullRequest.TargetBranch)
+                targetBranchName = $(System.PullRequest.TargetBranch)
 
                 release=$(release)"
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -148,7 +148,7 @@ stages:
                 publish=${{ variables.publish }}
                 canRelease=${{ variables.canRelease }}
                 publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
-                targetbranchName = ${{ variables['System.PullRequest.TargetBranch	'] }}
+                targetbranchName = $(System.PullRequest.TargetBranch)
 
                 release=$(release)"
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -148,6 +148,7 @@ stages:
                 publish=${{ variables.publish }}
                 canRelease=${{ variables.canRelease }}
                 publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
+                branchName = ${{ variables['Build.SourceBranch'] }}
 
                 release=$(release)"
 
@@ -364,6 +365,9 @@ stages:
               command: 'custom'
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run bundle-analysis:run'
+              script: |
+                echo ${{ variables['Build.SourceBranch'] }}
+                echo ${{ variables['Build.SourceBranchName'] }}
 
         # Docs
         - ${{ if ne(parameters.taskBuildDocs, false) }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -149,6 +149,7 @@ stages:
                 canRelease=${{ variables.canRelease }}
                 publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
                 branchName = ${{ variables['Build.SourceBranch'] }}
+                branchNameSource = ${{ variables['Build.SourceBranchName'] }}
 
                 release=$(release)"
 


### PR DESCRIPTION
The bundle size comparison tool is currently comparing baseline against main branch. The baseline for pull requests opened against the next branch are incorrect. This pull request aims to fix the baseline comparison by setting an env variable `TARGET_BRANCH_NAME` as branch that is the target of a pull request. By default, the env variable is set to `main`.

[AB#1570](https://dev.azure.com/fluidframework/internal/_workitems/edit/1570)