### PR TITLE
Remove setFlushMode call

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -104,13 +104,6 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
         dataObject2map1 = await dataObject2.getSharedObject<SharedMap>(map1Id);
         dataObject2map2 = await dataObject2.getSharedObject<SharedMap>(map2Id);
 
-        // TODO: to remove these directives in https://dev.azure.com/fluidframework/internal/_workitems/edit/658
-        // @ts-expect-error older versions rely on the "setFlushMode" method
-        if (runtimeOptions?.flushMode !== undefined && dataObject1.context.containerRuntime.setFlushMode) {
-            // @ts-expect-error older versions rely on the "setFlushMode" method
-            dataObject1.context.containerRuntime.setFlushMode(runtimeOptions.flushMode);
-        }
-
         await waitForCleanContainers(dataObject1, dataObject2);
         await provider.ensureSynchronized();
     }


### PR DESCRIPTION
[AB#658](https://dev.azure.com/fluidframework/internal/_workitems/edit/658)

For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

## Description

Call to `setFlushMode` in unit tests was kept even after removal from interface for back-compat.
`IContainerRuntimeBase.setFlushMode` is now fully removed.