### PR TITLE
Remove references to deleted file in YAML pipelines

### DIFF
--- a/common/build/build-common/gen_version.js
+++ b/common/build/build-common/gen_version.js
@@ -22,7 +22,6 @@ const pkgName = pkg.name;
 
 // For test builds, the package version starts with 0.0.0.  Code need to know the original version.
 // CI build create one with original version prefix is emitted into the environment for code logic to be used here.
-// See tools/pipelines/scripts/build-version.js
 const pkgVersion = process.env.SETVERSION_CODEVERSION
     ? process.env.SETVERSION_CODEVERSION
     : pkg.version;

--- a/tools/pipelines/build-azure-local-service.yml
+++ b/tools/pipelines/build-azure-local-service.yml
@@ -33,7 +33,6 @@ trigger:
     include:
     - server/azure-local-service
     - tools/pipelines/build-azure-local-service.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -53,7 +52,6 @@ pr:
     include:
     - server/azure-local-service
     - tools/pipelines/build-azure-local-service.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -38,7 +38,6 @@ trigger:
     include:
     - azure
     - tools/pipelines/build-azure.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -58,7 +57,6 @@ pr:
     include:
     - azure
     - tools/pipelines/build-azure.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -32,7 +32,6 @@ trigger:
     include:
     - tools/benchmark
     - tools/pipelines/build-benchmark-tool.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -51,7 +50,6 @@ pr:
     include:
     - tools/benchmark
     - tools/pipelines/build-benchmark-tool.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -34,7 +34,6 @@ trigger:
     include:
     - common/build/build-common
     - tools/pipelines/build-build-common.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -54,7 +53,6 @@ pr:
     include:
     - common/build/build-common
     - tools/pipelines/build-build-common.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -33,7 +33,6 @@ trigger:
     include:
     - build-tools
     - tools/pipelines/build-build-tools.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -52,7 +51,6 @@ pr:
     include:
     - build-tools
     - tools/pipelines/build-build-tools.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -24,7 +24,6 @@ trigger:
     - lerna-package-lock.json
     - tools/pipelines/build-bundle-size-artifacts.yml
     - tools/pipelines/build-client.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-bundle-size-tools.yml
+++ b/tools/pipelines/build-bundle-size-tools.yml
@@ -32,7 +32,6 @@ trigger:
     include:
     - tools/bundle-size-tools
     - tools/pipelines/build-bundle-size-tools.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -50,7 +49,6 @@ pr:
     include:
     - tools/bundle-size-tools
     - tools/pipelines/build-bundle-size-tools.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -45,7 +45,6 @@ trigger:
     - lerna.json
     - lerna-package-lock.json
     - tools/pipelines/build-client.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -71,7 +70,6 @@ pr:
     - lerna.json
     - lerna-package-lock.json
     - tools/pipelines/build-client.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -109,4 +107,3 @@ extends:
           node node_modules/@fluidframework/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js
           cp repo-package.json packages/package.json
           cp repo-package-lock.json packages/package-lock.json
-

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -34,7 +34,6 @@ trigger:
     include:
     - common/lib/common-definitions
     - tools/pipelines/build-common-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -54,7 +53,6 @@ pr:
     include:
     - common/lib/common-definitions
     - tools/pipelines/build-common-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -34,7 +34,6 @@ trigger:
     include:
     - common/lib/common-utils
     - tools/pipelines/build-common-utils.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -54,7 +53,6 @@ pr:
     include:
     - common/lib/common-utils
     - tools/pipelines/build-common-utils.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -31,7 +31,6 @@ trigger:
     include:
     - common/lib/container-definitions
     - tools/pipelines/build-container-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -48,7 +47,6 @@ pr:
     include:
     - common/lib/container-definitions
     - tools/pipelines/build-container-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -31,7 +31,6 @@ trigger:
     include:
     - common/lib/core-interfaces
     - tools/pipelines/build-core-interfaces.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -48,7 +47,6 @@ pr:
     include:
     - common/lib/core-interfaces
     - tools/pipelines/build-core-interfaces.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-docs-site.yml
+++ b/tools/pipelines/build-docs-site.yml
@@ -19,7 +19,6 @@ pr:
     include:
     - docs
     - tools/pipelines/build-docs-site.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -31,7 +31,6 @@ trigger:
     include:
     - common/lib/driver-definitions
     - tools/pipelines/build-driver-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -48,7 +47,6 @@ pr:
     include:
     - common/lib/driver-definitions
     - tools/pipelines/build-driver-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -34,7 +34,6 @@ trigger:
     include:
     - common/build/eslint-config-fluid
     - tools/pipelines/build-eslint-config-fluid.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -54,7 +53,6 @@ pr:
     include:
     - common/build/eslint-config-fluid
     - tools/pipelines/build-eslint-config-fluid.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -34,7 +34,6 @@ trigger:
     include:
     - common/lib/protocol-definitions
     - tools/pipelines/build-protocol-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -54,7 +53,6 @@ pr:
     include:
     - common/lib/protocol-definitions
     - tools/pipelines/build-protocol-definitions.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -32,7 +32,6 @@ trigger:
     include:
     - tools/test-tools
     - tools/pipelines/build-test-tools.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -50,7 +49,6 @@ pr:
     include:
     - tools/test-tools
     - tools/pipelines/build-test-tools.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -33,7 +33,6 @@ trigger:
     include:
     - server/tinylicious
     - tools/pipelines/build-tinylicious.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -53,7 +52,6 @@ pr:
     include:
     - server/tinylicious
     - tools/pipelines/build-tinylicious.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -42,7 +42,6 @@ trigger:
     include:
     - server/gitrest
     - tools/pipelines/server-gitrest.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -65,7 +64,6 @@ pr:
     include:
     - server/gitrest
     - tools/pipelines/server-gitrest.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -42,7 +42,6 @@ trigger:
     include:
     - server/historian
     - tools/pipelines/server-historian.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -65,7 +64,6 @@ pr:
     include:
     - server/historian
     - tools/pipelines/server-historian.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -42,7 +42,6 @@ trigger:
     include:
     - server/routerlicious
     - tools/pipelines/server-routerlicious.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
@@ -67,7 +66,6 @@ pr:
     include:
     - server/routerlicious
     - tools/pipelines/server-routerlicious.yml
-    - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml


### PR DESCRIPTION
## Description

Bit of cleanup in the ADO pipelines, removing references to a file that was [removed earlier this year](https://github.com/microsoft/FluidFramework/pull/10372) (its functionality was integrated into our build-common package).

Except for a comment in a `.js` file, all the changes are in the `triggers` section(s) of pipelines. Since the file does not exist anymore, the pipelines would never trigger because of changes to that path.