### PR TITLE
Start publishing @fluid-tools/build-cli

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-tools/build-cli",
   "version": "0.4.1000",
-  "private": true,
   "description": "Build tools for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {


### PR DESCRIPTION
Removes the private designation for @fluid-tools/build-cli package so we can start publishing it.