### PR TITLE
Add "none" as a valid option to the generate buildVersion command

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -33,7 +33,7 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
         }),
         release: Flags.string({
             description: "Indicates the build is a release build.",
-            options: ["release"],
+            options: ["release", "none"],
             env: "VERSION_RELEASE",
         }),
         patch: Flags.boolean({


### PR DESCRIPTION
The "none" value is passed sometimes as part of the CI build. This change informs the CLI that it's a valid value.