### PR TITLE
disable message batching for Azure customers

### DIFF
--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -10,6 +10,7 @@ import {
 } from "@fluidframework/aqueduct";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ContainerSchema,
@@ -156,7 +157,9 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
                 {},
                 registryEntries,
             );
-        super([rootDataObjectFactory.registryEntry], undefined, [defaultRouteRequestHandler(rootDataStoreId)]);
+        super([rootDataObjectFactory.registryEntry], undefined, [defaultRouteRequestHandler(rootDataStoreId)],
+            { flushMode: FlushMode.Immediate },
+        );
         this.rootDataObjectFactory = rootDataObjectFactory;
         this.initialObjects = schema.initialObjects;
     }

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -157,7 +157,10 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
                 {},
                 registryEntries,
             );
-        super([rootDataObjectFactory.registryEntry], undefined, [defaultRouteRequestHandler(rootDataStoreId)],
+        super(
+            [rootDataObjectFactory.registryEntry],
+            undefined,
+            [defaultRouteRequestHandler(rootDataStoreId)],
             // temporary workaround to disable message batching until the message batch size issue is resolved
             // resolution progress is tracked by the Feature 465 work item in AzDO
             { flushMode: FlushMode.Immediate },

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -158,6 +158,8 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
                 registryEntries,
             );
         super([rootDataObjectFactory.registryEntry], undefined, [defaultRouteRequestHandler(rootDataStoreId)],
+            // temporary workaround to disable message batching until the message batch size issue is resolved
+            // resolution progress is tracked by the Feature 465 work item in AzDO
             { flushMode: FlushMode.Immediate },
         );
         this.rootDataObjectFactory = rootDataObjectFactory;

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -17,6 +17,7 @@ import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils"
 import { IContainer, IErrorBase } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { GenericError } from "@fluidframework/container-utils";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 
 describeNoCompat("Message size", (getTestObjectProvider) => {
     const mapId = "mapId";
@@ -134,6 +135,16 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
         // Max op size is 768000, round down to account for some overhead
         const largeString = generateStringOfSize(750000);
         const messageCount = 1;
+        setMapKeys(dataObject1map, messageCount, largeString);
+        await provider.ensureSynchronized();
+
+        assertMapValues(dataObject2map, messageCount, largeString);
+    });
+
+    it("Batched small ops pass when batch is larger than max op size", async () => {
+        await setupContainers({ ...testContainerConfig, runtimeOptions: { flushMode: FlushMode.Immediate } }, {});
+        const largeString = generateStringOfSize(500000);
+        const messageCount = 10;
         setMapKeys(dataObject1map, messageCount, largeString);
         await provider.ensureSynchronized();
 

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -141,7 +141,11 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
         assertMapValues(dataObject2map, messageCount, largeString);
     });
 
-    it("Batched small ops pass when batch is larger than max op size", async () => {
+    it("Batched small ops pass when batch is larger than max op size", async function() {
+        // flush mode is not applicable for the local driver
+        if (provider.driver.type === "local") {
+            this.skip();
+        }
         await setupContainers({ ...testContainerConfig, runtimeOptions: { flushMode: FlushMode.Immediate } }, {});
         const largeString = generateStringOfSize(500000);
         const messageCount = 10;


### PR DESCRIPTION
### The problem
The problem reported by a customer via IcM. Attempting to sync a large data set consisting of batched multiple messages (less than 768kb each) will hit Socket.io buffer max size and the connection will close. The reason is the delta manager flushes batched messages periodically without enforcing the max op size. The max op size is only honored by the container runtime per each message submitted as imposed by the initial design.

### The solution
Disable the message batching by setting `flushMode` to `Intermediate` for Azure customers. The workaround should be reconsidered when the original batching problem is resolved.
