### PR TITLE
Removed existing flag, pending tests

### DIFF
--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -65,6 +65,9 @@
       "InterfaceDeclaration_IConnectionDetails": {
         "backCompat": false
       },
+      "InterfaceDeclaration_IContainerContext": {
+        "backCompat": false
+      },
       "RemovedInterfaceDeclaration_ICodeLoader": {
         "forwardCompat": false,
         "backCompat": false

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -112,7 +112,6 @@ export interface IRuntime extends IDisposable {
  * and the Container has created a new ContainerContext.
  */
 export interface IContainerContext extends IDisposable {
-    readonly existing: boolean | undefined;
     readonly options: ILoaderOptions;
     readonly clientId: string | undefined;
     readonly clientDetails: IClientDetails;
@@ -188,5 +187,5 @@ export interface IRuntimeFactory extends IProvideRuntimeFactory {
      * @param context - container context to be supplied to the runtime
      * @param existing - whether to instantiate for the first time or from an existing context
      */
-    instantiateRuntime(context: IContainerContext, existing?: boolean): Promise<IRuntime>;
+    instantiateRuntime(context: IContainerContext, existing: boolean): Promise<IRuntime>;
 }

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -384,6 +384,7 @@ declare function get_current_InterfaceDeclaration_IContainerContext():
 declare function use_old_InterfaceDeclaration_IContainerContext(
     use: TypeOnly<old.IContainerContext>);
 use_old_InterfaceDeclaration_IContainerContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerContext());
 
 /*

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -646,7 +646,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             tryFetchBlob<[string, string][]>(aliasBlobName),
         ]);
 
-        const loadExisting = existing === true || context.existing === true;
+        const loadExisting = existing === true;
 
         // read snapshot blobs needed for BlobManager to load
         const blobManagerSnapshot = await BlobManager.load(

--- a/packages/runtime/runtime-utils/src/runtimeFactoryHelper.ts
+++ b/packages/runtime/runtime-utils/src/runtimeFactoryHelper.ts
@@ -17,9 +17,7 @@ export abstract class RuntimeFactoryHelper<T = IContainerRuntime> implements IRu
         context: IContainerContext,
         existing: boolean,
     ): Promise<IRuntime> {
-        const fromExisting = existing === undefined
-            ? context.existing === true
-            : existing;
+        const fromExisting = existing;
         const runtime = await this.preInitialize(context, fromExisting);
 
         if (fromExisting) {

--- a/packages/runtime/runtime-utils/src/runtimeFactoryHelper.ts
+++ b/packages/runtime/runtime-utils/src/runtimeFactoryHelper.ts
@@ -15,7 +15,7 @@ export abstract class RuntimeFactoryHelper<T = IContainerRuntime> implements IRu
 
     public async instantiateRuntime(
         context: IContainerContext,
-        existing?: boolean,
+        existing: boolean,
     ): Promise<IRuntime> {
         const fromExisting = existing === undefined
             ? context.existing === true

--- a/packages/runtime/runtime-utils/src/test/runtimeFactoryHelper.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/runtimeFactoryHelper.spec.ts
@@ -56,30 +56,4 @@ describe("RuntimeFactoryHelper", () => {
 
         unit.verify();
     });
-
-    it("Instantiate when existing flag is unset", async () => {
-        unit.expects("instantiateFirstTime").once();
-        unit.expects("instantiateFromExisting").never();
-        await helper.instantiateRuntime(context as IContainerContext);
-
-        unit.verify();
-    });
-
-    it("Instantiate when existing flag is unset and context is existing", async () => {
-        const existingContext: Partial<IContainerContext> = { existing: true };
-        unit.expects("instantiateFirstTime").never();
-        unit.expects("instantiateFromExisting").once();
-        await helper.instantiateRuntime(existingContext as IContainerContext);
-
-        unit.verify();
-    });
-
-    it("Instantiate when existing flag takes precedence over context", async () => {
-        const existingContext: Partial<IContainerContext> = { existing: true };
-        unit.expects("instantiateFirstTime").once();
-        unit.expects("instantiateFromExisting").never();
-        await helper.instantiateRuntime(existingContext as IContainerContext, /* existing */ false);
-
-        unit.verify();
-    });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
@@ -36,7 +36,7 @@ class ContainerRuntimeFactoryWithGC extends ContainerRuntimeFactoryWithDefaultDa
     public async instantiateRuntime(
         context: IContainerContext,
     ): Promise<IRuntime> {
-        const runtime = await super.instantiateRuntime(context);
+        const runtime = await super.instantiateRuntime(context, false);
         // A hack to update the currentGCVersion.
         (runtime as any).garbageCollector.currentGCVersion += 1;
         return runtime;


### PR DESCRIPTION
[AB#994](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/994)

This PR modifies/ removes the usage of the `existing` field in runtime.