### PR TITLE
disable message batching for Azure customers

### DIFF
--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -10,6 +10,7 @@ import {
 } from "@fluidframework/aqueduct";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ContainerSchema,
@@ -156,7 +157,14 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
                 {},
                 registryEntries,
             );
-        super([rootDataObjectFactory.registryEntry], undefined, [defaultRouteRequestHandler(rootDataStoreId)]);
+        super(
+            [rootDataObjectFactory.registryEntry],
+            undefined,
+            [defaultRouteRequestHandler(rootDataStoreId)],
+            // temporary workaround to disable message batching until the message batch size issue is resolved
+            // resolution progress is tracked by the Feature 465 work item in AzDO
+            { flushMode: FlushMode.Immediate },
+        );
         this.rootDataObjectFactory = rootDataObjectFactory;
         this.initialObjects = schema.initialObjects;
     }

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -17,6 +17,7 @@ import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils"
 import { IContainer, IErrorBase } from "@fluidframework/container-definitions";
 import { ConfigTypes, IConfigProviderBase, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { GenericError } from "@fluidframework/container-utils";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 
 describeNoCompat("Message size", (getTestObjectProvider) => {
     const mapId = "mapId";
@@ -139,6 +140,20 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
         // Max op size is 768000, round down to account for some overhead
         const largeString = generateStringOfSize(750000);
         const messageCount = 1;
+        setMapKeys(dataObject1map, messageCount, largeString);
+        await provider.ensureSynchronized();
+
+        assertMapValues(dataObject2map, messageCount, largeString);
+    });
+
+    it("Batched small ops pass when batch is larger than max op size", async function() {
+        // flush mode is not applicable for the local driver
+        if (provider.driver.type === "local") {
+            this.skip();
+        }
+        await setupContainers({ ...testContainerConfig, runtimeOptions: { flushMode: FlushMode.Immediate } }, {});
+        const largeString = generateStringOfSize(500000);
+        const messageCount = 10;
         setMapKeys(dataObject1map, messageCount, largeString);
         await provider.ensureSynchronized();
 


### PR DESCRIPTION
### The problem
The problem reported by a customer via IcM. Attempting to sync a large data set consisting of batched multiple messages (less than 768kb each) will hit Socket.io buffer max size and the connection will close. The reason is the delta manager flushes batched messages periodically without enforcing the max op size. The max op size is only honored by the container runtime per each message submitted as imposed by the initial design.

### The solution
Disable the message batching by setting `flushMode` to `Intermediate` for Azure customers. The workaround should be reconsidered when the original batching problem is resolved.

> Cherry-picked from the next branch, PR #11568 