### PR TITLE
Fix and add tests for the buildVersion CLI

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -92,7 +92,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version)
-@fluid-tools/build-cli/0.3.2000 linux-x64 node-v14.20.0
+@fluid-tools/build-cli/0.4.3000 linux-x64 node-v14.20.0
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND
@@ -104,7 +104,7 @@ USAGE
 * [`flub bump deps PACKAGE_OR_RELEASE_GROUP`](#flub-bump-deps-package_or_release_group)
 * [`flub check layers`](#flub-check-layers)
 * [`flub commands`](#flub-commands)
-* [`flub generate buildVersion [FILE]`](#flub-generate-buildversion-file)
+* [`flub generate buildVersion`](#flub-generate-buildversion)
 * [`flub generate packageJson`](#flub-generate-packagejson)
 * [`flub help [COMMAND]`](#flub-help-command)
 * [`flub info`](#flub-info)
@@ -210,26 +210,26 @@ DESCRIPTION
 
 _See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blob/v2.2.0/src/commands/commands.ts)_
 
-## `flub generate buildVersion [FILE]`
+## `flub generate buildVersion`
 
 This command is used to compute the version number of Fluid packages. The release version number is based on what's in the lerna.json/package.json. The CI pipeline will supply the build number and branch to determine the prerelease suffix if it is not a tagged build
 
 ```
 USAGE
-  $ flub generate buildVersion [FILE] --build <value> [--testBuild] [--release release] [--patch] [--base <value>] [--tag
-    <value>] [-i] [--test] [-v]
+  $ flub generate buildVersion --build <value> [--testBuild <value>] [--release release|none] [--patch <value>] [--base
+    <value>] [--tag <value>] [-i <value>] [-v]
 
 FLAGS
-  -i, --includeInternalVersions  Include Fluid internal versions.
-  -v, --verbose                  Verbose logging.
-  --base=<value>                 The base version. This will be read from lerna.json/package.json if not provided.
-  --build=<value>                (required) The CI build number.
-  --patch                        Indicates the build is a patch build.
-  --release=<option>             Indicates the build is a release build.
-                                 <options: release>
-  --tag=<value>                  The tag name to use.
-  --test
-  --testBuild                    Indicates the build is a test build.
+  -i, --includeInternalVersions=<value>  Include Fluid internal versions.
+  -v, --verbose                          Verbose logging.
+  --base=<value>                         The base version. This will be read from lerna.json/package.json if not
+                                         provided.
+  --build=<value>                        (required) The CI build number.
+  --patch=<value>                        Indicates the build is a patch build.
+  --release=<option>                     Indicates the build is a release build.
+                                         <options: release|none>
+  --tag=<value>                          The tag name to use.
+  --testBuild=<value>                    Indicates the build is a test build.
 
 DESCRIPTION
   This command is used to compute the version number of Fluid packages. The release version number is based on what's in
@@ -295,7 +295,7 @@ DESCRIPTION
   Get info about the repo, release groups, and packages.
 ```
 
-_See code: [dist/commands/info.ts](https://github.com/microsoft/FluidFramework/blob/v0.3.2000/dist/commands/info.ts)_
+_See code: [dist/commands/info.ts](https://github.com/microsoft/FluidFramework/blob/v0.4.3000/dist/commands/info.ts)_
 
 ## `flub version VERSION`
 
@@ -341,7 +341,7 @@ EXAMPLES
     $ flub version 2.0.0-internal.1.0.0 --type current
 ```
 
-_See code: [@fluid-tools/version-tools](https://github.com/microsoft/FluidFramework/blob/v0.3.2000/dist/commands/version.ts)_
+_See code: [@fluid-tools/version-tools](https://github.com/microsoft/FluidFramework/blob/v0.4.3000/dist/commands/version.ts)_
 
 ## `flub version latest`
 

--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -67,14 +67,14 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
         ...BaseCommand.flags,
     };
 
-
     public async run(): Promise<void> {
         const context = await this.getContext();
         const flags = this.processedFlags;
         const isRelease = flags.release === "release";
         const useSimplePatchVersion = flags.patch?.toLowerCase() === "true";
         const useTestVersion = flags.testBuild?.toLowerCase() === "true";
-        const shouldIncludeInternalVersions = flags.includeInternalVersions?.toLowerCase() === "true";
+        const shouldIncludeInternalVersions =
+            flags.includeInternalVersions?.toLowerCase() === "true";
 
         let fileVersion = "";
 
@@ -102,7 +102,12 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
         }
 
         // Generate and print the version to console
-        const simpleVersion = getSimpleVersion(fileVersion, flags.build, isRelease, useSimplePatchVersion);
+        const simpleVersion = getSimpleVersion(
+            fileVersion,
+            flags.build,
+            isRelease,
+            useSimplePatchVersion,
+        );
         const version = useTestVersion ? `0.0.0-${flags.build}-test` : simpleVersion;
         this.log(`version=${version}`);
         this.log(`##vso[task.setvariable variable=version;isOutput=true]${version}`);

--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -67,7 +67,6 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
         ...BaseCommand.flags,
     };
 
-    // static args = [{ name: "file" }];
 
     public async run(): Promise<void> {
         const context = await this.getContext();

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -1,0 +1,228 @@
+import { expect, test } from "@oclif/test";
+
+const test_tags = [
+    "client_v2.0.0-internal.1.0.0",
+    "client_v1.2.4",
+    "client_v1.2.3",
+    "build-tools_v0.5.2002",
+    "build-tools_v0.4.2001",
+    "build-tools_v0.4.2000",
+    "build-tools_v0.4.1000",
+    "build-tools_v0.3.2000",
+];
+
+describe("generate:buildVersion", () => {
+    test.stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "0.4.0",
+            "--tag",
+            "build-tools",
+            "--release",
+            "none",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("outputs prerelease build number", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.4.0-12345");
+        });
+
+    test.env({
+        VERSION_BUILDNUMBER: "88802",
+    }).stdout()
+        .command([
+            "generate:buildVersion",
+            "--fileVersion",
+            "0.4.0",
+            "--tag",
+            "build-tools",
+            "--release",
+            "none",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("reads build number from env variable", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.4.0-88802");
+        });
+
+    test.stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "0.4.0",
+            "--tag",
+            "build-tools",
+            "--release",
+            "none",
+            "--patch",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("calculates patch version number correctly", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.4.12345");
+        });
+
+    test.env({
+        VERSION_PATCH: "true",
+    }).stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "0.4.0",
+            "--tag",
+            "build-tools",
+            "--release",
+            "none",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("reads patch setting from env variable", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.4.12345");
+        });
+
+    test.stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "0.5.2002",
+            "--tag",
+            "build-tools",
+            "--release",
+            "release",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("outputs isLatest=true when release is release", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.5.2002");
+            expect(ctx.stdout).to.contain("isLatest=true");
+        });
+
+    test.env({
+        VERSION_RELEASE: "release",
+    }).stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "0.5.2002",
+            "--tag",
+            "build-tools",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("reads release setting from env variable", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.5.2002");
+            expect(ctx.stdout).to.contain("isLatest=true");
+        });
+
+    test.env({
+        VERSION_TAGNAME: "build-tools",
+    }).stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "0.5.2002",
+            "--release",
+            "none",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("reads tag name from env variable", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.5.2002");
+            expect(ctx.stdout).to.contain("isLatest=true");
+        });
+
+    test.stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "1.2.4",
+            "--tag",
+            "client",
+            "--release",
+            "release",
+            "--includeInternalVersions",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("calculates internal versions as latest", (ctx) => {
+            expect(ctx.stdout).to.contain("version=1.2.4");
+            expect(ctx.stdout).to.contain("isLatest=false");
+        });
+
+    test.env({
+        VERSION_INCLUDE_INTERNAL_VERSIONS: "True",
+    }).stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "1.2.4",
+            "--tag",
+            "client",
+            "--release",
+            "release",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("reads internal versions setting from env variable", (ctx) => {
+            expect(ctx.stdout).to.contain("version=1.2.4");
+            expect(ctx.stdout).to.contain("isLatest=false");
+        });
+
+    test.stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "1.2.4",
+            "--tag",
+            "client",
+            "--release",
+            "none",
+            "--testBuild",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("calculates test build numbers correctly", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.0.0-12345-test");
+            expect(ctx.stdout).to.contain("isLatest=false");
+        });
+
+    test.env({
+        TEST_BUILD: "true",
+    }).stdout()
+        .command([
+            "generate:buildVersion",
+            "--build",
+            "12345",
+            "--fileVersion",
+            "1.2.4",
+            "--tag",
+            "client",
+            "--release",
+            "none",
+            "--tags",
+            ...test_tags,
+        ])
+        .it("reads test build setting from env variable", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.0.0-12345-test");
+            expect(ctx.stdout).to.contain("isLatest=false");
+        });
+});

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { expect, test } from "@oclif/test";
 
 const test_tags = [

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -60,6 +60,7 @@ describe("generate:buildVersion", () => {
             "--release",
             "none",
             "--patch",
+            "true",
             "--tags",
             ...test_tags,
         ])
@@ -135,7 +136,7 @@ describe("generate:buildVersion", () => {
             "--fileVersion",
             "0.5.2002",
             "--release",
-            "none",
+            "release",
             "--tags",
             ...test_tags,
         ])
@@ -156,6 +157,7 @@ describe("generate:buildVersion", () => {
             "--release",
             "release",
             "--includeInternalVersions",
+            "true",
             "--tags",
             ...test_tags,
         ])
@@ -197,6 +199,7 @@ describe("generate:buildVersion", () => {
             "--release",
             "none",
             "--testBuild",
+            "true",
             "--tags",
             ...test_tags,
         ])

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -37,7 +37,8 @@ describe("generate:buildVersion", () => {
 
     test.env({
         VERSION_BUILDNUMBER: "88802",
-    }).stdout()
+    })
+        .stdout()
         .command([
             "generate:buildVersion",
             "--fileVersion",
@@ -75,7 +76,8 @@ describe("generate:buildVersion", () => {
 
     test.env({
         VERSION_PATCH: "true",
-    }).stdout()
+    })
+        .stdout()
         .command([
             "generate:buildVersion",
             "--build",
@@ -114,7 +116,8 @@ describe("generate:buildVersion", () => {
 
     test.env({
         VERSION_RELEASE: "release",
-    }).stdout()
+    })
+        .stdout()
         .command([
             "generate:buildVersion",
             "--build",
@@ -133,7 +136,8 @@ describe("generate:buildVersion", () => {
 
     test.env({
         VERSION_TAGNAME: "build-tools",
-    }).stdout()
+    })
+        .stdout()
         .command([
             "generate:buildVersion",
             "--build",
@@ -173,7 +177,8 @@ describe("generate:buildVersion", () => {
 
     test.env({
         VERSION_INCLUDE_INTERNAL_VERSIONS: "True",
-    }).stdout()
+    })
+        .stdout()
         .command([
             "generate:buildVersion",
             "--build",
@@ -215,7 +220,8 @@ describe("generate:buildVersion", () => {
 
     test.env({
         TEST_BUILD: "true",
-    }).stdout()
+    })
+        .stdout()
         .command([
             "generate:buildVersion",
             "--build",


### PR DESCRIPTION
This change adds tests for the `generate buildVersion` CLI command and updates the code so that it reads environment variables correctly. oclif boolean flags do not get set from env variables, despite what the types indicate.