### PR TITLE
Change logger signature.

### DIFF
--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -77,14 +77,14 @@ export abstract class BaseCommand<T extends typeof BaseCommand.flags> extends Co
     protected async getLogger(): Promise<Logger> {
         if (this._logger === undefined) {
             this._logger = {
-                log: (msg: string | Error) => {
+                info: (msg: string | Error) => {
                     this.log(msg.toString());
                 },
-                logWarning: this.warn.bind(this),
-                logError: (msg: string | Error) => {
+                warning: this.warn.bind(this),
+                error: (msg: string | Error) => {
                     this.error(msg);
                 },
-                logVerbose: (msg: string | Error) => {
+                verbose: (msg: string | Error) => {
                     this.verbose(msg);
                 },
             };

--- a/build-tools/packages/build-cli/src/genMonoRepoPackageJson.ts
+++ b/build-tools/packages/build-cli/src/genMonoRepoPackageJson.ts
@@ -145,9 +145,7 @@ function processDependencies(
         const existing = repoPackageJson.dependencies[dep];
         if (existing) {
             if (existing !== version) {
-                logger.error(
-                    `Dependency version mismatch for ${dep}: ${existing} and ${version}`,
-                );
+                logger.error(`Dependency version mismatch for ${dep}: ${existing} and ${version}`);
             }
 
             continue;
@@ -176,9 +174,7 @@ function processDevDependencies(
         const existing = repoPackageJson.dependencies[dep] ?? repoPackageJson.devDependencies[dep];
         if (existing) {
             if (existing !== version) {
-                logger.error(
-                    `Dependency version mismatch for ${dep}: ${existing} and ${version}`,
-                );
+                logger.error(`Dependency version mismatch for ${dep}: ${existing} and ${version}`);
             }
 
             continue;

--- a/build-tools/packages/build-cli/src/genMonoRepoPackageJson.ts
+++ b/build-tools/packages/build-cli/src/genMonoRepoPackageJson.ts
@@ -88,12 +88,12 @@ async function generateMonoRepoPackageLockJson(
     const markTopLevelNonDev = (dep: string, ref: string, topRef: string) => {
         const item = repoPackageLockJson.dependencies[dep];
         if (item !== undefined) {
-            logger.logError(
+            logger.error(
                 `Missing ${dep} in lock file referenced by ${ref} from ${topRef} in ${monoRepo.kind.toLowerCase()}`,
             );
         }
 
-        logger.logVerbose(`NonDev Ref: ${topRef}..${ref} => ${dep}`);
+        logger.verbose(`NonDev Ref: ${topRef}..${ref} => ${dep}`);
 
         if (item.dev !== undefined) {
             topLevelDevCount--;
@@ -107,10 +107,10 @@ async function generateMonoRepoPackageLockJson(
         markTopLevelNonDev(dep, "<root>", "<root>");
     }
 
-    logger.log(
+    logger.info(
         `${monoRepo.kind}: ${format(totalDevCount)}/${format(totalCount)} locked devDependencies`,
     );
-    logger.log(
+    logger.info(
         `${monoRepo.kind}: ${format(topLevelDevCount)}/${format(
             topLevelTotalCount,
         )} top level locked devDependencies`,
@@ -145,7 +145,7 @@ function processDependencies(
         const existing = repoPackageJson.dependencies[dep];
         if (existing) {
             if (existing !== version) {
-                logger.logError(
+                logger.error(
                     `Dependency version mismatch for ${dep}: ${existing} and ${version}`,
                 );
             }
@@ -176,7 +176,7 @@ function processDevDependencies(
         const existing = repoPackageJson.dependencies[dep] ?? repoPackageJson.devDependencies[dep];
         if (existing) {
             if (existing !== version) {
-                logger.logError(
+                logger.error(
                     `Dependency version mismatch for ${dep}: ${existing} and ${version}`,
                 );
             }
@@ -229,7 +229,7 @@ export async function generateMonoRepoInstallPackageJson(monoRepo: MonoRepo, log
         path.join(monoRepo.repoPath, "repo-package.json"),
         JSON.stringify(repoPackageJson, undefined, 2),
     );
-    logger.log(
+    logger.info(
         `${monoRepo.kind}: ${format(devDepCount)}/${format(
             depCount + devDepCount,
         )} devDependencies`,

--- a/build-tools/packages/build-tools/src/bumpVersion/context.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/context.ts
@@ -70,7 +70,7 @@ export class Context {
     }
 
     public async collectVersionInfo(releaseGroup: MonoRepoKind | string): Promise<ReferenceVersionBag> {
-        this.logger.log("  Resolving published dependencies");
+        this.logger.info("  Resolving published dependencies");
 
         const depVersions =
             new ReferenceVersionBag(this.repo.resolvedRoot, this.fullPackageMap, this.collectVersions());
@@ -130,7 +130,7 @@ export class Context {
 
                     if (prereleaseSatisfies(depBuildPackage.version, version)) {
                         if (!depVersions.get(depBuildPackage)) {
-                            this.logger.logVerbose(`${depBuildPackage.nameColored}: Add from ${pkg.nameColored} ${version}`);
+                            this.logger.verbose(`${depBuildPackage.nameColored}: Add from ${pkg.nameColored} ${version}`);
                             if (depBuildPackage.monoRepo) {
                                 pendingDepCheck.push(...depBuildPackage.monoRepo.packages);
                             } else {

--- a/build-tools/packages/build-tools/src/common/logging.ts
+++ b/build-tools/packages/build-tools/src/common/logging.ts
@@ -9,17 +9,17 @@ import { commonOptions } from "./commonOptions";
 export type LoggingFunction = (msg: string | Error, ...args: unknown[]) => void;
 
 export interface Logger {
-    log: LoggingFunction,
-    logWarning: LoggingFunction,
-    logError: LoggingFunction,
-    logVerbose: LoggingFunction
+    info: LoggingFunction,
+    warning: LoggingFunction,
+    error: LoggingFunction,
+    verbose: LoggingFunction
 }
 
 export const defaultLogger: Logger = {
-    log: logStatus,
-    logWarning: logStatus,
-    logError: logError,
-    logVerbose: logVerbose
+    info: logStatus,
+    warning: logStatus,
+    error: logError,
+    verbose: logVerbose
 }
 
 export function logVerbose(msg: string | Error) {

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -86,13 +86,13 @@ export class MonoRepo {
         if (existsSync(lernaPath)) {
             const lerna = readJsonSync(lernaPath);
             if (lerna.version !== undefined) {
-                    logger.logVerbose(`${kind}: Loading version (${lerna.version}) from ${lernaPath}`);
+                    logger.verbose(`${kind}: Loading version (${lerna.version}) from ${lernaPath}`);
                 this.version = lerna.version;
                 versionFromLerna = true;
             }
 
             if (lerna.packages !== undefined) {
-                    logger.logVerbose(`${kind}: Loading packages from ${lernaPath}`);
+                    logger.verbose(`${kind}: Loading packages from ${lernaPath}`);
 
                 for (const dir of lerna.packages as string[]) {
                     // TODO: other glob pattern?
@@ -110,11 +110,11 @@ export class MonoRepo {
         const pkgJson = readJsonSync(packagePath);
         if (pkgJson.version === undefined && !versionFromLerna) {
             this.version = pkgJson.version;
-            logger.logVerbose(`${kind}: Loading version (${pkgJson.version}) from ${packagePath}`);
+            logger.verbose(`${kind}: Loading version (${pkgJson.version}) from ${packagePath}`);
         }
 
         if (pkgJson.workspaces !== undefined) {
-            logger.logVerbose(`${kind}: Loading packages from ${packagePath}`);
+            logger.verbose(`${kind}: Loading packages from ${packagePath}`);
             for (const dir of pkgJson.workspaces as string[]) {
                 this.packages.push(...Packages.loadGlob(dir, kind, ignoredDirs, this));
             }
@@ -133,7 +133,7 @@ export class MonoRepo {
     }
 
     public async install() {
-        this.logger.log(`${this.kind}: Installing - npm i`);
+        this.logger.info(`${this.kind}: Installing - npm i`);
         const installScript = "npm i";
         return execWithErrorAsync(installScript, { cwd: this.repoPath }, this.repoPath);
     }


### PR DESCRIPTION
The logger interface is used to enable existing build-tools to use the same logging infra as the new tools with minimal changes. After using the interface for a few weeks, I think these changes to the method names remove a lot of duplicate words in code. For example, `logger.logVerbose()` becomes `logger.verbose()`, or even `log.verbose()` if desired.