### PR TITLE
Allow querying for interval from its local reference endpoint

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -199,7 +199,7 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
 
 // @public
 export interface IntervalLocator {
-    id: string;
+    interval: SequenceInterval;
     label: string;
 }
 

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -197,6 +197,15 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
     };
 }
 
+// @public
+export interface IntervalLocator {
+    id: string;
+    label: string;
+}
+
+// @public
+export function intervalLocatorFromEndpoint(potentialEndpoint: LocalReferencePosition): IntervalLocator | undefined;
+
 // @public (undocumented)
 export enum IntervalType {
     // (undocumented)

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -22,6 +22,8 @@ export {
     Interval,
     IntervalCollection,
     IntervalCollectionIterator,
+    IntervalLocator,
+    intervalLocatorFromEndpoint,
     IntervalType,
     ISerializableInterval,
     ISerializedInterval,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -799,11 +799,10 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
         return interval;
     }
 
-    private addIdToEndpoints(interval: TInterval): void {
-        const id = interval.properties[reservedIntervalIdKey];
-        if (id && interval instanceof SequenceInterval) {
-            interval.start.addProperties({ [reservedIntervalIdKey]: id });
-            interval.end.addProperties({ [reservedIntervalIdKey]: id });
+    private linkEndpointsToInterval(interval: TInterval): void {
+        if (interval instanceof SequenceInterval) {
+            interval.start.addProperties({ interval });
+            interval.end.addProperties({ interval });
         }
     }
 
@@ -822,7 +821,7 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
     }
 
     public add(interval: TInterval) {
-        this.addIdToEndpoints(interval);
+        this.linkEndpointsToInterval(interval);
         this.addIntervalToIndex(interval);
         this.addIntervalListeners(interval);
     }
@@ -1670,13 +1669,13 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
  */
 export interface IntervalLocator {
     /**
-     * label for the collection the interval is a part of
+     * Label for the collection the interval is a part of
      */
     label: string;
     /**
-     * id of the interval
+     * Interval within that collection
      */
-    id: string;
+    interval: SequenceInterval;
 }
 
 /**
@@ -1687,8 +1686,8 @@ export interface IntervalLocator {
  */
 export function intervalLocatorFromEndpoint(potentialEndpoint: LocalReferencePosition): IntervalLocator | undefined {
     const {
-        [reservedIntervalIdKey]: id,
+        interval,
         [reservedRangeLabelsKey]: collectionNameArray,
     } = potentialEndpoint.properties ?? {};
-    return (id && collectionNameArray.length === 1) ? { label: collectionNameArray[0], id } : undefined;
+    return (interval && collectionNameArray?.length === 1) ? { label: collectionNameArray[0], interval } : undefined;
 }

--- a/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
@@ -148,10 +148,10 @@ describe("IntervalCollection snapshotting", () => {
         it("intervals can be retrieved from endpoints", async () => {
             const interval1 = collection.getIntervalById(id) ?? assert.fail("collection should have interval");
             const locator1 = intervalLocatorFromEndpoint(interval1.start);
-            assert.deepEqual(locator1, { id, label: "test" });
+            assert.deepEqual(locator1, { interval: interval1, label: "test" });
             const interval2 = collection.add(1, 2, IntervalType.SlideOnRemove);
             const locator2 = intervalLocatorFromEndpoint(interval2.start);
-            assert.deepEqual(locator2, { id: interval2.getIntervalId(), label: "test" });
+            assert.deepEqual(locator2, { interval: interval2, label: "test" });
         });
     });
 });

--- a/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
@@ -12,7 +12,7 @@ import {
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
-import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
+import { IntervalCollection, intervalLocatorFromEndpoint, IntervalType, SequenceInterval } from "../intervalCollection";
 
 const assertIntervals = (
     sharedString: SharedString,
@@ -143,6 +143,15 @@ describe("IntervalCollection snapshotting", () => {
             assertIntervals(sharedString2, collection2, [{ start: 0, end: 2 }]);
             containerRuntimeFactory.processAllMessages();
             assertIntervals(sharedString2, collection2, [{ start: 0, end: 2 }, { start: 2, end: 4 }]);
+        });
+
+        it("intervals can be retrieved from endpoints", async () => {
+            const interval1 = collection.getIntervalById(id) ?? assert.fail("collection should have interval");
+            const locator1 = intervalLocatorFromEndpoint(interval1.start);
+            assert.deepEqual(locator1, { id, label: "test" });
+            const interval2 = collection.add(1, 2, IntervalType.SlideOnRemove);
+            const locator2 = intervalLocatorFromEndpoint(interval2.start);
+            assert.deepEqual(locator2, { id: interval2.getIntervalId(), label: "test" });
         });
     });
 });


### PR DESCRIPTION
This adds an API to @fluidframework/sequence which enables recovering an interval from one of its endpoints. The specific API retrieves the label for the interval collection that endpoint is a part of, as well as the id of the interval. This required storing an additional prop on each endpoint reference. I also fixed a bug in treating the label field differently on reloaded intervals.

The motivation for this change is to enable reasonable undo-redo behaviors for SlideOnRemove intervals to be implementable. There is some discussion of the issue on #11269.

This includes the changes to interval collections from #11550 without suggesting exact implementation for undo-redo.

