### PR TITLE
Improve benchmark tool

### DIFF
--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/benchmark",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Benchmarking tools",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "npm run eslint:fix",
     "perf": "mocha --config ./.mocharc.js --timeout 999999 -r node_modules/@fluidframework/mocha-test-setup --perfMode --fgrep @Benchmark --reporter ./dist/MochaReporter.js \"./dist/**/*.tests.js\"",
     "test": "npm run test:mocha",
-    "test:mocha": "mocha \"dist/**/*.tests.js\" --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
+    "test:mocha": "mocha \"dist/test/**/*.js\" --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
     "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
     "tsc": "tsc"
   },

--- a/tools/benchmark/src/Configuration.ts
+++ b/tools/benchmark/src/Configuration.ts
@@ -54,10 +54,17 @@ export enum BenchmarkType {
 	OwnCorrectness,
 }
 
-export const TestTypes = {
-    ExecutionTime: "ExecutionTime",
-    MemoryUsage: "MemoryUsage",
-} as const;
+export enum TestType {
+	/**
+	 * Tests that measure execution time
+	 */
+	ExecutionTime,
+
+	/**
+	 * Tests that measure memory usage
+	 */
+	MemoryUsage,
+}
 
 /**
  * Names of all BenchmarkTypes.
@@ -69,6 +76,17 @@ for (const type of Object.values(BenchmarkType)) {
 		benchmarkTypes.push(type);
 	}
 }
+
+/**
+ * Names of all TestTypes.
+ */
+ export const testTypes: string[] = [];
+
+ for (const type of Object.values(TestType)) {
+     if (typeof type === "string") {
+         testTypes.push(type);
+     }
+ }
 
 /**
  * Arguments to `benchmark`

--- a/tools/benchmark/src/Configuration.ts
+++ b/tools/benchmark/src/Configuration.ts
@@ -54,6 +54,11 @@ export enum BenchmarkType {
 	OwnCorrectness,
 }
 
+export const TestTypes = {
+    ExecutionTime: "ExecutionTime",
+    MemoryUsage: "MemoryUsage",
+} as const;
+
 /**
  * Names of all BenchmarkTypes.
  */
@@ -136,6 +141,13 @@ export interface BenchmarkOptions extends MochaExclusiveOptions, HookArguments {
 	 * The kind of benchmark.
 	 */
 	type?: BenchmarkType;
+
+    /**
+	 * A free-form field to add a category to the test. This gets added to an internal version of the test name
+     * with an '\@' prepended to it, so it can be leveraged in combination with mocha's --grep/--fgrep options to
+     * only execute specific tests.
+	 */
+	category?: string;
 }
 
 /**
@@ -217,6 +229,13 @@ export const isChildProcess = process.argv.includes("--childProcess");
  * Performance test suites are tagged with this to allow filtering to only performance tests.
  */
 export const performanceTestSuiteTag = "@Benchmark";
+
+/**
+ * When a consumer specifies a category for a test, we append this value to the test name followed by the
+ * user-specified category. This is so we can then strip that information from the name safely, before
+ * writing the test name in reporters.
+ */
+export const userCategoriesSplitter = ":ff-cat:";
 
 /**
  * Reporter output location

--- a/tools/benchmark/src/MemoryTestRunner.ts
+++ b/tools/benchmark/src/MemoryTestRunner.ts
@@ -15,6 +15,7 @@ import {
     MochaExclusiveOptions,
     HookArguments,
     BenchmarkType,
+    userCategoriesSplitter,
 } from "./Configuration";
 import { getArrayStatistics } from "./ReporterUtilities";
 
@@ -87,6 +88,13 @@ export interface MemoryTestArguments extends MochaExclusiveOptions, HookArgument
      * Percentage of samples (0.1 - 1) to use for calculating the statistics. Defaults to 1.
      */
     samplePercentageToUse?: number;
+
+    /**
+	 * A free-form field to add a category to the test. This gets added to an internal version of the test name
+     * with an '\@' prepended to it, so it can be leveraged in combination with mocha's --grep/--fgrep options to
+     * only execute specific tests.
+	 */
+	category?: string;
 }
 
 /**
@@ -120,9 +128,13 @@ export interface MemoryTestArguments extends MochaExclusiveOptions, HookArgument
         benchmarkFn: args.benchmarkFn,
         type: args.type ?? BenchmarkType.Measurement,
         samplePercentageToUse: args.samplePercentageToUse ?? 1,
+        category: args.category ?? "",
     };
 
     options.title = `${performanceTestSuiteTag} @${BenchmarkType[options.type]} ${options.title}`;
+    if (options.category !== "") {
+        options.title = `${options.title} ${userCategoriesSplitter} @${options.category}`;
+    }
 
     const itFunction = options.only ? it.only : it;
     const test = itFunction(options.title, async () => {

--- a/tools/benchmark/src/MemoryTestRunner.ts
+++ b/tools/benchmark/src/MemoryTestRunner.ts
@@ -16,6 +16,7 @@ import {
     HookArguments,
     BenchmarkType,
     userCategoriesSplitter,
+    TestType,
 } from "./Configuration";
 import { getArrayStatistics } from "./ReporterUtilities";
 
@@ -111,6 +112,10 @@ export interface MemoryTestArguments extends MochaExclusiveOptions, HookArgument
  * Optionally, setup and teardown functions for the whole benchmark can be provided via the
  * `before` and `after` options. Each of them will run only once, before/after all the
  * iterations/samples.
+ *
+ * Tests created with this function get tagged with '\@MemoryUsage', so mocha's --grep/--fgrep
+ * options can be used to only run this type of tests by fitering on that value.
+ *
  * @public
  *
  * @alpha The specifics of how this function works and what its output means are still subject
@@ -131,7 +136,9 @@ export interface MemoryTestArguments extends MochaExclusiveOptions, HookArgument
         category: args.category ?? "",
     };
 
-    options.title = `${performanceTestSuiteTag} @${BenchmarkType[options.type]} ${options.title}`;
+    const benchmarkTypeTag = BenchmarkType[options.type];
+    const testTypeTag = TestType[TestType.MemoryUsage];
+    options.title = `${performanceTestSuiteTag} @${benchmarkTypeTag} @${testTypeTag} ${options.title}`;
     if (options.category !== "") {
         options.title = `${options.title} ${userCategoriesSplitter} @${options.category}`;
     }

--- a/tools/benchmark/src/MochaMemoryTestReporter.ts
+++ b/tools/benchmark/src/MochaMemoryTestReporter.ts
@@ -7,31 +7,19 @@ import * as path from "path";
 import * as fs from "fs";
 import Table from "easy-table";
 import { Runner, Suite, Test } from "mocha";
-import { benchmarkTypes, isChildProcess, performanceTestSuiteTag } from "./Configuration";
-import { bold, getArrayStatistics, green, italicize, pad, prettyNumber, red } from "./ReporterUtilities";
+import { isChildProcess } from "./Configuration";
+import {
+    bold,
+    green,
+    italicize,
+    pad,
+    prettyNumber,
+    red,
+    getArrayStatistics,
+    getName,
+    getSuiteName,
+} from "./ReporterUtilities";
 import { MemoryBenchmarkStats } from "./MemoryTestRunner";
-
-const tags = [performanceTestSuiteTag];
-
-for (const tag of benchmarkTypes) {
-    tags.push(`@${tag}`);
-}
-
-/**
- * Strip tags from name.
- */
-const getSuiteName = (suite: Suite): string => getName(suite.fullTitle());
-
-/**
- * Strip tags from name.
- */
-function getName(name: string): string {
-    let s = name;
-    for (const tag of tags) {
-        s = s.replace(tag, "");
-    }
-    return s.trim();
-}
 
 /**
  * Custom mocha reporter for memory tests. It can be used by passing the JavaScript version of this file to

--- a/tools/benchmark/src/MochaReporter.ts
+++ b/tools/benchmark/src/MochaReporter.ts
@@ -4,31 +4,9 @@
  */
 
 import { Runner, Suite, Test } from "mocha";
-import { benchmarkTypes, isChildProcess, performanceTestSuiteTag, ReporterOptions } from "./Configuration";
+import { isChildProcess, ReporterOptions } from "./Configuration";
 import { BenchmarkData, BenchmarkReporter, failedData } from "./Reporter";
-import { red } from "./ReporterUtilities";
-
-const tags = [performanceTestSuiteTag];
-
-for (const tag of benchmarkTypes) {
-    tags.push(`@${tag}`);
-}
-
-/**
- * Strip tags from name.
- */
-const getSuiteName = (suite: Suite): string => getName(suite.fullTitle());
-
-/**
- * Strip tags from name.
- */
-function getName(name: string): string {
-    let s = name;
-    for (const tag of tags) {
-        s = s.replace(tag, "");
-    }
-    return s.trim();
-}
+import { red, getName, getSuiteName } from "./ReporterUtilities";
 
 /**
  * Custom mocha reporter (can be used by passing the JavaScript version of this file to mocha with --reporter).

--- a/tools/benchmark/src/ReporterUtilities.ts
+++ b/tools/benchmark/src/ReporterUtilities.ts
@@ -5,11 +5,35 @@
 
 import Benchmark from "benchmark";
 import { assert } from "chai";
+import { Suite } from "mocha";
+import { benchmarkTypes, performanceTestSuiteTag, userCategoriesSplitter } from "./Configuration";
 
 /**
  * This file contains generic utilities of use to a mocha reporter, especially for convenient formatting of textual
  * output to the command line.
  */
+
+const tags = [performanceTestSuiteTag, ...benchmarkTypes.map((x) => `@${x}`)];
+
+/**
+ * Strip tags and user-specified category from a test suite's name.
+ */
+export const getSuiteName = (suite: Suite): string => getName(suite.fullTitle());
+
+/**
+ * Strip tags and user-specified category from the specified test/suite name.
+ */
+export function getName(name: string): string {
+    let s = name;
+    for (const tag of tags) {
+        s = s.replace(tag, "");
+    }
+    const indexOfSplitter = s.indexOf(userCategoriesSplitter);
+    if (indexOfSplitter >= 0) {
+        s = s.slice(0, indexOfSplitter);
+    }
+    return s.trim();
+}
 
 /**
  * @returns a red version of the input string

--- a/tools/benchmark/src/ReporterUtilities.ts
+++ b/tools/benchmark/src/ReporterUtilities.ts
@@ -6,14 +6,17 @@
 import Benchmark from "benchmark";
 import { assert } from "chai";
 import { Suite } from "mocha";
-import { benchmarkTypes, performanceTestSuiteTag, userCategoriesSplitter } from "./Configuration";
+import { benchmarkTypes, performanceTestSuiteTag, testTypes, userCategoriesSplitter } from "./Configuration";
 
 /**
  * This file contains generic utilities of use to a mocha reporter, especially for convenient formatting of textual
  * output to the command line.
  */
 
-const tags = [performanceTestSuiteTag, ...benchmarkTypes.map((x) => `@${x}`)];
+const tags = [
+    performanceTestSuiteTag,
+    ...benchmarkTypes.map((x) => `@${x}`),
+    ...testTypes.map((x) => `@${x}`)];
 
 /**
  * Strip tags and user-specified category from a test suite's name.

--- a/tools/benchmark/src/Runner.ts
+++ b/tools/benchmark/src/Runner.ts
@@ -14,6 +14,7 @@ import {
     isParentProcess,
     isInPerformanceTestingMode,
     performanceTestSuiteTag,
+    userCategoriesSplitter,
 } from "./Configuration";
 import { BenchmarkData } from "./Reporter";
 
@@ -45,10 +46,15 @@ export function benchmark(args: BenchmarkArguments): Test {
         only: args.only ?? false,
         before: args.before ?? (() => {}),
         after: args.after ?? (() => {}),
+        category: args.category ?? "",
     };
     const { isAsync, benchmarkFn: argsBenchmarkFn } = validateBenchmarkArguments(args);
     const typeTag = BenchmarkType[options.type];
-    const qualifiedTitle = `${performanceTestSuiteTag} @${typeTag} ${args.title}`;
+    let qualifiedTitle = `${performanceTestSuiteTag} @${typeTag} ${args.title}`;
+
+    if (options.category !== "") {
+        qualifiedTitle = `${qualifiedTitle} ${userCategoriesSplitter} @${options.category}`;
+    }
 
     const itFunction = options.only ? it.only : it;
     const test = itFunction(qualifiedTitle, async () => {

--- a/tools/benchmark/src/Runner.ts
+++ b/tools/benchmark/src/Runner.ts
@@ -15,6 +15,7 @@ import {
     isInPerformanceTestingMode,
     performanceTestSuiteTag,
     userCategoriesSplitter,
+    TestType,
 } from "./Configuration";
 import { BenchmarkData } from "./Reporter";
 
@@ -35,6 +36,10 @@ import { BenchmarkData } from "./Reporter";
  * the iterations until it hits a low uncertainty point.
  *
  * Optionally, setup and teardown functions can be provided via the `before` and `after` options.
+ *
+ * Tests created with this function get tagged with '\@ExecutionTime', so mocha's --grep/--fgrep
+ * options can be used to only run this type of tests by fitering on that value.
+ *
  * @public
  */
 export function benchmark(args: BenchmarkArguments): Test {
@@ -49,8 +54,9 @@ export function benchmark(args: BenchmarkArguments): Test {
         category: args.category ?? "",
     };
     const { isAsync, benchmarkFn: argsBenchmarkFn } = validateBenchmarkArguments(args);
-    const typeTag = BenchmarkType[options.type];
-    let qualifiedTitle = `${performanceTestSuiteTag} @${typeTag} ${args.title}`;
+    const benchmarkTypeTag = BenchmarkType[options.type];
+    const testTypeTag = TestType[TestType.ExecutionTime];
+    let qualifiedTitle = `${performanceTestSuiteTag} @${benchmarkTypeTag} @${testTypeTag} ${args.title}`;
 
     if (options.category !== "") {
         qualifiedTitle = `${qualifiedTitle} ${userCategoriesSplitter} @${options.category}`;

--- a/tools/benchmark/src/index.ts
+++ b/tools/benchmark/src/index.ts
@@ -24,7 +24,6 @@ export {
     MochaExclusiveOptions,
     HookFunction,
     HookArguments,
-    TestTypes,
     isInPerformanceTestingMode,
     validateBenchmarkArguments,
 } from "./Configuration";

--- a/tools/benchmark/src/index.ts
+++ b/tools/benchmark/src/index.ts
@@ -24,6 +24,7 @@ export {
     MochaExclusiveOptions,
     HookFunction,
     HookArguments,
+    TestTypes,
     isInPerformanceTestingMode,
     validateBenchmarkArguments,
 } from "./Configuration";

--- a/tools/benchmark/src/test/ReporterUtilities.spec.ts
+++ b/tools/benchmark/src/test/ReporterUtilities.spec.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { expect } from "chai";
+import { getArrayStatistics } from "../ReporterUtilities";
+
+describe("getArrayStatistics() function", () => {
+    it("Computes correct values when not dropping samples", () => {
+        const array = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+        const results = getArrayStatistics(array);
+
+        // All these hardcoded values correspond to the statistics of an array with integer samples 1 through 10
+        expect(results.mean).to.equal(5.5, "Computed incorrect mean");
+        expect(results.variance).to.equal(8.25, "Computed incorrect variance");
+        expect(results.deviation).to.equal(2.8722813232690143, "Computed incorrect standard deviation");
+        expect(results.sem).to.equal(0.9082951062292475, "Computed incorrect sample error of the mean");
+        expect(results.moe).to.equal(2.0545635302905576, "Computed incorrect margin of error");
+        expect(results.rme).to.equal(37.35570055073741, "Computed incorrect relative margin of error");
+
+        // Output array of samples doesn't need to be sorted if we're not dropping samples
+        expect(results.sample).to.deep.equal(array, "Did not return original array as samples");
+    });
+
+    it("Computes correct values when dropping samples", () => {
+        const array = [20, 20, 20, 20, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0];
+        const results = getArrayStatistics(array, 0.5);
+
+        // All these hardcoded values correspond to the statistics of an array with integer samples 1 through 10
+        expect(results.mean).to.equal(5.5, "Computed incorrect mean");
+        expect(results.variance).to.equal(8.25, "Computed incorrect variance");
+        expect(results.deviation).to.equal(2.8722813232690143, "Computed incorrect standard deviation");
+        expect(results.sem).to.equal(0.9082951062292475, "Computed incorrect sample error of the mean");
+        expect(results.moe).to.equal(2.0545635302905576, "Computed incorrect margin of error");
+        expect(results.rme).to.equal(37.35570055073741, "Computed incorrect relative margin of error");
+
+        // Output array of samples will be sorted if we dropped samples
+        const expectedSamples = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        expect(results.sample).to.deep.equal(expectedSamples, "Did not return original array as samples");
+    });
+
+    it("Does not mutate array", () => {
+        const array = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+
+        // When not dropping samples
+        getArrayStatistics(array);
+        expect(array).to.deep.equal([10, 9, 8, 7, 6, 5, 4, 3, 2, 1], "Array mutated when not dropping samples");
+
+        // When dropping samples
+        getArrayStatistics(array, 0.5);
+        expect(array).to.deep.equal([10, 9, 8, 7, 6, 5, 4, 3, 2, 1], "Array mutated when dropping samples");
+    });
+
+    it("Uses correct samples when dropping an even number", () => {
+        const array = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+        let results = getArrayStatistics(array, 0.8);
+        let expectedSamples = [2, 3, 4, 5, 6, 7, 8, 9];
+        expect(results.mean).to.equal(mean(expectedSamples), "Incorrect mean when using 0.8 of samples");
+        expect(results.sample).to.deep.equal(expectedSamples, "Incorrect list of samples when using 0.8 of them");
+
+        results = getArrayStatistics(array, 0.2);
+        expectedSamples = [5, 6];
+        expect(results.mean).to.equal(mean(expectedSamples), "Incorrect mean when using 0.2 of samples");
+        expect(results.sample).to.deep.equal(expectedSamples, "Incorrect list of samples when using 0.2 of them");
+    });
+
+    it("Uses correct samples when dropping an odd number", () => {
+        const array = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+        let results = getArrayStatistics(array, 0.9);
+        let expectedSamples = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        expect(results.mean).to.equal(mean(expectedSamples), "Incorrect mean when using 0.9 of samples");
+        expect(results.sample).to.deep.equal(expectedSamples, "Incorrect list of samples when using 0.9 of them");
+
+        results = getArrayStatistics(array, 0.1);
+        expectedSamples = [5];
+        expect(results.mean).to.equal(mean(expectedSamples), "Incorrect mean when using 0.1 of samples");
+        expect(results.sample).to.deep.equal(expectedSamples, "Incorrect list of samples when using 0.1 of them");
+    });
+});
+
+const mean = (array: number[]) => array.reduce((a, b) => a + b, 0) / array.length;

--- a/tools/benchmark/src/test/ReporterUtilities.spec.ts
+++ b/tools/benchmark/src/test/ReporterUtilities.spec.ts
@@ -7,6 +7,18 @@ import { expect } from "chai";
 import { getArrayStatistics } from "../ReporterUtilities";
 
 describe("getArrayStatistics() function", () => {
+    it("Throws if percentageOfSamplesToUse is out of range", () => {
+        const array = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+        expect(() => getArrayStatistics(array, 0.05)).to.throw(
+            Error,
+            "percentageOfSamplesToUse must be between 0.1 and 1 (inclusive)",
+            "Did not reject percentageOfSamplesToUse < 0.1");
+        expect(() => getArrayStatistics(array, 1.01)).to.throw(
+            Error,
+            "percentageOfSamplesToUse must be between 0.1 and 1 (inclusive)",
+            "Did not reject percentageOfSamplesToUse > 1.0");
+    });
+
     it("Computes correct values when not dropping samples", () => {
         const array = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
         const results = getArrayStatistics(array);


### PR DESCRIPTION
## Description

Some improvements to the benchmark tool:
- `benchmark()` and `benchmarkMemory()` now automatically tag tests with `@ExecutionTime` or `@MemoryUsage`, respectively, to allow for selective execution.
- Ability to add a user-specified category to tests, for selective execution.

Specifically for memory tests:
- Ability to define a percentage of samples to use when computing statistics. If not set to 1 (100%), the lowest and highest samples are dropped, and statistics are only computed from the remaining ones.
- Print the computed statistics to the output file when using the custom mocha reporter.
  - With this, the post-processing tool to send telemetry to Kusto won't have to recompute those numbers and will not need to know if the test configuration indicated that lowest/highest samples were to be dropped.
- Unit tests for function that computes statistics.
 