### PR TITLE
More EditManager testing

### DIFF
--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -190,6 +190,12 @@ class TestAnchorSet extends AnchorSet implements AnchorRebaseData {
 type TestChangeFamily = ChangeFamily<unknown, TestChangeset>;
 type TestEditManager = EditManager<TestChangeset, TestChangeFamily>;
 
+/**
+ * This is a hack to encode arbitrary information (the intentions) into a Delta.
+ * The resulting Delta does note represent a concrete change to a document tree.
+ * It is instead used as composite value in deep comparisons that verify that `EditManager` calls
+ * `ChangeFamily.intoDelta` with the expected change.
+ */
 function asDelta(intentions: number[]): Delta.Root {
     return intentions.length === 0 ? Delta.empty : new Map([[rootKey, intentions]]);
 }

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { fail, strict as assert } from "assert";
-import { verify } from "crypto";
 import { ChangeEncoder, ChangeFamily, JsonCompatible } from "../../change-family";
 import { Commit, EditManager, SessionId } from "../../edit-manager";
 import { ChangeRebaser } from "../../rebase";
@@ -14,10 +13,12 @@ import { brand, makeArray, RecursiveReadonly } from "../../util";
 interface NonEmptyTestChangeset {
     /**
      * Identifies the document state that the changeset should apply to.
+     * Represented as the concatenation of all previous intentions.
      */
     inputContext: number[];
     /**
      * Identifies the document state brought about by applying the changeset to the document.
+     * Represented as the concatenation of all previous intentions and the intentions in this change.
      */
     outputContext: number[];
     /**
@@ -252,11 +253,11 @@ describe("EditManager", () => {
             changeset: TestChangeRebaser.mintChangeset([1, 2], 3),
         };
         assert.deepEqual(manager.addLocalChange(c1.changeset), asDelta([1]));
-        assert.deepEqual(manager.addSequencedChange(c1), asDelta([]));
+        assert.deepEqual(manager.addSequencedChange(c1), Delta.empty);
         assert.deepEqual(manager.addLocalChange(c2.changeset), asDelta([2]));
-        assert.deepEqual(manager.addSequencedChange(c2), asDelta([]));
+        assert.deepEqual(manager.addSequencedChange(c2), Delta.empty);
         assert.deepEqual(manager.addLocalChange(c3.changeset), asDelta([3]));
-        assert.deepEqual(manager.addSequencedChange(c3), asDelta([]));
+        assert.deepEqual(manager.addSequencedChange(c3), Delta.empty);
         checkChangeList(manager, [1, 2, 3]);
     });
 
@@ -283,9 +284,9 @@ describe("EditManager", () => {
         assert.deepEqual(manager.addLocalChange(c1.changeset), asDelta([1]));
         assert.deepEqual(manager.addLocalChange(c2.changeset), asDelta([2]));
         assert.deepEqual(manager.addLocalChange(c3.changeset), asDelta([3]));
-        assert.deepEqual(manager.addSequencedChange(c1), asDelta([]));
-        assert.deepEqual(manager.addSequencedChange(c2), asDelta([]));
-        assert.deepEqual(manager.addSequencedChange(c3), asDelta([]));
+        assert.deepEqual(manager.addSequencedChange(c1), Delta.empty);
+        assert.deepEqual(manager.addSequencedChange(c2), Delta.empty);
+        assert.deepEqual(manager.addSequencedChange(c3), Delta.empty);
         checkChangeList(manager, [1, 2, 3]);
     });
 
@@ -529,12 +530,12 @@ describe("EditManager", () => {
         assert.deepEqual(manager.addSequencedChange(c2), asDelta([-3, 2, 3]));
         assert.deepEqual(manager.addLocalChange(c6.changeset), asDelta([6]));
         assert.deepEqual(manager.addLocalChange(c8.changeset), asDelta([8]));
-        assert.deepEqual(manager.addSequencedChange(c3), asDelta([]));
+        assert.deepEqual(manager.addSequencedChange(c3), Delta.empty);
         assert.deepEqual(manager.addSequencedChange(c4), asDelta([-8, -6, 4, 6, 8]));
         assert.deepEqual(manager.addSequencedChange(c5), asDelta([-8, -6, 5, 6, 8]));
-        assert.deepEqual(manager.addSequencedChange(c6), asDelta([]));
+        assert.deepEqual(manager.addSequencedChange(c6), Delta.empty);
         assert.deepEqual(manager.addSequencedChange(c7), asDelta([-8, 7, 8]));
-        assert.deepEqual(manager.addSequencedChange(c8), asDelta([]));
+        assert.deepEqual(manager.addSequencedChange(c8), Delta.empty);
         assert.deepEqual(manager.addSequencedChange(c9), asDelta([9]));
         checkChangeList(manager, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
     });

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -563,7 +563,6 @@ describe("EditManager", () => {
      * Despite that, it's good to keep the other tests cases for the following reasons:
      * - They give a clearer account of what the API usage is like.
      * - They are easier to debug.
-     * - They are less reliant on the `EditManager` implementation in their construction of test input.
      * - They help diagnose issues with the more complicated exhaustive test (e.g., if one of the above tests fails,
      *   but this one doesn't, then there might be something wrong with this test).
      */
@@ -669,7 +668,7 @@ function runScenario(scenario: readonly ScenarioStep[]): void {
         {
             const client = clientData[step.client];
             if (step.type === "Mint") {
-                const cs = TestChangeRebaser.mintChangeset(getTipContext(client.manager), ++changeCounter);
+                const cs = TestChangeRebaser.mintChangeset(client.intentions, ++changeCounter);
                 const delta = client.manager.addLocalChange(cs);
                 assert.deepEqual(delta, asDelta(cs.intentions));
                 client.localChanges.push({ change: cs, ref: client.ref });
@@ -739,15 +738,4 @@ function checkChangeList(manager: TestEditManager, intentions: number[]): void {
 
 function getAllChanges(manager: TestEditManager): RecursiveReadonly<TestChangeset>[] {
     return manager.getTrunk().map((c) => c.changeset).concat(manager.getLocalChanges());
-}
-
-function getTipContext(manager: TestEditManager): number[] {
-    const changes = getAllChanges(manager);
-    for (let i = changes.length - 1; i >= 0; --i) {
-        const change = changes[i];
-        if (isNonEmptyChange(change)) {
-            return [...change.outputContext];
-        }
-    }
-    return [];
 }

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -182,7 +182,7 @@ class TestChangeEncoder extends ChangeEncoder<TestChangeset> {
     }
 }
 
-class TestAnchorSet extends AnchorSet {
+class TestAnchorSet extends AnchorSet implements AnchorRebaseData {
     public rebases: RecursiveReadonly<NonEmptyTestChangeset>[] = [];
     public intentions: number[] = [];
 }
@@ -695,7 +695,7 @@ function runScenario(scenario: readonly ScenarioStep[]): void {
                         ...localIntentions,
                     );
                     assert.deepEqual(delta, asDelta(expected));
-                        // Update the intentions known to this client
+                    // Update the intentions known to this client
                     client.intentions.splice(
                         client.intentions.length - client.localChanges.length,
                         0,


### PR DESCRIPTION
More thorough testing of `EditManager`:
* Checking the deltas returned by `EditManager` when calling `addLocalChange` and `addSequencedChange`.
* Checking anchors are getting rebased over the correct intentions

Other changes:
* Refactored the `TestChangeRebaser` code to make it less stateful