### PR TITLE
MergeTree: Reimplement list

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -183,7 +183,7 @@ export class Client {
     // (undocumented)
     get mergeTreeMaintenanceCallback(): MergeTreeMaintenanceCallback | undefined;
     set mergeTreeMaintenanceCallback(callback: MergeTreeMaintenanceCallback | undefined);
-    peekPendingSegmentGroups(count?: number): SegmentGroup | SegmentGroup[];
+    peekPendingSegmentGroups(count?: number): SegmentGroup | SegmentGroup[] | undefined;
     posFromRelativePos(relativePos: IRelativePosition): number;
     rebasePosition(pos: number, seqNumberFrom: number, localSeq: number): number;
     regeneratePendingOp(resetOp: IMergeTreeOp, segmentGroup: SegmentGroup | SegmentGroup[]): IMergeTreeOp;

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -183,7 +183,7 @@ export class Client {
     // (undocumented)
     get mergeTreeMaintenanceCallback(): MergeTreeMaintenanceCallback | undefined;
     set mergeTreeMaintenanceCallback(callback: MergeTreeMaintenanceCallback | undefined);
-    peekPendingSegmentGroups(count?: number): SegmentGroup | SegmentGroup[] | undefined;
+    peekPendingSegmentGroups(count?: number): SegmentGroup | SegmentGroup[];
     posFromRelativePos(relativePos: IRelativePosition): number;
     rebasePosition(pos: number, seqNumberFrom: number, localSeq: number): number;
     regeneratePendingOp(resetOp: IMergeTreeOp, segmentGroup: SegmentGroup | SegmentGroup[]): IMergeTreeOp;
@@ -1139,7 +1139,7 @@ export interface SegmentGroup {
 // @public (undocumented)
 export class SegmentGroupCollection {
     constructor(segment: ISegment);
-    // (undocumented)
+    // @deprecated (undocumented)
     clear(): void;
     // (undocumented)
     copyTo(segment: ISegment): void;

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -115,7 +115,7 @@ export class Client {
      */
     public peekPendingSegmentGroups(count: number = 1): SegmentGroup | SegmentGroup[] | undefined {
         let node = this._mergeTree.pendingSegments?.last;
-        if (count === 1 && node) {
+        if (count === 1) {
             return node?.data;
         }
         const taken: SegmentGroup[] = [];

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -114,14 +114,15 @@ export class Client {
      * @param count - The number segment groups to get peek from the tail of the queue. Default 1.
      */
     public peekPendingSegmentGroups(count: number = 1): SegmentGroup | SegmentGroup[] | undefined {
-        let node = this._mergeTree.pendingSegments?.last;
-        if (count === 1) {
+        const pending = this._mergeTree.pendingSegments;
+        let node = pending?.last;
+        if (count === 1 || pending === undefined) {
             return node?.data;
         }
-        const taken: SegmentGroup[] = [];
-        while (taken.length < count && node) {
-            taken.unshift(node.data);
-            node = node.prev;
+        const taken: SegmentGroup[] = new Array(Math.min(count, pending.length));
+        for (let i = taken.length - 1; i >= 0; i--) {
+            taken[i] = node!.data;
+            node = node!.prev;
         }
         return taken;
     }

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -113,15 +113,15 @@ export class Client {
      * It is used to get the segment group(s) for the previous operations.
      * @param count - The number segment groups to get peek from the tail of the queue. Default 1.
      */
-    public peekPendingSegmentGroups(count: number = 1) {
-        let node = this._mergeTree.pendingSegments?.first;
+    public peekPendingSegmentGroups(count: number = 1): SegmentGroup | SegmentGroup[] | undefined {
+        let node = this._mergeTree.pendingSegments?.last;
         if (count === 1 && node) {
-            return node.data;
+            return node?.data;
         }
         const taken: SegmentGroup[] = [];
         while (taken.length < count && node) {
-            taken.push(node.data);
-            node = node.next;
+            taken.unshift(node.data);
+            node = node.prev;
         }
         return taken;
     }
@@ -737,7 +737,7 @@ export class Client {
         resetOp: IMergeTreeDeltaOp,
         segmentGroup: SegmentGroup): IMergeTreeDeltaOp[] {
         assert(!!segmentGroup, 0x033 /* "Segment group undefined" */);
-        const NACKedSegmentGroup = this._mergeTree.pendingSegments?.pop()?.data;
+        const NACKedSegmentGroup = this._mergeTree.pendingSegments?.shift()?.data;
         assert(segmentGroup === NACKedSegmentGroup,
             0x034 /* "Segment group not at head of merge tree pending queue" */);
 

--- a/packages/dds/merge-tree/src/collections/list.ts
+++ b/packages/dds/merge-tree/src/collections/list.ts
@@ -3,142 +3,125 @@
  * Licensed under the MIT License.
  */
 
-export function ListRemoveEntry<U>(entry: List<U>): List<U> | undefined {
-    if (entry === undefined) {
+import { UsageError } from "@fluidframework/container-utils";
+
+export interface ListNode<T> {
+    readonly list: List<T> | undefined;
+    readonly data: T;
+    readonly next: ListNode<T> | undefined;
+    readonly prev: ListNode<T> | undefined;
+}
+
+export interface ListNodeRange<T> {
+    first: ListNode<T>;
+    last: ListNode<T>;
+}
+
+class HeadNode<T> {
+    public _next: HeadNode<T> | DataNode<T> = this;
+    public _prev: HeadNode<T> | DataNode<T> = this;
+    public headNode: HeadNode<T>;
+    private readonly _list?: List<T>;
+    constructor(list: List<T> | undefined) {
+        this.headNode = this;
+        if (list) {
+            this._list = list;
+        }
+    }
+    public get next(): DataNode<T> | undefined {
+        return this._next === this.headNode
+            ? undefined
+            : this._next as DataNode<T>;
+    }
+    public get prev(): DataNode<T> | undefined {
+        return this._prev === this.headNode
+            ? undefined
+            : this._prev as DataNode<T>;
+    }
+    public get list() {
+        return this.headNode._list;
+    }
+}
+
+const DeadHead = new HeadNode<any>(undefined);
+
+class DataNode<T> extends HeadNode<T> implements ListNode<T> {
+    constructor(headNode: HeadNode<T>, public readonly data: T) {
+        super(undefined);
+        this.headNode = headNode;
+    }
+}
+
+function insertAfter<T>(node: DataNode<T> | HeadNode<T>, ... items: T[]): ListNodeRange<T> | undefined {
+    let previousNode = node;
+    const oldNext = previousNode._next;
+    let newRange: ListNodeRange<T> | undefined;
+    items.forEach((n) => {
+        const newNode = new DataNode<T>(node.headNode, n);
+        if (newRange === undefined) {
+            newRange = { first: newNode, last: newNode };
+        } else {
+            newRange.last = newNode;
+        }
+        newNode._prev = previousNode;
+        previousNode._next = newNode;
+        previousNode = newNode;
+    });
+    oldNext._prev = previousNode;
+    previousNode._next = oldNext;
+    return newRange;
+}
+
+export class List<T> implements
+    Iterable<ListNode<T>>,
+    Partial<ListNodeRange<T>>,
+    // try to match array signature and semantics where possible
+    Pick<ListNode<T>[], "pop" | "shift" | "length" | "includes"> {
+    pop(): ListNode<T> | undefined {
+        return this.remove(this.last);
+    }
+    push(...items: T[]) {
+        this._len += items.length;
+        const start = this.headNode._prev;
+        return insertAfter(start, ... items);
+    }
+
+    shift(): ListNode<T> | undefined {
+        return this.remove(this.first);
+    }
+
+    unshift(...items: T[]) {
+        this._len += items.length;
+        return insertAfter(this.headNode, ... items);
+    }
+
+    public includes(node: ListNode<T> | undefined): node is ListNode<T> {
+        return this._includes(node);
+    }
+
+    private _includes(node: ListNode<T> | undefined): node is DataNode<T> {
+        return node instanceof DataNode && node.headNode === this.headNode;
+    }
+
+    remove(node: ListNode<T> | undefined): ListNode<T> | undefined {
+        if (this._includes(node)) {
+            node._prev._next = node._next;
+            node._next._prev = node._prev;
+            node.headNode = node._next = node._prev = DeadHead;
+            this._len--;
+            return node;
+        }
         return undefined;
-    } else if (entry.isHead) {
-        return undefined;
-    } else {
-        entry.next.prev = entry.prev;
-        entry.prev.next = entry.next;
-        entry.next = deadhead;
-        entry.prev = deadhead;
-    }
-    return (entry);
-}
-
-function ListMakeEntry<U>(data: U): List<U> {
-    return new List<U>(false, data);
-}
-
-export function ListMakeHead<U>(): List<U> {
-    return new List<U>(true, undefined);
-}
-
-export class List<T> {
-    public next: List<T>;
-    public prev: List<T>;
-
-    constructor(public isHead: boolean, public data: T | undefined) {
-        this.prev = this;
-        this.next = this;
     }
 
-    public clear(): void {
-        if (this.isHead) {
-            this.prev = this;
-            this.next = this;
-        }
-    }
-
-    private add(data: T): List<T> {
-        const entry = ListMakeEntry(data);
-        this.prev.next = entry;
-        entry.next = this;
-        entry.prev = this.prev;
-        this.prev = entry;
-        return (entry);
-    }
-
-    public dequeue(): T | undefined {
-        if (!this.empty()) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const removedEntry = ListRemoveEntry(this.next)!;
-            return removedEntry.data;
-        }
-    }
-
-    public enqueue(data: T): List<T> {
-        return this.add(data);
-    }
-
-    public pop?(): T | undefined {
-        const removedEntry = ListRemoveEntry(this.prev);
-        return removedEntry ? removedEntry.data : undefined;
-    }
-
-    public walk(fn: (data: T, l: List<T>) => void): void {
-        for (let entry = this.next; !(entry.isHead); entry = entry.next) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            fn(entry.data!, entry);
-        }
-    }
-
-    public some(fn: (data: T, l: List<T>) => boolean, rev?: boolean): T[] {
-        const rtn: T[] = [];
-        const start = rev ? this.prev : this.next;
-        for (let entry = start; !(entry.isHead); entry = rev ? entry.prev : entry.next) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const data = entry.data!;
-            if (fn(data, entry)) {
-                if (rev) {
-                    // preserve list order when in reverse
-                    rtn.unshift(data);
-                } else {
-                    rtn.push(data);
-                }
-            }
-        }
-        return rtn;
-    }
-
-    public count(): number {
-        let entry: List<T>;
-        let i: number;
-
-        entry = this.next;
-        for (i = 0; !(entry.isHead); i++) {
-            entry = entry.next;
-        }
-        return (i);
-    }
-
-    public first(): T | undefined {
-        if (!this.empty()) {
-            return (this.next.data);
-        }
-    }
-
-    public last(): T | undefined {
-        if (!this.empty()) {
-            return (this.prev.data);
-        }
-    }
-
-    public empty(): boolean {
-        return (this.next === this);
-    }
-
-    public unshift(data: T): void {
-        const entry = ListMakeEntry(data);
-        entry.data = data;
-        entry.isHead = false;
-        entry.next = this.next;
-        entry.prev = this;
-        this.next = entry;
-        entry.next.prev = entry;
-    }
-
-    public [Symbol.iterator]() {
-        let node: List<T> | undefined = this.next;
-        const iterator: IterableIterator<T> = {
-            next(): IteratorResult<T> {
-                while (node && node.isHead === false) {
-                    const value = node.data;
-                    node = node.next;
-                    if (value !== undefined) {
-                        return { value, done: false };
-                    }
+    public [Symbol.iterator](): IterableIterator<ListNode<T>> {
+        let value = this.first;
+        const iterator: IterableIterator<ListNode<T>> = {
+            next(): IteratorResult<ListNode<T>> {
+                if (value !== undefined) {
+                    const rtn = { value, done: false };
+                    value = value.next;
+                    return rtn;
                 }
                 return { value: undefined, done: true };
             },
@@ -148,6 +131,41 @@ export class List<T> {
         };
         return iterator;
     }
+
+    private _len: number = 0;
+    private readonly headNode: HeadNode<T> | DataNode<T> = new HeadNode(this);
+    public get length() { return this._len; }
+    public get empty() { return this.headNode._next === this.headNode; }
+    public get first(): ListNode<T> | undefined {
+        return this.headNode.next;
+    }
+
+    public get last(): ListNode<T> | undefined {
+        return this.headNode.prev;
+    }
 }
 
-const deadhead = ListMakeHead<any>();
+export function walkList<T>(
+    list: List<T>,
+    visitor: (node: ListNode<T>) => boolean | void,
+    start?: ListNode<T>,
+    forward: boolean = true,
+) {
+    let current: ListNode<T> | undefined;
+    if (start) {
+        if (!list.includes(start)) {
+            throw new UsageError("start must be in the provided list");
+        }
+        current = start;
+    } else {
+        current = forward ? list.first : list.last;
+    }
+
+    while (current !== undefined) {
+        if (visitor(current) === false) {
+            return false;
+        }
+        current = forward ? current.next : current.prev;
+    }
+    return true;
+}

--- a/packages/dds/merge-tree/src/collections/list.ts
+++ b/packages/dds/merge-tree/src/collections/list.ts
@@ -137,7 +137,7 @@ export class List<T> implements
     private _len: number = 0;
     private readonly headNode: HeadNode<T> | DataNode<T> = new HeadNode(this);
     public get length() { return this._len; }
-    public get empty() { return this.headNode._next === this.headNode; }
+    public get empty() { return this._len === 0; }
     public get first(): ListNode<T> | undefined {
         return this.headNode.next;
     }

--- a/packages/dds/merge-tree/src/collections/list.ts
+++ b/packages/dds/merge-tree/src/collections/list.ts
@@ -80,7 +80,9 @@ export class List<T> implements
     pop(): ListNode<T> | undefined {
         return this.remove(this.last);
     }
-    push(...items: T[]) {
+
+    push(item: T): ListNodeRange<T>;
+    push(...items: T[]): ListNodeRange<T> | undefined {
         this._len += items.length;
         const start = this.headNode._prev;
         return insertAfter(start, ... items);
@@ -90,7 +92,7 @@ export class List<T> implements
         return this.remove(this.first);
     }
 
-    unshift(...items: T[]) {
+    unshift(...items: T[]): ListNodeRange<T> | undefined {
         this._len += items.length;
         return insertAfter(this.headNode, ... items);
     }

--- a/packages/dds/merge-tree/src/collections/list.ts
+++ b/packages/dds/merge-tree/src/collections/list.ts
@@ -20,10 +20,9 @@ export interface ListNodeRange<T> {
 class HeadNode<T> {
     public _next: HeadNode<T> | DataNode<T> = this;
     public _prev: HeadNode<T> | DataNode<T> = this;
-    public headNode: HeadNode<T>;
+    public headNode: HeadNode<T> = this;
     private readonly _list?: List<T>;
     constructor(list: List<T> | undefined) {
-        this.headNode = this;
         if (list) {
             this._list = list;
         }

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { UsageError } from "@fluidframework/container-utils";
-import { List, ListMakeHead, ListRemoveEntry } from "./collections";
+import { List, ListNode } from "./collections";
 import {
     ISegment,
 } from "./mergeTreeNodes";
@@ -51,7 +51,7 @@ class LocalReference implements LocalReferencePosition {
 
     private segment: ISegment | undefined;
     private offset: number = 0;
-    private listNode: List<LocalReference> | undefined;
+    private listNode: ListNode<LocalReference> | undefined;
 
     public callbacks?: Partial<Record<"beforeSlide" | "afterSlide", () => void>> | undefined;
 
@@ -63,7 +63,7 @@ class LocalReference implements LocalReferencePosition {
         this.properties = properties;
     }
 
-    public link(segment: ISegment | undefined, offset: number, listNode: List<LocalReference> | undefined) {
+    public link(segment: ISegment | undefined, offset: number, listNode: ListNode<LocalReference> | undefined) {
         if (listNode !== this.listNode
             && this.listNode !== undefined) {
             this.segment?.localRefs?.removeLocalRef(this);
@@ -160,7 +160,7 @@ export class LocalReferenceCollection {
      * @internal
      */
     public [Symbol.iterator]() {
-        const subiterators: IterableIterator<LocalReferencePosition>[] = [];
+        const subiterators: IterableIterator<ListNode<LocalReferencePosition>>[] = [];
         for (const refs of this.refsByOffset) {
             if (refs) {
                 if (refs.before) {
@@ -182,7 +182,7 @@ export class LocalReferenceCollection {
                     if (next.done === true) {
                         subiterators.shift();
                     } else {
-                        return next;
+                        return { done: next.done, value: next.value.data };
                     }
                 }
 
@@ -205,7 +205,7 @@ export class LocalReferenceCollection {
         const detachSegments = (refs: List<LocalReference> | undefined) => {
             if (refs) {
                 for (const r of refs) {
-                    this.removeLocalRef(r);
+                    this.removeLocalRef(r.data);
                 }
             }
         };
@@ -259,12 +259,12 @@ export class LocalReferenceCollection {
         assert(offset < this.segment.cachedLength, 0x348 /* offset cannot be beyond segment length */);
         const refsAtOffset = this.refsByOffset[offset] =
             this.refsByOffset[offset]
-            ?? { at: ListMakeHead() };
+            ?? { at: new List() };
         const atRefs = refsAtOffset.at =
             refsAtOffset.at
-            ?? ListMakeHead();
+            ?? new List();
 
-        lref.link(this.segment, offset, atRefs.enqueue(lref));
+        lref.link(this.segment, offset, atRefs.push(lref));
 
         if (refHasRangeLabels(lref) || refHasTileLabels(lref)) {
             this.hierRefCount++;
@@ -279,8 +279,8 @@ export class LocalReferenceCollection {
     public removeLocalRef(lref: LocalReferencePosition): LocalReferencePosition | undefined {
         if (this.has(lref)) {
             assertLocalReferences(lref);
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            ListRemoveEntry(lref.getListNode()!);
+            lref.getListNode()?.list?.remove(
+                lref.getListNode());
             lref.link(
                 lref.getSegment(),
                 lref.getOffset(),
@@ -343,22 +343,11 @@ export class LocalReferenceCollection {
         if (listNode === undefined) {
             return false;
         }
-        let prev = listNode;
-        let next = listNode;
-        while (prev?.isHead !== true && next?.isHead !== true) {
-            prev = prev?.prev;
-            next = next?.next;
-        }
-
-        const headNode = prev?.isHead === true ? prev : next;
-        if (headNode?.isHead !== true || headNode.empty()) {
-            return false;
-        }
         const offset = lref.getOffset();
         const refsAtOffset = this.refsByOffset[offset];
-        if (refsAtOffset?.before === headNode
-            || refsAtOffset?.at === headNode
-            || refsAtOffset?.after === headNode) {
+        if (refsAtOffset?.before === listNode.list
+            || refsAtOffset?.at === listNode.list
+            || refsAtOffset?.after === listNode.list) {
                 return true;
             }
         return false;
@@ -404,7 +393,7 @@ export class LocalReferenceCollection {
     }
 
     public addBeforeTombstones(...refs: Iterable<LocalReferencePosition>[]) {
-        const beforeRefs = this.refsByOffset[0]?.before ?? ListMakeHead();
+        const beforeRefs = this.refsByOffset[0]?.before ?? new List();
 
         if (this.refsByOffset[0]?.before === undefined) {
             const refsAtOffset = this.refsByOffset[0] ??= { before: beforeRefs };
@@ -417,7 +406,7 @@ export class LocalReferenceCollection {
                 if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
                     lref.callbacks?.beforeSlide?.();
                     beforeRefs.unshift(lref);
-                    lref.link(this.segment, 0, beforeRefs.next);
+                    lref.link(this.segment, 0, beforeRefs.first);
                     if (refHasRangeLabels(lref) || refHasTileLabels(lref)) {
                         this.hierRefCount++;
                     }
@@ -432,7 +421,7 @@ export class LocalReferenceCollection {
 
     public addAfterTombstones(...refs: Iterable<LocalReferencePosition>[]) {
         const lastOffset = this.segment.cachedLength - 1;
-        const afterRefs = this.refsByOffset[lastOffset]?.after ?? ListMakeHead();
+        const afterRefs = this.refsByOffset[lastOffset]?.after ?? new List();
 
         if (this.refsByOffset[lastOffset]?.after === undefined) {
             const refsAtOffset = this.refsByOffset[lastOffset] ??= { after: afterRefs };
@@ -444,8 +433,8 @@ export class LocalReferenceCollection {
                 assertLocalReferences(lref);
                 if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
                     lref.callbacks?.beforeSlide?.();
-                    afterRefs.enqueue(lref);
-                    lref.link(this.segment, lastOffset, afterRefs.prev);
+                    afterRefs.push(lref);
+                    lref.link(this.segment, lastOffset, afterRefs.last);
                     if (refHasRangeLabels(lref) || refHasTileLabels(lref)) {
                         this.hierRefCount++;
                     }

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -264,7 +264,7 @@ export class LocalReferenceCollection {
             refsAtOffset.at
             ?? new List();
 
-        lref.link(this.segment, offset, atRefs.push(lref));
+        lref.link(this.segment, offset, atRefs.push(lref).last);
 
         if (refHasRangeLabels(lref) || refHasTileLabels(lref)) {
             this.hierRefCount++;
@@ -281,6 +281,7 @@ export class LocalReferenceCollection {
             assertLocalReferences(lref);
             lref.getListNode()?.list?.remove(
                 lref.getListNode());
+
             lref.link(
                 lref.getSegment(),
                 lref.getOffset(),
@@ -345,9 +346,9 @@ export class LocalReferenceCollection {
         }
         const offset = lref.getOffset();
         const refsAtOffset = this.refsByOffset[offset];
-        if (refsAtOffset?.before === listNode.list
-            || refsAtOffset?.at === listNode.list
-            || refsAtOffset?.after === listNode.list) {
+        if (refsAtOffset?.before?.includes(listNode)
+            || refsAtOffset?.at?.includes(listNode)
+            || refsAtOffset?.after?.includes(listNode)) {
                 return true;
             }
         return false;

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -279,8 +279,9 @@ export class LocalReferenceCollection {
     public removeLocalRef(lref: LocalReferencePosition): LocalReferencePosition | undefined {
         if (this.has(lref)) {
             assertLocalReferences(lref);
-            lref.getListNode()?.list?.remove(
-                lref.getListNode());
+
+            const node = lref.getListNode();
+            node?.list?.remove(node);
 
             lref.link(
                 lref.getSegment(),

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1226,7 +1226,7 @@ export class MergeTree {
      */
     public ackPendingSegment(opArgs: IMergeTreeDeltaOpArgs) {
         const seq = opArgs.sequencedMessage!.sequenceNumber;
-        const pendingSegmentGroup = this.pendingSegments!.pop()?.data;
+        const pendingSegmentGroup = this.pendingSegments!.shift()?.data;
         const nodesToUpdate: IMergeBlock[] = [];
         let overwrite = false;
         if (pendingSegmentGroup !== undefined) {
@@ -1940,12 +1940,12 @@ export class MergeTree {
      */
     public rollback(op: IMergeTreeDeltaOp, localOpMetadata: SegmentGroup) {
         if (op.type === MergeTreeDeltaType.REMOVE) {
-            const pendingSegmentGroup = this.pendingSegments?.pop?.()?.data;
+            const pendingSegmentGroup = this.pendingSegments?.shift?.()?.data;
             if (pendingSegmentGroup === undefined || pendingSegmentGroup !== localOpMetadata) {
                 throw new Error("Rollback op doesn't match last edit");
             }
             for (const segment of pendingSegmentGroup.segments) {
-                const segmentSegmentGroup = segment.segmentGroups.pop ? segment.segmentGroups.pop() : undefined;
+                const segmentSegmentGroup = segment.segmentGroups.dequeue();
                 assert(segmentSegmentGroup === pendingSegmentGroup, "Unexpected segmentGroup in segment");
 
                 assert(segment.removedClientIds !== undefined
@@ -1980,7 +1980,7 @@ export class MergeTree {
                 }
             }
         } else if (op.type === MergeTreeDeltaType.INSERT || op.type === MergeTreeDeltaType.ANNOTATE) {
-            const pendingSegmentGroup = this.pendingSegments?.pop?.()?.data;
+            const pendingSegmentGroup = this.pendingSegments?.shift?.()?.data;
             if (pendingSegmentGroup === undefined || pendingSegmentGroup !== localOpMetadata
                 || (op.type === MergeTreeDeltaType.ANNOTATE && !pendingSegmentGroup.previousProps)) {
                 throw new Error("Rollback op doesn't match last edit");

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1940,12 +1940,12 @@ export class MergeTree {
      */
     public rollback(op: IMergeTreeDeltaOp, localOpMetadata: SegmentGroup) {
         if (op.type === MergeTreeDeltaType.REMOVE) {
-            const pendingSegmentGroup = this.pendingSegments?.shift?.()?.data;
+            const pendingSegmentGroup = this.pendingSegments?.pop?.()?.data;
             if (pendingSegmentGroup === undefined || pendingSegmentGroup !== localOpMetadata) {
                 throw new Error("Rollback op doesn't match last edit");
             }
             for (const segment of pendingSegmentGroup.segments) {
-                const segmentSegmentGroup = segment.segmentGroups.dequeue();
+                const segmentSegmentGroup = segment.segmentGroups?.pop?.();
                 assert(segmentSegmentGroup === pendingSegmentGroup, "Unexpected segmentGroup in segment");
 
                 assert(segment.removedClientIds !== undefined
@@ -1980,14 +1980,14 @@ export class MergeTree {
                 }
             }
         } else if (op.type === MergeTreeDeltaType.INSERT || op.type === MergeTreeDeltaType.ANNOTATE) {
-            const pendingSegmentGroup = this.pendingSegments?.shift?.()?.data;
+            const pendingSegmentGroup = this.pendingSegments?.pop?.()?.data;
             if (pendingSegmentGroup === undefined || pendingSegmentGroup !== localOpMetadata
                 || (op.type === MergeTreeDeltaType.ANNOTATE && !pendingSegmentGroup.previousProps)) {
                 throw new Error("Rollback op doesn't match last edit");
             }
             let i = 0;
             for (const segment of pendingSegmentGroup.segments) {
-                const segmentSegmentGroup = segment.segmentGroups.pop ? segment.segmentGroups.pop() : undefined;
+                const segmentSegmentGroup = segment.segmentGroups.pop?.();
                 assert(segmentSegmentGroup === pendingSegmentGroup, "Unexpected segmentGroup in segment");
 
                 const start = this.findRollbackPosition(segment);

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -27,7 +27,7 @@ export class SegmentGroupCollection {
     }
 
     public dequeue(): SegmentGroup | undefined {
-        return this.segmentGroups.pop()?.data;
+        return this.segmentGroups.shift()?.data;
     }
 
     public pop?(): SegmentGroup | undefined {

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -3,42 +3,50 @@
  * Licensed under the MIT License.
  */
 
-import { List, ListMakeHead } from "./collections";
+import { List, walkList } from "./collections";
 import { ISegment, SegmentGroup } from "./mergeTreeNodes";
 
 export class SegmentGroupCollection {
     private readonly segmentGroups: List<SegmentGroup>;
 
     constructor(private readonly segment: ISegment) {
-        this.segmentGroups = ListMakeHead<SegmentGroup>();
+        this.segmentGroups = new List<SegmentGroup>();
     }
 
     public get size() {
-        return this.segmentGroups.count();
+        return this.segmentGroups.length;
     }
 
     public get empty() {
-        return this.segmentGroups.empty();
+        return this.segmentGroups.empty;
     }
 
     public enqueue(segmentGroup: SegmentGroup) {
-        this.segmentGroups.enqueue(segmentGroup);
+        this.segmentGroups.push(segmentGroup);
         segmentGroup.segments.push(this.segment);
     }
 
     public dequeue(): SegmentGroup | undefined {
-        return this.segmentGroups.dequeue();
+        return this.segmentGroups.pop()?.data;
     }
 
     public pop?(): SegmentGroup | undefined {
-        return this.segmentGroups.pop ? this.segmentGroups.pop() : undefined;
+        return this.segmentGroups.pop ? this.segmentGroups.pop()?.data : undefined;
     }
 
+    /**
+     * @deprecated - method is unused and will be removed.
+     */
     public clear() {
-        this.segmentGroups.clear();
+        while (!this.segmentGroups.empty) {
+            this.segmentGroups.remove(this.segmentGroups.first);
+        }
     }
 
     public copyTo(segment: ISegment) {
-        this.segmentGroups.walk((sg) => segment.segmentGroups.enqueue(sg));
+        walkList(
+            this.segmentGroups,
+            (sg) => segment.segmentGroups.enqueue(sg.data),
+        );
     }
 }

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -26,7 +26,7 @@ describe("client.applyMsg", () => {
 
     it("Interleaved inserts, annotates, and deletes", () => {
         const changes = new Map<number, { msg: ISequencedDocumentMessage; segmentGroup: SegmentGroup; }>();
-        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.length, 0);
         for (let i = 0; i < 100; i++) {
             const len = client.getLength();
             const pos1 = Math.floor(len / 2);
@@ -38,7 +38,7 @@ describe("client.applyMsg", () => {
                     const msg = client.makeOpMessage(
                         client.removeRangeLocal(pos1, pos2),
                         i + 1);
-                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last()! });
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last!.data });
                     break;
                 }
 
@@ -46,7 +46,7 @@ describe("client.applyMsg", () => {
                 case 4: {
                     const str = `${i}`.repeat(imod6 + 5);
                     const msg = client.makeOpMessage(client.insertTextLocal(pos1, str), i + 1);
-                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last()! });
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last!.data });
                     break;
                 }
 
@@ -61,7 +61,7 @@ describe("client.applyMsg", () => {
                         },
                         undefined);
                     const msg = client.makeOpMessage(op, i + 1);
-                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last()! });
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last!.data });
                     break;
                 }
                 default:
@@ -88,7 +88,7 @@ describe("client.applyMsg", () => {
                 }
             }
         }
-        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.length, 0);
         for (let i = 0; i < client.getText().length; i++) {
             const segmentInfo = client.getContainingSegment(i);
 
@@ -131,11 +131,11 @@ describe("client.applyMsg", () => {
             props,
             undefined);
 
-        assert.equal(client.mergeTree.pendingSegments?.count(), 1);
+        assert.equal(client.mergeTree.pendingSegments?.length, 1);
 
         client.applyMsg(client.makeOpMessage(op, 17));
 
-        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.length, 0);
     });
 
     it("annotateSegmentLocal then removeRangeLocal", () => {
@@ -154,22 +154,22 @@ describe("client.applyMsg", () => {
             props,
             undefined);
 
-        assert.equal(client.mergeTree.pendingSegments?.count(), 1);
+        assert.equal(client.mergeTree.pendingSegments?.length, 1);
 
         const removeOp = client.removeRangeLocal(start, end);
 
         assert.equal(segmentInfo.segment?.removedSeq, UnassignedSequenceNumber);
-        assert.equal(client.mergeTree.pendingSegments?.count(), 2);
+        assert.equal(client.mergeTree.pendingSegments?.length, 2);
 
         client.applyMsg(client.makeOpMessage(annotateOp, 17));
 
         assert.equal(segmentInfo.segment?.removedSeq, UnassignedSequenceNumber);
-        assert.equal(client.mergeTree.pendingSegments?.count(), 1);
+        assert.equal(client.mergeTree.pendingSegments?.length, 1);
 
         client.applyMsg(client.makeOpMessage(removeOp, 18));
 
         assert.equal(segmentInfo.segment?.removedSeq, 18);
-        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.length, 0);
     });
 
     it("multiple interleaved annotateSegmentLocal", () => {
@@ -194,12 +194,12 @@ describe("client.applyMsg", () => {
 
             annotateEnd = Math.floor(annotateEnd / 2);
         }
-        assert.equal(client.mergeTree.pendingSegments?.count(), messages.length);
+        assert.equal(client.mergeTree.pendingSegments?.length, messages.length);
 
         for (const msg of messages) {
             client.applyMsg(msg);
         }
-        assert.equal(client.mergeTree.pendingSegments?.count(), 0);
+        assert.equal(client.mergeTree.pendingSegments?.length, 0);
     });
 
     it("overlapping deletes", () => {

--- a/packages/dds/merge-tree/src/test/collections.list.spec.ts
+++ b/packages/dds/merge-tree/src/test/collections.list.spec.ts
@@ -26,19 +26,19 @@ describe("Collections.List", () => {
 
     describe(".first", () => {
         it("Should return the first item in the list",
-            () => assert.equal(list.first, listCount - 1, "first item not expected value"));
+            () => assert.equal(list.first?.data, listCount - 1, "first item not expected value"));
     });
 
     describe(".last", () => {
         it("Should return the last item in the list",
-            () => assert.equal(list.last, 0, "last item not expected value"));
+            () => assert.equal(list.last?.data, 0, "last item not expected value"));
     });
 
     describe("walkList", () => {
         it("Should walk all items of the list", () => {
             let i = listCount - 1;
-            walkList(list, (data) => {
-                assert.equal(data, i, "elemeted not expected value");
+            walkList(list, (node) => {
+                assert.equal(node.data, i, "elemeted not expected value");
                 i--;
             });
         });
@@ -48,7 +48,7 @@ describe("Collections.List", () => {
         it("Should walk all items of the list", () => {
             let i = listCount - 1;
             for (const item of list) {
-                assert.equal(item, i, "elemeted not expected value");
+                assert.equal(item.data, i, "elemeted not expected value");
                 i--;
             }
         });
@@ -58,7 +58,7 @@ describe("Collections.List", () => {
         it("Should add item to the start of the list",
             () => {
                 list.unshift(99);
-                assert.equal(list.first, 99, "first item not expected value");
+                assert.equal(list.first?.data, 99, "first item not expected value");
                 assert.equal(list.length, listCount + 1, "The list count doesn't match the expected count.");
             });
     });
@@ -66,7 +66,7 @@ describe("Collections.List", () => {
         it("Should add item to the end of the list",
             () => {
                 list.push(99);
-                assert.equal(list.last, 99, "last item not expected value");
+                assert.equal(list.last?.data, 99, "last item not expected value");
                 assert.equal(list.length, listCount + 1, "The list count doesn't match the expected count.");
             });
     });

--- a/packages/dds/merge-tree/src/test/collections.list.spec.ts
+++ b/packages/dds/merge-tree/src/test/collections.list.spec.ts
@@ -5,8 +5,7 @@
 
 import { strict as assert } from "assert";
 import {
-    List,
-    ListMakeHead,
+    List, walkList,
 } from "../collections";
 
 describe("Collections.List", () => {
@@ -14,39 +13,31 @@ describe("Collections.List", () => {
     let list: List<number>;
 
     beforeEach(() => {
-        list = ListMakeHead<number>();
+        list = new List<number>();
         for (let i = 0; i < listCount; i++) {
             list.unshift(i);
         }
     });
 
-    describe(".count", () => {
+    describe(".length", () => {
         it("Should return the total number of items in the list",
-            () => assert.equal(list.count(), listCount, "The list count doesn't match the expected count."));
+            () => assert.equal(list.length, listCount, "The list count doesn't match the expected count."));
     });
 
     describe(".first", () => {
         it("Should return the first item in the list",
-            () => assert.equal(list.first(), listCount - 1, "first item not expected value"));
+            () => assert.equal(list.first, listCount - 1, "first item not expected value"));
     });
 
     describe(".last", () => {
         it("Should return the last item in the list",
-            () => assert.equal(list.last(), 0, "last item not expected value"));
+            () => assert.equal(list.last, 0, "last item not expected value"));
     });
 
-    describe(".isHead", () => {
-        it("Should return true for the head of the list",
-            () => assert.equal(list.isHead, true, "expected node is not head"));
-
-        it("Should return false when not the head of the list",
-            () => assert.equal(list.next.isHead, false, "unexpected node is head"));
-    });
-
-    describe(".walk", () => {
+    describe("walkList", () => {
         it("Should walk all items of the list", () => {
             let i = listCount - 1;
-            list.walk((data) => {
+            walkList(list, (data) => {
                 assert.equal(data, i, "elemeted not expected value");
                 i--;
             });
@@ -67,16 +58,16 @@ describe("Collections.List", () => {
         it("Should add item to the start of the list",
             () => {
                 list.unshift(99);
-                assert.equal(list.first(), 99, "first item not expected value");
-                assert.equal(list.count(), listCount + 1, "The list count doesn't match the expected count.");
+                assert.equal(list.first, 99, "first item not expected value");
+                assert.equal(list.length, listCount + 1, "The list count doesn't match the expected count.");
             });
     });
-    describe(".enqueue", () => {
+    describe(".push", () => {
         it("Should add item to the end of the list",
             () => {
-                list.enqueue(99);
-                assert.equal(list.last(), 99, "last item not expected value");
-                assert.equal(list.count(), listCount + 1, "The list count doesn't match the expected count.");
+                list.push(99);
+                assert.equal(list.last, 99, "last item not expected value");
+                assert.equal(list.length, listCount + 1, "The list count doesn't match the expected count.");
             });
     });
 });

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -155,7 +155,7 @@ export function generateOperationMessagesForClients(
         // and is our baseline
         const client = clients[random.integer(1, clients.length - 1)(mt)];
         const len = client.getLength();
-        const sg = client.mergeTree.pendingSegments?.last?.data;
+        const sg = client.peekPendingSegmentGroups();
         let op: IMergeTreeOp | undefined;
         if (len === 0 || len < minLength) {
             const text = client.longClientId!.repeat(random.integer(1, 3)(mt));
@@ -175,10 +175,10 @@ export function generateOperationMessagesForClients(
         }
         if (op !== undefined) {
             // Pre-check to avoid logger.toString() in the string template
-            if (sg === client.mergeTree.pendingSegments?.last?.data) {
+            if (sg === client.peekPendingSegmentGroups()) {
                 assert.notEqual(
                     sg,
-                    client.mergeTree.pendingSegments?.last?.data,
+                    client.peekPendingSegmentGroups(),
                     `op created but segment group not enqueued.${logger}`);
             }
             const message = client.makeOpMessage(op, --tempSeq);

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -155,7 +155,7 @@ export function generateOperationMessagesForClients(
         // and is our baseline
         const client = clients[random.integer(1, clients.length - 1)(mt)];
         const len = client.getLength();
-        const sg = client.mergeTree.pendingSegments?.last();
+        const sg = client.mergeTree.pendingSegments?.last?.data;
         let op: IMergeTreeOp | undefined;
         if (len === 0 || len < minLength) {
             const text = client.longClientId!.repeat(random.integer(1, 3)(mt));
@@ -175,10 +175,10 @@ export function generateOperationMessagesForClients(
         }
         if (op !== undefined) {
             // Pre-check to avoid logger.toString() in the string template
-            if (sg === client.mergeTree.pendingSegments?.last()) {
+            if (sg === client.mergeTree.pendingSegments?.last?.data) {
                 assert.notEqual(
                     sg,
-                    client.mergeTree.pendingSegments?.last(),
+                    client.mergeTree.pendingSegments?.last?.data,
                     `op created but segment group not enqueued.${logger}`);
             }
             const message = client.makeOpMessage(op, --tempSeq);

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -17,7 +17,7 @@ describe("resetPendingSegmentsToOp", () => {
     beforeEach(() => {
         client = new TestClient();
         client.startOrUpdateCollaboration("local user");
-        assert(client.mergeTree.pendingSegments?.empty());
+        assert(client.mergeTree.pendingSegments?.empty);
     });
 
     describe("with a number of nested inserts", () => {
@@ -43,13 +43,13 @@ describe("resetPendingSegmentsToOp", () => {
             for (let i = 0; i < insertCount; i++) {
                 const op = client.insertTextLocal(i, "hello")!;
                 opList.push(op);
-                assert.equal(client.mergeTree.pendingSegments?.count(), i + 1);
+                assert.equal(client.mergeTree.pendingSegments?.length, i + 1);
             }
         });
 
         it("acked insertSegment", async () => {
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
 
         it("only computes localPartialLengths once", () => {
@@ -79,90 +79,90 @@ describe("resetPendingSegmentsToOp", () => {
                 },
             );
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
             applyOpList(client);
             assert.equal(localPartialsComputeCount, 1);
         });
 
         it("nacked insertSegment", async () => {
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
-            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
+            assert.equal(client.mergeTree.pendingSegments?.length, expectedSegmentCount);
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
 
         it("acked removeRange", async () => {
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.removeRangeLocal(0, client.getLength())!);
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
 
         it("nacked removeRange", async () => {
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.removeRangeLocal(0, client.getLength())!);
-            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
-            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
+            assert.equal(client.mergeTree.pendingSegments?.length, expectedSegmentCount);
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
 
         it("nacked insertSegment and removeRange", async () => {
             opList.push(client.removeRangeLocal(0, client.getLength())!);
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
 
-            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
+            assert.equal(client.mergeTree.pendingSegments?.length, expectedSegmentCount * 2);
 
             applyOpList(client);
 
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
 
         it("acked annotateRange", async () => {
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
 
         it("nacked annotateRange", async () => {
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
-            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments!.first()!));
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
-            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount);
+            assert.equal(client.mergeTree.pendingSegments?.length, expectedSegmentCount);
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
 
         it("nacked insertSegment and annotateRange", async () => {
             opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
-            assert.equal(client.mergeTree.pendingSegments?.count(), expectedSegmentCount * 2);
+            assert.equal(client.mergeTree.pendingSegments?.length, expectedSegmentCount * 2);
             applyOpList(client);
-            assert(client.mergeTree.pendingSegments?.empty());
+            assert(client.mergeTree.pendingSegments?.empty);
         });
     });
 
@@ -182,7 +182,8 @@ describe("resetPendingSegmentsToOp", () => {
 
             const otherClient = new TestClient();
             otherClient.startOrUpdateCollaboration("other user");
-            const regeneratedInsert = client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first()!);
+            const regeneratedInsert =
+                client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first!.data);
             otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
             const { segment: otherSegment } = otherClient.getContainingSegment(0);
@@ -199,7 +200,8 @@ describe("resetPendingSegmentsToOp", () => {
 
             const otherClient = new TestClient();
             otherClient.startOrUpdateCollaboration("other user");
-            const regeneratedInsert = client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first()!);
+            const regeneratedInsert =
+                client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first!.data);
             otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
             const { segment: otherSegment } = otherClient.getContainingSegment(0);

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -79,14 +79,14 @@ describe("resetPendingSegmentsToOp", () => {
                 },
             );
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
             applyOpList(client);
             assert.equal(localPartialsComputeCount, 1);
         });
 
         it("nacked insertSegment", async () => {
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -109,7 +109,7 @@ describe("resetPendingSegmentsToOp", () => {
             assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.removeRangeLocal(0, client.getLength())!);
-            opList.push(client.regeneratePendingOp(opList.shift()!, client.peekPendingSegmentGroups()!));
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -121,7 +121,7 @@ describe("resetPendingSegmentsToOp", () => {
         it("nacked insertSegment and removeRange", async () => {
             opList.push(client.removeRangeLocal(0, client.getLength())!);
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
 
             assert.equal(client.mergeTree.pendingSegments?.length, expectedSegmentCount * 2);
 
@@ -144,7 +144,7 @@ describe("resetPendingSegmentsToOp", () => {
             assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
-            opList.push(client.regeneratePendingOp(opList.shift()!, client.peekPendingSegmentGroups()!));
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -156,7 +156,7 @@ describe("resetPendingSegmentsToOp", () => {
         it("nacked insertSegment and annotateRange", async () => {
             opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -183,7 +183,7 @@ describe("resetPendingSegmentsToOp", () => {
             const otherClient = new TestClient();
             otherClient.startOrUpdateCollaboration("other user");
             const regeneratedInsert =
-                client.regeneratePendingOp(insertOp, client.peekPendingSegmentGroups()!);
+                client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first!.data);
             otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
             const { segment: otherSegment } = otherClient.getContainingSegment(0);
@@ -201,7 +201,7 @@ describe("resetPendingSegmentsToOp", () => {
             const otherClient = new TestClient();
             otherClient.startOrUpdateCollaboration("other user");
             const regeneratedInsert =
-                client.regeneratePendingOp(insertOp, client.peekPendingSegmentGroups()!);
+                client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first!.data);
             otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
             const { segment: otherSegment } = otherClient.getContainingSegment(0);

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -79,14 +79,14 @@ describe("resetPendingSegmentsToOp", () => {
                 },
             );
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
             applyOpList(client);
             assert.equal(localPartialsComputeCount, 1);
         });
 
         it("nacked insertSegment", async () => {
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -109,7 +109,7 @@ describe("resetPendingSegmentsToOp", () => {
             assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.removeRangeLocal(0, client.getLength())!);
-            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments.first!.data));
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.peekPendingSegmentGroups()!));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -121,7 +121,7 @@ describe("resetPendingSegmentsToOp", () => {
         it("nacked insertSegment and removeRange", async () => {
             opList.push(client.removeRangeLocal(0, client.getLength())!);
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
 
             assert.equal(client.mergeTree.pendingSegments?.length, expectedSegmentCount * 2);
 
@@ -144,7 +144,7 @@ describe("resetPendingSegmentsToOp", () => {
             assert(client.mergeTree.pendingSegments?.empty);
 
             opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
-            opList.push(client.regeneratePendingOp(opList.shift()!, client.mergeTree.pendingSegments.first!.data));
+            opList.push(client.regeneratePendingOp(opList.shift()!, client.peekPendingSegmentGroups()!));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -156,7 +156,7 @@ describe("resetPendingSegmentsToOp", () => {
         it("nacked insertSegment and annotateRange", async () => {
             opList.push(client.annotateRangeLocal(0, client.getLength(), { foo: "bar" }, undefined)!);
             const oldops = opList;
-            opList = oldops.map((op) => client.regeneratePendingOp(op, client.mergeTree.pendingSegments!.first!.data));
+            opList = oldops.map((op) => client.regeneratePendingOp(op, client.peekPendingSegmentGroups()!));
             // we expect a nack op per segment since our original ops split segments
             // we should expect mores nack ops then original ops.
             // only the first op didn't split a segment, all the others did
@@ -183,7 +183,7 @@ describe("resetPendingSegmentsToOp", () => {
             const otherClient = new TestClient();
             otherClient.startOrUpdateCollaboration("other user");
             const regeneratedInsert =
-                client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first!.data);
+                client.regeneratePendingOp(insertOp, client.peekPendingSegmentGroups()!);
             otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
             const { segment: otherSegment } = otherClient.getContainingSegment(0);
@@ -201,7 +201,7 @@ describe("resetPendingSegmentsToOp", () => {
             const otherClient = new TestClient();
             otherClient.startOrUpdateCollaboration("other user");
             const regeneratedInsert =
-                client.regeneratePendingOp(insertOp, client.mergeTree.pendingSegments!.first!.data);
+                client.regeneratePendingOp(insertOp, client.peekPendingSegmentGroups()!);
             otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
             const { segment: otherSegment } = otherClient.getContainingSegment(0);

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -12,7 +12,6 @@ import random from "random-js";
 import { Client } from "../client";
 import {
     List,
-    ListMakeHead,
 } from "../collections";
 import { UnassignedSequenceNumber } from "../constants";
 import { ISegment, Marker } from "../mergeTreeNodes";
@@ -94,8 +93,8 @@ export class TestClient extends Client {
 
     public readonly mergeTree: MergeTree;
 
-    public readonly checkQ: List<string> = ListMakeHead<string>();
-    protected readonly q: List<ISequencedDocumentMessage> = ListMakeHead<ISequencedDocumentMessage>();
+    public readonly checkQ: List<string> = new List<string>();
+    protected readonly q: List<ISequencedDocumentMessage> = new List<ISequencedDocumentMessage>();
 
     private readonly textHelper: MergeTreeTextHelper;
     constructor(
@@ -124,21 +123,21 @@ export class TestClient extends Client {
     }
 
     public enqueueTestString() {
-        this.checkQ.enqueue(this.getText());
+        this.checkQ.push(this.getText());
     }
     public getMessageCount(): number {
-        return this.q.count();
+        return this.q.length;
     }
     public enqueueMsg(msg: ISequencedDocumentMessage) {
-        this.q.enqueue(msg);
+        this.q.push(msg);
     }
     public dequeueMsg(): ISequencedDocumentMessage | undefined {
-        return this.q.dequeue();
+        return this.q.pop()?.data;
     }
     public applyMessages(msgCount: number) {
         let currMsgCount = msgCount;
         while (currMsgCount > 0) {
-            const msg = this.q.dequeue();
+            const msg = this.q.pop()?.data;
             if (msg) {
                 this.applyMsg(msg);
             } else {

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -132,12 +132,12 @@ export class TestClient extends Client {
         this.q.push(msg);
     }
     public dequeueMsg(): ISequencedDocumentMessage | undefined {
-        return this.q.pop()?.data;
+        return this.q.shift()?.data;
     }
     public applyMessages(msgCount: number) {
         let currMsgCount = msgCount;
         while (currMsgCount > 0) {
-            const msg = this.q.pop()?.data;
+            const msg = this.dequeueMsg();
             if (msg) {
                 this.applyMsg(msg);
             } else {

--- a/packages/dds/merge-tree/src/test/testServer.ts
+++ b/packages/dds/merge-tree/src/test/testServer.ts
@@ -97,7 +97,7 @@ export class TestServer extends TestClient {
     applyMessages(msgCount: number) {
         let _msgCount = msgCount;
         while (_msgCount > 0) {
-            const msg = this.q.pop()?.data;
+            const msg = this.dequeueMsg();
             if (msg) {
                 if (msg.sequenceNumber >= 0) {
                     this.transformUpstreamMessage(msg);
@@ -191,7 +191,7 @@ export function checkTextMatchRelative(
     msg: ISequencedDocumentMessage) {
     const client = server.clients[clientId];
     const serverText = new MergeTreeTextHelper(server.mergeTree).getText(refSeq, clientId);
-    const cliText = client.checkQ.pop()?.data;
+    const cliText = client.checkQ.shift()?.data;
     if ((cliText === undefined) || (cliText !== serverText)) {
         console.log(`mismatch `);
         console.log(msg);

--- a/packages/dds/merge-tree/src/test/testServer.ts
+++ b/packages/dds/merge-tree/src/test/testServer.ts
@@ -97,7 +97,7 @@ export class TestServer extends TestClient {
     applyMessages(msgCount: number) {
         let _msgCount = msgCount;
         while (_msgCount > 0) {
-            const msg = this.q.dequeue();
+            const msg = this.q.pop()?.data;
             if (msg) {
                 if (msg.sequenceNumber >= 0) {
                     this.transformUpstreamMessage(msg);
@@ -191,7 +191,7 @@ export function checkTextMatchRelative(
     msg: ISequencedDocumentMessage) {
     const client = server.clients[clientId];
     const serverText = new MergeTreeTextHelper(server.mergeTree).getText(refSeq, clientId);
-    const cliText = client.checkQ.dequeue();
+    const cliText = client.checkQ.pop()?.data;
     if ((cliText === undefined) || (cliText !== serverText)) {
         console.log(`mismatch `);
         console.log(msg);


### PR DESCRIPTION
## Description

The pre-existing list class was inconsistent in terms of typing, naming and semantics which made it very hard to use and extend.  It also had a performance issue where whether an item was in a list, which is frequently used by local references was O(N). 

This change fully re-implements the list class. It remains a circularly linked list, but separates the list and node implementation for better typing, and adds a reference to the head node to each list node to support O(1) determining if a node is in a particular list. Additionally, all methods have been implemented to match array methods in terms of shape and semantics as closely as possible to ease usage for those familiar with javascript arrays. The new implementation does regress the unused clear method, which is now O(N) rather than O(1) as each not must be detached from the head node as well.
