### PR TITLE
Tree DDS EditManager fixes and tests

### DIFF
--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { ChangeFamily } from "../change-family";
 import { AnchorSet, Delta } from "../tree";
-import { brand, Brand, fail, RecursiveReadonly } from "../util";
+import { Brand, fail, RecursiveReadonly } from "../util";
 
 export interface Commit<TChangeset> {
     sessionId: SessionId;

--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -66,8 +66,10 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
     public addSequencedChange(newCommit: Commit<TChangeset>): Delta.Root {
         if (this.trunk.length > 0) {
             const lastSeqNumber = this.trunk[this.trunk.length - 1].seqNumber;
-            assert(newCommit.seqNumber > lastSeqNumber,
-                0x030/* Incoming remote op sequence# <= local collabWindow's currentSequence# */);
+            assert(
+                newCommit.seqNumber > lastSeqNumber,
+                "Incoming remote op sequence# <= local collabWindow's currentSequence#",
+            );
         }
         if (newCommit.sessionId === this.localSessionId) {
             // `newCommit` should correspond to the oldest change in `localChanges`, so we move it into trunk.

--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -27,6 +27,11 @@ export type SessionId = string;
 // TODO: Move logic into Rebaser if possible
 export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TChangeset>> {
     private readonly trunk: Commit<TChangeset>[] = [];
+    /**
+     * Branches are maintained to represent the local change list that the issuing client would have had
+     * at the time of submitting the last edit on the branch.
+     * This means the last change on a branch is always in its original (non-rebased) form.
+     */
     private readonly branches: Map<SessionId, Branch<TChangeset>> = new Map();
     private localChanges: TChangeset[] = [];
     private localSessionId: SessionId | undefined;
@@ -74,7 +79,7 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
         }
 
         const branch = this.getOrCreateBranch(newCommit.sessionId, newCommit.refNumber);
-        this.rebaseBranch(branch, newCommit.refNumber);
+        this.updateBranch(branch, newCommit.refNumber);
         const newChangeFullyRebased = this.rebaseChangeFromBranchToTrunk(newCommit.changeset, branch);
 
         // Note: we never use the refNumber of a commit in the trunk
@@ -105,7 +110,7 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
             changeToRebase,
         );
 
-        return this.rebaseOverCommits(changeRebasedToRef, this.getCommitsBetween(branch.refSeq, undefined));
+        return this.rebaseOverCommits(changeRebasedToRef, this.getCommitsAfter(branch.refSeq));
     }
 
     // TODO: Try to share more logic between this method and `rebaseBranch`
@@ -137,12 +142,32 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
         return netChange;
     }
 
-    private rebaseBranch(branch: Branch<TChangeset>, newRef: SeqNumber) {
-        const trunkChanges = this.getCommitsBetween(branch.refSeq, newRef);
+    /**
+     * Updates the `branch` to reflect the local changes that the session owner would have had after
+     * they learned of the commit with sequence number `newRef` being sequenced.
+     * Concretely, this means two things:
+     * 1. Rebasing the changes in the branch over any new trunk changes up to and including `newRef`.
+     * 2. Removing from the branch those changes that were sequenced before or at sequence number `newRef`.
+     * We can purge those because any new changes from this session (such as the one whose ref is `newRef`)
+     * will be independent from them (they will instead depend the trunk version of them, or some later changes
+     * in the trunk).
+     * @param branch - The branch to update.
+     * @param newRef - The point in the trunk to rebase the branch up to.
+     */
+    private updateBranch(branch: Branch<TChangeset>, newRef: SeqNumber) {
+        const trunkChanges = this.getCommitsAfterAndUpToInclusive(branch.refSeq, newRef);
+        if (trunkChanges.length === 0) {
+            assert(branch.refSeq === newRef, "Expected trunk changes");
+            // This early return avoids rebasing the branch changes over an empty sandwich.
+            return;
+        }
         const newBranchChanges: Commit<TChangeset>[] = [];
         const inverses: TChangeset[] = [];
 
         for (const commit of branch.localChanges) {
+            // If this commit was sequenced after the ref of the new commit then it means
+            // the new commit would have been based on a more up to date version of this commit.
+            // We need to compute this updated version.
             if (commit.seqNumber > newRef) {
                 let change = this.rebaseChange(commit.changeset, inverses);
                 change = this.rebaseOverCommits(change, trunkChanges);
@@ -172,14 +197,38 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
         );
     }
 
-    private getCommitsBetween(first: SeqNumber, last: SeqNumber | undefined): Commit<TChangeset>[] {
-        const firstIndex = this.getCommitIndex(first);
-        const lastIndex = last === undefined ? undefined : this.getCommitIndex(last);
-        return this.trunk.slice(firstIndex, lastIndex);
+    /**
+     * @param pred - The sequence number of the commit immediately before the commits of interest.
+     * @param last - The sequence number of the last commit of interest.
+     * @returns The trunk commits with sequence numbers greater than `pred` and smaller or equal to `last`,
+     * ordered in sequencing order.
+     */
+    private getCommitsAfterAndUpToInclusive(pred: SeqNumber, last: SeqNumber): Commit<TChangeset>[] {
+        // This check is not just a fast-path for the common case where no concurrent edits occurred,
+        // it also serves to handle the case where the `last` commit is the non-existent commit that the
+        // very first change on the document (and possibly others) will refer to.
+        if (pred === last) {
+            return [];
+        }
+        // The undefined case corresponds to the case where `pred` is a reference to the inception of the DDS.
+        const firstIndex = (this.getCommitIndex(pred) ?? -1) + 1;
+        const lastIndex = this.getCommitIndex(last) ?? fail("Unknown sequence number");
+        return this.trunk.slice(firstIndex, lastIndex + 1);
     }
 
-    private getCommitIndex(seqNumber: SeqNumber): number {
-        return this.trunk.findIndex((commit) => commit.seqNumber === seqNumber);
+    /**
+     * @param pred - The sequence number of the commit immediately before the commits of interest.
+     * @returns The commits that occurred after the commit with sequence number `pred` ordered in sequencing order.
+     */
+    private getCommitsAfter(pred: SeqNumber): Commit<TChangeset>[] {
+        // The undefined case corresponds to the case where `pred` is a reference to the inception of the DDS.
+        const firstIndex = (this.getCommitIndex(pred) ?? -1) + 1;
+        return this.trunk.slice(firstIndex);
+    }
+
+    private getCommitIndex(seqNumber: SeqNumber): number | undefined {
+        const found = this.trunk.findIndex((commit) => commit.seqNumber === seqNumber);
+        return found === -1 ? undefined : found;
     }
 
     private getOrCreateBranch(sessionId: SessionId, refSeq: SeqNumber): Branch<TChangeset> {

--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -64,6 +64,11 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
     }
 
     public addSequencedChange(newCommit: Commit<TChangeset>): Delta.Root {
+        if (this.trunk.length > 0) {
+            const lastSeqNumber = this.trunk[this.trunk.length - 1].seqNumber;
+            assert(newCommit.seqNumber > lastSeqNumber,
+                0x030/* Incoming remote op sequence# <= local collabWindow's currentSequence# */);
+        }
         if (newCommit.sessionId === this.localSessionId) {
             // `newCommit` should correspond to the oldest change in `localChanges`, so we move it into trunk.
             // `localChanges` are already rebased to the trunk, so we can use the stored change instead of rebasing the

--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -59,13 +59,6 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
     }
 
     public addSequencedChange(newCommit: Commit<TChangeset>): Delta.Root {
-        if (this.trunk.length > 0) {
-            const lastSeqNumber = this.trunk[this.trunk.length - 1].seqNumber;
-            const nextSeqNumber: SeqNumber = brand(lastSeqNumber as number + 1);
-            assert(newCommit.seqNumber === nextSeqNumber,
-                0x34a /* Expected incoming commit to be next sequenced commit */);
-        }
-
         if (newCommit.sessionId === this.localSessionId) {
             // `newCommit` should correspond to the oldest change in `localChanges`, so we move it into trunk.
             // `localChanges` are already rebased to the trunk, so we can use the stored change instead of rebasing the

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -161,7 +161,7 @@ class TestChangeRebaser implements ChangeRebaser<TestChangeset> {
         }
     }
 
-    public checkChangeList(changes: readonly RecursiveReadonly<TestChangeset>[], intentions: number[]): void {
+    public static checkChangeList(changes: readonly RecursiveReadonly<TestChangeset>[], intentions: number[]): void {
         const filtered = changes.filter(isNonEmptyChange);
         let intentionsSeen: number[] = [];
         let index = 0;
@@ -253,7 +253,7 @@ describe("EditManager", () => {
         manager.addSequencedChange(c2);
         manager.addLocalChange(c3.changeset);
         manager.addSequencedChange(c3);
-        checkChangeList(manager, rebaser, [1, 2, 3]);
+        checkChangeList(manager, [1, 2, 3]);
     });
 
     it("Can handle non-concurrent local changes being sequenced later", () => {
@@ -282,7 +282,7 @@ describe("EditManager", () => {
         manager.addSequencedChange(c1);
         manager.addSequencedChange(c2);
         manager.addSequencedChange(c3);
-        checkChangeList(manager, rebaser, [1, 2, 3]);
+        checkChangeList(manager, [1, 2, 3]);
     });
 
     it("Can handle non-concurrent peer changes sequenced immediately", () => {
@@ -305,7 +305,7 @@ describe("EditManager", () => {
             refNumber: brand(2),
             changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
         });
-        checkChangeList(manager, rebaser, [1, 2, 3]);
+        checkChangeList(manager, [1, 2, 3]);
     });
 
     it("Can handle non-concurrent peer changes sequenced later", () => {
@@ -328,7 +328,7 @@ describe("EditManager", () => {
             refNumber: brand(0),
             changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
         });
-        checkChangeList(manager, rebaser, [1, 2, 3]);
+        checkChangeList(manager, [1, 2, 3]);
     });
 
     it("Can rebase a single peer change over multiple peer changes", () => {
@@ -357,7 +357,7 @@ describe("EditManager", () => {
             refNumber: brand(0),
             changeset: TestChangeRebaser.mintChangeset([], 4),
         });
-        checkChangeList(manager, rebaser, [1, 2, 3, 4]);
+        checkChangeList(manager, [1, 2, 3, 4]);
     });
 
     it("Can rebase multiple non-interleaved peer changes", () => {
@@ -398,7 +398,7 @@ describe("EditManager", () => {
             refNumber: brand(0),
             changeset: TestChangeRebaser.mintChangeset([4, 5], 6),
         });
-        checkChangeList(manager, rebaser, [1, 2, 3, 4, 5, 6]);
+        checkChangeList(manager, [1, 2, 3, 4, 5, 6]);
     });
 
     it("Can rebase multiple interleaved peer changes", () => {
@@ -439,7 +439,7 @@ describe("EditManager", () => {
             refNumber: brand(0),
             changeset: TestChangeRebaser.mintChangeset([2, 5], 6),
         });
-        checkChangeList(manager, rebaser, [1, 2, 3, 4, 5, 6]);
+        checkChangeList(manager, [1, 2, 3, 4, 5, 6]);
     });
 
     it("Can rebase multiple interleaved peer and local changes", () => {
@@ -510,7 +510,7 @@ describe("EditManager", () => {
         manager.addSequencedChange(c7);
         manager.addSequencedChange(c8);
         manager.addSequencedChange(c9);
-        checkChangeList(manager, rebaser, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        checkChangeList(manager, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
     });
 
     /**
@@ -656,7 +656,7 @@ function runScenario(scenario: readonly ScenarioStep[]): void {
         }
         // Check the validity of the managers
         for (const client of clientData) {
-            checkChangeList(client.manager, rebaser, client.intentions);
+            checkChangeList(client.manager, client.intentions);
             const intentionsThatAnchorsWereRebasedOver =
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 rebaser.anchorRebases.get(client.manager.anchors!)?.intentions;
@@ -677,8 +677,8 @@ function newClientData(family: TestChangeFamily, iClient: number): ClientData {
     };
 }
 
-function checkChangeList(manager: TestEditManager, rebaser: TestChangeRebaser, intentions: number[]): void {
-    rebaser.checkChangeList(getAllChanges(manager), intentions);
+function checkChangeList(manager: TestEditManager, intentions: number[]): void {
+    TestChangeRebaser.checkChangeList(getAllChanges(manager), intentions);
 }
 
 function getAllChanges(manager: TestEditManager): RecursiveReadonly<TestChangeset>[] {

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -15,11 +15,11 @@ interface NonEmptyTestChangeset {
     /**
      * Identifies the document state that the changeset should apply to.
      */
-    inputContext: number;
+    inputContext: number[];
     /**
      * Identifies the document state brought about by applying the changeset to the document.
      */
-    outputContext: number;
+    outputContext: number[];
     /**
      * Identifies the editing intentions included in the changeset.
      * Editing intentions can be thought of as user actions, where each user action is unique.
@@ -40,41 +40,70 @@ export type TestChangeset = NonEmptyTestChangeset | EmptyTestChangeset;
 function isNonEmptyChange(
     change: RecursiveReadonly<TestChangeset>,
 ): change is RecursiveReadonly<NonEmptyTestChangeset> {
-    return "inputContext" in change && "outputContext" in change;
+    return "inputContext" in change;
 }
 
 interface AnchorRebaseData {
     rebases: RecursiveReadonly<NonEmptyTestChangeset>[];
-    intentions: Set<number>;
+    intentions: number[];
 }
 
 class TestChangeRebaser implements ChangeRebaser<TestChangeset> {
-    private contextCounter: number = 0;
-    private intentionCounter: number = 0;
     public readonly anchorRebases: Map<AnchorSet, AnchorRebaseData> = new Map();
 
+    public static mintChangeset(inputContext: readonly number[], intentionOpt: number): NonEmptyTestChangeset {
+        const intention = intentionOpt;
+        return {
+            inputContext: [...inputContext],
+            intentions: [intention],
+            outputContext: TestChangeRebaser.composeIntentions(inputContext, [intention]),
+        };
+    }
+
+    public static composeIntentions(base: readonly number[], extras: readonly number[]): number[] {
+        const composed = [...base];
+        let last: number | undefined = composed[composed.length - 1];
+        for (const extra of extras) {
+            // Check wether we are composing intentions that cancel each other out.
+            // This helps us ensure that we always represent sequences of intentions
+            // in the same canonical form.
+            if (last === -extra) {
+                composed.pop();
+                last = composed[composed.length - 1];
+            } else {
+                composed.push(extra);
+                last = extra;
+            }
+        }
+        return composed;
+    }
+
     public compose(changes: TestChangeset[]): TestChangeset {
-        let inputContext: number | undefined;
-        let outputContext: number | undefined;
-        const intentions: number[] = [];
+        let inputContext: number[] | undefined;
+        let outputContext: number[] | undefined;
+        let intentions: number[] = [];
         for (const change of changes) {
             if (isNonEmptyChange(change)) {
-                if (outputContext !== undefined) {
-                    // One can only compose changes of the output context of each change N matches
-                    // the input context of the change N+1.
-                    assert.equal(outputContext, change.inputContext);
-                }
                 inputContext ??= change.inputContext;
-                outputContext = change.outputContext;
-                intentions.push(...change.intentions);
+                if (outputContext !== undefined) {
+                    // The input context should match the output context of the previous change.
+                    assert.deepEqual(change.inputContext, outputContext);
+                }
+                outputContext = TestChangeRebaser.composeIntentions(
+                    outputContext ?? inputContext,
+                    change.intentions,
+                );
+                intentions = TestChangeRebaser.composeIntentions(
+                    intentions,
+                    change.intentions,
+                );
             }
         }
         if (inputContext !== undefined) {
             return {
                 inputContext,
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                outputContext: outputContext!,
                 intentions,
+                outputContext: outputContext ?? fail(),
             };
         }
         return emptyChange;
@@ -94,16 +123,11 @@ class TestChangeRebaser implements ChangeRebaser<TestChangeset> {
     public rebase(change: TestChangeset, over: TestChangeset): TestChangeset {
         if (isNonEmptyChange(change)) {
             if (isNonEmptyChange(over)) {
+                // Rebasing should only occur between two changes with the same input context
+                assert.deepEqual(change.inputContext, over.inputContext);
                 return {
                     inputContext: over.outputContext,
-                    // Note that we mint a new context ID for each rebased operation.
-                    // This means that rebasing some change A over some change B will produce
-                    // a change with a different output context every time.
-                    // This lack of fidelity could make some of the tests fail when they
-                    // should not, but will not make tests pass if they should not.
-                    // If a rebaser implementation needed to leverage this missing fidelity then this gap could
-                    // be addressed by using a more complex encoding to represent contexts.
-                    outputContext: ++this.contextCounter,
+                    outputContext: TestChangeRebaser.composeIntentions(over.outputContext, change.intentions),
                     intentions: change.intentions,
                 };
             }
@@ -116,11 +140,11 @@ class TestChangeRebaser implements ChangeRebaser<TestChangeset> {
         if (isNonEmptyChange(over)) {
             let data = this.anchorRebases.get(anchors);
             if (data === undefined) {
-                data = { rebases: [], intentions: new Set() };
+                data = { rebases: [], intentions: [] };
                 this.anchorRebases.set(anchors, data);
             }
             let lastChange: RecursiveReadonly<NonEmptyTestChangeset> | undefined;
-            const { rebases, intentions } = data;
+            const { rebases } = data;
             for (let iChange = rebases.length - 1; iChange >= 0; --iChange) {
                 const change = rebases[iChange];
                 if (isNonEmptyChange(change)) {
@@ -130,40 +154,28 @@ class TestChangeRebaser implements ChangeRebaser<TestChangeset> {
             }
             if (lastChange !== undefined) {
                 // The new change should apply to the context brought about by the previous change
-                assert.equal(over.inputContext, lastChange.outputContext);
+                assert.deepEqual(over.inputContext, lastChange.outputContext);
             }
-            updateIntentionSet(over.intentions, intentions);
+            data.intentions = TestChangeRebaser.composeIntentions(data.intentions, over.intentions);
             rebases.push(over);
         }
     }
 
-    public mintChangeset(inputContext: number): NonEmptyTestChangeset {
-        return {
-            inputContext,
-            outputContext: ++this.contextCounter,
-            intentions: [++this.intentionCounter],
-        };
-    }
-
-    public checkChangeList(changes: readonly RecursiveReadonly<TestChangeset>[], intentions?: Set<number>): void {
+    public checkChangeList(changes: readonly RecursiveReadonly<TestChangeset>[], intentions: number[]): void {
         const filtered = changes.filter(isNonEmptyChange);
-        const intentionsSeen = new Set<number>();
-        const intentionsExpected = new Set<number>(
-            intentions ??
-            makeArray(this.intentionCounter, (i: number) => i + 1),
-        );
+        let intentionsSeen: number[] = [];
         let index = 0;
         for (const change of filtered) {
-            updateIntentionSet(change.intentions, intentionsSeen);
+            intentionsSeen = TestChangeRebaser.composeIntentions(intentionsSeen, change.intentions);
             if (index > 0) {
                 const prev = filtered[index - 1];
                 // The current change should apply to the context brought about by the previous change
-                assert.equal(change.inputContext, prev.outputContext);
+                assert.deepEqual(change.inputContext, prev.outputContext);
             }
             ++index;
         }
         // All expected intentions were present
-        assert.deepEqual(intentionsSeen, intentionsExpected);
+        assert.deepEqual(intentionsSeen, intentions);
     }
 }
 
@@ -178,25 +190,6 @@ class TestChangeEncoder extends ChangeEncoder<TestChangeset> {
 
 type TestChangeFamily = ChangeFamily<unknown, TestChangeset>;
 type TestEditManager = EditManager<TestChangeset, TestChangeFamily>;
-
-function updateIntentionSet(
-    intentions: readonly number[],
-    intentionsSeen: Set<number>,
-) {
-    for (const intention of intentions) {
-        if (intention > 0) {
-            // The same intention should never be applied multiple times
-            assert(!intentionsSeen.has(intention));
-            intentionsSeen.add(intention);
-            // The intention should be part of the expected set for this client
-        } else if (intention < 0) {
-            // We are dealing with the inverse of an intention.
-            // In order for the inverse to apply, the non-inverse should have been applied already
-            assert(intentionsSeen.has(-intention));
-            intentionsSeen.delete(-intention);
-        }
-    }
-}
 
 function changeFamilyFactory(): {
     family: ChangeFamily<unknown, TestChangeset>;
@@ -231,313 +224,293 @@ const peerSessionId2: SessionId = "2";
 const NUM_STEPS = 5;
 const NUM_CLIENTS = 3;
 
+type TestCommit = Commit<TestChangeset>;
+
 describe("EditManager", () => {
     it("Can handle non-concurrent local changes being sequenced immediately", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
-        manager.addLocalChange(cs1);
-        manager.addSequencedChange({
+        const c1: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
-        });
-        manager.addLocalChange(cs2);
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([], 1),
+        };
+        const c2: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(2),
             refNumber: brand(1),
-            changeset: cs2,
-        });
-        manager.addLocalChange(cs3);
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([1], 2),
+        };
+        const c3: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(3),
             refNumber: brand(2),
-            changeset: cs3,
-        });
-        checkChangeList(manager, rebaser);
+            changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
+        };
+        manager.addLocalChange(c1.changeset);
+        manager.addSequencedChange(c1);
+        manager.addLocalChange(c2.changeset);
+        manager.addSequencedChange(c2);
+        manager.addLocalChange(c3.changeset);
+        manager.addSequencedChange(c3);
+        checkChangeList(manager, rebaser, [1, 2, 3]);
     });
 
     it("Can handle non-concurrent local changes being sequenced later", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
-        manager.addLocalChange(cs1);
-        manager.addLocalChange(cs2);
-        manager.addLocalChange(cs3);
-        manager.addSequencedChange({
+        const c1: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([], 1),
+        };
+        const c2: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(2),
             refNumber: brand(0),
-            changeset: cs2,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([1], 2),
+        };
+        const c3: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(3),
             refNumber: brand(0),
-            changeset: cs3,
-        });
-        checkChangeList(manager, rebaser);
+            changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
+        };
+        manager.addLocalChange(c1.changeset);
+        manager.addLocalChange(c2.changeset);
+        manager.addLocalChange(c3.changeset);
+        manager.addSequencedChange(c1);
+        manager.addSequencedChange(c2);
+        manager.addSequencedChange(c3);
+        checkChangeList(manager, rebaser, [1, 2, 3]);
     });
 
     it("Can handle non-concurrent peer changes sequenced immediately", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
+            changeset: TestChangeRebaser.mintChangeset([], 1),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(2),
             refNumber: brand(1),
-            changeset: cs2,
+            changeset: TestChangeRebaser.mintChangeset([1], 2),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(3),
             refNumber: brand(2),
-            changeset: cs3,
+            changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
         });
-        checkChangeList(manager, rebaser);
+        checkChangeList(manager, rebaser, [1, 2, 3]);
     });
 
     it("Can handle non-concurrent peer changes sequenced later", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
+            changeset: TestChangeRebaser.mintChangeset([], 1),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(2),
             refNumber: brand(0),
-            changeset: cs2,
+            changeset: TestChangeRebaser.mintChangeset([1], 2),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(3),
             refNumber: brand(0),
-            changeset: cs3,
+            changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
         });
-        checkChangeList(manager, rebaser);
+        checkChangeList(manager, rebaser, [1, 2, 3]);
     });
 
     it("Can rebase a single peer change over multiple peer changes", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
-        const cs4 = rebaser.mintChangeset(0);
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
+            changeset: TestChangeRebaser.mintChangeset([], 1),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(2),
             refNumber: brand(1),
-            changeset: cs2,
+            changeset: TestChangeRebaser.mintChangeset([1], 2),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(3),
             refNumber: brand(2),
-            changeset: cs3,
+            changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId2,
             seqNumber: brand(4),
             refNumber: brand(0),
-            changeset: cs4,
+            changeset: TestChangeRebaser.mintChangeset([], 4),
         });
-        checkChangeList(manager, rebaser);
+        checkChangeList(manager, rebaser, [1, 2, 3, 4]);
     });
 
     it("Can rebase multiple non-interleaved peer changes", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
-        const cs4 = rebaser.mintChangeset(0);
-        const cs5 = rebaser.mintChangeset(cs4.outputContext);
-        const cs6 = rebaser.mintChangeset(cs5.outputContext);
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
+            changeset: TestChangeRebaser.mintChangeset([], 1),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(2),
             refNumber: brand(1),
-            changeset: cs2,
+            changeset: TestChangeRebaser.mintChangeset([1], 2),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(3),
             refNumber: brand(2),
-            changeset: cs3,
+            changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId2,
             seqNumber: brand(4),
             refNumber: brand(0),
-            changeset: cs4,
+            changeset: TestChangeRebaser.mintChangeset([], 4),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId2,
             seqNumber: brand(5),
             refNumber: brand(0),
-            changeset: cs5,
+            changeset: TestChangeRebaser.mintChangeset([4], 5),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId2,
             seqNumber: brand(6),
             refNumber: brand(0),
-            changeset: cs6,
+            changeset: TestChangeRebaser.mintChangeset([4, 5], 6),
         });
-        checkChangeList(manager, rebaser);
+        checkChangeList(manager, rebaser, [1, 2, 3, 4, 5, 6]);
     });
 
     it("Can rebase multiple interleaved peer changes", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
-        const cs4 = rebaser.mintChangeset(0);
-        const cs5 = rebaser.mintChangeset(cs4.outputContext);
-        const cs6 = rebaser.mintChangeset(cs5.outputContext);
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
+            changeset: TestChangeRebaser.mintChangeset([], 1),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId2,
             seqNumber: brand(2),
             refNumber: brand(0),
-            changeset: cs4,
+            changeset: TestChangeRebaser.mintChangeset([], 2),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(3),
             refNumber: brand(1),
-            changeset: cs2,
+            changeset: TestChangeRebaser.mintChangeset([1], 3),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId1,
             seqNumber: brand(4),
             refNumber: brand(2),
-            changeset: cs3,
+            changeset: TestChangeRebaser.mintChangeset([1, 2, 3], 4),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId2,
             seqNumber: brand(5),
             refNumber: brand(0),
-            changeset: cs5,
+            changeset: TestChangeRebaser.mintChangeset([2], 5),
         });
         manager.addSequencedChange({
             sessionId: peerSessionId2,
             seqNumber: brand(6),
             refNumber: brand(0),
-            changeset: cs6,
+            changeset: TestChangeRebaser.mintChangeset([2, 5], 6),
         });
-        checkChangeList(manager, rebaser);
+        checkChangeList(manager, rebaser, [1, 2, 3, 4, 5, 6]);
     });
 
     it("Can rebase multiple interleaved peer and local changes", () => {
         const { rebaser, manager } = editManagerFactory();
-        const cs1 = rebaser.mintChangeset(0);
-        const cs2 = rebaser.mintChangeset(cs1.outputContext);
-        const cs3 = rebaser.mintChangeset(cs2.outputContext);
-        const cs4 = rebaser.mintChangeset(0);
-        const cs5 = rebaser.mintChangeset(cs4.outputContext);
-        const cs6 = rebaser.mintChangeset(cs5.outputContext);
-        const cs7 = rebaser.mintChangeset(0);
-        manager.addLocalChange(cs7);
-        manager.addSequencedChange({
+        const c1: TestCommit = {
             sessionId: peerSessionId1,
             seqNumber: brand(1),
             refNumber: brand(0),
-            changeset: cs1,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([], 1),
+        };
+        const c2: TestCommit = {
             sessionId: peerSessionId2,
             seqNumber: brand(2),
             refNumber: brand(0),
-            changeset: cs4,
-        });
-        const cs8 = rebaser.mintChangeset(getTipContext(manager));
-        manager.addLocalChange(cs8);
-        const cs9 = rebaser.mintChangeset(getTipContext(manager));
-        manager.addLocalChange(cs9);
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([], 2),
+        };
+        const c3: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(3),
             refNumber: brand(0),
-            changeset: cs7,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([], 3),
+        };
+        const c4: TestCommit = {
             sessionId: peerSessionId1,
             seqNumber: brand(4),
             refNumber: brand(1),
-            changeset: cs2,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([1], 4),
+        };
+        const c5: TestCommit = {
             sessionId: peerSessionId1,
             seqNumber: brand(5),
             refNumber: brand(2),
-            changeset: cs3,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([1, 2, 4], 5),
+        };
+        const c6: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(6),
             refNumber: brand(2),
-            changeset: cs8,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([1, 2, 3], 6),
+        };
+        const c7: TestCommit = {
             sessionId: peerSessionId2,
             seqNumber: brand(7),
             refNumber: brand(0),
-            changeset: cs5,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([2], 7),
+        };
+        const c8: TestCommit = {
             sessionId: localSessionId,
             seqNumber: brand(8),
             refNumber: brand(2),
-            changeset: cs9,
-        });
-        manager.addSequencedChange({
+            changeset: TestChangeRebaser.mintChangeset([1, 2, 3, 6], 8),
+        };
+        const c9: TestCommit = {
             sessionId: peerSessionId2,
             seqNumber: brand(9),
             refNumber: brand(0),
-            changeset: cs6,
-        });
-        checkChangeList(manager, rebaser);
+            changeset: TestChangeRebaser.mintChangeset([2, 7], 9),
+        };
+        manager.addLocalChange(c3.changeset);
+        manager.addSequencedChange(c1);
+        manager.addSequencedChange(c2);
+        manager.addLocalChange(c6.changeset);
+        manager.addLocalChange(c8.changeset);
+        manager.addSequencedChange(c3);
+        manager.addSequencedChange(c4);
+        manager.addSequencedChange(c5);
+        manager.addSequencedChange(c6);
+        manager.addSequencedChange(c7);
+        manager.addSequencedChange(c8);
+        manager.addSequencedChange(c9);
+        checkChangeList(manager, rebaser, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
     });
 
     /**
@@ -555,6 +528,9 @@ describe("EditManager", () => {
             seq: 0,
         };
         for (const scenario of buildScenario([], meta)) {
+            const name = scenario.map((step) => `${step.type}${step.client}`).join("-");
+            console.debug(name);
+            // it(name, () => { runScenario(scenario); });
             runScenario(scenario);
         }
     });
@@ -634,25 +610,25 @@ interface ClientData {
     /** The last sequence number received by the client */
     ref: SeqNumber;
     /** Intentions that the client should be aware of */
-    intentions: Set<number>;
+    intentions: number[];
 }
 
 function runScenario(scenario: readonly ScenarioStep[]): void {
-    const name = scenario.map((step) => `${step.type}${step.client}`).join("-");
     const { rebaser, family } = changeFamilyFactory();
     const trunk: Commit<TestChangeset>[] = [];
     const clientData: ClientData[] = makeArray(NUM_CLIENTS, (iClient) => newClientData(family, iClient));
+    let changeCounter = 0;
     for (const step of scenario) {
         // Perform the step
         {
             const client = clientData[step.client];
             if (step.type === "Mint") {
-                const cs = rebaser.mintChangeset(getTipContext(client.manager));
+                const cs = TestChangeRebaser.mintChangeset(getTipContext(client.manager), ++changeCounter);
                 client.manager.addLocalChange(cs);
                 client.localChanges.push({ change: cs, ref: client.ref });
-                cs.intentions.forEach((intention) => client.intentions.add(intention));
+                cs.intentions.forEach((intention) => client.intentions.push(intention));
             } else if (step.type === "Sequence") {
-                const local = client.localChanges.shift() ?? fail("No local changes to sequence");
+                const local = client.localChanges[0] ?? fail("No local changes to sequence");
                 trunk.push({
                     changeset: local.change,
                     refNumber: brand(local.ref),
@@ -662,7 +638,19 @@ function runScenario(scenario: readonly ScenarioStep[]): void {
             } else { // step.type === "Receive"
                 const commit = trunk[client.ref];
                 client.manager.addSequencedChange(commit);
-                commit.changeset.intentions.forEach((intention) => client.intentions.add(intention));
+                // If the change came from this client
+                if (commit.sessionId === step.client.toString()) {
+                    // Discard the local change
+                    client.localChanges.shift();
+                    // Do not update the intentions
+                } else {
+                    // Update the intentions known to this client
+                    client.intentions.splice(
+                        client.intentions.length - client.localChanges.length,
+                        0,
+                        ...commit.changeset.intentions,
+                    );
+                }
                 client.ref += 1;
             }
         }
@@ -673,7 +661,7 @@ function runScenario(scenario: readonly ScenarioStep[]): void {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 rebaser.anchorRebases.get(client.manager.anchors!)?.intentions;
             // Check the anchors have been updated if applicable
-            assert.deepEqual(intentionsThatAnchorsWereRebasedOver ?? new Set(), client.intentions);
+            assert.deepEqual(intentionsThatAnchorsWereRebasedOver ?? [], client.intentions);
         }
     }
 }
@@ -685,11 +673,11 @@ function newClientData(family: TestChangeFamily, iClient: number): ClientData {
         manager,
         localChanges: [],
         ref: 0,
-        intentions: new Set(),
+        intentions: [],
     };
 }
 
-function checkChangeList(manager: TestEditManager, rebaser: TestChangeRebaser, intentions?: Set<number>): void {
+function checkChangeList(manager: TestEditManager, rebaser: TestChangeRebaser, intentions: number[]): void {
     rebaser.checkChangeList(getAllChanges(manager), intentions);
 }
 
@@ -697,13 +685,13 @@ function getAllChanges(manager: TestEditManager): RecursiveReadonly<TestChangese
     return manager.getTrunk().map((c) => c.changeset).concat(manager.getLocalChanges());
 }
 
-function getTipContext(manager: TestEditManager): number {
+function getTipContext(manager: TestEditManager): number[] {
     const changes = getAllChanges(manager);
     for (let i = changes.length - 1; i >= 0; --i) {
         const change = changes[i];
         if (isNonEmptyChange(change)) {
-            return change.outputContext;
+            return [...change.outputContext];
         }
     }
-    return 0;
+    return [];
 }

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -528,9 +528,9 @@ describe("EditManager", () => {
             seq: 0,
         };
         for (const scenario of buildScenario([], meta)) {
-            const name = scenario.map((step) => `${step.type}${step.client}`).join("-");
-            console.debug(name);
-            // it(name, () => { runScenario(scenario); });
+            // Uncomment the lines below to see which scenario fails first.
+            // const name = scenario.map((step) => `${step.type}${step.client}`).join("-");
+            // console.debug(name);
             runScenario(scenario);
         }
     });


### PR DESCRIPTION
## `EditManager` Changes
* Removed invalid expectation that seq numbers received by a DDS are sequential
* Fixed some off-by-one errors
* Added support for refs to the non-existent edit at the start of history
* Added more doc comments to clarify logic and invariants
* Added a fast path to avoid needless rebasing when a new change for a branch is based on nothing but that branch

## Changes to Tests
* Added an additional assert that verifies rebase operation are always valid
* Changed the `TestChangeRebaser` to make the expected value of input and output contexts less arbitrary and less opaque.
* Fixed invalid test scenarios