### PR TITLE
Update scope for npm dependencies

### DIFF
--- a/tools/pipelines/dependency-injection/.npmrc
+++ b/tools/pipelines/dependency-injection/.npmrc
@@ -4,5 +4,5 @@ always-auth=false
 @fluidframework:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
 @fluid-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
 @ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
-@ms:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
+@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
 always-auth=true

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -156,7 +156,7 @@ jobs:
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-internal:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-            echo "@ms:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+            echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
             echo "always-auth=true" >> ./.npmrc
             cat .npmrc
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -186,7 +186,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
-          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger'
+          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger@0.0.11'
           customRegistry: 'useNpmrc'
 
       # Download Test Files & Install Extra Dependencies


### PR DESCRIPTION
## Description

As part of recent changes to some of our internal infrastructure I updated the scope for some NPM dependencies in the `@ff-internal/aria-logger` package. Pipelines are currently installing the latest version of aria-logger but setting up authentication for the older scope for the dependencies.

This PR updates the scope/feed used in the pipelines and pins the installed version of aria-logger so that future changes to it aren't a (potential) immediate break in the pipelines. 

## Reviewer Guidance

Pinning the version of aria-logger that we install in the pipelines means one more change we need to make there in order for any improvements made to aria-logger to be reflected, but it makes them a bit more robust. Given the low frequency of changes to aria-logger, I think the trade-off is acceptable.
