### PR TITLE
MergeTree: Make SortedSegmentSet Iterative and Add Some Tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,5 @@
         "unaugmented"
     ],
     "editor.detectIndentation": true,
-    "editor.insertSpaces": false, // Use detectIndentation instead
+    "editor.insertSpaces": true, // Use detectIndentation instead
 }

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1168,9 +1168,7 @@ export interface SortedDictionary<TKey, TData> extends Dictionary<TKey, TData> {
 }
 
 // @public
-export class SortedSegmentSet<T extends ISegment | {
-    readonly segment: ISegment;
-} = ISegment> {
+export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> {
     // (undocumented)
     addOrUpdate(newItem: T, update?: (existingItem: T, newItem: T) => T): void;
     // (undocumented)
@@ -1182,6 +1180,11 @@ export class SortedSegmentSet<T extends ISegment | {
     // (undocumented)
     get size(): number;
 }
+
+// @public (undocumented)
+export type SortedSegmentSetItem = ISegment | {
+    readonly segment: ISegment;
+};
 
 // @public (undocumented)
 export class Stack<T> {

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -15,7 +15,8 @@ import { ISegment } from "./mergeTreeNodes";
  * the segments changes. This invariant allows ensure the segments stay ordered and unique, and that new segments
  * can be inserted into that order.
  */
-export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment; } = ISegment> {
+export class SortedSegmentSet<
+    T extends ISegment | { readonly segment: ISegment; } = ISegment> {
     private readonly ordinalSortedItems: T[] = [];
 
     public get size(): number {
@@ -27,7 +28,7 @@ export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment;
     }
 
     public addOrUpdate(newItem: T, update?: (existingItem: T, newItem: T) => T) {
-        const position = this.findOrdinalPosition(this.getOrdinal(newItem));
+        const position = this.findItemPosition(newItem);
         if (position.exists) {
             if (update) {
                 update(this.ordinalSortedItems[position.index], newItem);
@@ -38,7 +39,7 @@ export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment;
     }
 
     public remove(item: T): boolean {
-        const position = this.findOrdinalPosition(this.getOrdinal(item));
+        const position = this.findItemPosition(item);
         if (position.exists) {
             this.ordinalSortedItems.splice(position.index, 1);
             return true;
@@ -47,7 +48,7 @@ export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment;
     }
 
     public has(item: T): boolean {
-        const position = this.findOrdinalPosition(this.getOrdinal(item));
+        const position = this.findItemPosition(item);
         return position.exists;
     }
 
@@ -61,25 +62,52 @@ export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment;
         return maybeSegment.ordinal;
     }
 
-    private findOrdinalPosition(ordinal: string, start?: number, end?: number): { exists: boolean; index: number; } {
+    private findItemPosition(item: T): { exists: boolean; index: number; } {
         if (this.ordinalSortedItems.length === 0) {
             return { exists: false, index: 0 };
         }
-        if (start === undefined || end === undefined) {
-            return this.findOrdinalPosition(ordinal, 0, this.ordinalSortedItems.length - 1);
-        }
-        const index = start + Math.floor((end - start) / 2);
-        if (this.getOrdinal(this.ordinalSortedItems[index]) > ordinal) {
-            if (start === index) {
+        let start = 0;
+        let end = this.ordinalSortedItems.length - 1;
+        const itemOrdinal = this.getOrdinal(item);
+        let index = -1;
+
+        while (start <= end) {
+            index = start + Math.floor((end - start) / 2);
+            const indexOrdinal = this.getOrdinal(this.ordinalSortedItems[index]);
+            if (indexOrdinal > itemOrdinal) {
+                if (start === index) {
+                    return { exists: false, index };
+                }
+                end = index - 1;
+            } else if (indexOrdinal < itemOrdinal) {
+                if (index === end) {
+                    return { exists: false, index: index + 1 };
+                }
+                start = index + 1;
+            } else if (indexOrdinal === itemOrdinal) {
+                // at this point we've found the ordinal of the item
+                // so we need to find the index of the item instance
+                //
+                if (item === this.ordinalSortedItems[index]) {
+                    return { exists: true, index };
+                }
+                for (let b = index - 1; b >= 0 && this.getOrdinal(this.ordinalSortedItems[b]) === itemOrdinal; b--) {
+                    if (this.ordinalSortedItems[b] === item) {
+                        return { exists: true, index: b };
+                    }
+                }
+                for (index + 1;
+                    index < this.ordinalSortedItems.length
+                        && this.getOrdinal(this.ordinalSortedItems[index]) === itemOrdinal;
+                    index++
+                ) {
+                    if (this.ordinalSortedItems[index] === item) {
+                        return { exists: true, index };
+                    }
+                }
                 return { exists: false, index };
             }
-            return this.findOrdinalPosition(ordinal, start, index - 1);
-        } else if (this.getOrdinal(this.ordinalSortedItems[index]) < ordinal) {
-            if (index === end) {
-                return { exists: false, index: index + 1 };
-            }
-            return this.findOrdinalPosition(ordinal, index + 1, end);
         }
-        return { exists: true, index };
+        return { exists: false, index };
     }
 }

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -5,6 +5,8 @@
 
 import { ISegment } from "./mergeTreeNodes";
 
+export type SortedSegmentSetItem = ISegment | { readonly segment: ISegment; };
+
 /**
  * Stores a unique and sorted set of segments, or objects with segments
  *
@@ -16,7 +18,7 @@ import { ISegment } from "./mergeTreeNodes";
  * can be inserted into that order.
  */
 export class SortedSegmentSet<
-    T extends ISegment | { readonly segment: ISegment; } = ISegment> {
+    T extends SortedSegmentSetItem= ISegment> {
     private readonly ordinalSortedItems: T[] = [];
 
     public get size(): number {

--- a/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
+++ b/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { SortedSegmentSet, SortedSegmentSetItem } from "../sortedSegmentSet";
+import { ISegment } from "../mergeTreeNodes";
+import { TestClient } from "./testClient";
+const segmentCount = 15;
+
+function validateSorted<T extends SortedSegmentSetItem>(
+    set: SortedSegmentSet<T>, getOrdinal: (item: T) => string, prefix: string) {
+    for (let i = 0; i < set.size - 1; i++) {
+        assert(getOrdinal(set.items[i]) <= getOrdinal(set.items[i + 1]), `${prefix}: Not sorted at item ${i}`);
+    }
+}
+
+function validateSet<T extends SortedSegmentSetItem>(
+    client: TestClient, set: SortedSegmentSet<T>, getOrdinal: (item: T) => string) {
+    validateSorted(set, getOrdinal, "initial");
+
+    // add content to shift ordinals in tree
+    for (let i = 0; i < segmentCount * 5; i++) {
+        client.insertTextLocal((i * 3) % client.getLength(), `X`);
+    }
+    validateSorted(set, getOrdinal, "after insert");
+
+    for (let i = set.size; set.size > 0; i += set.size) {
+        // jump around the list a bit, so its not just an in-order remove
+        const item = set.items[i % set.size];
+        assert.equal(set.remove(item), true, "remove failed");
+        assert.equal(set.has(item), false);
+        validateSorted(set, getOrdinal, "during remove");
+    }
+}
+
+describe("SortedSegmentSet", () => {
+    const localUserLongId = "localUser";
+    let client: TestClient;
+    beforeEach(() => {
+        client = new TestClient();
+        for (let i = 0; i < segmentCount; i++) {
+            client.insertTextLocal(client.getLength(), `${i} `);
+        }
+        client.startOrUpdateCollaboration(localUserLongId);
+    });
+
+    it("SortedSegmentSet of objects with segments", () => {
+        const set = new SortedSegmentSet<{ segment: ISegment; }>();
+        for (let i = 0; i < client.getLength(); i++) {
+            for (const pos of [i, client.getLength() - 1 - i]) {
+                const segment = client.getContainingSegment(pos).segment;
+                assert(segment);
+                const item = { segment };
+                assert.equal(set.has(item), false);
+                set.addOrUpdate(item);
+                assert.equal(set.has(item), true);
+            }
+        }
+        assert.equal(set.size, client.getLength() * 2);
+        validateSet(client, set, (i) => i.segment.ordinal);
+    });
+
+    it("SortedSegmentSet of segments", () => {
+        const set = new SortedSegmentSet();
+        for (let i = 0; i < client.getLength(); i++) {
+            for (const pos of [i, client.getLength() - 1 - i]) {
+                const segment = client.getContainingSegment(pos).segment;
+                assert(segment);
+                set.addOrUpdate(segment);
+                assert.equal(set.has(segment), true);
+            }
+        }
+        assert.equal(set.size, segmentCount);
+        validateSet(client, set, (i) => i.ordinal);
+    });
+});


### PR DESCRIPTION
## Description
This is related to #11603 and #1009. Like the merge tree walk functions the recursiveness here was also causing perf issue when trying during undo, which frequently adds and removes items from a SortedSegmentSet  via a tracking group. There were no directly test for SortedSegmentSet, as it was mainly tested via tracking groups, so adding a couple tests. Additionally, using a SortedSegmentSet  with an object that provided a segments {segment: ISegment} was broken previously. This change also fixes that issue by allowing multiple elements with a match ordinal.

[AB#151](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/151)
