### PR TITLE
WIP: Undo-redo for intervals

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -197,6 +197,15 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
     };
 }
 
+// @public
+export interface IntervalLocator {
+    id: string;
+    label: string;
+}
+
+// @public
+export function intervalLocatorFromEndpoint(potentialEndpoint: LocalReferencePosition): IntervalLocator | undefined;
+
 // @public (undocumented)
 export enum IntervalType {
     // (undocumented)

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -22,6 +22,8 @@ export {
     Interval,
     IntervalCollection,
     IntervalCollectionIterator,
+    IntervalLocator,
+    intervalLocatorFromEndpoint,
     IntervalType,
     ISerializableInterval,
     ISerializedInterval,

--- a/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
@@ -12,7 +12,7 @@ import {
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
-import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
+import { IntervalCollection, intervalLocatorFromEndpoint, IntervalType, SequenceInterval } from "../intervalCollection";
 
 const assertIntervals = (
     sharedString: SharedString,
@@ -143,6 +143,15 @@ describe("IntervalCollection snapshotting", () => {
             assertIntervals(sharedString2, collection2, [{ start: 0, end: 2 }]);
             containerRuntimeFactory.processAllMessages();
             assertIntervals(sharedString2, collection2, [{ start: 0, end: 2 }, { start: 2, end: 4 }]);
+        });
+
+        it("intervals can be retrieved from endpoints", async () => {
+            const interval1 = collection.getIntervalById(id) ?? assert.fail("collection should have interval");
+            const locator1 = intervalLocatorFromEndpoint(interval1.start);
+            assert.deepEqual(locator1, { id, label: "test" });
+            const interval2 = collection.add(1, 2, IntervalType.SlideOnRemove);
+            const locator2 = intervalLocatorFromEndpoint(interval2.start);
+            assert.deepEqual(locator2, { id: interval2.getIntervalId(), label: "test" });
         });
     });
 });

--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -77,7 +77,6 @@ export class SharedSegmentSequenceRevertible implements IRevertible {
                 if (current !== undefined
                     && current.operation === event.deltaOperation
                     && matchProperties(current.propertyDelta, range.propertyDeltas)) {
-                        // TODO: Figure out if this case applies for removed segs
                     current.trackingGroup.link(range.segment);
                 } else {
                     const tg = new TrackingGroup();

--- a/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
+++ b/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
@@ -145,10 +145,22 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
     });
 
     it("Intervals endpoints are slid back to original position", () => {
-        const assertIntervalMatches = (interval: SequenceInterval, expected: { start: number; end: number }): void => {
-            assert.equal(sharedString.localReferencePositionToPosition(interval.start), expected.start, "Start mismatch");
-            assert.equal(sharedString.localReferencePositionToPosition(interval.end), expected.end, "End mismatch");
-        }
+        const assertIntervalMatches = (
+            intervalActual: SequenceInterval,
+            expected: { start: number; end: number; },
+        ): void => {
+            assert.equal(
+                sharedString.localReferencePositionToPosition(intervalActual.start),
+                expected.start,
+                "Start mismatch",
+            );
+            assert.equal(
+                sharedString.localReferencePositionToPosition(intervalActual.end),
+                expected.end,
+                "End mismatch",
+            );
+        };
+
         sharedString.insertText(0, text);
         const collection = sharedString.getIntervalCollection("test");
         const interval = collection.add(10, 20, IntervalType.SlideOnRemove);
@@ -161,6 +173,8 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
 
         while (undoRedoStack.undoOperation()) { }
 
-        assertIntervalMatches(interval, { start: 10, end: 20 });
+        const id = interval.getIntervalId() ?? assert.fail("expected interval to have id");
+        const postUndoInterval = collection.getIntervalById(id);
+        assertIntervalMatches(postUndoInterval, { start: 10, end: 20 });
     });
 });


### PR DESCRIPTION
## Description

This adds an API to `@fluidframework/sequence` which enables recovering an interval from one of its endpoints. The specific API retrieves the label for the interval collection that endpoint is a part of, as well as the `id` of the interval. This required storing an additional prop on each endpoint reference. I also fixed a bug in treating the label field differently on reloaded intervals.

The motivation for this change is to enable reasonable undo-redo behaviors for SlideOnRemove intervals to be implementable. There is some discussion of the issue on #11269. To that end, I also augmented the example undo-redo handler we have implemented for sequence to demonstrate how one might go about reverting refs. A real implementation would likely filter which refs to restore based on their properties.

One alternative approach I could think of would be to push elements onto the undo-redo stack when the `changeInterval` event is emitted from an interval collection. This is only remotely plausible once the changes from #10966 are released (currently in next). However, that approach suffers from a few timing-related issues: the interval change due to slide won't be emitted until the remote is acked, which is awkward for app code to handle (e.g. one might want to undo an operation before it's acked), and also means we'd need to expose additional APIs on sequence to resolve the correct "previous position": the `previousInterval` argument on the change event only provides a ReferencePosition that lives on a removed segment, but the interval collection APIs operate in terms of positions. So one would need to find the "equivalent position on the newly inserted segments," which would need something like a rebase op. A sample of how that might look (without getting the rebase logic correct) can be found [here](https://github.com/Abe27342/FluidFramework/commit/016064d88cbca54c4d0990bd907ea04e8e5ce03d).

Going with this approach closes #11269.