### PR TITLE
Change accepted versions for dependency

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@fluid-tools/version-tools": "^0.4.3000",
     "@fluidframework/build-tools": "^0.4.3000",
-    "@oclif/core": "^1.9.5",
+    "@oclif/core": "~1.9.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.1",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -46,7 +46,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@oclif/core": "^1.9.5",
+    "@oclif/core": "~1.9.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.1",


### PR DESCRIPTION
## Description

Change the version ranges we can take for the `@oclif-core` dependency. While using it in a new tool I noticed that starting with v1.13.0, [it is built with target of `es2020`](https://github.com/oclif/core/releases/tag/v1.13.0), and becomes incompatible with our current configuration when we run our tools:

![image](https://user-images.githubusercontent.com/716334/187000220-65365cd9-9da9-46b4-816d-0282b8ed4c10.png)

These packages currently locked on to v1.9.5. There probably won't be more updates to version 1.9.x, given that `@oclif/core` is already on 1.16.0, but this should prevent an unexpected break if we have to regenerate the lockfile for these packages for some reason and reinstall the dependency.

I was able to use v1.12.0 successfully in the new tool, but for now I didn't want to potentially introduce behavior changes in these packages, so I just made sure the dependency won't update to >1.13.0.
