### PR TITLE
Change Rebaser Verifier

### DIFF
--- a/packages/dds/tree/src/test/util/testChangeRebaser.spec.ts
+++ b/packages/dds/tree/src/test/util/testChangeRebaser.spec.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { ChangeRebaser } from "../../rebase";
+import { AnchorSet } from "../../tree";
+import { testChangeRebaser } from "../../util";
+
+function commutativeRebaser<TChange>(data: {
+    compose: (changes: TChange[]) => TChange;
+    invert: (changes: TChange) => TChange;
+    rebaseAnchors: (anchor: AnchorSet, over: TChange) => void;
+}): ChangeRebaser<TChange> {
+    return {
+        rebase: (change: TChange, over: TChange) => change,
+        ...data,
+    };
+}
+
+const counterRebaser = commutativeRebaser({
+    compose: (changes: number[]) => changes.reduce((a, b) => a + b, 0),
+    invert: (change: number) => -change,
+    rebaseAnchors: (anchor: AnchorSet, over: number) => {},
+});
+
+describe("testChangeRebaser", () => {
+    it("test counter with safe integers", () => {
+        const output = testChangeRebaser(counterRebaser, new Set([-1, 2, 3, 0, -2, 4]), (a, b) => a === b);
+        assert.equal(output.diffRebaseOrder, "PASSED");
+        assert.equal(output.diffComposeOrder, "PASSED");
+        assert.equal(output.nestedComposeRebaseOrder, "PASSED");
+        assert.equal(output.doUndoPair, "PASSED");
+        assert.equal(output.sandwichRebase, "PASSED");
+        assert.equal(output.changeWithInverse, "PASSED");
+    });
+
+    it("test counter with unsafe integers", () => {
+        const output = testChangeRebaser(counterRebaser, new Set([Number.MAX_SAFE_INTEGER, -10, 2]), (a, b) => a === b);
+        assert.equal(output.diffRebaseOrder, "PASSED");
+        assert.notEqual(output.diffComposeOrder, "PASSED");
+        assert.equal(output.nestedComposeRebaseOrder, "PASSED");
+        assert.equal(output.doUndoPair, "PASSED");
+        assert.equal(output.sandwichRebase, "PASSED");
+        assert.equal(output.changeWithInverse, "PASSED");
+    });
+
+    it("test counter of floats with varying number of digits", () => {
+        const output = testChangeRebaser(
+            counterRebaser,
+            new Set([1.0, 1.22, -1.222]),
+            (a, b) => a === b,
+        );
+        assert.equal(output.diffRebaseOrder, "PASSED");
+        assert.notEqual(output.diffComposeOrder, "PASSED");
+        assert.equal(output.nestedComposeRebaseOrder, "PASSED");
+        assert.equal(output.doUndoPair, "PASSED");
+        assert.equal(output.sandwichRebase, "PASSED");
+        assert.equal(output.changeWithInverse, "PASSED");
+    });
+
+    // This test case contains all the different "edge case" numbers
+    it("test counter with special number types", () => {
+        const output = testChangeRebaser(
+            counterRebaser,
+            new Set([
+                Number.NaN,
+                Number.MAX_VALUE,
+                Number.MIN_VALUE,
+                Number.POSITIVE_INFINITY,
+                Number.NEGATIVE_INFINITY,
+                Number.MIN_SAFE_INTEGER,
+                Number.MAX_SAFE_INTEGER,
+            ]),
+            (a, b) => a === b,
+        );
+        assert.notEqual(output.diffRebaseOrder, "PASSED");
+        assert.notEqual(output.diffComposeOrder, "PASSED");
+        assert.notEqual(output.nestedComposeRebaseOrder, "PASSED");
+        assert.notEqual(output.doUndoPair, "PASSED");
+        assert.equal(output.sandwichRebase, "PASSED");
+        assert.notEqual(output.changeWithInverse, "PASSED");
+    });
+});

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -17,3 +17,4 @@ export * from "./typeCheck";
 export * from "./brand";
 export * from "./offsetList";
 export * from "./stackyIterator";
+export * from "./testChangeRebaser";

--- a/packages/dds/tree/src/util/testChangeRebaser.ts
+++ b/packages/dds/tree/src/util/testChangeRebaser.ts
@@ -1,0 +1,130 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ChangeRebaser } from "../rebase";
+
+interface outputType {
+    "diffRebaseOrder": string | any[];
+    "diffComposeOrder": string | any[];
+    "nestedComposeRebaseOrder": string | any[];
+    "doUndoPair": string | any[];
+    "sandwichRebase": string | any[];
+    "changeWithInverse": string | any[];
+}
+export function testChangeRebaser<TChange>(rebaser: ChangeRebaser<TChange>,
+    changes: ReadonlySet<TChange>,
+    isEquivalent: (a: TChange, b: TChange) => boolean): outputType {
+    const rebase = rebaser.rebase.bind(rebaser);
+    const compose = rebaser.compose.bind(rebaser);
+    const invert = rebaser.invert.bind(rebaser);
+
+    const output: outputType = {
+        diffRebaseOrder: "PASSED",
+        diffComposeOrder: "PASSED",
+        nestedComposeRebaseOrder: "PASSED",
+        doUndoPair: "PASSED",
+        sandwichRebase: "PASSED",
+        changeWithInverse: "PASSED",
+    };
+
+    for (const changeA of changes) {
+        if (!checkChangeWithInverse(changeA)) {
+            output.changeWithInverse = [changeA];
+        }
+        for (const changeB of changes) {
+            if (!checkDoUndoPair(changeA, changeB)) {
+                output.doUndoPair = [changeA, changeB];
+            }
+            if (!checkSandwichRebase(changeA, changeB)) {
+                output.doUndoPair = [changeA, changeB];
+            }
+            for (const changeC of changes) {
+                if (!checkDiffRebaseOrder(changeA, changeB, changeC)) {
+                    output.diffRebaseOrder = [changeA, changeB, changeC];
+                }
+                if (!checkDiffComposeOrder(changeA, changeB, changeC)) {
+                    output.diffComposeOrder = [changeA, changeB, changeC];
+                }
+                if (!checkNestedComposeRebaseOrder(changeA, changeB, changeC)) {
+                    output.nestedComposeRebaseOrder = [changeA, changeB, changeC];
+                }
+            }
+        }
+    }
+
+    return output;
+
+    // Requirement testing the rebasing of composed changes and rebased changes.
+    function checkDiffRebaseOrder(changeA: TChange, changeB: TChange, changeC: TChange) {
+        const rebaseChangeset1 = rebase(
+            changeA,
+            compose([changeB, changeC]),
+        );
+        const rebaseChangeset2 = rebase(
+            rebase(changeA, changeB),
+            changeC,
+        );
+        return isEquivalent(rebaseChangeset1, rebaseChangeset2);
+    }
+
+    // Requirement checking different ordering of composed changes
+    function checkDiffComposeOrder(changeA: TChange, changeB: TChange, changeC: TChange) {
+        const changeset1 = compose([
+            changeA,
+            compose([changeB, changeC]),
+        ]);
+        const changeset2 = compose([
+            compose([changeA, changeB]),
+            changeC,
+        ]);
+        const changeset3 = compose([changeA, changeB, changeC]);
+        return isEquivalent(changeset1, changeset2) && isEquivalent(changeset1, changeset3);
+    }
+
+    function checkNestedComposeRebaseOrder(changeA: TChange, changeB: TChange, changeC: TChange) {
+        const changeset1 = rebase(
+            compose([changeA, changeB]),
+            changeC,
+        );
+        const changeset2 = compose([
+            rebase(changeA, changeC),
+            rebase(
+                changeB,
+                compose([
+                    invert(changeA),
+                    changeC,
+                    rebase(changeA, changeC),
+                ]),
+            ),
+        ]);
+        return isEquivalent(changeset1, changeset2);
+    }
+
+    // requirement for do-undo pair
+    function checkDoUndoPair(changeA: TChange, changeB: TChange) {
+        const inv = invert(changeB);
+        const r1 = rebase(changeA, changeB);
+        const r2 = rebase(r1, inv);
+        return isEquivalent(r2, changeA);
+    }
+
+    // requirement for sandwich rebasing
+    function checkSandwichRebase(changeA: TChange, changeB: TChange) {
+        const invB = invert(changeB);
+        const r1 = rebase(changeA, changeB);
+        const r2 = rebase(r1, invB);
+        const r3 = rebase(r2, changeB);
+        return isEquivalent(r3, r1);
+    }
+
+    // requirement for compose of a change with it's inverse.
+    function checkChangeWithInverse(changeA: TChange) {
+        const changeset = compose([
+            invert(changeA),
+            changeA,
+        ]);
+        return isEquivalent(changeset, compose([]));
+    }
+}


### PR DESCRIPTION
## Description

This PR aims to provide a function to test the changeRebaser class when provided with a ChangeRebaser object, set of changes, and an equivalence function. Currently the test cases in "testChangeRebaser.spec.ts" created are for the "counter" field kind.

## Reviewer Guidance

### Questions
1. A number of inputs (i.e. infinity, NAN, MAX_INTEGER, etc. ) were used to provide breaking examples for the requirements. However, one of the requirements (sandwich rebase) does not seem to fail with any of these inputs.

`(A ↷ B) ↷ [B⁻¹, B] === A ↷ B`

Would there be any example inputs with the counter field kinds which can break this requirement? Or would it be best to create a rebaser object which may have "incorrect" rebase logic, but designed to make this requirement fail (just for testing purposes)?