### PR TITLE
Accept both json and binary in trees latest stress test (#11443)

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -18,7 +18,7 @@
                 },
                 "odsp-odsp-df":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
                         "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 }
@@ -102,7 +102,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [1]
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [2]
                     }
                 }
             }


### PR DESCRIPTION
cherry-pick #11443 to release/1.2 branch

Haven't seen these recently but future OCE will likely see 406 if changes are made to the release branch.