### PR TITLE
Remove Azure CLI and Github CLI from devcontainer definition.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,11 @@
     // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "node",
     "features": {
-        "azure-cli": "latest",
-        "github-cli": "latest",
-        "git-lfs": "latest"
+        "git-lfs": "latest",
+        // We do not install Azure CLI and Github CLI because of security considerations
+        // when creating Github Codespaces instances. It's ok to install them manually if
+        // using this file to develop in a local container.
+        // "azure-cli": "latest",  // DO NOT UNCOMMENT
+        // "github-cli": "latest", // DO NOT UNCOMMENT
     }
 }


### PR DESCRIPTION
## Description

Comment Azure CLI and Github CLI in the devcontainer.json file. After discussion within the team, having them be part of the default setup used for Github Codespaces instances is not ideal for security reasons.

## Reviewer Guidance

Ping @alexvy86 or @curtisman for details on the internal discussion.
