### PR TITLE
Use strict api-extractor config in `container-loader`

### DIFF
--- a/packages/loader/container-loader/api-extractor.json
+++ b/packages/loader/container-loader/api-extractor.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "@fluidframework/build-common/api-extractor-common-report.json"
+  "extends": "@fluidframework/build-common/api-extractor-common-strict.json"
 }


### PR DESCRIPTION
Package contents were already compliant with strict config, so no other changes were required.