### PR TITLE
[bump] build-tools: 0.3.2000 => 0.4.1000 (major)

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/**"
   ],
-  "version": "0.3.2000"
+  "version": "0.4.1000"
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/build-cli",
-  "version": "0.3.2000",
+  "version": "0.4.1000",
   "private": true,
   "description": "Build tools for the Fluid Framework",
   "homepage": "https://fluidframework.com",
@@ -43,8 +43,8 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluid-tools/version-tools": "^0.3.2000",
-    "@fluidframework/build-tools": "^0.3.2000",
+    "@fluid-tools/version-tools": "^0.4.1000",
+    "@fluidframework/build-tools": "^0.4.1000",
     "@oclif/core": "^1.9.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",

--- a/build-tools/packages/build-cli/src/packageVersion.ts
+++ b/build-tools/packages/build-cli/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/build-cli";
-export const pkgVersion = "0.3.2000";
+export const pkgVersion = "0.4.1000";

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/build-tools",
-  "version": "0.3.2000",
+  "version": "0.4.1000",
   "description": "Fluid Build tools",
   "homepage": "https://fluidframework.com",
   "repository": {
@@ -49,7 +49,7 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
-    "@fluid-tools/version-tools": "^0.3.2000",
+    "@fluid-tools/version-tools": "^0.4.1000",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
     "async": "^3.2.0",
     "chalk": "^2.4.2",

--- a/build-tools/packages/build-tools/src/packageVersion.ts
+++ b/build-tools/packages/build-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/build-tools";
-export const pkgVersion = "0.3.2000";
+export const pkgVersion = "0.4.1000";

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/version-tools",
-  "version": "0.3.2000",
+  "version": "0.4.1000",
   "description": "Versioning tools for Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/build-tools/packages/version-tools/src/packageVersion.ts
+++ b/build-tools/packages/version-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/version-tools";
-export const pkgVersion = "0.3.2000";
+export const pkgVersion = "0.4.1000";


### PR DESCRIPTION
Post-release major bump of build-tools.

There's a conflicting version of build-tools that was released before I switched to using the "virtualPatch" version scheme. This bump will enable me to release 0.4.1000 which will supersede the duplicate. The bump should have been done after the build-tools 0.3.2000 release but it wasn't.