### PR TITLE
Fix gc dataStore no duplicate routes test

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -67,7 +67,7 @@ export const createDocumentId: () => string;
 export function createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, documentServiceFactory: IDocumentServiceFactory, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger, options?: ILoaderOptions): IHostLoader;
 
 // @public (undocumented)
-export function createSummarizer(provider: ITestObjectProvider, container: IContainer, summaryVersion?: string, gcOptions?: IGCRuntimeOptions): Promise<ISummarizer>;
+export function createSummarizer(provider: ITestObjectProvider, container: IContainer, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase): Promise<ISummarizer>;
 
 // @public (undocumented)
 export function createSummarizerFromFactory(provider: ITestObjectProvider, container: IContainer, dataStoreFactory: IFluidDataStoreFactory, summaryVersion?: string, containerRuntimeFactoryType?: typeof ContainerRuntimeFactoryWithDefaultDataStore): Promise<ISummarizer>;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -11,11 +11,14 @@ import {
     createSummarizer,
     summarizeNow,
     waitForContainerConnection,
+    mockConfigProvider,
+    ITestContainerConfig,
 } from "@fluidframework/test-utils";
 import { describeNoCompat, ITestDataObject } from "@fluidframework/test-version-utils";
-import { gcTreeKey, ISummarizer } from "@fluidframework/container-runtime";
-import { SummaryType } from "@fluidframework/protocol-definitions";
+import { gcBlobPrefix, gcTreeKey, ISummarizer } from "@fluidframework/container-runtime";
+import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
 import { SharedMap } from "@fluidframework/map";
+import { IGarbageCollectionState } from "@fluidframework/runtime-definitions";
 import { defaultGCConfig } from "./gcTestConfigs";
 
 /**
@@ -34,12 +37,13 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
 
     beforeEach(async () => {
         provider = getTestObjectProvider({ syncSummarizer: true });
+    });
+
+    it("DDS changes do not create new GC blobs", async () => {
         mainContainer = await provider.makeTestContainer(defaultGCConfig);
         mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
         await waitForContainerConnection(mainContainer);
-    });
 
-    it("Back routes added by GC are removed when passed from data stores to DDSes", async () => {
         const dds = SharedMap.create(mainDataStore._runtime);
         mainDataStore._root.set("dds", dds.handle);
 
@@ -56,5 +60,53 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
         assert(gcObject !== undefined, "Expected a gc blob!");
         assert(gcObject.type === SummaryType.Handle, "Expected a handle!");
         assert(gcObject.handleType === SummaryType.Tree, "Expected a gc tree handle!");
+    });
+
+    it("Back routes added by GC are removed when passed from data stores to DDSes", async () => {
+        const settings = {};
+        const configProvider = mockConfigProvider(settings);
+        const newConfig: ITestContainerConfig = {
+            runtimeOptions: defaultGCConfig.runtimeOptions,
+            loaderProps: { configProvider },
+        };
+        settings["Fluid.GarbageCollection.TrackGCState"] = "false";
+        mainContainer = await provider.makeTestContainer(newConfig);
+        mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+        await waitForContainerConnection(mainContainer);
+
+        const dds = SharedMap.create(mainDataStore._runtime);
+        mainDataStore._root.set("dds", dds.handle);
+
+        const summarizer1 = await createSummarizer(provider, mainContainer, undefined, undefined, configProvider);
+        let summaryResult = await waitForSummary(summarizer1);
+
+        // Change ds1 but not the root dds
+        dds.set("change", "change1");
+
+        summarizer1.close();
+        const summarizer2 = await createSummarizer(
+            provider,
+            mainContainer,
+            summaryResult.summaryVersion,
+            undefined,
+            configProvider,
+        );
+
+        // Get GC State
+        summaryResult = await waitForSummary(summarizer2);
+        const gcTree = summaryResult.summaryTree.tree[gcTreeKey];
+        assert(gcTree !== undefined, "Expected a gc blob!");
+        assert(gcTree.type === SummaryType.Tree, "Expected a Tree!");
+        const gcBlob = gcTree.tree[`${gcBlobPrefix}_root`] as ISummaryBlob;
+        const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;
+
+        // Validate GC State
+        for (const [_, gcData] of Object.entries(gcState.gcNodes)) {
+            const seenRoutes = new Set<string>();
+            gcData.outboundRoutes.forEach((route) => {
+                assert(!seenRoutes.has(route), `There should be no duplicate routes! Duplicate Route: ${route}`);
+                seenRoutes.add(route);
+            });
+        }
     });
 });

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -19,6 +19,7 @@ import {
     IFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { ITestContainerConfig, ITestObjectProvider } from "./testObjectProvider";
 import { mockConfigProvider } from "./TestConfigs";
 
@@ -96,13 +97,14 @@ export async function createSummarizer(
     container: IContainer,
     summaryVersion?: string,
     gcOptions?: IGCRuntimeOptions,
+    configProvider: IConfigProviderBase = mockConfigProvider(),
 ): Promise<ISummarizer> {
     const testContainerConfig: ITestContainerConfig = {
         runtimeOptions: {
             summaryOptions: defaultSummaryOptions,
             gcOptions,
         },
-        loaderProps: { configProvider: mockConfigProvider() },
+        loaderProps: { configProvider },
     };
 
     const loader = provider.makeTestLoader(testContainerConfig);


### PR DESCRIPTION
[AB#739](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/739)

What happened was the test was just returning a gc tree summary handle instead of the actual blob. Without trackState make sure duplicate routes aren't created.