### PR TITLE
r11s-driver: reduce API export surface

### DIFF
--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -4,30 +4,13 @@
 
 ```ts
 
-import * as api from '@fluidframework/driver-definitions';
-import * as api_2 from '@fluidframework/protocol-definitions';
-import { DocumentStorageServiceProxy } from '@fluidframework/driver-utils';
-import { GitManager } from '@fluidframework/server-services-client';
-import { IClient } from '@fluidframework/protocol-definitions';
-import { IDeltasFetchResult } from '@fluidframework/driver-definitions';
-import { IDeltaStorageService } from '@fluidframework/driver-definitions';
-import { IDocumentDeltaStorageService } from '@fluidframework/driver-definitions';
 import { IDocumentService } from '@fluidframework/driver-definitions';
 import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
-import { IDocumentStorageService } from '@fluidframework/driver-definitions';
-import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
-import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISession } from '@fluidframework/server-services-client';
-import { ISnapshotTree } from '@fluidframework/protocol-definitions';
-import { IStream } from '@fluidframework/driver-definitions';
-import { ISummaryContext } from '@fluidframework/driver-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
-import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
-import { IVersion } from '@fluidframework/protocol-definitions';
-import { RestWrapper } from '@fluidframework/server-services-client';
 
 // @public
 export class DefaultTokenProvider implements ITokenProvider {
@@ -39,21 +22,6 @@ export class DefaultTokenProvider implements ITokenProvider {
 }
 
 // @public
-export class DeltaStorageService implements IDeltaStorageService {
-    constructor(url: string, restWrapper: RestWrapper, logger: ITelemetryLogger, getRestWrapper?: () => Promise<RestWrapper>, getDeltaStorageUrl?: () => string);
-    // (undocumented)
-    get(tenantId: string, id: string, from: number, // inclusive
-    to: number): Promise<IDeltasFetchResult>;
-}
-
-// @public
-export class DocumentDeltaStorageService implements IDocumentDeltaStorageService {
-    constructor(tenantId: string, id: string, deltaStorageService: IDeltaStorageService, documentStorageService: DocumentStorageService);
-    // (undocumented)
-    fetchMessages(from: number, to: number | undefined, abortSignal?: AbortSignal, cachedOnly?: boolean, fetchReason?: string): IStream<ISequencedDocumentMessage[]>;
-}
-
-// @public
 export class DocumentPostCreateError extends Error {
     constructor(
     innerError: Error);
@@ -61,43 +29,6 @@ export class DocumentPostCreateError extends Error {
     readonly name = "DocumentPostCreateError";
     // (undocumented)
     get stack(): string | undefined;
-}
-
-// @public
-export class DocumentService implements api.IDocumentService {
-    // Warning: (ae-forgotten-export) The symbol "ICache" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ISnapshotTreeVersion" needs to be exported by the entry point index.d.ts
-    constructor(_resolvedUrl: api.IResolvedUrl, ordererUrl: string, deltaStorageUrl: string, storageUrl: string, logger: ITelemetryLogger, tokenProvider: ITokenProvider, tenantId: string, documentId: string, driverPolicies: IRouterliciousDriverPolicies, blobCache: ICache<ArrayBufferLike>, snapshotTreeCache: ICache<ISnapshotTreeVersion>, discoverFluidResolvedUrl: () => Promise<api.IFluidResolvedUrl>);
-    connectToDeltaStorage(): Promise<api.IDocumentDeltaStorageService>;
-    connectToDeltaStream(client: IClient): Promise<api.IDocumentDeltaConnection>;
-    connectToStorage(): Promise<api.IDocumentStorageService>;
-    // (undocumented)
-    dispose(): void;
-    // (undocumented)
-    protected documentId: string;
-    // (undocumented)
-    protected ordererUrl: string;
-    // (undocumented)
-    get resolvedUrl(): api.IResolvedUrl;
-    // (undocumented)
-    protected tenantId: string;
-    // (undocumented)
-    protected tokenProvider: ITokenProvider;
-}
-
-// @public (undocumented)
-export class DocumentStorageService extends DocumentStorageServiceProxy {
-    constructor(id: string, manager: GitManager, logger: ITelemetryLogger, policies?: IDocumentStorageServicePolicies, driverPolicies?: IRouterliciousDriverPolicies, blobCache?: ICache<ArrayBufferLike>, snapshotTreeCache?: ICache<ISnapshotTreeVersion>, noCacheGitManager?: GitManager | undefined, getStorageManager?: (disableCache?: boolean) => Promise<GitManager>);
-    // (undocumented)
-    getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null>;
-    // (undocumented)
-    readonly id: string;
-    // (undocumented)
-    get logTailSha(): string | undefined;
-    // (undocumented)
-    manager: GitManager;
-    // (undocumented)
-    noCacheGitManager?: GitManager | undefined;
 }
 
 // @public (undocumented)
@@ -128,24 +59,6 @@ export interface ITokenResponse {
 export interface ITokenService {
     // (undocumented)
     extractClaims(token: string): ITokenClaims;
-}
-
-// @public
-export class NullBlobStorageService implements IDocumentStorageService {
-    // (undocumented)
-    createBlob(file: ArrayBufferLike): Promise<api_2.ICreateBlobResponse>;
-    // (undocumented)
-    downloadSummary(handle: api_2.ISummaryHandle): Promise<api_2.ISummaryTree>;
-    // (undocumented)
-    getSnapshotTree(version?: api_2.IVersion): Promise<api_2.ISnapshotTree | null>;
-    // (undocumented)
-    getVersions(versionId: string | null, count: number): Promise<api_2.IVersion[]>;
-    // (undocumented)
-    readBlob(blobId: string): Promise<ArrayBufferLike>;
-    // (undocumented)
-    get repositoryUrl(): string;
-    // (undocumented)
-    uploadSummaryWithContext(summary: api_2.ISummaryTree, context: ISummaryContext): Promise<string>;
 }
 
 // @public

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -62,6 +62,7 @@
     "@fluidframework/driver-base": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "@fluidframework/driver-definitions": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "@fluidframework/driver-utils": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
+    "@fluidframework/protocol-base": "^0.1037.1000",
     "@fluidframework/protocol-definitions": "^1.0.0",
     "@fluidframework/routerlicious-driver": ">=2.0.0-internal.1.1.0 <2.0.0-internal.2.0.0",
     "@fluidframework/server-local-server": "^0.1037.1000",

--- a/packages/drivers/local-driver/src/index.ts
+++ b/packages/drivers/local-driver/src/index.ts
@@ -7,5 +7,6 @@ export * from "./localDeltaStorageService";
 export * from "./localDocumentDeltaConnection";
 export * from "./localDocumentService";
 export * from "./localDocumentServiceFactory";
+export * from "./localDocumentStorageService";
 export * from "./localResolver";
 export * from "./localSessionStorageDb";

--- a/packages/drivers/local-driver/src/localDocumentStorageService.ts
+++ b/packages/drivers/local-driver/src/localDocumentStorageService.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { stringToBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
+import {
+	IDocumentStorageService,
+	IDocumentStorageServicePolicies,
+	ISummaryContext,
+} from "@fluidframework/driver-definitions";
+import {
+	ICreateBlobResponse,
+	ISnapshotTreeEx,
+	ISummaryHandle,
+	ISummaryTree,
+	IVersion,
+} from "@fluidframework/protocol-definitions";
+import { buildHierarchy } from "@fluidframework/protocol-base";
+import { GitManager, ISummaryUploadManager, SummaryTreeUploadManager } from "@fluidframework/server-services-client";
+
+export class LocalDocumentStorageService implements IDocumentStorageService {
+	// The values of this cache is useless. We only need the keys. So we are always putting
+	// empty strings as values.
+	protected readonly blobsShaCache = new Map<string, string>();
+	private readonly summaryTreeUploadManager: ISummaryUploadManager;
+
+	public get repositoryUrl(): string {
+		return "";
+	}
+
+	constructor(
+		private readonly id: string,
+		private readonly manager: GitManager,
+		public readonly policies: IDocumentStorageServicePolicies = {},
+	) {
+		this.summaryTreeUploadManager = new SummaryTreeUploadManager(
+			manager,
+			this.blobsShaCache,
+			this.getPreviousFullSnapshot.bind(this),
+		);
+	}
+
+	public async getVersions(versionId: string | null, count: number): Promise<IVersion[]> {
+		const id = versionId ? versionId : this.id;
+		const commits = await this.manager.getCommits(id, count);
+		return commits.map((commit) => ({
+			date: commit.commit.author.date,
+			id: commit.sha,
+			treeId: commit.commit.tree.sha,
+		}));
+	}
+
+	public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTreeEx | null> {
+		let requestVersion = version;
+		if (!requestVersion) {
+			const versions = await this.getVersions(this.id, 1);
+			if (versions.length === 0) {
+				return null;
+			}
+
+			requestVersion = versions[0];
+		}
+
+		const rawTree = await this.manager.getTree(requestVersion.treeId);
+		const tree = buildHierarchy(rawTree, this.blobsShaCache, true);
+		return tree;
+	}
+
+	public async readBlob(blobId: string): Promise<ArrayBufferLike> {
+		const blob = await this.manager.getBlob(blobId);
+		this.blobsShaCache.set(blob.sha, "");
+		const bufferContent = stringToBuffer(blob.content, blob.encoding);
+		return bufferContent;
+	}
+
+	public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
+		return this.summaryTreeUploadManager.writeSummaryTree(
+			summary,
+			context.ackHandle ?? "",
+			"channel",
+		);
+	}
+
+	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+		const uint8ArrayFile = new Uint8Array(file);
+		return this.manager.createBlob(
+			Uint8ArrayToString(
+				uint8ArrayFile, "base64"),
+			"base64").then((r) => ({ id: r.sha, url: r.url }));
+	}
+
+	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
+		throw new Error("NOT IMPLEMENTED!");
+	}
+
+	private async getPreviousFullSnapshot(parentHandle: string): Promise<ISnapshotTreeEx | null | undefined> {
+		return parentHandle
+			? this.getVersions(parentHandle, 1)
+				.then(async (versions) => {
+					// Clear the cache as the getSnapshotTree call will fill the cache.
+					this.blobsShaCache.clear();
+					return this.getSnapshotTree(versions[0]);
+				})
+			: undefined;
+	}
+}

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -103,6 +103,27 @@
   },
   "typeValidation": {
     "version": "2.0.0",
-    "broken": {}
+    "broken": {
+      "RemovedClassDeclaration_DeltaStorageService": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "RemovedClassDeclaration_DocumentDeltaStorageService": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "RemovedClassDeclaration_DocumentService": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "RemovedClassDeclaration_DocumentStorageService": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "RemovedClassDeclaration_NullBlobStorageService": {
+        "forwardCompat": false,
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
+// Tokens
 export * from "./defaultTokenProvider";
-export * from "./deltaStorageService";
-export * from "./documentService";
-export * from "./documentServiceFactory";
-export * from "./documentStorageService";
-export * from "./nullBlobStorageService";
-export * from "./policies";
 export * from "./tokens";
+
+// Factory
+export * from "./documentServiceFactory";
+
+// Configuration
+export * from "./policies";

--- a/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.ts
+++ b/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.ts
@@ -40,50 +40,26 @@ use_old_ClassDeclaration_DefaultTokenProvider(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DeltaStorageService": {"forwardCompat": false}
+* "RemovedClassDeclaration_DeltaStorageService": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_DeltaStorageService():
-    TypeOnly<old.DeltaStorageService>;
-declare function use_current_ClassDeclaration_DeltaStorageService(
-    use: TypeOnly<current.DeltaStorageService>);
-use_current_ClassDeclaration_DeltaStorageService(
-    get_old_ClassDeclaration_DeltaStorageService());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DeltaStorageService": {"backCompat": false}
+* "RemovedClassDeclaration_DeltaStorageService": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_DeltaStorageService():
-    TypeOnly<current.DeltaStorageService>;
-declare function use_old_ClassDeclaration_DeltaStorageService(
-    use: TypeOnly<old.DeltaStorageService>);
-use_old_ClassDeclaration_DeltaStorageService(
-    get_current_ClassDeclaration_DeltaStorageService());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DocumentDeltaStorageService": {"forwardCompat": false}
+* "RemovedClassDeclaration_DocumentDeltaStorageService": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_DocumentDeltaStorageService():
-    TypeOnly<old.DocumentDeltaStorageService>;
-declare function use_current_ClassDeclaration_DocumentDeltaStorageService(
-    use: TypeOnly<current.DocumentDeltaStorageService>);
-use_current_ClassDeclaration_DocumentDeltaStorageService(
-    get_old_ClassDeclaration_DocumentDeltaStorageService());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DocumentDeltaStorageService": {"backCompat": false}
+* "RemovedClassDeclaration_DocumentDeltaStorageService": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_DocumentDeltaStorageService():
-    TypeOnly<current.DocumentDeltaStorageService>;
-declare function use_old_ClassDeclaration_DocumentDeltaStorageService(
-    use: TypeOnly<old.DocumentDeltaStorageService>);
-use_old_ClassDeclaration_DocumentDeltaStorageService(
-    get_current_ClassDeclaration_DocumentDeltaStorageService());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -112,50 +88,26 @@ use_old_ClassDeclaration_DocumentPostCreateError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DocumentService": {"forwardCompat": false}
+* "RemovedClassDeclaration_DocumentService": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_DocumentService():
-    TypeOnly<old.DocumentService>;
-declare function use_current_ClassDeclaration_DocumentService(
-    use: TypeOnly<current.DocumentService>);
-use_current_ClassDeclaration_DocumentService(
-    get_old_ClassDeclaration_DocumentService());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DocumentService": {"backCompat": false}
+* "RemovedClassDeclaration_DocumentService": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_DocumentService():
-    TypeOnly<current.DocumentService>;
-declare function use_old_ClassDeclaration_DocumentService(
-    use: TypeOnly<old.DocumentService>);
-use_old_ClassDeclaration_DocumentService(
-    get_current_ClassDeclaration_DocumentService());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DocumentStorageService": {"forwardCompat": false}
+* "RemovedClassDeclaration_DocumentStorageService": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_DocumentStorageService():
-    TypeOnly<old.DocumentStorageService>;
-declare function use_current_ClassDeclaration_DocumentStorageService(
-    use: TypeOnly<current.DocumentStorageService>);
-use_current_ClassDeclaration_DocumentStorageService(
-    get_old_ClassDeclaration_DocumentStorageService());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DocumentStorageService": {"backCompat": false}
+* "RemovedClassDeclaration_DocumentStorageService": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_DocumentStorageService():
-    TypeOnly<current.DocumentStorageService>;
-declare function use_old_ClassDeclaration_DocumentStorageService(
-    use: TypeOnly<old.DocumentStorageService>);
-use_old_ClassDeclaration_DocumentStorageService(
-    get_current_ClassDeclaration_DocumentStorageService());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -256,26 +208,14 @@ use_old_InterfaceDeclaration_ITokenService(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_NullBlobStorageService": {"forwardCompat": false}
+* "RemovedClassDeclaration_NullBlobStorageService": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_NullBlobStorageService():
-    TypeOnly<old.NullBlobStorageService>;
-declare function use_current_ClassDeclaration_NullBlobStorageService(
-    use: TypeOnly<current.NullBlobStorageService>);
-use_current_ClassDeclaration_NullBlobStorageService(
-    get_old_ClassDeclaration_NullBlobStorageService());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_NullBlobStorageService": {"backCompat": false}
+* "RemovedClassDeclaration_NullBlobStorageService": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_NullBlobStorageService():
-    TypeOnly<current.NullBlobStorageService>;
-declare function use_old_ClassDeclaration_NullBlobStorageService(
-    use: TypeOnly<old.NullBlobStorageService>);
-use_old_ClassDeclaration_NullBlobStorageService(
-    get_current_ClassDeclaration_NullBlobStorageService());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
## Description

No external consumers of R11s driver should rely on internals like DocumentService or DocumentDeltaStorage. All entry should be through DocumentServiceFactory. There are a few extra exports like DefaultTokenProvider and token types that are necessary for consumers.

Unfortunately, DocumentStorageService is shared with local-driver so I've implemented a simplified LocalDocumentStorageService class within `local-driver` that is very reminiscent of the r11s-driver DocumentStorageService from 2020.

This should help reduce the need to add a hodge-podge of optional params in internal driver classes for the sake of backwards compatibility.

## Does this introduce a breaking change?

Removes export of some internal class declarations.
