### PR TITLE
Tree: Cleanup and document dependencies within tree

### DIFF
--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -255,8 +255,15 @@ Some of the principles used to guide this are:
 
 - Reducing transitive dependencies:
 
-    Try to keep the total number of dependencies of a given component small when possible, with a particular emphasis on avoiding stateful dependencies for code with complex conditional logic.
-    This is important for testability, since complex conditional logic requires heavy unit testing, which is very difficult for stateful systems and systems with lots of dependencies.
+    Try to keep the total number of dependencies of a given component small when possible.
+    This applies both at the module level, but also for the actual object defined by those modules.
+    One particular kind of dependency we make a particular effort to avoid are dependencies on stateful systems from code that has complex conditional logic.
+    One example of this is in [rebase](./src/rebase/README.md) where we ensured that the stateful system, `Rebaser` is not depended on by the actual change specific rebase policy.
+    Instead the actual replace policy logic for changes is behind the `ChangeRebaser` interface, which does not depend on `Rebaser` and exposes the policy as pure functions (and thus is stateless).
+    This is important for testability, since complex conditional logic (like `ChangeRebaser` implementations) require extensive unit testing,
+    which is very difficult (and often slow) for stateful systems and systems with lots of dependencies.
+    If we instead took the pattern of putting the change rebasing policy in `Rebaser` subclasses,
+    this would violate this guiding principal and result in much harder to isolate and test policy logic.
 
     Another aspect of reducing transitive dependencies is reducing the required dependencies for particular scenarios.
     This means factoring out code that is not always required (such as support for extra features and optimizations) such that they can be omitted when not needed.

--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -262,7 +262,7 @@ Some of the principles used to guide this are:
     This means factoring out code that is not always required (such as support for extra features and optimizations) such that they can be omitted when not needed.
     `shared-tree-core` is an excellent example of this: it can be run with no indexes, and trivial a change family allowing it to have very few required dependencies.
     This often takes the form of either depending on interfaces (which can have their implementation swapped out or mocked), like [`ChangeFamily`](./src/change-family/README.md), or collection functionality in a registry, like we do for `FieldKinds` and `shared-tree-core`'s indexes.
-    Dependency injection is one for of this.
+    Dependency injection is one example of a useful pattern for reducing transitive dependencies.
     In addition to simplifying reasoning about the system (less total to think about for a given scenario) and simplifying testing,
     this approach also makes the lifecycle for new features easier to manage, since they can be fully implemented and tested without having to modify code outside of themselves.
     This makes pre-releases, stabilization and eventual deprecation of these features much easier, and even makes publishing them from separate packages possible if it ends up needing an even more separated lifecycle.

--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -238,9 +238,9 @@ graph LR;
 `@fluid-internal/tree` depends on the Fluid runtime (various packages in `@fluidframework/*`)
 and will be depended on directly by application using it (though at that time it will be moved out of `@fluid-internal`).
 `@fluid-internal/tree` is also complex,
-so its implementation is broken up into several parts with have carefully controlled dependencies to help ensure the codebase is maintainable.
+so its implementation is broken up into several parts which have carefully controlled dependencies to help ensure the codebase is maintainable.
 The goal of this internal structuring is to make evolution and maintenance easy.
-Some of the principals used to guide this are:
+Some of the principles used to guide this are:
 
 - Avoid cyclic dependencies:
 
@@ -256,9 +256,9 @@ Some of the principals used to guide this are:
 - Reducing transitive dependencies:
 
     Try to keep the total number of dependencies of a given component small when possible, with a particular emphasis on avoiding stateful dependencies for code with complex conditional logic.
-    This is important for testability, since complex conditional logic requires heavy unit testing, which is very difficult for stateful system and systems with lots of dependencies.
+    This is important for testability, since complex conditional logic requires heavy unit testing, which is very difficult for stateful systems and systems with lots of dependencies.
 
-    Another aspect of reducing transitive dependencies is reducing the required dependencies for particular sceneries.
+    Another aspect of reducing transitive dependencies is reducing the required dependencies for particular scenarios.
     This means factoring out code that is not always required (such as support for extra features and optimizations) such that they can be omitted when not needed.
     `shared-tree-core` is an excellent example of this: it can be run with no indexes, and trivial a change family allowing it to have very few required dependencies.
     This often takes the form of either depending on interfaces (which can have their implementation swapped out or mocked), like [`ChangeFamily`](./src/change-family/README.md), or collection functionality in a registry, like we do for `FieldKinds` and `shared-tree-core`'s indexes.
@@ -267,9 +267,9 @@ Some of the principals used to guide this are:
     this approach also makes the lifecycle for new features easier to manage, since they can be fully implemented and tested without having to modify code outside of themselves.
     This makes pre-releases, stabilization and eventual deprecation of these features much easier, and even makes publishing them from separate packages possible if it ends up needing an even more separated lifecycle.
 
-    Additionally, this architectural approach can lead to smaller applications by not pulling in unended functionality.
+    Additionally, this architectural approach can lead to smaller applications by not pulling in unneeded functionality.
 
-These approaches have lead to a dependency structure that looks roughly like the below diagram.
+These approaches have led to a dependency structure that looks roughly like the diagram below.
 A more exact structure can be observed from the `fence.json` files which are enforced via [good-fences](https://www.npmjs.com/package/good-fences).
 In this diagram, some dependency arrows for dependencies which are already included transitively are omitted.
 

--- a/packages/dds/tree/src/change-family/README.md
+++ b/packages/dds/tree/src/change-family/README.md
@@ -1,0 +1,14 @@
+# change-family
+
+Abstraction for change families.
+
+A change family is a collection of types of changes which can be used within a document, and support for building, serializing and rebasing them over each-other.
+This includes things like policies for how to edit sequences, clearing optional fields, swapping trees, updating counters, schema editing etc.
+
+A change family has to handle all its supported changes identically between all clients, and across all versions.
+Support for new kinds of changes can be added, but updating applications to use the new changes must be done carefully to avoid breaking old clients.
+
+Applications that only have ephemeral sessions and never persist documents with trailing ops may be able to relax this constraint somewhat.
+
+A change family can even include domain or application specific change types,
+though those are typically instead decomposed into simpler changes to avoid the above stability constraint for such high level concepts.

--- a/packages/dds/tree/src/change-family/fence.json
+++ b/packages/dds/tree/src/change-family/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": [ "change-family" ],
     "exports": [ "index" ],
-    "imports": [ "changeset", "rebase", "tree" ]
+    "imports": [ "rebase", "tree" ]
 }

--- a/packages/dds/tree/src/changeset/fence.json
+++ b/packages/dds/tree/src/changeset/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": [ "changeset" ],
     "exports": [ "index"],
-    "imports": ["schema-stored","tree","util"]
+    "imports": ["tree","util"]
 }

--- a/packages/dds/tree/src/edit-manager/fence.json
+++ b/packages/dds/tree/src/edit-manager/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": [ "edit-manager" ],
     "exports": [ "index" ],
-    "imports": [ "change-family", "changeset", "tree", "rebase", "util" ]
+    "imports": [ "change-family", "tree", "util" ]
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fence.json
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": [ "modular-schema" ],
     "exports": [ "index"],
-    "imports": ["schema-stored","schema-view","tree","util","rebase","dependency-tracking","changeset","change-family"]
+    "imports": ["schema-stored","schema-view","tree","util","rebase","dependency-tracking","change-family"]
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/README.md
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/README.md
@@ -1,0 +1,5 @@
+# sequence-change-family
+
+[`change-family`](../../change-family/README.md) that treats all fields like sequences.
+
+TODO: Maybe move `change-set` to be part of this.

--- a/packages/dds/tree/src/schema-stored/fence.json
+++ b/packages/dds/tree/src/schema-stored/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": ["schema-stored"],
     "exports": ["index"],
-    "imports": ["util","dependency-tracking","rebase"]
+    "imports": ["util","dependency-tracking"]
 }

--- a/packages/dds/tree/src/shared-tree-core/fence.json
+++ b/packages/dds/tree/src/shared-tree-core/fence.json
@@ -2,12 +2,8 @@
     "tags": [ "shared-tree-core" ],
     "exports": ["index"],
     "imports": [
-        "changeset",
         "change-family",
-        "dependency-tracking",
         "edit-manager",
-        "rebase",
-        "schema-stored",
         "tree",
         "util"
     ]


### PR DESCRIPTION
## Description

Documents the existing dependency structure, adds a couple missing readmes, and removes some unused deps from the fence files.

## Reviewer Guidance

Focus here should be on the readme content and related changes. Feedback on the actual dependency structure (other than the removed deps) is a separate concern beyond this PR.
