### PR TITLE
Remove Quorum DDS optimization

### DIFF
--- a/packages/dds/quorum/src/quorum.ts
+++ b/packages/dds/quorum/src/quorum.ts
@@ -247,7 +247,6 @@ export class Quorum<T = unknown> extends SharedObject<IQuorumEvents> implements 
                     value,
                     0 /* refSeq */,
                     0 /* setSequenceNumber */,
-                    "detachedClient" /* clientId */,
                 );
             });
             return;
@@ -301,7 +300,6 @@ export class Quorum<T = unknown> extends SharedObject<IQuorumEvents> implements 
         value: T | undefined,
         refSeq: number,
         setSequenceNumber: number,
-        clientId: string,
     ): void => {
         const currentValue = this.values.get(key);
         // We use a consensus-like approach here, so a proposal is valid if the value is unset or if there is no
@@ -317,9 +315,8 @@ export class Quorum<T = unknown> extends SharedObject<IQuorumEvents> implements 
 
         const accepted = currentValue?.accepted;
 
-        // We expect signoffs from all connected clients at the time the set was sequenced, except for the client
-        // who issued the set (that client implicitly signs off).
-        const expectedSignoffs = this.getSignoffClients().filter((quorumMemberId) => quorumMemberId !== clientId);
+        // We expect signoffs from all connected clients at the time the set was sequenced.
+        const expectedSignoffs = this.getSignoffClients();
 
         const newQuorumValue: QuorumValue<T> = {
             accepted,
@@ -334,7 +331,8 @@ export class Quorum<T = unknown> extends SharedObject<IQuorumEvents> implements 
         this.emit("pending", key);
 
         if (expectedSignoffs.length === 0) {
-            // Only the submitting client was connected at the time the set was sequenced.
+            // At least the submitting client should be amongst the expectedSignoffs, but keeping this check around
+            // as extra protection and in case we bring back the "submitting client implicitly accepts" optimization.
             this.values.set(key, {
                 accepted: { value, sequenceNumber: setSequenceNumber },
                 pending: undefined,
@@ -489,7 +487,7 @@ export class Quorum<T = unknown> extends SharedObject<IQuorumEvents> implements 
 
             switch (op.type) {
                 case "set":
-                    this.incomingOp.emit("set", op.key, op.value, op.refSeq, message.sequenceNumber, message.clientId);
+                    this.incomingOp.emit("set", op.key, op.value, op.refSeq, message.sequenceNumber);
                     break;
 
                 case "accept":

--- a/packages/dds/quorum/src/quorum.ts
+++ b/packages/dds/quorum/src/quorum.ts
@@ -315,7 +315,8 @@ export class Quorum<T = unknown> extends SharedObject<IQuorumEvents> implements 
 
         const accepted = currentValue?.accepted;
 
-        // We expect signoffs from all connected clients at the time the set was sequenced.
+        // We expect signoffs from all connected clients at the time the set was sequenced (including the client who
+        // sent the set).
         const expectedSignoffs = this.getSignoffClients();
 
         const newQuorumValue: QuorumValue<T> = {


### PR DESCRIPTION
It's reasonable to assume that the client submitting a "set" op would accept the op.  However, using this as an optimization correctly would require the sender to recognize this unique state they are in (not quite pending because they might lose the "set" race, but also not in rest state because other clients might perceive them as in "accept" state).

Adding the states and inspection API surface to handle this in-between state is probably more complexity than the optimization is worth, so I'm electing to remove it.  Now all clients will react to incoming "set" ops the same way and be expected to explicitly "accept" them.