### PR TITLE
Port pipelines fix to `release/1.2` branch

### DIFF
--- a/tools/pipelines/dependency-injection/.npmrc
+++ b/tools/pipelines/dependency-injection/.npmrc
@@ -4,5 +4,5 @@ always-auth=false
 @fluidframework:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
 @fluid-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
 @ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
-@ms:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
+@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
 always-auth=true

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -176,7 +176,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
-          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger@0.0.11'
+          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger'
           customRegistry: 'useNpmrc'
 
       # Download Test Files & Install Extra Dependencies

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -146,7 +146,7 @@ jobs:
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-internal:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-            echo "@ms:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+            echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
             echo "always-auth=true" >> ./.npmrc
             cat .npmrc
 
@@ -176,7 +176,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
-          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger'
+          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger@0.0.11'
           customRegistry: 'useNpmrc'
 
       # Download Test Files & Install Extra Dependencies


### PR DESCRIPTION
## Description

Port fix (https://github.com/microsoft/FluidFramework/pull/11615 and https://github.com/microsoft/FluidFramework/pull/11623) for updated npm scope in pipelines to the `release/1.2` branch. This should address the failures we're seeing right now in the test pipelines.

## Other information or known dependencies

A release is not necessary for this.