### PR TITLE
Update deployment details with updated helm chart versions and values

### DIFF
--- a/server/routerlicious/kubernetes/README.md
+++ b/server/routerlicious/kubernetes/README.md
@@ -50,8 +50,10 @@ You'll also need to have a Redis, MongoDB, Rabbitmq, and Historian instances run
 
 We install MongoDB and Rabbitmq from the helm stable repository. We also configure MongoDB to use the managed-premium storage class in AKS.
 
-`helm install --set persistence.storageClass=managed-premium,persistence.size=4094Gi,usePassword=false,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> wiggly-dog bitnami/mongodb`
-`helm install --set rbac.create=false,auth.username=prague,auth.password=[password],persistence.enabled=true,persistence.size=16Gi,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> wiggly-snake bitnami/rabbitmq`
+In the following commands you can omit the optional key+value pairs to use the defaults defined in the Helm Chart. Also, replace the `<helm-release-name>` with the appropriate value.
+
+`helm install --set persistence.storageClass=managed-premium,persistence.size=4094Gi,usePassword=false,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> <helm-release-name> bitnami/mongodb`
+`helm install --set rbac.create=false,auth.username=prague,auth.password=[password],persistence.enabled=true,persistence.size=16Gi,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> <helm-release-name> bitnami/rabbitmq`
 
 Redis, Kafka and Historian come from the `/server/charts` directory. You'll want to install each of them.
 

--- a/server/routerlicious/kubernetes/README.md
+++ b/server/routerlicious/kubernetes/README.md
@@ -50,8 +50,8 @@ You'll also need to have a Redis, MongoDB, Rabbitmq, and Historian instances run
 
 We install MongoDB and Rabbitmq from the helm stable repository. We also configure MongoDB to use the managed-premium storage class in AKS.
 
-`helm install --set persistence.storageClass=managed-premium,persistence.size=4094Gi,usePassword=false stable/mongodb`
-`helm install --set rbacEnabled=false,rabbitmq.username=prague,rabbitmq.password=[rabbitmq password],persistence.enabled=true,persistence.size=16Gi stable/rabbitmq`
+`helm install --set persistence.storageClass=managed-premium,persistence.size=4094Gi,usePassword=false,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> wiggly-dog bitnami/mongodb`
+`helm install --set rbac.create=false,auth.username=prague,auth.password=[password],persistence.enabled=true,persistence.size=16Gi,image.registry=<optional-registry>,image.repository=<optional-repo-name>,image.tag=<optional-tag> wiggly-snake bitnami/rabbitmq`
 
 Redis, Kafka and Historian come from the `/server/charts` directory. You'll want to install each of them.
 

--- a/server/routerlicious/kubernetes/nginx/README.md
+++ b/server/routerlicious/kubernetes/nginx/README.md
@@ -50,7 +50,7 @@ HELM_RELEASE_NAME=ingress-controller-prod
 VALUES_FILE=values-prod.yaml
 ```
 
-Then define some common variables and deploy the Helm chart:
+Then define some common variables and deploy the Helm chart. In the following commands you can omit the optional key+value pairs to use the defaults defined in the Helm Chart.
 
 ```bash
 HELM_CHART_NAME=ingress-nginx
@@ -58,9 +58,9 @@ HELM_CHART_REPO=https://kubernetes.github.io/ingress-nginx
 HELM_CHART_VERSION=4.2.1
 
 helm upgrade --install --set controller.image.registry=<registry> \
-	--set controller.image.image=<repo-name> \
-	--set controller.image.tag=<tag> \
-	--set controller.image.digest=<digest> \
+	--set controller.image.image=<optional-repo-name> \
+	--set controller.image.tag=<optional-tag> \
+	--set controller.image.digest=<optional-digest> \
 	$HELM_RELEASE_NAME $HELM_CHART_NAME --version $HELM_CHART_VERSION --repo $HELM_CHART_REPO -f $VALUES_FILE --namespace $K8S_NAMESPACE --create-namespace
 
 

--- a/server/routerlicious/kubernetes/nginx/README.md
+++ b/server/routerlicious/kubernetes/nginx/README.md
@@ -55,10 +55,14 @@ Then define some common variables and deploy the Helm chart:
 ```bash
 HELM_CHART_NAME=ingress-nginx
 HELM_CHART_REPO=https://kubernetes.github.io/ingress-nginx
-HELM_CHART_VERSION=4.1.4
+HELM_CHART_VERSION=4.2.1
 
-helm upgrade --install $HELM_RELEASE_NAME $HELM_CHART_NAME --version $HELM_CHART_VERSION --repo $HELM_CHART_REPO -f $VALUES_FILE --namespace $K8S_NAMESPACE --create-namespace
-```
+helm upgrade --install --set controller.image.registry=<registry> \
+	--set controller.image.image=<repo-name> \
+	--set controller.image.tag=<tag> \
+	--set controller.image.digest=<digest> \
+	$HELM_RELEASE_NAME $HELM_CHART_NAME --version $HELM_CHART_VERSION --repo $HELM_CHART_REPO -f $VALUES_FILE --namespace $K8S_NAMESPACE --create-namespace
+
 
 The output will include a command that you can use to check the status of the `Service` object, something similar to this:
 


### PR DESCRIPTION
The Helm charts used by ingress-controller, RabbitMQ and MongoDB needed to be updated to use the more recent bitnami and docker helm charts, as well as images. This PR documents the change in chart versions and query parameters necessary to deploy them.