### PR TITLE
Tree: update sub-readmes

### DIFF
--- a/packages/dds/tree/src/changeset/README.md
+++ b/packages/dds/tree/src/changeset/README.md
@@ -1,4 +1,4 @@
-# Changeset
+# changeset
 
 Abstraction for Changesets (supporting the needs of Rebaser), and an implementation of Delta which can an be applied to Forests.
 

--- a/packages/dds/tree/src/checkout/README.md
+++ b/packages/dds/tree/src/checkout/README.md
@@ -1,4 +1,4 @@
-# Checkout
+# checkout
 
 Abstraction for Checkouts.
 

--- a/packages/dds/tree/src/edit-manager/README.md
+++ b/packages/dds/tree/src/edit-manager/README.md
@@ -1,0 +1,13 @@
+# edit-manager
+
+This modules handles Fluid's approach to sequenced vs local edits.
+It uses reference sequence numbers to construct the tree of branches capturing each clients observed stated when Ops were sent.
+Generic over the [`change-family`](../change-family/README.md).
+
+TODO:
+Should be a wrapper on top of [`rebaser`](../rebase/README.md).
+Also since this modules is only a single file and does not have extra dependencies beyond `rebaser`,
+it could be merged into `rebaser`, or its consumer (`shared-tree-core`)
+to keep the top level module count down.
+Another option would be to turn `rebaser` into just an interface project (used by change rebaser implementations),
+and move the actual `Rebaser` implementation here to reduce dependencies of change rebasers.

--- a/packages/dds/tree/src/forest/README.md
+++ b/packages/dds/tree/src/forest/README.md
@@ -1,3 +1,3 @@
-# Forest
+# forest
 
 Abstractions for representing, editing and observing collections of trees.

--- a/packages/dds/tree/src/rebase/README.md
+++ b/packages/dds/tree/src/rebase/README.md
@@ -1,4 +1,4 @@
-# Rebase
+# rebase
 
 Abstractions and utilities for rebasing.
 

--- a/packages/dds/tree/src/schema-stored/README.md
+++ b/packages/dds/tree/src/schema-stored/README.md
@@ -1,4 +1,4 @@
-# Schema-Stored
+# schema-stored
 
 This folder contains proof of concept level prototype code for a schema system for trees.
 It is focused on how the schema system could work: mostly regarding what data could be stored where,

--- a/packages/dds/tree/src/schema-view/README.md
+++ b/packages/dds/tree/src/schema-view/README.md
@@ -1,4 +1,4 @@
-# Schema-View
+# schema-view
 
 This folder extends "Schema-Stored", adding APIs for applications to view and interact with documents which use stored-schema.
 Included are utilities for declaring schema with strong typescript types,

--- a/packages/dds/tree/src/shared-tree-core/README.md
+++ b/packages/dds/tree/src/shared-tree-core/README.md
@@ -1,4 +1,4 @@
-# Shared Tree Core
+# shared-tree-core
 
 Provides a SharedObject for a tree which handles the collaboration window, and keeping indexes up to date.
 

--- a/packages/dds/tree/src/shared-tree/README.md
+++ b/packages/dds/tree/src/shared-tree/README.md
@@ -1,4 +1,4 @@
-# Shared Tree
+# shared-tree
 
 Provides a SharedObject for a tree.
 

--- a/packages/dds/tree/src/test/README.md
+++ b/packages/dds/tree/src/test/README.md
@@ -1,0 +1,4 @@
+# test
+
+This folder contains tests for the whole package.
+The folder hierarchy within mirrors that of the rest of the `src` directory.

--- a/packages/dds/tree/src/transaction/README.md
+++ b/packages/dds/tree/src/transaction/README.md
@@ -1,4 +1,4 @@
-# Transaction
+# transaction
 
 This folder contains a proof-of-concept level prototype code for a transaction system for editing [checkouts](../checkout/README.md).
 

--- a/packages/dds/tree/src/tree/README.md
+++ b/packages/dds/tree/src/tree/README.md
@@ -1,0 +1,15 @@
+# tree
+
+Types related to this package's flavor of tree.
+This means a tree with typed nodes that have named fields and contain values.
+
+TODO:
+The scope of this directory needs some refinement.
+Its relation to schema-stored should be clarified (and maybe inverted),
+and AnchorSet (at least the implementation logic) should probably move elsewhere.
+
+TODO:
+This module having the same name as the package (other than scope/qualification) but meaning something rather different is confusing.
+Consider refactoring this module out of existence or renaming it (maybe something like `tree-types`, `tree-nodes` or `typed-tree`.)
+Another option is to give a name to this specific tree abstraction (named fields with sequences + values), and use that name for the module:
+`flex-tree` has been proposed for a name for this in the past.

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -23,9 +23,12 @@ const NeverAnchor: Anchor = brand(0);
  * See {@link Rebaser} for how to update across revisions.
  */
 export class AnchorSet {
-    // Incrementing counter to give each anchor in this set a unique index for its identifier.
-    // "0" is reserved for the `NeverAnchor`
+    /**
+     * Incrementing counter to give each anchor in this set a unique index for its identifier.
+     * "0" is reserved for the `NeverAnchor`.
+     */
     private anchorCounter = 1;
+
     /**
      * Special root node under which all anchors in this anchor set are transitively parented.
      * This does not appear in the UpPaths (instead they use undefined for the root).
@@ -38,6 +41,7 @@ export class AnchorSet {
      * TODO: check for and enforce this.
      */
     private readonly root = new PathNode(this, EmptyKey, 0, undefined);
+
     // TODO: anchor system could be optimized a bit to avoid the maps (Anchor is ref to Path, path has ref count).
     // For now use this more encapsulated approach with maps.
     private readonly anchorToPath: Map<Anchor, PathNode> = new Map();

--- a/packages/dds/tree/src/util/README.md
+++ b/packages/dds/tree/src/util/README.md
@@ -1,0 +1,9 @@
+# util
+
+This module contains miscellaneous typescript utilities.
+To be here these utilities must meet the following requirements:
+
+- Not be logically specific to anything in this package.
+- Could be factored out into its own Package.
+- Is not currently worth factoring out into a separate package.
+- Is not needed by users outside this package except to consume this package.

--- a/packages/dds/tree/src/util/fence.json
+++ b/packages/dds/tree/src/util/fence.json
@@ -1,6 +1,6 @@
 {
     "tags": [ "util" ],
     "exports": [ "index"],
-    // This module should have no imports. See comment in index.ts.
+    // This module should have no imports. See comment in README.md.
     "imports": []
 }

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -3,15 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/**
- * This module contains miscellaneous typescript utilities.
- * To be here these utilities must meet the following requirements:
- * - Not be logically specific to anything in this package.
- * - Could be factored out into its own Package.
- * - Is not currently worth factoring out into a separate package.
- * - Is not needed by users outside this package except to consume this package.
- */
-
 export * from "./utils";
 export * from "./typeCheck";
 export * from "./brand";


### PR DESCRIPTION
## Description

Make every directory under `src` in Tree have a readme, and update them all to have the title exactly match the directory name.

