### PR TITLE
Fix the labeler + adding back the pendingsummaries value/k…

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Label base branches
     steps:
-      - uses: srvaroa/labeler@cc2f468623534d06a41e5dc591e9b6a1355a5e7b # pin@main
+      - uses: srvaroa/labeler@36ad6b8842ea13d9ce2e4d22993bbf6fc0d20b5e # pin@v0.9
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   external_label:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Label base branches
     steps:
-      - uses: srvaroa/labeler@36ad6b8842ea13d9ce2e4d22993bbf6fc0d20b5e # pin@v0.9
+      - uses: srvaroa/labeler@cc2f468623534d06a41e5dc591e9b6a1355a5e7b # pin@main
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   external_label:

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -228,6 +228,10 @@ export class SummarizerNode implements IRootSummarizerNode {
             const props = {
                 summaryRefSeq,
                 pendingSize: this.pendingSummaries.size ?? undefined,
+                pendingHandle: this.pendingSummaries.size > 0 ?
+                    this.pendingSummaries.keys().next().value : undefined,
+                pendingSeqNumber: this.pendingSummaries.size > 0 ?
+                    this.pendingSummaries.values().next().value : undefined,
             };
             this.defaultLogger.sendTelemetryEvent({
                 eventName: "PendingSummaryNotFound",


### PR DESCRIPTION
Adding back the pending summaries value/key - the stack on the previous error was clearly showing an error while trying to get the pending value's reference number. Adding it back as it will be used when tracking missing pending summaries in FRS. 