### PR TITLE
Remove ability to disable isolated channels

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -103,7 +103,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     deleteUnusedRoutes(unusedRoutes: string[]): void;
     // (undocumented)
     get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    readonly disableIsolatedChannels: boolean;
     // (undocumented)
     dispose(error?: Error): void;
     // (undocumented)
@@ -620,8 +619,6 @@ export interface ISummaryOpMessage extends ISequencedDocumentMessage {
 
 // @public (undocumented)
 export interface ISummaryRuntimeOptions {
-    // @deprecated (undocumented)
-    disableIsolatedChannels?: boolean;
     // @deprecated (undocumented)
     disableSummaries?: boolean;
     // @deprecated (undocumented)

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -82,14 +82,9 @@ import {
 function createAttributes(
     pkg: readonly string[],
     isRootDataStore: boolean,
-    disableIsolatedChannels: boolean,
 ): WriteFluidDataStoreAttributes {
     const stringifiedPkg = JSON.stringify(pkg);
-    return disableIsolatedChannels ? {
-        pkg: stringifiedPkg,
-        snapshotFormatVersion: "0.1",
-        isRootDataStore,
-    } : {
+    return {
         pkg: stringifiedPkg,
         summaryFormatVersion: 2,
         isRootDataStore,
@@ -98,9 +93,8 @@ function createAttributes(
 export function createAttributesBlob(
     pkg: readonly string[],
     isRootDataStore: boolean,
-    disableIsolatedChannels: boolean,
 ): ITreeEntry {
-    const attributes = createAttributes(pkg, isRootDataStore, disableIsolatedChannels);
+    const attributes = createAttributes(pkg, isRootDataStore);
     return new BlobTreeEntry(dataStoreAttributesBlobName, JSON.stringify(attributes));
 }
 
@@ -123,7 +117,6 @@ export interface IFluidDataStoreContextProps {
     readonly scope: FluidObject;
     readonly createSummarizerNodeFn: CreateChildSummarizerNodeFn;
     readonly writeGCDataAtRoot: boolean;
-    readonly disableIsolatedChannels: boolean;
     readonly pkg?: Readonly<string[]>;
 }
 
@@ -255,7 +248,6 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     public readonly storage: IDocumentStorageService;
     public readonly scope: FluidObject;
     private readonly writeGCDataAtRoot: boolean;
-    protected readonly disableIsolatedChannels: boolean;
     protected pkg?: readonly string[];
 
     constructor(
@@ -271,7 +263,6 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         this.storage = props.storage;
         this.scope = props.scope;
         this.writeGCDataAtRoot = props.writeGCDataAtRoot;
-        this.disableIsolatedChannels = props.disableIsolatedChannels;
         this.pkg = props.pkg;
 
         // URIs use slashes as delimiters. Handles use URIs.
@@ -468,18 +459,15 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const summarizeResult = await this.channel!.summarize(fullTree, trackState, telemetryContext);
-        let pathPartsForChildren: string[] | undefined;
 
-        if (!this.disableIsolatedChannels) {
-            // Wrap dds summaries in .channels subtree.
-            wrapSummaryInChannelsTree(summarizeResult);
-            pathPartsForChildren = [channelsTreeName];
-        }
+        // Wrap dds summaries in .channels subtree.
+        wrapSummaryInChannelsTree(summarizeResult);
+        const pathPartsForChildren = [channelsTreeName];
 
         // Add data store's attributes to the summary.
         const { pkg } = await this.getInitialSnapshotDetails();
         const isRoot = await this.isRoot();
-        const attributes = createAttributes(pkg, isRoot, this.disableIsolatedChannels);
+        const attributes = createAttributes(pkg, isRoot);
         addBlobToSummary(summarizeResult, dataStoreAttributesBlobName, JSON.stringify(attributes));
 
         // Add GC data to the summary if it's not written at the root.
@@ -921,16 +909,13 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 
         const summarizeResult = this.channel.getAttachSummary();
 
-        if (!this.disableIsolatedChannels) {
-            // Wrap dds summaries in .channels subtree.
-            wrapSummaryInChannelsTree(summarizeResult);
-        }
+        // Wrap dds summaries in .channels subtree.
+        wrapSummaryInChannelsTree(summarizeResult);
 
         // Add data store's attributes to the summary.
         const attributes = createAttributes(
             this.pkg,
             this.isInMemoryRoot(),
-            this.disableIsolatedChannels,
         );
         addBlobToSummary(summarizeResult, dataStoreAttributesBlobName, JSON.stringify(attributes));
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -143,7 +143,6 @@ export class DataStores implements IDisposable {
                         { type: CreateSummarizerNodeSource.FromSummary },
                     ),
                     writeGCDataAtRoot: this.writeGCDataAtRoot,
-                    disableIsolatedChannels: this.runtime.disableIsolatedChannels,
                 });
             } else {
                 if (typeof value !== "object") {
@@ -164,7 +163,6 @@ export class DataStores implements IDisposable {
                     snapshotTree,
                     isRootDataStore: undefined,
                     writeGCDataAtRoot: this.writeGCDataAtRoot,
-                    disableIsolatedChannels: this.runtime.disableIsolatedChannels,
                 });
             }
             this.contexts.addBoundOrRemoted(dataStoreContext);
@@ -245,13 +243,11 @@ export class DataStores implements IDisposable {
                         entries: [createAttributesBlob(
                             pkg,
                             true /* isRootDataStore */,
-                            this.runtime.disableIsolatedChannels,
                         )],
                     },
                 },
             ),
             writeGCDataAtRoot: this.writeGCDataAtRoot,
-            disableIsolatedChannels: this.runtime.disableIsolatedChannels,
             pkg,
         });
 
@@ -356,7 +352,6 @@ export class DataStores implements IDisposable {
             snapshotTree: undefined,
             isRootDataStore: isRoot,
             writeGCDataAtRoot: this.writeGCDataAtRoot,
-            disableIsolatedChannels: this.runtime.disableIsolatedChannels,
         });
         this.contexts.addUnbound(context);
         return context;
@@ -378,7 +373,6 @@ export class DataStores implements IDisposable {
             snapshotTree: undefined,
             isRootDataStore: false,
             writeGCDataAtRoot: this.writeGCDataAtRoot,
-            disableIsolatedChannels: this.runtime.disableIsolatedChannels,
             createProps: props,
         });
         this.contexts.addUnbound(context);

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -122,7 +122,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -149,7 +148,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -176,7 +174,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -203,7 +200,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -230,7 +226,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -254,7 +249,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -281,7 +275,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -308,7 +301,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {
@@ -335,7 +327,6 @@ describe("Data Store Creation Tests", () => {
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
-                disableIsolatedChannels: false,
             });
 
             try {

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -162,7 +162,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
             ]);
             const codeLoader = new LocalCodeLoader(
                 [[codeDetails, factory]],
-                { summaryOptions: { disableIsolatedChannels } });
+                {});
             const testLoader = new Loader({
                 urlResolver,
                 documentServiceFactory,

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -31,7 +31,6 @@ import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server"
 
 describe(`Container Serialization Backwards Compatibility`, () => {
     const loaderContainerTracker = new LoaderContainerTracker();
-    let disableIsolatedChannels: boolean;
     let filename: string;
     const contentFolder = "content/serializedContainerTestContent";
 
@@ -45,16 +44,12 @@ describe(`Container Serialization Backwards Compatibility`, () => {
     }
 
     for (filename of recurseFiles(contentFolder)) {
-        disableIsolatedChannels = false;
-        tests();
-        disableIsolatedChannels = true;
         tests();
     }
 
     function tests(): void {
         const filenameShort = filename.slice(contentFolder.length + 1);
-        it(`Rehydrate container from ${filenameShort} and check contents before attach${
-            disableIsolatedChannels ? " (disable isolated channels)" : ""}`, async () => {
+        it(`Rehydrate container from ${filenameShort} and check contents before attach`, async () => {
             const snapshotTree = fs.readFileSync(filename, "utf8");
 
             const loader = createTestLoader();
@@ -89,8 +84,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
             assert.strictEqual(sparseMatrix.id, sparseMatrixId, "Sparse matrix should exist!!");
         });
 
-        it(`Rehydrate container from ${filenameShort} round trip serialize/deserialize${
-            disableIsolatedChannels ? " (disable isolated channels)" : ""}`, async () => {
+        it(`Rehydrate container from ${filenameShort} round trip serialize/deserialize`, async () => {
             const snapshotTree = fs.readFileSync(filename, "utf8");
 
             const loader = createTestLoader();
@@ -162,7 +156,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
             ]);
             const codeLoader = new LocalCodeLoader(
                 [[codeDetails, factory]],
-                {});
+                { });
             const testLoader = new Loader({
                 urlResolver,
                 documentServiceFactory,

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -114,8 +114,6 @@ function buildSummaryTree(attr, quorumVal, summarizer): ISummaryTree {
 }
 
 describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) => {
-    let disableIsolatedChannels = false;
-
     function assertSubtree(tree: ISnapshotTreeWithBlobContents, key: string, msg?: string):
         ISnapshotTreeWithBlobContents {
         const subTree = tree.trees[key];
@@ -123,9 +121,8 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
         return subTree;
     }
 
-    const assertChannelsTree = (rootOrDatastore: ISnapshotTreeWithBlobContents) => disableIsolatedChannels
-        ? rootOrDatastore
-        : assertSubtree(rootOrDatastore, ".channels");
+    const assertChannelsTree = (rootOrDatastore: ISnapshotTreeWithBlobContents) =>
+        assertSubtree(rootOrDatastore, ".channels");
     const assertProtocolTree = (root: ISnapshotTreeWithBlobContents) => assertSubtree(root, ".protocol");
 
     function assertChannelTree(rootOrDatastore: ISnapshotTreeWithBlobContents, key: string, msg?: string) {
@@ -195,7 +192,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
         ]);
         const codeLoader = new LocalCodeLoader(
             [[codeDetails, factory]],
-            { summaryOptions: { disableIsolatedChannels } });
+            {});
         const testLoader = new Loader({
             urlResolver: provider.urlResolver,
             documentServiceFactory: provider.documentServiceFactory,
@@ -797,13 +794,4 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
 
     // Run once with isolated channels
     tests();
-
-    // Run again with isolated channels disabled
-    describe("With isolated channels disabled", () => {
-        before(() => {
-            disableIsolatedChannels = true;
-        });
-
-        tests();
-    });
 });

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -188,7 +188,7 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
     });
 
     it("should generate summary tree", async () => {
-        const container = await createContainer(provider, { disableIsolatedChannels: false });
+        const container = await createContainer(provider, {});
         const defaultDataStore = await requestFluidObject<ITestDataObject>(container, defaultDataStoreId);
         const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
 
@@ -233,50 +233,6 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
         assert(dataStoreChannelsTree?.type === SummaryType.Tree, "Expected .channels tree in default data store.");
 
         const defaultDdsNode = dataStoreChannelsTree.tree.root;
-        assert(defaultDdsNode?.type === SummaryType.Tree, "Expected default root DDS in summary.");
-        assert(!defaultDdsNode.unreferenced, "Default root DDS should be referenced.");
-        assert(defaultDdsNode.tree[".attributes"]?.type === SummaryType.Blob,
-            "Expected .attributes blob in default root DDS summary tree.");
-    });
-
-    it("Should generate summary tree with isolated channels disabled", async () => {
-        const container = await createContainer(provider, { disableIsolatedChannels: true });
-        const defaultDataStore = await requestFluidObject<ITestDataObject>(container, defaultDataStoreId);
-        const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
-        await provider.ensureSynchronized();
-
-        const { stats, summary } = await containerRuntime.summarize({
-            runGC: false,
-            fullTree: false,
-            trackState: false,
-            summaryLogger: new TelemetryNullLogger(),
-        });
-
-        // Validate stats
-        assert(stats.handleNodeCount === 0, "Expecting no handles for first summary.");
-        // .component, and .attributes blobs
-        assert(stats.blobNodeCount >= 2, `Stats expected at least 2 blob nodes, but had ${stats.blobNodeCount}.`);
-        // root node, default data store, and default root dds
-        assert(stats.treeNodeCount >= 3, `Stats expected at least 3 tree nodes, but had ${stats.treeNodeCount}.`);
-
-        // Validate summary
-        assert(!summary.unreferenced, "Root summary should be referenced.");
-        assert(summary.tree[channelsTreeName] === undefined, "Unexpected .channels tree in summary root.");
-
-        const defaultDataStoreNode = summary.tree[defaultDataStore._context.id];
-        assert(defaultDataStoreNode?.type === SummaryType.Tree, "Expected default data store tree in summary.");
-        assert(!defaultDataStoreNode.unreferenced, "Default data store should be referenced.");
-        assert(defaultDataStoreNode.tree[".component"]?.type === SummaryType.Blob,
-            "Expected .component blob in default data store summary tree.");
-        const attributes = readBlobContent(defaultDataStoreNode.tree[".component"].content) as Record<string, unknown>;
-        assert(attributes.snapshotFormatVersion === "0.1", "Datastore attributes snapshotFormatVersion should be 0.1");
-        assert(attributes.summaryFormatVersion === undefined, "Unexpected datastore attributes summaryFormatVersion");
-        assert(attributes.disableIsolatedChannels === undefined,
-            "Unexpected datastore attributes disableIsolatedChannels");
-        assert(defaultDataStoreNode.tree[channelsTreeName] === undefined,
-            "Unexpected .channels tree in default data store.");
-
-        const defaultDdsNode = defaultDataStoreNode.tree.root;
         assert(defaultDdsNode?.type === SummaryType.Tree, "Expected default root DDS in summary.");
         assert(!defaultDdsNode.unreferenced, "Default root DDS should be referenced.");
         assert(defaultDdsNode.tree[".attributes"]?.type === SummaryType.Blob,
@@ -332,7 +288,7 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 
     it("TelemetryContext is populated with data", async () => {
         const mockLogger = new MockLogger();
-        const container = await createContainer(provider, { disableIsolatedChannels: true }, mockLogger);
+        const container = await createContainer(provider, {}, mockLogger);
         const defaultDataStore = await requestFluidObject<ITestDataObject>(container, defaultDataStoreId);
         const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
         await provider.ensureSynchronized();

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -57,7 +57,6 @@ const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
 };
 
 const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
-    disableIsolatedChannels: [undefined],
     disableSummaries: [false],
     initialSummarizerDelayMs: numberCases,
     summaryConfigOverrides: [undefined],


### PR DESCRIPTION


## Description

Since January,  Bohemia has moved out of this mode in which one can disable channels and, as there are  no clients who need this functionality, we are removing it. 

For now,  nonDataStorePaths, rootHasIsolatedChannel will still be present to allow us to support it on read paths. 

[AB 1508](https://dev.azure.com/fluidframework/internal/_workitems/edit/1508)

