### PR TITLE
Set idle socket keepalive time to 4 seconds

### DIFF
--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -1613,6 +1613,23 @@
       "resolved": "https://registry.npmjs.org/address/-/address-1.2.0.tgz",
       "integrity": "sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig=="
     },
+    "agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+        }
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1871,6 +1888,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "body-parser": {
       "version": "1.20.0",
@@ -3744,6 +3771,13 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4030,7 +4064,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -4446,6 +4484,14 @@
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "i": {
@@ -5679,6 +5725,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.3",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -47,6 +47,7 @@
     "@fluidframework/server-services-telemetry": "^0.1037.1000",
     "@fluidframework/server-services-utils": "^0.1037.1000",
     "@fluidframework/server-test-utils": "^0.1037.1000",
+    "agentkeepalive": "^4.2.1",
     "axios": "^0.26.0",
     "body-parser": "^1.17.1",
     "charwise": "^3.0.1",

--- a/server/tinylicious/src/index.ts
+++ b/server/tinylicious/src/index.ts
@@ -5,9 +5,9 @@
  */
 
 import * as path from "path";
-import http from "http";
 import Axios from "axios";
 import winston from "winston";
+import Agent from "agentkeepalive";
 import { runService } from "@fluidframework/server-services-shared";
 import { configureLogging } from "@fluidframework/server-services-utils";
 import { TinyliciousResourcesFactory } from "./resourcesFactory";
@@ -16,11 +16,11 @@ import { TinyliciousRunnerFactory } from "./runnerFactory";
 // Each TCP connect has a delay to allow it to be reuse after close, and unit test make a lot of connection,
 // which might cause port exhaustion.
 
-// Tinylicious includes end points for ths historian for the client. But even we bundle all the service in
-// a monolithic process, it still uses sockets to communicate with the historian service.  For these call,
-// keep the TCP connection open so that they can be reused
+// Tinylicious includes end points for the historian for the client. But even though we bundle all the
+// services in a monolithic process, it still uses sockets to communicate with the historian service.
+// For these calls, keep the TCP connection open so that they can be reused
 // TODO: Set this globally since the Historian use the global Axios default instance.  Make this encapsulated.
-Axios.defaults.httpAgent = new http.Agent({ keepAlive: true });
+Axios.defaults.httpAgent = new Agent({ keepAlive: true });
 
 const configPath = path.join(__dirname, "../config.json");
 


### PR DESCRIPTION
The tinylicious tests infrequently but consistently fail with 502 error code. A possible cause might be because the node (Axios) server socket timeout is 15s, whereas the underlying socket timeout default timeout is 5s. This PR switches to using agentkeepalive package that forces the Node server to understand and close connections idle sockets after 4 seconds so that Node doesn't try to use an already closed socket.