### PR TITLE
TreeDDS changeset format: remove AttachGroup construct

### DIFF
--- a/packages/dds/tree/src/changeset/format.ts
+++ b/packages/dds/tree/src/changeset/format.ts
@@ -52,11 +52,11 @@ export namespace Transposed {
 
 	export type Mark =
 		| SizedMark
-		| AttachGroup;
+		| Attach;
 
 	export type ObjectMark =
 		| SizedObjectMark
-		| AttachGroup;
+		| Attach;
 
 	export type SizedMark =
 		| Skip
@@ -70,8 +70,6 @@ export namespace Transposed {
 		| ModifyReattach
 		| ModifyDetach
 		| GapEffectSegment;
-
-	export type AttachGroup = Attach[];
 
 	export interface Tomb {
 		type: "Tomb";

--- a/packages/dds/tree/src/changeset/markListFactory.ts
+++ b/packages/dds/tree/src/changeset/markListFactory.ts
@@ -4,7 +4,7 @@
  */
 
 import { Skip, Transposed as T } from "./format";
-import { extendAttachGroup, isAttachGroup, isObjMark, isSkipMark, tryExtendMark } from "./utils";
+import { isObjMark, isSkipMark, tryExtendMark } from "./utils";
 
 /**
  * Helper class for constructing an offset list of marks that...
@@ -37,20 +37,9 @@ export class MarkListFactory {
             this.offset = 0;
         }
         const prev = this.list[this.list.length - 1];
-        if (isObjMark(prev)) {
-            if (isAttachGroup(prev)) {
-                if (isAttachGroup(mark)) {
-                    extendAttachGroup(prev, mark);
-                    return;
-                }
-            } else if (
-                !isAttachGroup(mark)
-                && prev.type === mark.type
-            ) {
-                // Neither are attach groups
-                if (tryExtendMark(prev, mark)) {
-                    return;
-                }
+        if (isObjMark(prev) && prev.type === mark.type) {
+            if (tryExtendMark(prev, mark)) {
+                return;
             }
         }
         this.list.push(mark);

--- a/packages/dds/tree/src/changeset/toDelta.ts
+++ b/packages/dds/tree/src/changeset/toDelta.ts
@@ -7,6 +7,7 @@ import { unreachableCase } from "@fluidframework/common-utils";
 import { brand, brandOpaque, clone, fail, OffsetListFactory } from "../util";
 import { FieldKey, Value, Delta } from "../tree";
 import { ProtoNode, Transposed as T } from "./format";
+import { isSkipMark } from "./utils";
 
 /**
  * Converts a Changeset into a Delta.
@@ -23,7 +24,7 @@ export function toDelta(changeset: T.LocalChangeset): Delta.Root {
 function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
     const out = new OffsetListFactory<Delta.Mark>();
     for (const mark of marks) {
-        if (typeof mark === "number") {
+        if (isSkipMark(mark)) {
             out.pushOffset(mark);
         } else {
             // Inline into `switch(mark.type)` once we upgrade to TS 4.7
@@ -205,7 +206,7 @@ function applyOrCollectModifications(
             const outMarks = new OffsetListFactory<InsertedFieldsMark>();
             let index = 0;
             for (const mark of modifyFields[key]) {
-                if (typeof mark === "number") {
+                if (isSkipMark(mark)) {
                     index += mark;
                     outMarks.pushOffset(mark);
                 } else {

--- a/packages/dds/tree/src/changeset/toDelta.ts
+++ b/packages/dds/tree/src/changeset/toDelta.ts
@@ -25,57 +25,49 @@ function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
     for (const mark of marks) {
         if (typeof mark === "number") {
             out.pushOffset(mark);
-        } else if (Array.isArray(mark)) {
-            for (const attach of mark) {
-                // Inline into `switch(attach.type)` once we upgrade to TS 4.7
-                const type = attach.type;
-                switch (type) {
-                    case "Insert": {
-                        const insertMark: Delta.Insert = {
-                            type: Delta.MarkType.Insert,
-                            content: cloneTreeContent(attach.content),
-                        };
-                        out.pushContent(insertMark);
-                        break;
-                    }
-                    case "MInsert": {
-                        const cloned = cloneAndModify(attach);
-                        if (cloned.fields.size > 0) {
-                            const insertMark: Delta.InsertAndModify = {
-                                type: Delta.MarkType.InsertAndModify,
-                                ...cloned,
-                            };
-                            out.pushContent(insertMark);
-                        } else {
-                            const insertMark: Delta.Insert = {
-                                type: Delta.MarkType.Insert,
-                                content: [cloned.content],
-                            };
-                            out.pushContent(insertMark);
-                        }
-                        break;
-                    }
-                    case "MoveIn": {
-                        const moveMark: Delta.MoveIn = {
-                            type: Delta.MarkType.MoveIn,
-                            moveId: brandOpaque<Delta.MoveId>(attach.id),
-                        };
-                        out.pushContent(moveMark);
-                        break;
-                    }
-                    case "MMoveIn":
-                        fail(ERR_NOT_IMPLEMENTED);
-                    case "Bounce":
-                    case "Intake":
-                        // These have no impacts on the document state.
-                        break;
-                    default: unreachableCase(type);
-                }
-            }
         } else {
             // Inline into `switch(mark.type)` once we upgrade to TS 4.7
             const type = mark.type;
             switch (type) {
+                case "Insert": {
+                    const insertMark: Delta.Insert = {
+                        type: Delta.MarkType.Insert,
+                        content: cloneTreeContent(mark.content),
+                    };
+                    out.pushContent(insertMark);
+                    break;
+                }
+                case "MInsert": {
+                    const cloned = cloneAndModify(mark);
+                    if (cloned.fields.size > 0) {
+                        const insertMark: Delta.InsertAndModify = {
+                            type: Delta.MarkType.InsertAndModify,
+                            ...cloned,
+                        };
+                        out.pushContent(insertMark);
+                    } else {
+                        const insertMark: Delta.Insert = {
+                            type: Delta.MarkType.Insert,
+                            content: [cloned.content],
+                        };
+                        out.pushContent(insertMark);
+                    }
+                    break;
+                }
+                case "MoveIn": {
+                    const moveMark: Delta.MoveIn = {
+                        type: Delta.MarkType.MoveIn,
+                        moveId: brandOpaque<Delta.MoveId>(mark.id),
+                    };
+                    out.pushContent(moveMark);
+                    break;
+                }
+                case "MMoveIn":
+                    fail(ERR_NOT_IMPLEMENTED);
+                case "Bounce":
+                case "Intake":
+                    // These have no impacts on the document state.
+                    break;
                 case "Modify": {
                     if (mark.tomb === undefined) {
                         out.pushContent({
@@ -216,45 +208,37 @@ function applyOrCollectModifications(
                 if (typeof mark === "number") {
                     index += mark;
                     outMarks.pushOffset(mark);
-                } else if (Array.isArray(mark)) {
-                    for (const attach of mark) {
-                        // Inline into `switch(attach.type)` once we upgrade to TS 4.7
-                        const type = attach.type;
-                        switch (type) {
-                            case "Insert": {
-                                const content = cloneTreeContent(attach.content);
-                                outNodes.splice(index, 0, ...content);
-                                index += content.length;
-                                outMarks.pushOffset(content.length);
-                                break;
-                            }
-                            case "MInsert": {
-                                const cloned = cloneAndModify(attach);
-                                if (cloned.fields.size > 0) {
-                                    outMarks.pushContent({
-                                        type: Delta.MarkType.Modify,
-                                        fields: cloned.fields,
-                                    });
-                                }
-                                outNodes.splice(index, 0, cloned.content);
-                                index += 1;
-                                break;
-                            }
-                            case "MoveIn":
-                            case "MMoveIn":
-                                // TODO: convert into a Delta.MoveIn/MoveInAndModify
-                                fail(ERR_NOT_IMPLEMENTED);
-                            case "Bounce":
-                                fail(ERR_BOUNCE_ON_INSERT);
-                            case "Intake":
-                                fail(ERR_INTAKE_ON_INSERT);
-                            default: unreachableCase(type);
-                        }
-                    }
                 } else {
                     // Inline into `switch(mark.type)` once we upgrade to TS 4.7
                     const type = mark.type;
                     switch (type) {
+                        case "Insert": {
+                            const content = cloneTreeContent(mark.content);
+                            outNodes.splice(index, 0, ...content);
+                            index += content.length;
+                            outMarks.pushOffset(content.length);
+                            break;
+                        }
+                        case "MInsert": {
+                            const cloned = cloneAndModify(mark);
+                            if (cloned.fields.size > 0) {
+                                outMarks.pushContent({
+                                    type: Delta.MarkType.Modify,
+                                    fields: cloned.fields,
+                                });
+                            }
+                            outNodes.splice(index, 0, cloned.content);
+                            index += 1;
+                            break;
+                        }
+                        case "MoveIn":
+                        case "MMoveIn":
+                            // TODO: convert into a Delta.MoveIn/MoveInAndModify
+                            fail(ERR_NOT_IMPLEMENTED);
+                        case "Bounce":
+                            fail(ERR_BOUNCE_ON_INSERT);
+                        case "Intake":
+                            fail(ERR_INTAKE_ON_INSERT);
                         case "Modify": {
                             if ("tomb" in mark) {
                                 continue;

--- a/packages/dds/tree/src/changeset/utils.ts
+++ b/packages/dds/tree/src/changeset/utils.ts
@@ -8,25 +8,29 @@ import { fail } from "../util";
 import { Skip, Transposed as T } from "./format";
 
 export function isAttach(mark: T.Mark): mark is T.Attach {
-    return isObjMark(mark) && "type" in mark &&
-        (
+    return isObjMark(mark)
+        && "type" in mark
+        && (
             mark.type === "Insert"
             || mark.type === "MInsert"
             || mark.type === "MoveIn"
             || mark.type === "MMoveIn"
             || mark.type === "Bounce"
             || mark.type === "Intake"
-        );
+        )
+    ;
 }
 
 export function isReattach(mark: T.Mark): mark is T.Reattach | T.ModifyReattach {
-    return isObjMark(mark) && "type" in mark &&
-        (
+    return isObjMark(mark)
+        && "type" in mark
+        && (
             mark.type === "Revive"
             || mark.type === "MRevive"
             || mark.type === "Return"
             || mark.type === "MReturn"
-        );
+        )
+    ;
 }
 
 export function isTomb(mark: T.Mark): mark is T.Tomb {
@@ -70,6 +74,18 @@ export function isEqualGaps(lhs: T.GapEffect[] | undefined, rhs: T.GapEffect[] |
         }
     }
     return true;
+}
+
+/**
+ * @returns `true` iff `lhs` and `rhs`'s `HasPlaceFields` fields are structurally equal.
+ */
+export function isEqualPlace(lhs: Readonly<T.HasPlaceFields>, rhs: Readonly<T.HasPlaceFields>): boolean {
+    return lhs.heed === rhs.heed
+    && lhs.tiebreak === rhs.tiebreak
+    && lhs.src?.id === rhs.src?.id
+    && lhs.src?.change === rhs.src?.change
+    && lhs.scorch?.id === rhs.scorch?.id
+    && lhs.scorch?.change === rhs.scorch?.change;
 }
 
 export function isEqualGapEffect(lhs: Readonly<T.GapEffect>, rhs: Readonly<T.GapEffect>): boolean {
@@ -261,14 +277,7 @@ export function tryExtendMark(lhs: T.ObjectMark, rhs: Readonly<T.ObjectMark>): b
         case "Insert":
         case "MoveIn": {
             const lhsAttach = lhs as T.Insert | T.MoveIn;
-            if (
-                rhs.id === lhsAttach.id
-                && rhs.heed === lhsAttach.heed
-                && rhs.tiebreak === lhsAttach.tiebreak
-                && rhs.src?.id === lhsAttach.src?.id
-                && rhs.src?.change === lhsAttach.src?.change
-                && rhs.scorch?.id === lhsAttach.scorch?.id
-                && rhs.scorch?.change === lhsAttach.scorch?.change) {
+            if (rhs.id === lhsAttach.id ?? isEqualPlace(lhsAttach, rhs)) {
                 if (rhs.type === "Insert") {
                     const lhsInsert = lhsAttach as T.Insert;
                     lhsInsert.content.push(...rhs.content);

--- a/packages/dds/tree/src/changeset/utils.ts
+++ b/packages/dds/tree/src/changeset/utils.ts
@@ -7,8 +7,16 @@ import { unreachableCase } from "@fluidframework/common-utils";
 import { fail } from "../util";
 import { Skip, Transposed as T } from "./format";
 
-export function isAttachGroup(mark: T.Mark): mark is T.AttachGroup {
-    return Array.isArray(mark);
+export function isAttach(mark: T.Mark): mark is T.Attach {
+    return isObjMark(mark) && "type" in mark &&
+        (
+            mark.type === "Insert"
+            || mark.type === "MInsert"
+            || mark.type === "MoveIn"
+            || mark.type === "MMoveIn"
+            || mark.type === "Bounce"
+            || mark.type === "Intake"
+        );
 }
 
 export function isReattach(mark: T.Mark): mark is T.Reattach | T.ModifyReattach {
@@ -79,16 +87,18 @@ export function getOutputLength(mark: T.Mark): number {
     if (isSkipMark(mark)) {
         return mark;
     }
-    if (isAttachGroup(mark)) {
-        return mark.reduce((prev, attach) => prev + getAttachLength(attach), 0);
-    }
     const type = mark.type;
     switch (type) {
         case "Tomb":
         case "Gap":
         case "Revive":
         case "Return":
+        case "MoveIn":
             return mark.count;
+        case "Insert":
+            return mark.content.length;
+        case "MInsert":
+        case "MMoveIn":
         case "MReturn":
         case "MRevive":
         case "Modify":
@@ -97,6 +107,8 @@ export function getOutputLength(mark: T.Mark): number {
         case "MDelete":
         case "MoveOut":
         case "MMoveOut":
+        case "Intake":
+        case "Bounce":
             return 0;
         default: unreachableCase(type);
     }
@@ -110,7 +122,7 @@ export function getInputLength(mark: T.Mark): number {
     if (isSkipMark(mark)) {
         return mark;
     }
-    if (isAttachGroup(mark)) {
+    if (isAttach(mark)) {
         return 0;
     }
     const type = mark.type;
@@ -190,76 +202,33 @@ export function splitMarkOnOutput<TMark extends T.Mark>(mark: TMark, length: num
     if (isSkipMark(mark)) {
         return [length, remainder] as [TMark, TMark];
     }
-    if (isAttachGroup(mark)) {
-        return splitAttachGroup(mark, length) as [TMark, TMark];
-    }
-    const markObj = mark as T.SizedObjectMark;
+    const markObj = mark as T.ObjectMark;
     const type = markObj.type;
     switch (type) {
         case "Modify":
         case "MReturn":
         case "MRevive":
+        case "MInsert":
+        case "MMoveIn":
             fail(`Unable to split ${type} mark of length 1`);
         case "MDelete":
         case "MMoveOut":
         case "Delete":
         case "MoveOut":
+        case "Bounce":
+        case "Intake":
             fail(`Unable to split ${type} mark of length 0`);
+        case "Insert":
+            return [
+                { ...markObj, content: markObj.content.slice(0, length) },
+                { ...markObj, content: markObj.content.slice(length) },
+            ] as [TMark, TMark];
+        case "MoveIn":
         case "Return":
         case "Revive":
         case "Tomb":
         case "Gap":
             return [{ ...markObj, count: length }, { ...markObj, count: remainder }] as [TMark, TMark];
-        default: unreachableCase(type);
-    }
-}
-
-function splitAttachGroup<TAttach extends T.Attach>(mark: TAttach[], length: number): [TAttach[], TAttach[]] {
-    const groupA: TAttach[] = [];
-    const groupB: TAttach[] = [...mark];
-    let groupALength = 0;
-    while (groupALength < length) {
-        const attach = groupB.shift();
-        if (attach === undefined) {
-            fail("Discrepancy between getMarkLength and splitMark");
-        }
-        const len = getAttachLength(attach);
-        if (groupALength + len <= length) {
-            groupA.push(attach);
-            groupALength += len;
-        } else {
-            const [partA, partB] = splitAttachMark(attach, length - groupALength);
-            groupA.push(partA);
-            groupB.unshift(partB);
-            groupALength = length;
-        }
-    }
-    return [groupA, groupB];
-}
-
-function splitAttachMark<TAttach extends T.Attach>(attach: TAttach, length: number): [TAttach, TAttach] {
-    const markLength = getAttachLength(attach);
-    const remainder = markLength - length;
-    if (length < 1 || markLength <= length) {
-        fail(`Unable to split mark of length ${markLength} into marks of lengths ${length} and ${remainder}`);
-    }
-    const type = attach.type;
-    switch (type) {
-        case "Bounce":
-        case "Intake":
-        case "MInsert":
-        case "MMoveIn":
-            fail("Unable to split mark");
-        case "Insert":
-            return [
-                { ...attach, content: attach.content.slice(0, length) },
-                { ...attach, content: attach.content.slice(length) },
-            ];
-        case "MoveIn":
-            return [
-                { ...attach, count: length },
-                { ...attach, count: remainder },
-            ];
         default: unreachableCase(type);
     }
 }
@@ -277,59 +246,40 @@ export function isObjMark(mark: T.Mark | undefined): mark is T.ObjectMark {
 }
 
 /**
- * Appends the contents of the `addendum` to the `group`.
- * @param group - The attach group to append attach marks to. Is mutated by this function.
- * @param addendum - The array of attach marks to append. Is not mutated by this function.
- */
-export function extendAttachGroup(group: T.AttachGroup, addendum: T.AttachGroup): void {
-    const lastLeft = group[group.length - 1];
-    const firstRight = addendum[0];
-    if (lastLeft !== undefined
-        && firstRight !== undefined
-        && lastLeft.type === firstRight.type
-        && lastLeft.id === firstRight.id) {
-        const type = lastLeft.type;
-        switch (type) {
-            case "Insert":
-            case "MoveIn": {
-                const firstRightAttach = firstRight as T.Insert | T.MoveIn;
-                if (lastLeft.heed === firstRightAttach.heed
-                    && lastLeft.tiebreak === firstRightAttach.tiebreak
-                    && lastLeft.src?.id === firstRightAttach.src?.id
-                    && lastLeft.src?.change === firstRightAttach.src?.change
-                    && lastLeft.scorch?.id === firstRightAttach.scorch?.id
-                    && lastLeft.scorch?.change === firstRightAttach.scorch?.change) {
-                    if (lastLeft.type === "Insert") {
-                        const firstRightInsert = firstRight as T.Insert;
-                        lastLeft.content.push(...firstRightInsert.content);
-                    } else {
-                        const firstRightMoveIn = firstRight as T.MoveIn;
-                        lastLeft.count += firstRightMoveIn.count;
-                    }
-                    group.push(...addendum.slice(1));
-                    return;
-                }
-                break;
-            }
-            default: break;
-        }
-    }
-    group.push(...addendum);
-}
-
-/**
  * Attempts to extend `lhs` to include the effects of `rhs`.
  * @param lhs - The mark to extend.
  * @param rhs - The effect so extend `rhs` with.
  * @returns `true` iff the function was able to mutate `lhs` to include the effects of `rhs`.
  * When `false` is returned, `lhs` is left untouched.
  */
-export function tryExtendMark(lhs: T.SizedObjectMark, rhs: Readonly<T.SizedObjectMark>): boolean {
+export function tryExtendMark(lhs: T.ObjectMark, rhs: Readonly<T.ObjectMark>): boolean {
     if (rhs.type !== lhs.type) {
         return false;
     }
     const type = rhs.type;
     switch (type) {
+        case "Insert":
+        case "MoveIn": {
+            const lhsAttach = lhs as T.Insert | T.MoveIn;
+            if (
+                rhs.id === lhsAttach.id
+                && rhs.heed === lhsAttach.heed
+                && rhs.tiebreak === lhsAttach.tiebreak
+                && rhs.src?.id === lhsAttach.src?.id
+                && rhs.src?.change === lhsAttach.src?.change
+                && rhs.scorch?.id === lhsAttach.scorch?.id
+                && rhs.scorch?.change === lhsAttach.scorch?.change) {
+                if (rhs.type === "Insert") {
+                    const lhsInsert = lhsAttach as T.Insert;
+                    lhsInsert.content.push(...rhs.content);
+                } else {
+                    const lhsMoveIn = lhsAttach as T.MoveIn;
+                    lhsMoveIn.count += rhs.count;
+                }
+                return true;
+            }
+            break;
+        }
         case "Delete":
         case "MoveOut": {
             const lhsDetach = lhs as T.Detach;

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/invert.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ChangesetTag, isAttachGroup, isSkipMark, OpId, Transposed as T } from "../../changeset";
+import { ChangesetTag, isSkipMark, OpId, Transposed as T } from "../../changeset";
 import { fail } from "../../util";
 import { SequenceChangeset } from "./sequenceChangeset";
 
@@ -63,25 +63,16 @@ function invertMarkList(markList: T.MarkList, opIdToTag: IdToTagLookup): T.MarkL
 function invertMark(mark: T.Mark, opIdToTag: IdToTagLookup): T.Mark[] {
     if (isSkipMark(mark)) {
         return [mark];
-    } else if (isAttachGroup(mark)) {
-        const inverseMarks: T.Mark[] = [];
-        for (const attach of mark) {
-            switch (attach.type) {
-                case "Insert":
-                case "MInsert": {
-                    inverseMarks.push({
-                        type: "Delete",
-                        id: attach.id,
-                        count: attach.type === "Insert" ? attach.content.length : 1,
-                    });
-                    break;
-                }
-                default: fail("Not implemented");
-            }
-        }
-        return inverseMarks;
     } else {
         switch (mark.type) {
+            case "Insert":
+            case "MInsert": {
+                return [{
+                    type: "Delete",
+                    id: mark.id,
+                    count: mark.type === "Insert" ? mark.content.length : 1,
+                }];
+            }
             case "Delete": {
                 return [{
                     type: "Revive",

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/rebase.ts
@@ -6,7 +6,7 @@
 import {
     getInputLength,
     getOutputLength,
-    isAttachGroup,
+    isAttach,
     isReattach,
     isSkipMark,
     MarkListFactory,
@@ -60,7 +60,7 @@ function rebaseMarkList(currMarkList: T.MarkList, baseMarkList: T.MarkList): T.M
             break;
         }
 
-        if (isAttachGroup(currMark)) {
+        if (isAttach(currMark)) {
             // We currently ignore the ways in which base marks could affect attaches.
             // These are:
             // 1. Slices with which the attach would commute.
@@ -87,7 +87,7 @@ function rebaseMarkList(currMarkList: T.MarkList, baseMarkList: T.MarkList): T.M
             // We ignore #2 because we do not yet produce tombs.
             factory.pushOffset(getOutputLength(baseMark));
             currIter.push(currMark);
-        } else if (isAttachGroup(baseMark)) {
+        } else if (isAttach(baseMark)) {
             // We currently ignore the ways in which curr marks overlap with these attaches.
             // These are:
             // 1. Slice ranges that include prior insertions

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
@@ -36,7 +36,7 @@ export class SequenceEditBuilder extends ProgressiveEditBuilder<SequenceChangese
         const id = this.opId++;
         const content = jsonableTreeFromCursor(cursor);
         const insert: T.Insert = { type: "Insert", id, content: [content] };
-        this.applyMarkAtPath([insert], place);
+        this.applyMarkAtPath(insert, place);
     }
 
     public delete(place: PlacePath, count: number) {
@@ -51,7 +51,7 @@ export class SequenceEditBuilder extends ProgressiveEditBuilder<SequenceChangese
         }
         const id = this.opId++;
         const moveOut: T.Detach = { type: "MoveOut", id, count };
-        const moveIn: T.AttachGroup = [{ type: "MoveIn", id, count }];
+        const moveIn: T.MoveIn = { type: "MoveIn", id, count };
         if (source.parent === destination.parent) {
             const srcIndex = source.parentIndex;
             const dstIndex = destination.parentIndex;
@@ -78,8 +78,8 @@ export class SequenceEditBuilder extends ProgressiveEditBuilder<SequenceChangese
                         const id2 = this.opId++;
                         marks.push(
                             { type: "MoveOut", id, count: gap },
-                            [{ type: "MoveIn", id, count: count - gap }],
-                            [{ type: "MoveIn", id: id2, count: gap }],
+                            { type: "MoveIn", id, count: count - gap },
+                            { type: "MoveIn", id: id2, count: gap },
                             { type: "MoveOut", id: id2, count: count - gap },
                         );
                     } else {

--- a/packages/dds/tree/src/test/changeset/samples.ts
+++ b/packages/dds/tree/src/test/changeset/samples.ts
@@ -11,7 +11,7 @@ import { Effects, Transposed as T } from "../../changeset";
  */
 export namespace InsertRoot {
     export const e1: T.MarkList = [
-        [{
+        {
             type: "Insert",
             id: 0, // ID of the insert operation
             content: [ // Serialized trees
@@ -38,7 +38,7 @@ export namespace InsertRoot {
                     },
                 },
             ],
-        }],
+        },
     ];
 }
 
@@ -58,11 +58,11 @@ export namespace SwapCousins {
             fields: {
                 foo: [
                     { type: "MoveOut", id: 0, count: 1 },
-                    [{ type: "MoveIn", id: 1, count: 1 }],
+                    { type: "MoveIn", id: 1, count: 1 },
                 ],
                 bar: [
                     { type: "MoveOut", id: 1, count: 1 },
-                    [{ type: "MoveIn", id: 0, count: 1 }],
+                    { type: "MoveIn", id: 0, count: 1 },
                 ],
             },
         }],
@@ -107,27 +107,27 @@ export namespace SwapParentChild {
                             }],
                         },
                     },
-                    [{
+                    {
                         type: "MMoveIn",
                         id: 1,
                         fields: {
                             bar: [
-                                [{
+                                {
                                     type: "MMoveIn",
                                     id: 0,
                                     fields: {
                                         baz: [
-                                            [{
+                                            {
                                                 type: "MoveIn",
                                                 id: 2,
                                                 count: 1,
-                                            }],
+                                            },
                                         ],
                                     },
-                                }],
+                                },
                             ],
                         },
-                    }],
+                    },
                 ],
             },
         }],
@@ -182,11 +182,11 @@ export namespace ScenarioA {
                     },
                 ],
                 bar: [
-                    [{
+                    {
                         type: "MoveIn",
                         id: 0,
                         count: 3, // B C D
-                    }],
+                    },
                 ],
             },
         }],
@@ -199,7 +199,7 @@ export namespace ScenarioA {
             fields: {
                 foo: [
                     2,
-                    [{ type: "Insert", id: 0, content: [nodeX], heed: Effects.All }],
+                    { type: "Insert", id: 0, content: [nodeX], heed: Effects.All },
                 ],
             },
         }],
@@ -238,11 +238,9 @@ export namespace ScenarioA {
                     },
                 ],
                 bar: [
-                    [
-                        { type: "MoveIn", id: 0, count: 0 }, // B C
-                        { type: "MoveIn", id: 1, count: 0 }, // C-D
-                        { type: "MoveIn", id: 2, count: 1 }, // D
-                    ],
+                    { type: "MoveIn", id: 0, count: 0 }, // B C
+                    { type: "MoveIn", id: 1, count: 0 }, // C-D
+                    { type: "MoveIn", id: 2, count: 1 }, // D
                 ],
             },
         }],
@@ -257,7 +255,7 @@ export namespace ScenarioA {
                 foo: [
                     1,
                     { type: "Tomb", change: 1, count: 1 }, // B
-                    [{ type: "Insert", id: 0, content: [nodeX], heed: Effects.All }],
+                    { type: "Insert", id: 0, content: [nodeX], heed: Effects.All },
                     { type: "Tomb", change: 1, count: 1 }, // C
                 ],
             },
@@ -274,21 +272,19 @@ export namespace ScenarioA {
                 foo: [
                     1,
                     { type: "Tomb", change: 1, count: 1 }, // B
-                    [{ type: "Bounce", id: 0, heed: Effects.All }],
+                    { type: "Bounce", id: 0, heed: Effects.All },
                     { type: "Tomb", change: 1, count: 1 }, // C
                 ],
                 bar: [
-                    [
-                        {
-                            type: "Insert",
-                            id: 0,
-                            content: [nodeX],
-                            heed: Effects.All,
-                            src: { change: 2, id: 0 },
-                        },
-                        { type: "Intake", change: 2, id: 1 },
-                        { type: "Intake", change: 2, id: 2 },
-                    ],
+                    {
+                        type: "Insert",
+                        id: 0,
+                        content: [nodeX],
+                        heed: Effects.All,
+                        src: { change: 2, id: 0 },
+                    },
+                    { type: "Intake", change: 2, id: 1 },
+                    { type: "Intake", change: 2, id: 2 },
                 ],
             },
         }],

--- a/packages/dds/tree/src/test/changeset/toDelta.spec.ts
+++ b/packages/dds/tree/src/test/changeset/toDelta.spec.ts
@@ -87,11 +87,7 @@ describe("toDelta", () => {
 
     it("insert root", () => {
         const changeset: T.MarkList = [
-            [{
-                type: "Insert",
-                id: opId,
-                content,
-            }],
+            { type: "Insert", id: opId, content },
         ];
         const mark: Delta.Insert = {
             type: Delta.MarkType.Insert,
@@ -108,11 +104,7 @@ describe("toDelta", () => {
             fields: {
                 foo: [
                     42,
-                    [{
-                        type: "Insert",
-                        id: opId,
-                        content,
-                    }],
+                    { type: "Insert", id: opId, content },
                 ],
             },
         }];
@@ -181,11 +173,11 @@ describe("toDelta", () => {
                         count: 10,
                     },
                     8,
-                    [{
+                    {
                         type: "MoveIn",
                         id: opId,
                         count: 10,
-                    }],
+                    },
                 ],
             },
         }];
@@ -220,11 +212,11 @@ describe("toDelta", () => {
                 ],
                 bar: [
                         8,
-                    [{
+                    {
                         type: "MoveIn",
                         id: opId,
                         count: 10,
-                    }],
+                    },
                 ],
             },
         }];
@@ -266,11 +258,11 @@ describe("toDelta", () => {
                 }],
                 detached: [
                     8,
-                    [{
+                    {
                         type: "MoveIn",
                         id: opId,
                         count: 10,
-                    }],
+                    },
                 ],
             },
         };
@@ -313,11 +305,11 @@ describe("toDelta", () => {
                         count: 10,
                     },
                     3,
-                    [{
+                    {
                         type: "Insert",
                         id: opId,
                         content,
-                    }],
+                    },
                     1,
                     {
                         type: "Modify",
@@ -352,7 +344,7 @@ describe("toDelta", () => {
     describe("Modifications to inserted content", () => {
         it("values", () => {
             const changeset: T.MarkList = [
-                [{
+                {
                     type: "MInsert",
                     id: opId,
                     content: content[0],
@@ -363,7 +355,7 @@ describe("toDelta", () => {
                             value: { id: opId, value: 4343 },
                         }],
                     },
-                }],
+                },
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,
@@ -382,26 +374,26 @@ describe("toDelta", () => {
 
         it("inserts", () => {
             const changeset: T.MarkList = [
-                [{
+                {
                     type: "MInsert",
                     id: opId,
                     content: content[0],
                     fields: {
                         foo: [
-                            [{
+                            {
                                 type: "Insert",
                                 id: opId,
                                 content: [{ type, value: 44 }],
-                            }],
+                            },
                             1,
-                            [{
+                            {
                                     type: "Insert",
                                     id: opId,
                                     content: [{ type, value: 45 }],
-                            }],
+                            },
                         ],
                     },
-                }],
+                },
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,
@@ -424,22 +416,22 @@ describe("toDelta", () => {
 
         it("modified inserts", () => {
             const changeset: T.MarkList = [
-                [{
+                {
                     type: "MInsert",
                     id: opId,
                     content: content[0],
                     fields: {
                         foo: [
                             1,
-                            [{
+                            {
                                 type: "MInsert",
                                 id: opId,
                                 content: { type, value: 45 },
                                 value: { id: opId, value: 4545 },
-                            }],
+                            },
                         ],
                     },
-                }],
+                },
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,
@@ -458,7 +450,7 @@ describe("toDelta", () => {
 
         it("delete", () => {
             const changeset: T.MarkList = [
-                [{
+                {
                     type: "MInsert",
                     id: opId,
                     content: content[0],
@@ -471,7 +463,7 @@ describe("toDelta", () => {
                             },
                         ],
                     },
-                }],
+                },
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,

--- a/packages/dds/tree/src/test/sequence-change-family/cases.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/cases.ts
@@ -60,7 +60,7 @@ export const cases: {
         marks: {
             root: [
                 1,
-                [{ type: "Insert", id: 1, content: [{ type, value: 1 }, { type, value: 2 }] }],
+                { type: "Insert", id: 1, content: [{ type, value: 1 }, { type, value: 2 }] },
             ],
         },
     },
@@ -70,7 +70,7 @@ export const cases: {
                 type: "Modify",
                 fields: {
                     foo: [
-                        [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                        { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                     ],
                 },
             }],
@@ -80,16 +80,16 @@ export const cases: {
         marks: {
             root: [
                 1,
-                [{
+                {
                     type: "MInsert",
                     id: 1,
                     content: { type, value: 1 },
                     fields: {
                         foo: [
-                            [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                            { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                         ],
                     },
-                }],
+                },
             ],
         },
     },

--- a/packages/dds/tree/src/test/sequence-change-family/compose.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/compose.spec.ts
@@ -45,7 +45,7 @@ describe("SequenceChangeFamily - Compose", () => {
         const insertion: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                 ],
             },
         };
@@ -67,7 +67,7 @@ describe("SequenceChangeFamily - Compose", () => {
                     {
                         type: "Modify",
                         fields: {
-                            foo: [[{ type: "Insert", id: 1, content: [{ type, value: 1 }] }]],
+                            foo: [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
                         },
                     },
                 ],
@@ -155,7 +155,7 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }, { type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }, { type, value: 2 }] },
                 ],
             },
         };
@@ -165,7 +165,7 @@ describe("SequenceChangeFamily - Compose", () => {
                     type: "Modify",
                     fields: {
                         foo: [
-                            [{ type: "Insert", id: 2, content: [{ type, value: 42 }] }],
+                            { type: "Insert", id: 2, content: [{ type, value: 42 }] },
                         ],
                     },
                 }],
@@ -173,19 +173,19 @@ describe("SequenceChangeFamily - Compose", () => {
         };
         const expected: SequenceChangeset = {
             marks: {
-                root: [[
+                root: [
                     {
                         type: "MInsert",
                         id: 1,
                         content: { type, value: 1 },
                         fields: {
                             foo: [
-                                [{ type: "Insert", id: 2, content: [{ type, value: 42 }] }],
+                                { type: "Insert", id: 2, content: [{ type, value: 42 }] },
                             ],
                         },
                     },
                     { type: "Insert", id: 1, content: [{ type, value: 2 }] },
-                ]],
+                ],
             },
         };
         const actual = compose([insert, modify]);
@@ -196,16 +196,16 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{
+                    {
                         type: "MInsert",
                         id: 1,
                         content: { type, value: 1 },
                         fields: {
                             foo: [
-                                [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                                { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                             ],
                         },
-                    }],
+                    },
                 ],
             },
         };
@@ -215,7 +215,7 @@ describe("SequenceChangeFamily - Compose", () => {
                     type: "Modify",
                     fields: {
                         bar: [
-                            [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                            { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                         ],
                     },
                 }],
@@ -224,19 +224,19 @@ describe("SequenceChangeFamily - Compose", () => {
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{
+                    {
                         type: "MInsert",
                         id: 1,
                         content: { type, value: 1 },
                         fields: {
                             foo: [
-                                [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                                { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                             ],
                             bar: [
-                                [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                                { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                             ],
                         },
-                    }],
+                    },
                 ],
             },
         };
@@ -258,7 +258,7 @@ describe("SequenceChangeFamily - Compose", () => {
                     type: "Modify",
                     fields: {
                         foo: [
-                            [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                            { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                         ],
                     },
                 }],
@@ -272,7 +272,7 @@ describe("SequenceChangeFamily - Compose", () => {
                         type: "Modify",
                         fields: {
                             foo: [
-                                [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                                { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                             ],
                         },
                     },
@@ -297,7 +297,7 @@ describe("SequenceChangeFamily - Compose", () => {
                     type: "Modify",
                     fields: {
                         foo: [
-                            [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                            { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                         ],
                     },
                 }],
@@ -312,7 +312,7 @@ describe("SequenceChangeFamily - Compose", () => {
                         tomb,
                         fields: {
                             foo: [
-                                [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                                { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                             ],
                         },
                     },
@@ -331,7 +331,7 @@ describe("SequenceChangeFamily - Compose", () => {
                     type: "Modify",
                     fields: {
                         foo: [
-                            [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                            { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                         ],
                         bar: [
                             { type: "Delete", id: 2, count: 1 },
@@ -347,7 +347,7 @@ describe("SequenceChangeFamily - Compose", () => {
                     fields: {
                         bar: [
                             1,
-                            [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                            { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                         ],
                         baz: [
                             { type: "Delete", id: 4, count: 1 },
@@ -363,12 +363,12 @@ describe("SequenceChangeFamily - Compose", () => {
                     type: "Modify",
                     fields: {
                         foo: [
-                            [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                            { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                         ],
                         bar: [
                             { type: "Delete", id: 2, count: 1 },
                             1,
-                            [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                            { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                         ],
                         baz: [
                             { type: "Delete", id: 4, count: 1 },
@@ -398,11 +398,11 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [
+                    { type: "Insert", id: 1, content: [
                         { type, value: 1 },
                         { type, value: 2 },
                         { type, value: 3 },
-                    ] }],
+                    ] },
                 ],
             },
         };
@@ -418,10 +418,10 @@ describe("SequenceChangeFamily - Compose", () => {
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [
+                    { type: "Insert", id: 1, content: [
                         { type, value: 1 },
                         { type, value: 3 },
-                    ] }],
+                    ] },
                 ],
             },
         };
@@ -431,7 +431,7 @@ describe("SequenceChangeFamily - Compose", () => {
     it("insert ○ delete (across inserts)", () => {
         const insert: SequenceChangeset = {
             marks: {
-                root: [[
+                root: [
                     { type: "Insert", id: 1, content: [
                         { type, value: 1 },
                         { type, value: 2 },
@@ -444,7 +444,7 @@ describe("SequenceChangeFamily - Compose", () => {
                         { type, value: 5 },
                         { type, value: 6 },
                     ] },
-                ]],
+                ],
             },
         };
         const deletion: SequenceChangeset = {
@@ -458,14 +458,14 @@ describe("SequenceChangeFamily - Compose", () => {
         const actual = compose([insert, deletion]);
         const expected: SequenceChangeset = {
             marks: {
-                root: [[
+                root: [
                     { type: "Insert", id: 1, content: [
                         { type, value: 1 },
                     ] },
                     { type: "Insert", id: 3, content: [
                         { type, value: 6 },
                     ] },
-                ]],
+                ],
             },
         };
         assert.deepEqual(actual, expected);
@@ -557,14 +557,14 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                 ],
             },
         };
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                     { type: "Modify", value: { id: 0, value: 1 } },
                 ],
             },
@@ -578,14 +578,14 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                 ],
             },
         };
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                     {
                         type: "Modify",
                         fields: {
@@ -616,7 +616,7 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -624,7 +624,7 @@ describe("SequenceChangeFamily - Compose", () => {
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                     { type: "Delete", id: 1, count: 3 },
                 ],
             },
@@ -644,7 +644,7 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -652,7 +652,7 @@ describe("SequenceChangeFamily - Compose", () => {
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                     { type: "Revive", id: 1, count: 5, tomb },
                 ],
             },
@@ -665,18 +665,18 @@ describe("SequenceChangeFamily - Compose", () => {
         const insertA: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     2,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }, { type, value: 3 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }, { type, value: 3 }] },
                 ],
             },
         };
         const insertB: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                    { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                     4,
-                    [{ type: "Insert", id: 4, content: [{ type, value: 4 }] }],
+                    { type: "Insert", id: 4, content: [{ type, value: 4 }] },
                 ],
             },
         };
@@ -684,16 +684,12 @@ describe("SequenceChangeFamily - Compose", () => {
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [
-                        { type: "Insert", id: 3, content: [{ type, value: 3 }] },
-                        { type: "Insert", id: 1, content: [{ type, value: 1 }] },
-                    ],
+                    { type: "Insert", id: 3, content: [{ type, value: 3 }] },
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     2,
-                    [
-                        { type: "Insert", id: 2, content: [{ type, value: 2 }] },
-                        { type: "Insert", id: 4, content: [{ type, value: 4 }] },
-                        { type: "Insert", id: 2, content: [{ type, value: 3 }] },
-                    ],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
+                    { type: "Insert", id: 4, content: [{ type, value: 4 }] },
+                    { type: "Insert", id: 2, content: [{ type, value: 3 }] },
                 ],
             },
         };
@@ -815,9 +811,9 @@ describe("SequenceChangeFamily - Compose", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     2,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }, { type, value: 3 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }, { type, value: 3 }] },
                 ],
             },
         };
@@ -835,11 +831,11 @@ describe("SequenceChangeFamily - Compose", () => {
             marks: {
                 root: [
                     { type: "Revive", id: 3, count: 1, tomb },
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     2,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                     { type: "Revive", id: 4, count: 1, tomb },
-                    [{ type: "Insert", id: 2, content: [{ type, value: 3 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 3 }] },
                 ],
             },
         };

--- a/packages/dds/tree/src/test/sequence-change-family/invert.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/invert.spec.ts
@@ -51,11 +51,11 @@ describe("SequenceChangeFamily - Invert", () => {
 
             it("insert => delete", () => {
                 const input = asForest([
-                    [{
+                    {
                         type: "Insert",
                         id: 1,
                         content: [{ type, value: 42 }, { type, value: 43 }],
-                    }],
+                    },
                 ]);
                 const expected = asForest([
                     {
@@ -70,12 +70,12 @@ describe("SequenceChangeFamily - Invert", () => {
 
             it("modified insert => delete", () => {
                 const input = asForest([
-                    [{
+                    {
                         type: "MInsert",
                         id: 1,
                         content: { type, value: 42 },
                         fields: { foo: [{ type: "Modify", value: { id: 1, value: 42 } }] },
-                    }],
+                    },
                 ]);
                 const expected = asForest([
                     {

--- a/packages/dds/tree/src/test/sequence-change-family/markListFactory.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/markListFactory.spec.ts
@@ -8,9 +8,7 @@ import { MarkListFactory, Transposed as T } from "../../changeset";
 import { TreeSchemaIdentifier } from "../../schema-stored";
 import { brand } from "../../util";
 
-const dummyMark: T.AttachGroup = [];
-const bounce1: T.Bounce = { type: "Bounce", id: 1 };
-const bounce2: T.Bounce = { type: "Bounce", id: 1 };
+const dummyMark: T.Detach = { type: "Delete", id: 0, count: 1 };
 const type: TreeSchemaIdentifier = brand("Node");
 
 describe("MarkListFactory", () => {
@@ -44,47 +42,28 @@ describe("MarkListFactory", () => {
         assert.deepStrictEqual(factory.list, [dummyMark]);
     });
 
-    it("Can merge consecutive attach groups", () => {
-        const factory = new MarkListFactory();
-        const insert: T.Insert = { type: "Insert", id: 0, content: [] };
-        const bounce: T.Bounce = { type: "Bounce", id: 1 };
-        factory.pushContent([insert]);
-        factory.pushContent([bounce]);
-        assert.deepStrictEqual(factory.list, [[insert, bounce]]);
-    });
-
     it("Can merge consecutive inserts", () => {
         const factory = new MarkListFactory();
         const insert1: T.Insert = { type: "Insert", id: 0, content: [{ type, value: 1 }] };
         const insert2: T.Insert = { type: "Insert", id: 0, content: [{ type, value: 2 }] };
-        factory.pushContent([bounce1, insert1]);
-        factory.pushContent([insert2, bounce2]);
-        assert.deepStrictEqual(factory.list, [[
-            bounce1,
+        factory.pushContent(insert1);
+        factory.pushContent(insert2);
+        assert.deepStrictEqual(factory.list, [
             {
                 type: "Insert",
                 id: 0,
                 content: [{ type, value: 1 }, { type, value: 2 }],
             },
-            bounce2,
-        ]]);
+        ]);
     });
 
     it("Can merge consecutive move-ins", () => {
         const factory = new MarkListFactory();
         const move1: T.MoveIn = { type: "MoveIn", id: 0, count: 1 };
         const move2: T.MoveIn = { type: "MoveIn", id: 0, count: 1 };
-        factory.pushContent([bounce1, move1]);
-        factory.pushContent([move2, bounce2]);
-        assert.deepStrictEqual(factory.list, [[
-            bounce1,
-            {
-                type: "MoveIn",
-                id: 0,
-                count: 2,
-            },
-            bounce2,
-        ]]);
+        factory.pushContent(move1);
+        factory.pushContent(move2);
+        assert.deepStrictEqual(factory.list, [{ type: "MoveIn", id: 0, count: 2 }]);
     });
 
     it("Can merge consecutive deletes", () => {

--- a/packages/dds/tree/src/test/sequence-change-family/rebase.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/rebase.spec.ts
@@ -184,11 +184,11 @@ describe("SequenceChangeFamily - Rebase", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     2,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                     4,
-                    [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                    { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                 ],
             },
         };
@@ -205,11 +205,11 @@ describe("SequenceChangeFamily - Rebase", () => {
             marks: {
                 root: [
                     // Earlier insert is unaffected
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     1, // Overlapping insert has its index reduced
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                     2, // Later insert has its index reduced
-                    [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                    { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                 ],
             },
         };
@@ -355,7 +355,7 @@ describe("SequenceChangeFamily - Rebase", () => {
             marks: {
                 root: [
                     2,
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -388,7 +388,7 @@ describe("SequenceChangeFamily - Rebase", () => {
             marks: {
                 root: [
                     2,
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -425,7 +425,7 @@ describe("SequenceChangeFamily - Rebase", () => {
             marks: {
                 root: [
                     3,
-                    [{ type: "Insert", id: 1, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -452,9 +452,9 @@ describe("SequenceChangeFamily - Rebase", () => {
         const insertA: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     2,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -462,7 +462,7 @@ describe("SequenceChangeFamily - Rebase", () => {
             marks: {
                 root: [
                     1,
-                    [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                    { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                 ],
             },
         };
@@ -470,9 +470,9 @@ describe("SequenceChangeFamily - Rebase", () => {
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     3,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -496,7 +496,7 @@ describe("SequenceChangeFamily - Rebase", () => {
                 root: [
                     2,
                     // TODO: test both tiebreak policies
-                    [{ type: "Insert", id: 3, content: [{ type, value: 3 }] }],
+                    { type: "Insert", id: 3, content: [{ type, value: 3 }] },
                 ],
             },
         };
@@ -626,9 +626,9 @@ describe("SequenceChangeFamily - Rebase", () => {
         const insert: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     2,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                 ],
             },
         };
@@ -644,9 +644,9 @@ describe("SequenceChangeFamily - Rebase", () => {
         const expected: SequenceChangeset = {
             marks: {
                 root: [
-                    [{ type: "Insert", id: 1, content: [{ type, value: 1 }] }],
+                    { type: "Insert", id: 1, content: [{ type, value: 1 }] },
                     3,
-                    [{ type: "Insert", id: 2, content: [{ type, value: 2 }] }],
+                    { type: "Insert", id: 2, content: [{ type, value: 2 }] },
                 ],
             },
         };

--- a/packages/dds/tree/src/test/sequence-change-family/sequenceChangeRebaser.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/sequenceChangeRebaser.spec.ts
@@ -20,12 +20,8 @@ const tomb = "Dummy Changeset Tag";
 
 const testMarks: [string, T.Mark][] = [
     ["SetValue", { type: "Modify", value: { id: 0, value: 42 } }],
-    ["MInsert", [{ type: "MInsert", id: 0, content: { type, value: 42 }, value: { id: 0, value: 43 } }]],
-    ["Insert-1x2", [{ type: "Insert", id: 0, content: [{ type, value: 42 }, { type, value: 43 }] }]],
-    ["Insert-2x1", [
-        { type: "Insert", id: 0, content: [{ type, value: 42 }] },
-        { type: "Insert", id: 1, content: [{ type, value: 43 }] },
-    ]],
+    ["MInsert", { type: "MInsert", id: 0, content: { type, value: 42 }, value: { id: 0, value: 43 } }],
+    ["Insert", { type: "Insert", id: 0, content: [{ type, value: 42 }, { type, value: 43 }] }],
     ["Delete", { type: "Delete", id: 0, count: 2 }],
     ["Revive", { type: "Revive", id: 0, count: 2, tomb }],
 ];


### PR DESCRIPTION
Removes the `AttachGroup` array from the tree DDS changeset format. Instead, the elements of the array are represented inline.

Motivation: the distinction was not being leveraged but made the code more complex.