### PR TITLE
[main > lts]: Fix contentType header parsing in fetch snapshot (#11435)

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -252,9 +252,15 @@ async function fetchLatestSnapshotCore(
                     driverVersion: pkgVersion,
                 };
                 let parsedSnapshotContents: IOdspResponse<ISnapshotContents> | undefined;
+                let contentTypeToRead: string | undefined;
+                if (contentType?.indexOf("application/ms-fluid") !== -1) {
+                    contentTypeToRead = "application/ms-fluid";
+                } else if (contentType?.indexOf("application/json") !== -1) {
+                    contentTypeToRead = "application/json";
+                }
 
                 try {
-                    switch (contentType) {
+                    switch (contentTypeToRead) {
                         case "application/json": {
                             const text = await odspResponse.content.text();
                             propsToLog.bodySize = text.length;
@@ -549,14 +555,12 @@ export async function downloadSnapshot(
     };
     // Decide what snapshot format to fetch as per the feature gate.
     switch (snapshotFormatFetchType) {
-        case SnapshotFormatSupportType.JsonAndBinary:
-            headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
-            break;
         case SnapshotFormatSupportType.Binary:
             headers.accept = `application/ms-fluid; v=${currentReadVersion}`;
             break;
         default:
-            headers.accept = "application/json";
+            // By default ask both versions and let the server decide the format.
+            headers.accept = `application/json, application/ms-fluid; v=${currentReadVersion}`;
     }
 
     const odspResponse = await (epochTracker?.fetch(url, fetchOptions, "treesLatest", true, scenarioName) ??


### PR DESCRIPTION
## Description

1.) Fix contentType header parsing in fetch snapshot.
2.) By default, accept both json and binary format in trees/latest call if not value is provided by feature gate.