### PR TITLE
r11s-driver: fix 401 regression from rediscovery work (#11643)

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -205,18 +205,17 @@ export class DocumentService implements api.IDocumentService {
 
         // Attempt to establish connection.
         // Retry with new token on authorization error; otherwise, allow container layer to handle.
-        let connection: api.IDocumentDeltaConnection;
         try {
-            connection = await connect();
+            const connection = await connect();
+            return connection;
         } catch (error: any) {
             if (error?.statusCode === 401) {
                 // Fetch new token and retry once,
                 // otherwise 401 will be bubbled up as non-retriable AuthorizationError.
-                connection = await connect(true /* refreshToken */);
+                return connect(true /* refreshToken */);
             }
             throw error;
         }
-        return connection;
     }
 
     /**


### PR DESCRIPTION
There was some interim code that was not cleaned up after changing approaches for rediscovery. This resulted in an error being thrown regardless of retrying the connection internally. Specifically, a 401 error will be thrown as non-retryable even after it successfully retried and connected.