### PR TITLE
Fix package publishing pipeline for non-lerna packages

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -95,7 +95,7 @@ steps:
       for packageName in $packages
       do
         echo $packageName
-        if [[ $sorted ]]; then
+        if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
         else
           f=$packageName

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -94,6 +94,7 @@ steps:
         echo $packageName
         if [[ $sorted ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
+          echo "sorted"
         else
           f=$packageName
           echo "not sorted"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -85,19 +85,20 @@ steps:
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
         sorted=true
+        echo "sorted"
       else
         packages=*.tgz
         sorted=false
+        echo "not sorted"
       fi
+      echo $sorted
       for packageName in $packages
       do
         echo $packageName
         if [[ $sorted ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
-          echo "sorted"
         else
           f=$packageName
-          echo "not sorted"
         fi
         echo $f
         if [[ $f != "" ]]; then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -87,7 +87,6 @@ steps:
         sorted=true
       else
         packages=*.tgz
-        echo $packages
         sorted=false
       fi
       for packageName in $packages
@@ -97,7 +96,6 @@ steps:
           else
             f=$packageName
           fi
-          echo $f
           if [[ $f != "" ]]; then
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -85,22 +85,17 @@ steps:
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
         sorted=true
-        echo "sorted"
       else
         packages=*.tgz
         sorted=false
-        echo "not sorted"
       fi
-      echo $sorted
       for packageName in $packages
       do
-        echo $packageName
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
         else
           f=$packageName
         fi
-        echo $f
         if [[ $f != "" ]]; then
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -87,6 +87,7 @@ steps:
         sorted=true
       else
         packages=*.tgz
+        echo $packages
         sorted=false
       fi
       for packageName in $packages
@@ -96,6 +97,7 @@ steps:
           else
             f=$packageName
           fi
+          echo $f
           if [[ $f != "" ]]; then
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -87,7 +87,6 @@ steps:
         sorted=true
       else
         packages=*.tgz
-        echo $packages
         sorted=false
       fi
       for packageName in $packages
@@ -97,6 +96,7 @@ steps:
           f=$(find -name "${packageName}-[0-9]*.tgz")
         else
           f=$packageName
+          echo "not sorted"
         fi
         echo $f
         if [[ $f != "" ]]; then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -82,10 +82,20 @@ steps:
       echo Tag: $tag
       cp .npmrc ~/.npmrc
       t1=0
-      sortedPackages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
-      for packageName in $sortedPackages
+      if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
+        packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
+        sorted=true
+      else
+        packages=*.tgz
+        sorted=false
+      fi
+      for packageName in $packages
       do
-          f=$(find -name "${packageName}-[0-9]*.tgz")
+          if [[ $sorted ]]; then
+            f=$(find -name "${packageName}-[0-9]*.tgz")
+          else
+            f=$packageName
+          fi
           if [[ $f != "" ]]; then
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -87,41 +87,44 @@ steps:
         sorted=true
       else
         packages=*.tgz
+        echo $packages
         sorted=false
       fi
       for packageName in $packages
       do
-          if [[ $sorted ]]; then
-            f=$(find -name "${packageName}-[0-9]*.tgz")
-          else
-            f=$packageName
-          fi
-          if [[ $f != "" ]]; then
-            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-            if grep -q "npm ERR!" "publish_log"
-            then
-                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+        echo $packageName
+        if [[ $sorted ]]; then
+          f=$(find -name "${packageName}-[0-9]*.tgz")
+        else
+          f=$packageName
+        fi
+        echo $f
+        if [[ $f != "" ]]; then
+          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+          if grep -q "npm ERR!" "publish_log"
+          then
+              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+              then
+                let t1+=1
+              else
+                echo Package has already been published.
+                local_f="${f}_local"
+                mv "$f" "$local_f"
+                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                npm pack $package_name
+                if cmp -s "$f" "$local_f"
                 then
-                  let t1+=1
+                  echo Continuing as published package matches the current one that was attempting to be released.
                 else
-                  echo Package has already been published.
-                  local_f="${f}_local"
-                  mv "$f" "$local_f"
-                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                  npm pack $package_name
-                  if cmp -s "$f" "$local_f"
-                  then
-                    echo Continuing as published package matches the current one that was attempting to be released.
-                  else
-                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                    let t1+=1
-                  fi
-                  rm "$f"
-                  mv "$local_f" "$f"
+                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                  let t1+=1
                 fi
-            fi
-            rm publish_log
+                rm "$f"
+                mv "$local_f" "$f"
+              fi
           fi
+          rm publish_log
+        fi
       done
       rm ~/.npmrc
       exit $t1


### PR DESCRIPTION
The publish package pipeline currently fails silently when publishing packages that don't use lerna because it is assumed that packagePublishOrder is generated which is not true in this case. 