### PR TITLE
Fix logic with patch flag in `generate buildVersion`

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -89,7 +89,7 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
             this.error("Test build shouldn't be released");
         }
 
-        if (useSimplePatchVersion && flags.tag !== undefined) {
+        if (!useSimplePatchVersion && flags.tag !== undefined) {
             const tagName = `${flags.tag}_v${fileVersion}`;
             const out = childProcess.execSync(`git tag -l ${tagName}`, { encoding: "utf8" });
             if (out.trim() === tagName) {

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -240,8 +240,6 @@ describe("generate:buildVersion", () => {
             expect(ctx.stdout).to.contain("isLatest=false");
         });
 
-    const t9sTags = [];
-
     test.env({
         VERSION_BUILDNUMBER: "88879",
         VERSION_TAGNAME: "tinylicious",

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -239,4 +239,42 @@ describe("generate:buildVersion", () => {
             expect(ctx.stdout).to.contain("version=0.0.0-12345-test");
             expect(ctx.stdout).to.contain("isLatest=false");
         });
+
+    const t9sTags = [];
+
+    test.env({
+        VERSION_BUILDNUMBER: "88879",
+        VERSION_TAGNAME: "tinylicious",
+        TEST_BUILD: "false",
+        VERSION_RELEASE: "release",
+        VERSION_PATCH: "true",
+        VERSION_INCLUDE_INTERNAL_VERSIONS: "False",
+    })
+        .stdout()
+        .command([
+            "generate:buildVersion",
+            "--fileVersion",
+            "0.4.0",
+            "--tag",
+            "tinylicious",
+            "--tags",
+            "tinylicious_v0.2.0",
+            "tinylicious_v0.2.3810",
+            "tinylicious_v0.3.10860",
+            "tinylicious_v0.4.0",
+            "tinylicious_v0.4.11798",
+            "tinylicious_v0.4.13835",
+            "tinylicious_v0.4.17169",
+            "tinylicious_v0.4.18879",
+            "tinylicious_v0.4.21640",
+            "tinylicious_v0.4.34614",
+            "tinylicious_v0.4.38350",
+            "tinylicious_v0.4.45136",
+            "tinylicious_v0.4.57763",
+            "tinylicious_v0.4.86381",
+        ])
+        .it("tinylicious test case from 2022-08-26", (ctx) => {
+            expect(ctx.stdout).to.contain("version=0.4.88879");
+            expect(ctx.stdout).to.contain("isLatest=true");
+        });
 });


### PR DESCRIPTION
Missed a `!` operator in an if check... Added a broken test case then fixed it.