### PR TITLE
Update lockfile

### DIFF
--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/benchmark",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Description

Fixes `package-lock.json` in `@fluid-tools/benchmark` to match the version in `package.json`, so we can publish it to npm. Forgot to run `npm i` after bumping the package version in https://github.com/microsoft/FluidFramework/pull/11661. 
