### PR TITLE
Fix AB 357 - MaxConsecutiveReconnects and Remove FG MaxOpSizeInBytes

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -501,11 +501,6 @@ interface IPendingRuntimeState {
 
 const maxConsecutiveReconnectsKey = "Fluid.ContainerRuntime.MaxConsecutiveReconnects";
 
-// Feature gate for the max op size. If the value is negative, chunking is enabled
-// and all ops over 16k would be chunked. If the value is positive, all ops with
-// a size strictly larger will be rejected and the container closed with an error.
-const maxOpSizeInBytesKey = "Fluid.ContainerRuntime.MaxOpSizeInBytes";
-
 // By default, we should reject any op larger than 768KB,
 // in order to account for some extra overhead from serialization
 // to not reach the 1MB limits in socket.io and Kafka.
@@ -781,10 +776,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private readonly summaryCollection: SummaryCollection;
 
     private readonly summarizerNode: IRootSummarizerNodeWithGC;
-    private readonly _maxOpSizeInBytes: number;
 
     private readonly maxConsecutiveReconnects: number;
-    private readonly defaultMaxConsecutiveReconnects = 15;
+    private readonly defaultMaxConsecutiveReconnects = 7;
 
     private _orderSequentiallyCalls: number = 0;
     private _flushMode: FlushMode;
@@ -974,7 +968,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.maxOpsSinceLastSummary = this.getMaxOpsSinceLastSummary();
         this.initialSummarizerDelayMs = this.getInitialSummarizerDelayMs();
 
-        this._maxOpSizeInBytes = (this.mc.config.getNumber(maxOpSizeInBytesKey) ?? defaultMaxOpSizeInBytes);
         this.maxConsecutiveReconnects =
             this.mc.config.getNumber(maxConsecutiveReconnectsKey) ?? this.defaultMaxConsecutiveReconnects;
 
@@ -1564,7 +1557,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         // There might be no change of state due to Container calling this API after loading runtime.
         const changeOfState = this._connected !== connected;
-        const reconnection = changeOfState && connected;
+        const reconnection = changeOfState && !connected;
         this._connected = connected;
 
         if (!connected) {
@@ -1573,6 +1566,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this._perfSignalData.trackingSignalSequenceNumber = undefined;
         }
 
+        // Fail while disconnected
         if (reconnection) {
             this.consecutiveReconnects++;
 
@@ -2572,7 +2566,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 }
             }
 
-            clientSequenceNumber = this.submitMaybeChunkedMessages(
+            clientSequenceNumber = this.submitMessage(
                 type,
                 content,
                 serializedContent,
@@ -2595,7 +2589,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    private submitMaybeChunkedMessages(
+    private submitMessage(
         type: ContainerMessageType,
         content: any,
         serializedContent: string,
@@ -2603,53 +2597,20 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         batch: boolean,
         opMetadataInternal: unknown = undefined,
     ): number {
-        if (this._maxOpSizeInBytes >= 0) {
-            // Chunking disabled
-            if (!serializedContent || serializedContent.length <= this._maxOpSizeInBytes) {
-                return this.submitRuntimeMessage(type, content, batch, opMetadataInternal);
-            }
-
-            // When chunking is disabled, we ignore the server max message size
-            // and if the content length is larger than the client configured message size
-            // instead of splitting the content, we will fail by explicitly close the container
-            this.closeFn(new GenericError(
-                "OpTooLarge",
-                /* error */ undefined,
-                {
-                    length: serializedContent.length,
-                    limit: this._maxOpSizeInBytes,
-                }));
-            return -1;
-        }
-
-        // Chunking enabled, fallback on the server's max message size
-        // and split the content accordingly
-        if (!serializedContent || serializedContent.length <= serverMaxOpSize) {
+        if (!serializedContent || serializedContent.length <= defaultMaxOpSizeInBytes) {
             return this.submitRuntimeMessage(type, content, batch, opMetadataInternal);
         }
 
-        return this.submitChunkedMessage(type, serializedContent, serverMaxOpSize);
-    }
-
-    private submitChunkedMessage(type: ContainerMessageType, content: string, maxOpSize: number): number {
-        const contentLength = content.length;
-        const chunkN = Math.floor((contentLength - 1) / maxOpSize) + 1;
-        let offset = 0;
-        let clientSequenceNumber: number = 0;
-        for (let i = 1; i <= chunkN; i = i + 1) {
-            const chunkedOp: IChunkedOp = {
-                chunkId: i,
-                contents: content.substr(offset, maxOpSize),
-                originalType: type,
-                totalChunks: chunkN,
-            };
-            offset += maxOpSize;
-            clientSequenceNumber = this.submitRuntimeMessage(
-                ContainerMessageType.ChunkedOp,
-                chunkedOp,
-                false);
-        }
-        return clientSequenceNumber;
+        // If the content length is larger than the client configured message size
+        // instead of splitting the content, we will fail by explicitly close the container
+        this.closeFn(new GenericError(
+            "OpTooLarge",
+            /* error */ undefined,
+            {
+                length: serializedContent.length,
+                limit: defaultMaxOpSizeInBytes,
+            }));
+        return -1;
     }
 
     private submitSystemMessage(

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -312,7 +312,7 @@ describe("Runtime", () => {
         });
 
         describe("Pending state progress tracking", () => {
-            const maxReconnects = 15;
+            const maxReconnects = 7;
 
             let containerRuntime: ContainerRuntime;
             const mockLogger = new MockLogger();
@@ -424,8 +424,8 @@ describe("Runtime", () => {
                     assert.strictEqual(error.getTelemetryProperties().pendingMessages, maxReconnects);
                     mockLogger.assertMatchAny([{
                         eventName: "ContainerRuntime:ReconnectsWithNoProgress",
-                        attempts: 7,
-                        pendingMessages: 7,
+                        attempts: 3,
+                        pendingMessages: 3,
                     }]);
                 });
 
@@ -442,7 +442,7 @@ describe("Runtime", () => {
                     assert.equal(containerErrors.length, 0);
                     mockLogger.assertMatchAny([{
                         eventName: "ContainerRuntime:ReconnectsWithNoProgress",
-                        attempts: 7,
+                        attempts: 3,
                         pendingMessages: 1,
                     }]);
                 });
@@ -520,8 +520,8 @@ describe("Runtime", () => {
                     assert.strictEqual(error.getTelemetryProperties().pendingMessages, maxReconnects);
                     mockLogger.assertMatchAny([{
                         eventName: "ContainerRuntime:ReconnectsWithNoProgress",
-                        attempts: 7,
-                        pendingMessages: 7,
+                        attempts: 3,
+                        pendingMessages: 3,
                     }]);
                 });
         });


### PR DESCRIPTION
[AB357](https://dev.azure.com/fluidframework/internal/_workitems/edit/357)
1) Fail on disconnect, not on connect. 
2) Reduce defaultMaxConsecutiveReconnects  to 7
3) Remove FG  ("Fluid.ContainerRuntime.MaxOpSizeInBytes") 