### PR TITLE
FIx noops

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -107,6 +107,9 @@ export class BlobCacheStorageService extends DocumentStorageServiceProxy {
 // @public
 export function buildSnapshotTree(entries: ITreeEntry[], blobMap: Map<string, ArrayBufferLike>): ISnapshotTree;
 
+// @public (undocumented)
+export function canBeCoalescedByService(message: ISequencedDocumentMessage | IDocumentMessage): boolean;
+
 // @public
 export const canRetryOnError: (error: any) => boolean;
 
@@ -237,7 +240,9 @@ export const isFluidResolvedUrl: (resolved: IResolvedUrl | undefined) => resolve
 export function isOnline(): OnlineStatus;
 
 // @public (undocumented)
-export function isRuntimeMessage(message: ISequencedDocumentMessage | IDocumentMessage): boolean;
+export function isRuntimeMessage(message: {
+    type: string;
+}): boolean;
 
 // @public
 export interface ISummaryTreeAssemblerProps {
@@ -260,6 +265,12 @@ export class LocationRedirectionError extends LoggingError implements ILocationR
 
 // @public (undocumented)
 export function logNetworkFailure(logger: ITelemetryLogger, event: ITelemetryErrorEvent, error?: any): void;
+
+// @public (undocumented)
+export enum MessageType2 {
+    // (undocumented)
+    Accept = "accept"
+}
 
 // @public (undocumented)
 export class MultiDocumentServiceFactory implements IDocumentServiceFactory {

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -5,6 +5,9 @@
 
 export enum MessageType {
     // Empty operation message. Used to send an updated reference sequence number.
+    // Relay service is free to coalesce these messages or fully drop them, if
+    // another op was used to update MSN to a number equal or higher than referenced
+    // sequence number in Noop.
     NoOp = "noop",
 
     // System message sent to indicate a new client has joined the collaboration
@@ -18,6 +21,9 @@ export enum MessageType {
 
     // Message used to reject a pending proposal
     Reject = "reject",
+
+    // Message send by client accepting proposal
+    Accept = "accept",
 
     // Summary op
     Summarize = "summarize",

--- a/packages/loader/container-loader/src/collabWindowTracker.ts
+++ b/packages/loader/container-loader/src/collabWindowTracker.ts
@@ -5,7 +5,7 @@
 
 import { assert, Timer } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { isRuntimeMessage } from "@fluidframework/driver-utils";
+import { isRuntimeMessage, MessageType2 } from "@fluidframework/driver-utils";
 
 const defaultNoopTimeFrequency = 2000;
 const defaultNoopCountFrequency = 50;
@@ -34,7 +34,7 @@ export class CollabWindowTracker {
     private readonly timer: Timer | undefined;
 
     constructor(
-        private readonly submit: (type: MessageType, contents: any) => void,
+        private readonly submit: (type: MessageType) => void,
         NoopTimeFrequency: number = defaultNoopTimeFrequency,
         private readonly NoopCountFrequency: number = defaultNoopCountFrequency,
     ) {
@@ -93,7 +93,7 @@ export class CollabWindowTracker {
 
     private submitNoop(immediate: boolean) {
         // Anything other than null is immediate noop
-        this.submit(MessageType.NoOp, immediate ? "" : null);
+        this.submit(immediate ? (MessageType2.Accept as unknown as MessageType) : MessageType.NoOp);
         assert(this.opsCountSinceNoop === 0,
             0x243 /* "stopSequenceNumberUpdate should be called as result of sending any op!" */);
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1416,7 +1416,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const protocol = protocolHandlerBuilder(
             attributes,
             quorumSnapshot,
-            (key, value) => this.submitMessage(MessageType.Propose, { key, value }),
+            (key, value) => this.submitMessage(MessageType.Propose, JSON.stringify({ key, value })),
             this._initialClients ?? [],
         );
 
@@ -1719,10 +1719,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     { messageType: type }));
                 return -1;
         }
-        return this.submitMessage(type, contents, batch, metadata);
+        return this.submitMessage(type, JSON.stringify(contents), batch, metadata);
     }
 
-    private submitMessage(type: MessageType, contents: any, batch?: boolean, metadata?: any): number {
+    private submitMessage(type: MessageType, contents?: string, batch?: boolean, metadata?: any): number {
         if (this.connectionState !== ConnectionState.Connected) {
             this.mc.logger.sendErrorEvent({ eventName: "SubmitMessageWithNoConnection", type });
             return -1;
@@ -1767,10 +1767,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.serviceConfiguration !== undefined,
                     0x2e4 /* "there should be service config for active connection" */);
                 this.collabWindowTracker = new CollabWindowTracker(
-                    (type, contents) => {
+                    (type) => {
                         assert(this.activeConnection(),
                             0x241 /* "disconnect should result in stopSequenceNumberUpdate() call" */);
-                        this.submitMessage(type, contents);
+                        this.submitMessage(type);
                     },
                     this.serviceConfiguration.noopTimeFrequency,
                     this.serviceConfiguration.noopCountFrequency,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -199,12 +199,12 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     public get readOnlyInfo() { return this.connectionManager.readOnlyInfo; }
     public get clientDetails() { return this.connectionManager.clientDetails; }
 
-    public submit(type: MessageType, contents: any, batch = false, metadata?: any) {
+    public submit(type: MessageType, contents?: string, batch = false, metadata?: any) {
         if (this.currentlyProcessingOps && this.preventConcurrentOpSend) {
             this.close(new UsageError("Making changes to data model is disallowed while processing ops."));
         }
         const messagePartial: Omit<IDocumentMessage, "clientSequenceNumber"> = {
-            contents: JSON.stringify(contents),
+            contents,
             metadata,
             referenceSequenceNumber: this.lastProcessedSequenceNumber,
             type,
@@ -218,7 +218,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
             return -1;
         }
 
-        this.opsSize += message.contents.length;
+        if (contents !== undefined) {
+            this.opsSize += contents.length;
+        }
 
         this.messageBuffer.push(message);
 

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -18,6 +18,7 @@ import {
     ISignalMessage,
     MessageType,
 } from "@fluidframework/protocol-definitions";
+import { canBeCoalescedByService } from "@fluidframework/driver-utils";
 
 /**
  * Function to be used for creating a protocol handler.
@@ -68,7 +69,7 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
                 throw new Error("Remote message's clientId is missing from the quorum");
             }
 
-            if (client?.shouldHaveLeft === true && message.type !== MessageType.NoOp) {
+            if (client?.shouldHaveLeft === true && !canBeCoalescedByService(message)) {
                 // pre-0.58 error message: messageClientIdShouldHaveLeft
                 throw new Error("Remote message's clientId already should have left");
             }

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -14,6 +14,7 @@ import {
     MessageType,
 } from "@fluidframework/protocol-definitions";
 import { MockDocumentDeltaConnection, MockDocumentService } from "@fluidframework/test-loader-utils";
+import { MessageType2 } from "@fluidframework/driver-utils";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import { DeltaManager } from "../deltaManager";
 import { CollabWindowTracker } from "../collabWindowTracker";
@@ -66,8 +67,8 @@ describe("Loader", () => {
                 );
 
                 const tracker = new CollabWindowTracker(
-                    (type: MessageType, contents: any) => {
-                        deltaManager.submit(type, contents);
+                    (type: MessageType) => {
+                        deltaManager.submit(type);
                         // CollabWindowTracker expects every op submitted (including noops) to result in this call:
                         tracker.stopSequenceNumberUpdate();
                     },
@@ -143,10 +144,16 @@ describe("Loader", () => {
 
             describe("Update Minimum Sequence Number", () => {
                 // helper function asserting that there is exactly one well-formed no-op
-                function assertOneValidNoOp(messages: IDocumentMessage[], immediate: boolean = false) {
+                function assertOneValidNoOp(messages: IDocumentMessage[]) {
                     assert.strictEqual(1, messages.length);
                     assert.strictEqual(MessageType.NoOp, messages[0].type);
-                    assert.strictEqual(immediate ? "" : null, JSON.parse(messages[0].contents as string));
+                    assert.strictEqual(undefined, messages[0].contents);
+                }
+
+                function assertOneValidAcceptOp(messages: IDocumentMessage[]) {
+                    assert.strictEqual(1, messages.length);
+                    assert.strictEqual(MessageType2.Accept, messages[0].type);
+                    assert.strictEqual(undefined, messages[0].contents);
                 }
 
                 it("Infinite frequency parameters disables periodic noops completely", async () => {
@@ -270,7 +277,7 @@ describe("Loader", () => {
                     await startDeltaManager();
 
                     emitter.on(submitEvent, (messages: IDocumentMessage[]) => {
-                        assertOneValidNoOp(messages, true);
+                        assertOneValidAcceptOp(messages);
                         runCount++;
                     });
 

--- a/packages/loader/driver-utils/src/messageRecognition.ts
+++ b/packages/loader/driver-utils/src/messageRecognition.ts
@@ -22,6 +22,7 @@ export function isClientMessage(message: ISequencedDocumentMessage | IDocumentMe
         case MessageType.Propose:
         case MessageType.Reject:
         case MessageType.NoOp:
+        case MessageType.Summarize:
             return true;
         default:
             return false;
@@ -35,8 +36,8 @@ export function isClientMessage(message: ISequencedDocumentMessage | IDocumentMe
  * "op"
  * "summarize"
  */
-export function isRuntimeMessage(message: ISequencedDocumentMessage | IDocumentMessage): boolean {
-    return message.type === MessageType.Operation || message.type === MessageType.Summarize;
+export function isRuntimeMessage(message: { type: string; }): boolean {
+    return message.type === MessageType.Operation;
 }
 
 enum RuntimeMessage {
@@ -66,4 +67,17 @@ export function isUnpackedRuntimeMessage(message: ISequencedDocumentMessage): bo
         return true;
     }
     return false;
+}
+
+// ADO #1385: staging code changes across layers.
+// Eventually to be replaced by MessageType.accept
+export enum MessageType2 {
+    Accept = "accept",
+}
+
+// ADO #1385: To be moved to packages/protocol-base/src/protocol.ts
+export function canBeCoalescedByService(message: ISequencedDocumentMessage | IDocumentMessage): boolean {
+    // This assumes that in the future rely service may implement coalescing of accept messages,
+    // same way it was doing coalescing of immediate noops in the past.
+    return message.type === MessageType.NoOp || message.type === MessageType2.Accept;
 }

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -239,7 +239,7 @@ export class RunningSummarizer implements IDisposable {
     public handleOp(op: ISequencedDocumentMessage) {
         this.heuristicData.lastOpSequenceNumber = op.sequenceNumber;
 
-        if (op.type !== MessageType.Summarize && isRuntimeMessage(op)) {
+        if (isRuntimeMessage(op)) {
             this.heuristicData.numRuntimeOps++;
         } else {
             this.heuristicData.numNonRuntimeOps++;


### PR DESCRIPTION
Splitting noop logic out of https://github.com/microsoft/FluidFramework/pull/11262/files

Through code review, I've noticed that we send content="null" for non-immediate noops, but service expects content === null to differentiate immediate vs. non-immediate noops. In other words, non-immediate noops are considered to be immediate noops by service and they are never coalesced! I've noticed it only because I worked (not part of this PR) to move content strigification out of loader layer into runtime.

While we can fix it on service side (and leave client as is), I really do not like current design and special types based on type of content. So splitting noops into "accept" (formerly - immediate noops) and noops (non-immediate). Once this change propagates through the system, service can
- coalesce ALL noops.
-  service may choose to do some special treatment of accept ops, though I do not see any reason for that. For example, today service will drop it if such op does not change MSN. Given they are used only for acceptance of code proposals (which are very rare), I'd suggest simplifying service logic and not have any handling for it.