### PR TITLE
Update CI pipeline to support installing build-tools from npm

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -33,7 +33,7 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
         }),
         release: Flags.string({
             description: "Indicates the build is a release build.",
-            options: ["release"],
+            options: ["release", "none"],
             env: "VERSION_RELEASE",
         }),
         patch: Flags.boolean({

--- a/tools/pipelines/build-azure-local-service.yml
+++ b/tools/pipelines/build-azure-local-service.yml
@@ -21,10 +21,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -65,7 +65,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/azure-local-service
     tagName: azure-local-service
     taskBuild: build

--- a/tools/pipelines/build-azure-local-service.yml
+++ b/tools/pipelines/build-azure-local-service.yml
@@ -21,6 +21,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -61,6 +65,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: server/azure-local-service
     tagName: azure-local-service
     taskBuild: build

--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 - name: nonScopedPackages
   displayName: Non-scoped packages to publish
   type: object
@@ -75,7 +75,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: azure
     tagName: azure
     poolBuild: Large

--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 - name: nonScopedPackages
   displayName: Non-scoped packages to publish
   type: object
@@ -71,6 +75,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: azure
     tagName: azure
     poolBuild: Large

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -21,10 +21,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -63,7 +63,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: tools/benchmark
     tagName:
     taskBuild: build

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -21,6 +21,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -59,6 +63,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: tools/benchmark
     tagName:
     taskBuild: build

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -62,6 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/build/build-common
     tagName: build-common
     taskBuild: false

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -66,7 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/build/build-common
     tagName: build-common
     taskBuild: false

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -64,7 +64,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: build-tools
     tagName: build-tools
     taskBuild: build

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -60,6 +64,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: build-tools
     tagName: build-tools
     taskBuild: build

--- a/tools/pipelines/build-bundle-size-tools.yml
+++ b/tools/pipelines/build-bundle-size-tools.yml
@@ -21,10 +21,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -62,7 +62,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: tools/bundle-size-tools
     tagName:
     taskBuild: build

--- a/tools/pipelines/build-bundle-size-tools.yml
+++ b/tools/pipelines/build-bundle-size-tools.yml
@@ -21,6 +21,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -58,6 +62,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: tools/bundle-size-tools
     tagName:
     taskBuild: build

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 - name: nonScopedPackages
   displayName: Non-scoped packages to publish
   type: object
@@ -80,6 +84,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: .
     tagName: client
     poolBuild: Large

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 - name: nonScopedPackages
   displayName: Non-scoped packages to publish
   type: object
@@ -84,7 +84,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     nonScopedPackages: ${{ parameters.nonScopedPackages }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: .
     tagName: client
     poolBuild: Large

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -62,6 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/lib/common-definitions
     tagName: common-definitions
     taskTest: false

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -66,7 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/common-definitions
     tagName: common-definitions
     taskTest: false

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -62,5 +66,6 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/lib/common-utils
     tagName: common-utils

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -66,6 +66,6 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/common-utils
     tagName: common-utils

--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -60,7 +60,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/container-definitions
     tagName: container-definitions
     taskTest: false

--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -56,6 +60,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/lib/container-definitions
     tagName: container-definitions
     taskTest: false

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -60,7 +60,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/core-interfaces
     tagName: core-interfaces
     taskTest: false

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -56,6 +60,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/lib/core-interfaces
     tagName: core-interfaces
     taskTest: false

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -60,7 +60,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/driver-definitions
     tagName: driver-definitions
     taskTest: false

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -56,6 +60,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/lib/driver-definitions
     tagName: driver-definitions
     taskTest: false

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -66,7 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/build/eslint-config-fluid
     tagName: eslint-config-fluid
     taskBuild: print-config

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -62,6 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/build/eslint-config-fluid
     tagName: eslint-config-fluid
     taskBuild: print-config

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -22,6 +22,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -62,6 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: common/lib/protocol-definitions
     tagName: protocol-definitions
     taskTest: false

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -22,10 +22,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -66,7 +66,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/protocol-definitions
     tagName: protocol-definitions
     taskTest: false

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -21,10 +21,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -62,7 +62,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: tools/test-tools
     tagName:
     taskBuild: build

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -21,6 +21,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -58,6 +62,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: tools/test-tools
     tagName:
     taskBuild: build

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -21,10 +21,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -65,7 +65,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/tinylicious
     tagName: tinylicious
     taskBuild: build

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -21,6 +21,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -61,6 +65,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: server/tinylicious
     tagName: tinylicious
     taskBuild: build

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -31,6 +31,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -75,6 +79,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     releaseKind: ${{ parameters.releaseKind }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: server/gitrest
     containerName: fluidframework/routerlicious/gitrest
     test: test

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -31,10 +31,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -79,7 +79,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     releaseKind: ${{ parameters.releaseKind }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/gitrest
     containerName: fluidframework/routerlicious/gitrest
     test: test

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -21,6 +21,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -58,6 +62,7 @@ extends:
     releaseImage: true
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: server/gitssh
     containerName: fluidframework/routerlicious/gitssh
     setVersion: false

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -21,10 +21,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -62,7 +62,7 @@ extends:
     releaseImage: true
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/gitssh
     containerName: fluidframework/routerlicious/gitssh
     setVersion: false

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -31,6 +31,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -75,6 +79,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     releaseKind: ${{ parameters.releaseKind }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: server/historian
     containerName: fluidframework/routerlicious/historian
     test: test

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -31,10 +31,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -79,7 +79,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     releaseKind: ${{ parameters.releaseKind }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/historian
     containerName: fluidframework/routerlicious/historian
     test: test

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -30,6 +30,10 @@ parameters:
     - default
     - skip
     - force
+- name: installBuildToolsFromRepo
+  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
+  type: boolean
+  default: true
 
 trigger:
   branches:
@@ -79,6 +83,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     releaseKind: ${{ parameters.releaseKind }}
+    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
     buildDirectory: server/routerlicious
     containerName: fluidframework/routerlicious/server
     buildNumberInPatch: false

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -30,10 +30,10 @@ parameters:
     - default
     - skip
     - force
-- name: installBuildToolsFromRepo
-  displayName: Use the Fluid build tools that are in the repo (as opposed to installing the latest release from npm)
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
 
 trigger:
   branches:
@@ -83,7 +83,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     releaseKind: ${{ parameters.releaseKind }}
-    installBuildToolsFromRepo: ${{ parameters.installBuildToolsFromRepo }}
+    buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/routerlicious
     containerName: fluidframework/routerlicious/server
     buildNumberInPatch: false

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -62,6 +62,10 @@ parameters:
   type: string
   default: Small
 
+- name: installBuildToolsFromRepo
+  type: boolean
+  default: false
+
 trigger: none
 
 variables:

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -62,9 +62,9 @@ parameters:
   type: string
   default: Small
 
-- name: installBuildToolsFromRepo
-  type: boolean
-  default: false
+- name: buildToolsVersionToInstall
+  type: string
+  default: repo
 
 trigger: none
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -85,9 +85,9 @@ parameters:
   type: boolean
   default: false
 
-- name: installBuildToolsFromRepo
-  type: boolean
-  default: false
+- name: buildToolsVersionToInstall
+  type: string
+  default: repo
 
 trigger: none
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -85,6 +85,10 @@ parameters:
   type: boolean
   default: false
 
+- name: installBuildToolsFromRepo
+  type: boolean
+  default: false
+
 trigger: none
 
 variables:

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -22,7 +22,6 @@ steps:
   - task: Bash@3
     name: PrependPath
     displayName: Prepend build-tools CLI to path
-    condition: eq(parameters.installBuildToolsFromRepo, true)
     inputs:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -51,7 +51,7 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        npm install --global @fluid-internal/build-cli@$(FLUID_BUILD_TOOLS_VERSION)
+        npm install --global @fluid-tools/build-cli@$(FLUID_BUILD_TOOLS_VERSION)
 
 - task: Bash@3
   name: BuildToolsInstallCheck

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -50,7 +50,7 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        npm install --global @fluid-tools/build-cli@$(FLUID_BUILD_TOOLS_VERSION)
+        npm install --global "@fluid-tools/build-cli@$(FLUID_BUILD_TOOLS_VERSION)"
 
 - task: Bash@3
   name: BuildToolsInstallCheck

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -50,7 +50,7 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        npm install --global "@fluid-tools/build-cli@${{ parameters.feedName }}"
+        npm install --global "@fluid-tools/build-cli@${{ parameters.buildToolsVersionToInstall }}"
 
 - task: Bash@3
   name: BuildToolsInstallCheck

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -12,13 +12,13 @@ parameters:
 - name: includeInternalVersions
   type: boolean
   default: false
-- name: installBuildToolsFromRepo
-  type: boolean
-  default: true
+- name: buildToolsVersionToInstall
+  type: string
+  default: repo
 
 # Set version
 steps:
-- ${{ if eq(parameters.installBuildToolsFromRepo, true) }}:
+- ${{ if eq(parameters.buildToolsVersionToInstall, 'repo') }}:
   - task: Bash@3
     name: PrependPath
     displayName: Prepend build-tools CLI to path
@@ -42,7 +42,7 @@ steps:
         npm ci
         popd
 
-- ${{ if eq(parameters.installBuildToolsFromRepo, false) }}:
+- ${{ if ne(parameters.buildToolsVersionToInstall, 'repo') }}:
   - task: Bash@3
     name: InstallBuildTools
     displayName: Install Fluid Build Tools (from npm)
@@ -50,7 +50,7 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        npm install --global "@fluid-tools/build-cli@$(FLUID_BUILD_TOOLS_VERSION)"
+        npm install --global "@fluid-tools/build-cli@${{ parameters.feedName }}"
 
 - task: Bash@3
   name: BuildToolsInstallCheck

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -12,32 +12,54 @@ parameters:
 - name: includeInternalVersions
   type: boolean
   default: false
+- name: installBuildToolsFromRepo
+  type: boolean
+  default: true
 
 # Set version
 steps:
+- ${{ if eq(parameters.installBuildToolsFromRepo, true) }}:
+  - task: Bash@3
+    name: PrependPath
+    displayName: Prepend build-tools CLI to path
+    condition: eq(parameters.installBuildToolsFromRepo, true)
+    inputs:
+      targetType: 'inline'
+      workingDirectory: ${{ parameters.buildDirectory }}
+      script: |
+        # Prepend the cli bin dir to the path. See
+        # <https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#prependpath-prepend-a-path-to-the--path-environment-variable>
+        # more information.
+        echo "##vso[task.prependpath]$(Build.SourcesDirectory)/build-tools/packages/build-cli/bin"
+
+  - task: Bash@3
+    name: InstallBuildTools
+    displayName: Install Fluid Build Tools (from repo)
+    inputs:
+      targetType: 'inline'
+      workingDirectory: ${{ parameters.buildDirectory }}
+      script: |
+        pushd "$(Build.SourcesDirectory)/build-tools"
+        npm ci
+        popd
+
+- ${{ if eq(parameters.installBuildToolsFromRepo, false) }}:
+  - task: Bash@3
+    name: InstallBuildTools
+    displayName: Install Fluid Build Tools (from npm)
+    inputs:
+      targetType: 'inline'
+      workingDirectory: ${{ parameters.buildDirectory }}
+      script: |
+        npm install --global @fluid-internal/build-cli@$(FLUID_BUILD_TOOLS_VERSION)
+
 - task: Bash@3
-  name: PrependPath
-  displayName: Prepend build-tools CLI to path
+  name: BuildToolsInstallCheck
+  displayName: Check Build Tools Installation
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
-      # Prepend the cli bin dir to the path. See
-      # <https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#prependpath-prepend-a-path-to-the--path-environment-variable>
-      # more information.
-      echo "##vso[task.prependpath]$(Build.SourcesDirectory)/build-tools/packages/build-cli/bin"
-
-- task: Bash@3
-  name: InstallBuildTools
-  displayName: Install Fluid Build Tools
-  inputs:
-    targetType: 'inline'
-    workingDirectory: ${{ parameters.buildDirectory }}
-    script: |
-      pushd "$(Build.SourcesDirectory)/build-tools"
-      npm ci
-      popd
-
       # Output the help and full command list for debugging purposes
       flub --help
       flub commands

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -25,6 +25,8 @@ parameters:
 
 variables:
 - group: prague-key-vault
+# Variables that control how the Fluid build tools are installed and behave
+- group: build-tools-config
 - name: skipComponentGovernanceDetection
   value: true
 - name: testBuild

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -25,8 +25,6 @@ parameters:
 
 variables:
 - group: prague-key-vault
-# Variables that control how the Fluid build tools are installed and behave
-- group: build-tools-config
 - name: skipComponentGovernanceDetection
   value: true
 - name: testBuild


### PR DESCRIPTION
We use our homegrown build-tools to do some tasks in our CI pipelines. It's helpful to be able to install the local in-repo version of the tools in most cases, but sometimes we want to install from npm instead. This change enables us to control the version of the build tools that are installed via a pipeline variable that's set when the pipeline is run.