### PR TITLE
remove t9s skip in containerDirtyFlag

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
@@ -122,10 +122,6 @@ describeNoCompat("Container dirty flag", (getTestObjectProvider) => {
         });
 
         it("handles container with pending ops not to be sent out", async function() {
-            // GitHub issue: #9534
-            if (provider.driver.type === "tinylicious") {
-                this.skip();
-            }
             const pendingOps = await getPendingOps(provider, true, (c, d, map) => {
                 [...Array(lots).keys()].map((i) => map.set(i.toString(), i));
             });


### PR DESCRIPTION
Removing tinylicious skip in containerDirtyFlag.spec.ts to test against CI since this bug seems to not be reproducible locally