### PR TITLE
Remove pending summary logging 

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -225,9 +225,7 @@ export class SummaryManager implements IDisposable {
                 // In order to allow the last summary to run, we not only need a stop reason that would
                 // allow it but also, startWithInitialDelay to be false (start the summarization immediately),
                 // which would happen when we have a high enough number of unsummarized ops.
-                if (startWithInitialDelay ||
-                    this.summaryCollection.opsSinceLastAck < this.opsToBypassInitialDelay ||
-                      !Summarizer.stopReasonCanRunLastSummary(shouldSummarizeState.stopReason)) {
+                if (startWithInitialDelay || !Summarizer.stopReasonCanRunLastSummary(shouldSummarizeState.stopReason)) {
                     this.state = SummaryManagerState.Starting;
                     summarizer.stop(shouldSummarizeState.stopReason);
                     return `early exit after starting summarizer ${shouldSummarizeState.stopReason}`;

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -225,7 +225,9 @@ export class SummaryManager implements IDisposable {
                 // In order to allow the last summary to run, we not only need a stop reason that would
                 // allow it but also, startWithInitialDelay to be false (start the summarization immediately),
                 // which would happen when we have a high enough number of unsummarized ops.
-                if (startWithInitialDelay || !Summarizer.stopReasonCanRunLastSummary(shouldSummarizeState.stopReason)) {
+                if (startWithInitialDelay ||
+                    this.summaryCollection.opsSinceLastAck < this.opsToBypassInitialDelay ||
+                      !Summarizer.stopReasonCanRunLastSummary(shouldSummarizeState.stopReason)) {
                     this.state = SummaryManagerState.Starting;
                     summarizer.stop(shouldSummarizeState.stopReason);
                     return `early exit after starting summarizer ${shouldSummarizeState.stopReason}`;

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -227,15 +227,12 @@ export class SummarizerNode implements IRootSummarizerNode {
 
             const props = {
                 summaryRefSeq,
-                pendingSize: this.pendingSummaries.size,
-                pendingHandle: this.pendingSummaries.size > 0 ? this.pendingSummaries.keys[0] : undefined,
-                pendingSeqNumber: this.pendingSummaries.size > 0 ?
-                    this.pendingSummaries.values[0].referenceSequenceNumber : undefined,
+                pendingSize: this.pendingSummaries.size ?? undefined,
             };
             this.defaultLogger.sendTelemetryEvent({
                 eventName: "PendingSummaryNotFound",
                 proposalHandle,
-                referenceSequenceNumber: this.referenceSequenceNumber,
+                referenceSequenceNumber: this.referenceSequenceNumber ?? undefined,
                 details: JSON.stringify(props),
             });
         }


### PR DESCRIPTION
Remove pending summary logging and make sure we log undefined in case the summarizer node has been disposed of. 

