### PR TITLE
Add app insights key to docs build pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -127,6 +127,7 @@ stages:
             echo RELEASE_VERSION: $(RELEASE_VERSION)
             echo MAIN_BRANCH_VERSION: $(MAIN_BRANCH_VERSION)
             echo N1_VERSION: $(N1_VERSION)
+            echo HUGO_PARAMS_APPINSIGHTKEY=$(HUGO_PARAMS_APPINSIGHTKEY)
             echo releasePipeline ${{ variables.releasePipeline }}
             echo latestPipeline ${{ variables.latestPipeline }}
             echo n1Pipeline ${{ variables.n1Pipeline }}


### PR DESCRIPTION
The app insights instrumentation key was not added to the CI pipeline when we moved the website publishing to ADO from GitHub actions back in May. The variable has already been added to the CI/CD config, so this change just outputs the value for debugging purposes.