### PR TITLE
Validate attach orders is flaky in t9s

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -100,7 +100,7 @@ export enum DataObjectFactoryType {
 export const defaultTimeoutDurationMs = 250;
 
 // @public (undocumented)
-export function ensureContainerConnected(container: Container): Promise<void>;
+export function ensureContainerConnected(container: Container, timeoutDurationMs?: number): Promise<void>;
 
 // @public
 export class EventAndErrorTrackingLogger extends TelemetryLogger {

--- a/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
@@ -82,6 +82,7 @@ export class RetriableGitManager implements IGitManager {
     }
 
     public async createGitTree(params: git.ICreateTreeParams): Promise<git.ITree> {
+        console.log("retriableGitManager: createGitTree");
         return this.runWithRetry(
             async () => this.internalGitManager.createGitTree(params),
             "gitManager_createGitTree",
@@ -89,6 +90,7 @@ export class RetriableGitManager implements IGitManager {
     }
 
     public async createTree(files: protocol.ITree): Promise<git.ITree> {
+        console.log("retriableManager yeee");
         return this.runWithRetry(
             async () => this.internalGitManager.createTree(files),
             "gitManager_createTree",
@@ -96,6 +98,7 @@ export class RetriableGitManager implements IGitManager {
     }
 
     public async createCommit(commit: git.ICreateCommitParams): Promise<git.ICommit> {
+        console.log("createCommit");
         return this.runWithRetry(
             async () => this.internalGitManager.createCommit(commit),
             "gitManager_createCommit",
@@ -110,6 +113,7 @@ export class RetriableGitManager implements IGitManager {
     }
 
     public async createRef(branch: string, sha: string): Promise<git.IRef> {
+        console.log("createRef");
         return this.runWithRetry(
             async () => this.internalGitManager.createRef(branch, sha),
             "gitManager_createRef",
@@ -117,6 +121,7 @@ export class RetriableGitManager implements IGitManager {
     }
 
     public async upsertRef(branch: string, commitSha: string): Promise<git.IRef> {
+        console.log("upsertRef");
         return this.runWithRetry(
             async () => this.internalGitManager.upsertRef(branch, commitSha),
             "gitManager_upsertRef",

--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -167,6 +167,7 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
             },
             async () => {
                 const summaryUploadManager = await this.getSummaryUploadManager();
+                console.log("uploadSummaryWithContext");
                 return summaryUploadManager.writeSummaryTree(summary, context.ackHandle ?? "", "channel");
             },
         );
@@ -186,6 +187,7 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
                 size: uint8ArrayFile.length,
             },
             async (event) => {
+                console.log("createBlob");
                 const manager = await this.getStorageManager();
                 const response = await manager.createBlob(
                     Uint8ArrayToString(

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1804,6 +1804,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      */
     private async fetchSnapshotTree(specifiedVersion: string | undefined):
         Promise<{ snapshot?: ISnapshotTree; versionId?: string; }> {
+        console.log("fetchSnapshotTree: ", specifiedVersion);
         const version = await this.getVersion(specifiedVersion ?? null);
 
         if (version === undefined && specifiedVersion !== undefined) {

--- a/packages/loader/driver-utils/src/blobAggregationStorage.ts
+++ b/packages/loader/driver-utils/src/blobAggregationStorage.ts
@@ -263,6 +263,7 @@ export class BlobAggregationStorage extends SnapshotExtractor implements IDocume
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
         const summaryNew = this.allowPacking ? await this.compressSmallBlobs(summary) : summary;
+        console.log("blob agregation:?");
         return this.storage.uploadSummaryWithContext(summaryNew, context);
     }
 

--- a/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
@@ -35,6 +35,7 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
     constructor(protected readonly internalStorageService: IDocumentStorageService) { }
 
     public async getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null> {
+        console.log("documentStorageProxy:");
         return this.internalStorageService.getSnapshotTree(version, scenarioName);
     }
 

--- a/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
@@ -6,7 +6,6 @@ import { strict as assert } from "assert";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     createLoader,
-    ensureContainerConnected,
     ITestFluidObject,
     timeoutPromise,
 } from "@fluidframework/test-utils";
@@ -19,7 +18,6 @@ import { SequenceDeltaEvent, SharedString, SharedStringFactory } from "@fluidfra
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
-import { Container } from "@fluidframework/container-loader";
 
 // during these point succeeding objects won't even exist locally
 const ContainerCreated = 0;
@@ -76,8 +74,6 @@ describeFullCompat("Validate Attach lifecycle", (getTestObjectProvider) => {
                     if (testConfig.containerSaveAfterAttach) {
                         await attachP;
                     }
-                    await ensureContainerConnected(initContainer as Container, timeoutDurationMs);
-                    provider.updateDocumentId(initContainer.resolvedUrl);
                 };
                 if (testConfig.containerAttachPoint === ContainerCreated) {
                     // point 0 - at container create, datastore and dss don't exist

--- a/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
@@ -6,6 +6,7 @@ import { strict as assert } from "assert";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     createLoader,
+    ensureContainerConnected,
     ITestFluidObject,
     timeoutPromise,
 } from "@fluidframework/test-utils";
@@ -18,6 +19,7 @@ import { SequenceDeltaEvent, SharedString, SharedStringFactory } from "@fluidfra
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
+import { Container } from "@fluidframework/container-loader";
 
 // during these point succeeding objects won't even exist locally
 const ContainerCreated = 0;
@@ -74,6 +76,8 @@ describeFullCompat("Validate Attach lifecycle", (getTestObjectProvider) => {
                     if (testConfig.containerSaveAfterAttach) {
                         await attachP;
                     }
+                    await ensureContainerConnected(initContainer as Container, timeoutDurationMs);
+                    provider.updateDocumentId(initContainer.resolvedUrl);
                 };
                 if (testConfig.containerAttachPoint === ContainerCreated) {
                     // point 0 - at container create, datastore and dss don't exist

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -25,9 +25,10 @@ export async function timeoutAwait<T = void>(
     return Promise.race([promise, timeoutPromise<T>(() => { }, timeoutOptions)]);
 }
 
-export async function ensureContainerConnected(container: Container): Promise<void> {
+export async function ensureContainerConnected(container: Container, timeoutDurationMs?: number): Promise<void> {
     if (!container.connected) {
-        return timeoutPromise((resolve) => container.once("connected", () => resolve()));
+        return timeoutPromise((resolve) => container.once("connected", () => resolve()),
+        { durationMs: timeoutDurationMs, errorMsg: "ensureContainerConnected timeout" });
     }
 }
 

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -25,20 +25,6 @@ variables:
   value: $(Pipeline.Workspace)/test
 
 stages:
-  # end-to-end tests local server
-  - stage:
-    displayName: e2e - local server
-    dependsOn: []
-    jobs:
-    - template: templates/include-test-real-service.yml
-      parameters:
-        poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
-        testWorkspace: ${{ variables.testWorkspace }}
-        testCommand: test:realsvc:local:report
-        env:
-          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-
   # end-to-end tests tinylicious
   - stage:
     displayName: e2e - tinylicious
@@ -51,83 +37,4 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:tinylicious:report
         env:
-          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-
-  # end-to-end tests routerlicious
-  - stage:
-    displayName: e2e - routerlicious
-    dependsOn: []
-    jobs:
-    - template: templates/include-test-real-service.yml
-      parameters:
-        poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
-        testWorkspace: ${{ variables.testWorkspace }}
-        testCommand: test:realsvc:routerlicious:report
-        continueOnError: true
-        splitTestVariants:
-          - name: Non-compat
-            flags: --compatVersion=0
-          - name: N-1
-            flags: --compatVersion=-1
-          - name: N-2
-            flags: --compatVersion=-2
-          - name: LTS
-            flags: --compatVersion=LTS
-        env:
-          fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s)
-          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-
-  # end-to-end tests frs
-  - stage:
-    displayName: e2e - frs
-    dependsOn: []
-    jobs:
-    - template: templates/include-test-real-service.yml
-      parameters:
-        poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
-        testWorkspace: ${{ variables.testWorkspace }}
-        timeoutInMinutes: 360
-        continueOnError: true
-        testCommand: test:realsvc:frs:report
-        splitTestVariants:
-          - name: Non-compat
-            flags: --compatVersion=0
-          - name: N-1
-            flags: --compatVersion=-1
-          - name: N-2
-            flags: --compatVersion=-2
-          - name: LTS
-            flags: --compatVersion=LTS
-        env:
-          fluid__test__driver__frs: $(automation-fluid-test-driver-frs)
-          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-
-  # end-to-end tests odsp
-  - stage:
-    displayName:  e2e - odsp
-    dependsOn: []
-    jobs:
-    - template: templates/include-test-real-service.yml
-      parameters:
-        poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
-        testWorkspace: ${{ variables.testWorkspace }}
-        timeoutInMinutes: 360
-        continueOnError: true
-        testCommand: test:realsvc:odsp:report
-        splitTestVariants:
-          - name: Non-compat
-            flags: --compatVersion=0 --tenantIndex=0
-          - name: N-1
-            flags: --compatVersion=-1 --tenantIndex=1
-          - name: N-2
-            flags: --compatVersion=-2 --tenantIndex=2
-          - name: LTS
-            flags: --compatVersion=LTS --tenantIndex=3
-        env:
-          login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
-          login__odsp__test__tenants: $(automation-e2e-login-odsp-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
## Description

> [#AB550](https://dev.azure.com/fluidframework/internal/_workitems/edit/550)
> Attachlifecycle.spec.ts is throwing flaky errors. Some of them are related to time out and other ones related to r11s fetch error (see below)
> Still investigating about the root cause of the issue but looks like this is a legitimate server-side error.

## Any relevant logs or outputs

![image](https://user-images.githubusercontent.com/105010181/184945096-1501d6c0-6d59-4b9a-901c-7882effdeb35.png)

