### PR TITLE
docs: Improve formatting of `@fluidframework/counter` source-code docs

### DIFF
--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -39,7 +39,7 @@ const snapshotFileName = "header";
 /**
  * A shared object that holds a number that can be incremented or decremented.
  *
- * @remarks Note that 1SharedCounter1 only operates on integer values. This is validated at runtime.
+ * @remarks Note that `SharedCounter` only operates on integer values. This is validated at runtime.
  *
  * @example Creating a `SharedCounter`:
  *

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -174,7 +174,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
      * Process a counter operation (op).
      *
      * @param message - The message to prepare.
-     * @param local - Whether the message was sent by the local client.
+     * @param local - Whether or not the message was sent by the local client.
      * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
      * For messages from a remote client, this will be `undefined`.
      *

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -17,7 +17,7 @@ import { CounterFactory } from "./counterFactory";
 import { ISharedCounter, ISharedCounterEvents } from "./interfaces";
 
 /**
- * Describes the operation (op) format for incrementing the counter.
+ * Describes the operation (op) format for incrementing the {@link SharedCounter}.
  */
 interface IIncrementOperation {
     type: "increment";
@@ -25,7 +25,7 @@ interface IIncrementOperation {
 }
 
 /**
- * Used in snapshotting.
+ * @remarks Used in snapshotting.
  */
 interface ICounterSnapshotFormat {
     /**
@@ -39,10 +39,12 @@ const snapshotFileName = "header";
 /**
  * A shared object that holds a number that can be incremented or decremented.
  *
- * @remarks
- * ### Creation
+ * @remarks Note that 1SharedCounter1 only operates on integer values. This is validated at runtime.
  *
- * To create a `SharedCounter`, get the factory and call create with a runtime and string ID:
+ * @example Creating a `SharedCounter`:
+ *
+ * First, get the factory and call {@link @fluidframework/datastore-definitions#IChannelFactory.create}
+ * with a runtime and string ID:
  *
  * ```typescript
  * const factory = SharedCounter.getFactory();
@@ -50,19 +52,21 @@ const snapshotFileName = "header";
  * ```
  *
  * The initial value of a new `SharedCounter` is 0.
- * If you wish to initialize the counter to a different value, you may call {@link ISharedCounter.increment} before
+ * If you wish to initialize the counter to a different value, you may call {@link SharedCounter.increment} before
  * attaching the Container, or before inserting it into an existing shared object.
  *
- * ### Usage
+ * @example Using the `SharedCounter`:
  *
- * Once created, you can call `increment` to modify the value with either a positive or negative number:
+ * Once created, you can call {@link SharedCounter.increment} to modify the value with either a positive or
+ * negative number:
  *
  * ```typescript
  * counter.increment(10); // add 10 to the counter value
  * counter.increment(-5); // subtract 5 from the counter value
  * ```
  *
- * To observe changes to the value (including those from remote clients), register for the `"incremented"` event:
+ * To observe changes to the value (including those from remote clients), register for the
+ * {@link ISharedCounterEvents | incremented} event:
  *
  * ```typescript
  * counter.on("incremented", (incrementAmount, newValue) => {
@@ -70,16 +74,15 @@ const snapshotFileName = "header";
  * });
  * ```
  *
- * Note that SharedCounter only operates on integer values. This is validated at runtime.
- *
  * @public
  */
 export class SharedCounter extends SharedObject<ISharedCounterEvents> implements ISharedCounter {
     /**
-     * Create a new shared counter
+     * Create a new {@link SharedCounter}.
      *
-     * @param runtime - data store runtime the new shared counter belongs to
-     * @param id - optional name of the shared counter
+     * @param runtime - The data store runtime to which the new `SharedCounter` will belong.
+     * @param id - Optional name of the `SharedCounter`. If not provided, one will be generated.
+     *
      * @returns newly create shared counter (but not attached yet)
      */
     public static create(runtime: IFluidDataStoreRuntime, id?: string): SharedCounter {
@@ -91,7 +94,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
     }
 
     /**
-     * Get a factory for SharedCounter to register with the data store.
+     * Get a factory for {@link SharedCounter} to register with the data store.
      *
      * @returns a factory that creates and load SharedCounter
      */
@@ -133,9 +136,10 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
     }
 
     /**
-     * Create a summary for the counter
+     * Create a summary for the counter.
      *
-     * @returns the summary of the current state of the counter
+     * @returns The summary of the current state of the counter.
+     *
      * @internal
      */
     protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
@@ -150,6 +154,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
 
     /**
      * {@inheritDoc @fluidframework/shared-object-base#SharedObject.loadCore}
+     *
      * @internal
      */
     protected async loadCore(storage: IChannelStorageService): Promise<void> {
@@ -160,6 +165,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
 
     /**
      * Called when the object has disconnected from the delta stream.
+     *
      * @internal
      */
     protected onDisconnect(): void { }
@@ -167,10 +173,11 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
     /**
      * Process a counter operation (op).
      *
-     * @param message - the message to prepare
-     * @param local - whether the message was sent by the local client
+     * @param message - The message to prepare.
+     * @param local - Whether the message was sent by the local client.
      * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
-     * For messages from a remote client, this will be undefined.
+     * For messages from a remote client, this will be `undefined`.
+     *
      * @internal
      */
     protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void {
@@ -190,6 +197,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
 
     /**
      * Not implemented.
+     *
      * @internal
      */
     protected applyStashedOp() {

--- a/packages/dds/counter/src/counterFactory.ts
+++ b/packages/dds/counter/src/counterFactory.ts
@@ -14,11 +14,19 @@ import { ISharedCounter } from "./interfaces";
 import { pkgVersion } from "./packageVersion";
 
 /**
- * The factory that defines the counter
+ * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link SharedCounter}.
+ *
+ * @sealed
  */
 export class CounterFactory implements IChannelFactory {
+    /**
+     * Static value for {@link CounterFactory."type"}.
+     */
     public static readonly Type = "https://graph.microsoft.com/types/counter";
 
+    /**
+     * Static value for {@link CounterFactory.attributes}.
+     */
     public static readonly Attributes: IChannelAttributes = {
         type: CounterFactory.Type,
         snapshotFormatVersion: "0.1",

--- a/packages/dds/counter/src/index.ts
+++ b/packages/dds/counter/src/index.ts
@@ -4,8 +4,8 @@
  */
 
 /**
- * This package contains the SharedCounter distributed data structure. A SharedCounter is a shared object
- * which holds a number that can be incremented or decremented.
+ * This package contains the {@link SharedCounter} distributed data structure.
+ * A `SharedCounter` is a shared object which holds a whole number that can be incremented or decremented.
  *
  * @packageDocumentation
  */

--- a/packages/dds/counter/src/interfaces.ts
+++ b/packages/dds/counter/src/interfaces.ts
@@ -30,11 +30,14 @@ export interface ISharedCounterEvents extends ISharedObjectEvents {
 export interface ISharedCounter extends ISharedObject<ISharedCounterEvents> {
     /**
      * The counter value.
+     *
+     * @remarks Must be a whole number.
      */
     value: number;
 
     /**
-     * Increments or decrements the value.  Must only increment or decrement by a whole number value.
+     * Increments or decrements the value.
+     * Must only increment or decrement by a whole number value.
      *
      * @param incrementAmount - A whole number to increment or decrement by.
      */

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -205,7 +205,7 @@ export interface IChannelServices {
  * appropriate in-memory object.
  *
  * @example If a collaboration includes a {@link https://fluidframework.com/docs/data-structures/map/ | SharedMap},
- * a the collaborating clients will need to have access to a factory that can produce the `SharedMap` obect.
+ * the collaborating clients will need to have access to a factory that can produce the `SharedMap` obect.
  *
  * @remarks Factories follow a common model but enable custom behavior.
  */


### PR DESCRIPTION
`@fluidframework/counter` is now promoted more directly on our website, including its API docs. This PR is aimed at cleaning up those docs for public consumption.

Mostly simple typo fixes and capitalization/punctuation improvements. But it also moves `SharedCounter`'s summary docs away from using embedded Markdown syntax (which is not supported) toward using `@example` tag syntax for its flow examples.

Additional feedback and suggestions are encouraged!!