### PR TITLE
stress test: check if disposed before calling set

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -296,12 +296,15 @@ export class LoadTestDataStoreModel {
      * Upload a unique attachment blob and store the handle in a unique key on the root map
      */
     public async writeBlob(blobNumber: number) {
+        if (this.runtime.disposed) {
+            return;
+        }
+        const blobSize = this.config.testConfig.blobSize ?? defaultBlobSize;
+        // upload a unique blob, since they may be deduped otherwise
+        const buffer = Buffer.alloc(blobSize, `${this.config.runId}/${blobNumber}:`);
+        assert(buffer.byteLength === blobSize, "incorrect buffer size");
+        const handle = await this.runtime.uploadBlob(buffer);
         if (!this.runtime.disposed) {
-            const blobSize = this.config.testConfig.blobSize ?? defaultBlobSize;
-            // upload a unique blob, since they may be deduped otherwise
-            const buffer = Buffer.alloc(blobSize, `${this.config.runId}/${blobNumber}:`);
-            assert(buffer.byteLength === blobSize, "incorrect buffer size");
-            const handle = await this.runtime.uploadBlob(buffer);
             this.root.set(this.blobKey(blobNumber), handle);
         }
     }


### PR DESCRIPTION
BlobManager used to reject pending blob uploads when disposed. It now does nothing on dispose, however it will resolve the promise on disconnect event, which will happen if connected at dispose time. As a result, resolution of the promise returned by uploadBlob() does not imply the container is not disposed, and we should check before submitting ops.