### PR TITLE
Fix object forest passing cursors where nodes are needed

### DIFF
--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -65,14 +65,14 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         // which can edit, but is the only cursor allowed at the time.
 
         const moves: Map<Delta.MoveId, DetachedField> = new Map();
-        const currentNode: Cursor = this.allocateCursor();
+        const cursor: Cursor = this.allocateCursor();
         let currentField: FieldKey | undefined;
         const moveIn = (index: number, toAttach: DetachedField): number => {
             assert(currentField !== undefined, 0x363 /* must be in field to onMoveIn */);
             const children = this.roots.get(toAttach) ?? fail("Can not attach non-existent range");
             this.roots.delete(toAttach);
             let dstField: ObjectField;
-            if (currentNode.state === ITreeSubscriptionCursorState.Cleared) {
+            if (cursor.state === ITreeSubscriptionCursorState.Cleared) {
                 const dst = keyAsDetachedField(currentField);
                 assert(toAttach !== dst, 0x364 /* can not attach range to itself */);
                 // TODO: protect against parenting under itself creating a cycle as well:
@@ -82,7 +82,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
                 if (children.length === 0) {
                     return 0; // Prevent creating 0 sized fields when inserting empty into empty.
                 }
-                dstField = getGenericTreeField(currentNode, currentField, true);
+                dstField = getGenericTreeField(cursor.getNode(), currentField, true);
             }
             assertValidIndex(index, dstField, true);
             // TODO: this will fail for very large moves due to argument limits.
@@ -103,10 +103,10 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
             onMoveOut: (index: number, count: number, id?: Delta.MoveId): void => {
                 assert(currentField !== undefined, 0x367 /* must be in field to onMoveOut */);
                 let srcField: ObjectField;
-                if (currentNode.state === ITreeSubscriptionCursorState.Cleared) {
+                if (cursor.state === ITreeSubscriptionCursorState.Cleared) {
                     srcField = this.getRoot(keyAsDetachedField(currentField));
                 } else {
-                    srcField = getGenericTreeField(currentNode, currentField, false);
+                    srcField = getGenericTreeField(cursor.getNode(), currentField, false);
                 }
                 const field = this.detachRangeOfChildren(srcField, index, index + count);
                 if (id !== undefined) {
@@ -124,7 +124,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
             },
             onSetValue: (value: Value): void => {
                 assert(currentField === undefined, 0x36a /* must be in node to onSetValue */);
-                const node = currentNode.getNode();
+                const node = cursor.getNode();
                 if (value !== undefined) {
                     node.value = value;
                 } else {
@@ -134,20 +134,20 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
             enterNode: (index: number): void => {
                 assert(currentField !== undefined, 0x36b /* must be in field to enterNode */);
                 let result: TreeNavigationResult;
-                if (currentNode.state === ITreeSubscriptionCursorState.Cleared) {
-                    result = this.tryMoveCursorTo(this.root(keyAsDetachedField(currentField), index), currentNode);
+                if (cursor.state === ITreeSubscriptionCursorState.Cleared) {
+                    result = this.tryMoveCursorTo(this.root(keyAsDetachedField(currentField), index), cursor);
                 } else {
-                    result = currentNode.down(currentField, index);
+                    result = cursor.down(currentField, index);
                 }
                 assert(result === TreeNavigationResult.Ok, 0x36c /* can only enter existing nodes */);
                 currentField = undefined;
             },
             exitNode: (index: number): void => {
                 assert(currentField === undefined, 0x36d /* must be in node to exitNode */);
-                currentField = currentNode.getParentFieldKey();
-                const result = currentNode.up();
+                currentField = cursor.getParentFieldKey();
+                const result = cursor.up();
                 if (result === TreeNavigationResult.NotFound) {
-                    currentNode.clear();
+                    cursor.clear();
                 }
             },
             enterField: (key: FieldKey): void => {
@@ -160,7 +160,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
             },
         };
         visitDelta(delta, visitor);
-        currentNode.free();
+        cursor.free();
     }
 
     public observeItem(item: ObjectField | JsonableTree, observer: ObservingDependent | undefined): void {


### PR DESCRIPTION
The solutions to this type checking issue come with their own issues so it was decided to keep things in their current state and work towards keeping JsonableTree out of public APIs as well as rely on testing to catch these issues.