### PR TITLE
Fix PendingStateManager replayPendingStates

### DIFF
--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -434,5 +434,16 @@ export class PendingStateManager implements IDisposable {
             }
             pendingStatesCount--;
         }
+
+        // There are some cases where ops are stashed but not flushed. We need to ensure they are resubmitted
+        while (messageBatchQueue.length > 0) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const message = messageBatchQueue.dequeue()!;
+            this.stateHandler.reSubmit(
+                message.messageType,
+                message.content,
+                message.localOpMetadata,
+                message.opMetadata);
+        }
     }
 }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

## Description

There were some cases where "flush" was not called when in `FlushMode.TurnBased`, causing some ops to not get replayed by the `PendingStateManager`. The "flush" calls were most likely not made because the ops were created when the container was not connected.