### PR TITLE
Temporary disable generateServiceSummary in t9s

### DIFF
--- a/server/tinylicious/src/resourcesFactory.ts
+++ b/server/tinylicious/src/resourcesFactory.ts
@@ -6,7 +6,12 @@
 import { LocalOrdererManager } from "@fluidframework/server-local-server";
 import { DocumentStorage } from "@fluidframework/server-services-shared";
 import { generateToken, Historian } from "@fluidframework/server-services-client";
-import { MongoDatabaseManager, MongoManager, IResourcesFactory } from "@fluidframework/server-services-core";
+import {
+    MongoDatabaseManager,
+    MongoManager,
+    IResourcesFactory,
+    DefaultServiceConfiguration,
+} from "@fluidframework/server-services-core";
 import * as utils from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
 import { Server } from "socket.io";
@@ -64,7 +69,14 @@ export class TinyliciousResourcesFactory implements IResourcesFactory<Tinyliciou
                 return new Historian(url, false, false);
             },
             winston,
-            undefined /* serviceConfiguration */,
+            {
+                // Temporary disable generateServiceSummary, as it causes SummaryNack with client summaries
+                // See AB#1627
+                scribe: {
+                    ...DefaultServiceConfiguration.scribe,
+                    generateServiceSummary: false,
+                },
+            },
             pubsub);
 
         return new TinyliciousResources(


### PR DESCRIPTION
With `generateServiceSummary` enabled, scribe will generate a service summary when there no client to save the last pending ops and checkpoint states.  However, this can cause it to conflict if a new client joins and start summarizing, causing SummaryNack from mismatch parents.

This is impacting e2e test targeting t9s, so for now, disable it in t9s to stabilize the test.
[AB#1627](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1627) is the follow up issue.

Pending build/publish a new tinylicious and update dependency before reenable the first for [AB#1454](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1454)