### PR TITLE
Float version when installing aria-logger in ADO pipelines

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -186,7 +186,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
-          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger@0.0.11'
+          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger'
           customRegistry: 'useNpmrc'
 
       # Download Test Files & Install Extra Dependencies


### PR DESCRIPTION
## Description

Undoing change discussed [here](https://github.com/microsoft/FluidFramework/pull/11615/files#r951920981), so the pipelines install the latest version of aria-logger instead of a pinned one.

Significant changes in aria-logger that could cause issues on the pipeline workflows seem like they would be infrequent enough that we'd rather remove the pain point of having to update that version manually every time, and deal with the sporadic break if/when they show up.