### PR TITLE
Add a default factory getter to legacy SharedTree

### DIFF
--- a/api-report/experimental-tree.api.md
+++ b/api-report/experimental-tree.api.md
@@ -846,6 +846,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     static getFactory(...args: SharedTreeArgs<WriteFormat.v0_0_2>): SharedTreeFactory;
     // (undocumented)
     static getFactory(...args: SharedTreeArgs<WriteFormat.v0_1_1>): SharedTreeFactory;
+    static getFactory(): SharedTreeFactory;
     // (undocumented)
     getRuntime(): IFluidDataStoreRuntime;
     getWriteFormat(): WriteFormat;
@@ -908,8 +909,7 @@ export enum SharedTreeEvent {
 
 // @public
 export class SharedTreeFactory implements IChannelFactory {
-    constructor(...args: SharedTreeArgs<WriteFormat.v0_0_2>);
-    constructor(...args: SharedTreeArgs<WriteFormat.v0_1_1>);
+    constructor(...args: SharedTreeArgs);
     // (undocumented)
     static Attributes: IChannelAttributes;
     // (undocumented)

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -204,8 +204,6 @@ export class SharedTreeFactory implements IChannelFactory {
 	 * @param options - Configuration options for this tree
 	 * @returns A factory that creates `SharedTree`s and loads them from storage.
 	 */
-	constructor(...args: SharedTreeArgs<WriteFormat.v0_0_2>);
-	constructor(...args: SharedTreeArgs<WriteFormat.v0_1_1>);
 	constructor(...args: SharedTreeArgs) {
 		this.args = args;
 	}
@@ -392,20 +390,19 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 
 	public static getFactory(...args: SharedTreeArgs<WriteFormat.v0_1_1>): SharedTreeFactory;
 
-	public static getFactory(...args: SharedTreeArgs): SharedTreeFactory {
-		const [writeFormat] = args;
+	/**
+	 * Get a factory for SharedTree to register with the data store, using the latest write version and default options.
+	 */
+	public static getFactory(): SharedTreeFactory;
+
+	public static getFactory(...args: SharedTreeArgs | []): SharedTreeFactory {
+		const [formatArg, options] = args;
+		const writeFormat = formatArg ?? WriteFormat.v0_1_1;
 		// 	On 0.1.1 documents, due to current code limitations, all clients MUST agree on the value of `summarizeHistory`.
 		//  Note that this means staged rollout changing this value should not be attempted.
 		//  It is possible to update shared-tree to correctly handle such a staged rollout, but that hasn't been implemented.
 		//  See the skipped test in SharedTreeFuzzTests.ts for more details on this issue.
-		switch (writeFormat) {
-			case WriteFormat.v0_0_2:
-				return new SharedTreeFactory(...(args as SharedTreeArgs<WriteFormat.v0_0_2>));
-			case WriteFormat.v0_1_1:
-				return new SharedTreeFactory(...(args as SharedTreeArgs<WriteFormat.v0_1_1>));
-			default:
-				fail('Unknown write format');
-		}
+		return new SharedTreeFactory(writeFormat, options);
 	}
 
 	/**

--- a/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
@@ -5,6 +5,7 @@
 
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { LoaderHeader } from '@fluidframework/container-definitions';
+import { MockFluidDataStoreRuntime } from '@fluidframework/test-runtime-utils';
 import { expect } from 'chai';
 import { StableRange, StablePlace, BuildNode, Change } from '../../ChangeTypes';
 import { Mutable } from '../../Common';
@@ -51,6 +52,12 @@ export function runSharedTreeVersioningTests(
 			localMode: false,
 			writeFormat: newVersion,
 		};
+
+		it('defaults to latest version if no version is specified when creating factory', () => {
+			const sharedTree = SharedTree.getFactory().create(new MockFluidDataStoreRuntime(), 'SharedTree');
+			const writeFormats = Object.values(WriteFormat);
+			expect(sharedTree.getWriteFormat()).to.equal(writeFormats[writeFormats.length - 1]);
+		});
 
 		it('only processes edit ops if they have the same version', () => {
 			const { tree, containerRuntimeFactory } = setUpTestSharedTree(treeOptions);


### PR DESCRIPTION
Some container creation flows require that each SharedObject being created has a parameterless `getFactory()` function.