### PR TITLE
GC Sweep Tests: Enable inactive object x errors and file logging

### DIFF
--- a/packages/test/test-gc-sweep-tests/src/ignoreErrorLogger.ts
+++ b/packages/test/test-gc-sweep-tests/src/ignoreErrorLogger.ts
@@ -13,6 +13,8 @@ import { ITelemetryBaseEvent, ITelemetryGenericEvent } from "@fluidframework/com
  */
 export class IgnoreErrorLogger extends EventAndErrorTrackingLogger {
     private readonly ignoredEvents: Map<string, ITelemetryGenericEvent> = new Map();
+    public readonly events: ITelemetryBaseEvent[] = [];
+    public readonly inactiveObjectEvents: ITelemetryBaseEvent[] = [];
 
     public ignoreExpectedEventTypes(...anyIgnoredEvents: ITelemetryGenericEvent[]) {
         for (const event of anyIgnoredEvents) {
@@ -21,6 +23,11 @@ export class IgnoreErrorLogger extends EventAndErrorTrackingLogger {
     }
 
     send(event: ITelemetryBaseEvent): void {
+        this.events.push(event);
+        if (event.eventName.includes("InactiveObject")) {
+            this.inactiveObjectEvents.push(event);
+        }
+        // For ignored events, make them generic events.
         if (this.ignoredEvents.has(event.eventName)) {
             let matches = true;
             const ie = this.ignoredEvents.get(event.eventName);

--- a/packages/test/test-gc-sweep-tests/src/ignoreErrorLogger.ts
+++ b/packages/test/test-gc-sweep-tests/src/ignoreErrorLogger.ts
@@ -4,24 +4,17 @@
  */
 
 import { EventAndErrorTrackingLogger } from "@fluidframework/test-utils";
-import { ITelemetryBaseEvent, ITelemetryGenericEvent } from "@fluidframework/common-definitions";
+import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 
 /**
  * Ignores certain error types (does not pay attention to count)
  * Potentially, we may want to raise the severity of telemetry as an error. i.e - inactiveObjectX telemetry
  */
 export class IgnoreErrorLogger extends EventAndErrorTrackingLogger {
-    private readonly ignoredEvents: Map<string, ITelemetryGenericEvent> = new Map();
     public readonly events: ITelemetryBaseEvent[] = [];
     public readonly inactiveObjectEvents: ITelemetryBaseEvent[] = [];
     public readonly errorEvents: ITelemetryBaseEvent[] = [];
     public readonly errorEventStats: { [key: string]: number; } = {};
-
-    public ignoreExpectedEventTypes(...anyIgnoredEvents: ITelemetryGenericEvent[]) {
-        for (const event of anyIgnoredEvents) {
-            this.ignoredEvents.set(event.eventName, event);
-        }
-    }
 
     send(event: ITelemetryBaseEvent): void {
         this.events.push(event);

--- a/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
+++ b/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
@@ -273,6 +273,12 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
                 errorCount: errorList.length,
             };
 
+            const runData = {
+                stats,
+                actions: actionsList,
+                errors: errorList,
+            };
+
             fs.mkdirSync(`nyc/testData-${seed}`, { recursive: true });
             fs.writeFileSync(`nyc/testData-${seed}/events.json`, JSON.stringify(overrideLogger.events));
             fs.writeFileSync(`nyc/testData-${seed}/inactiveObjectEvents.json`, JSON.stringify(overrideLogger.inactiveObjectEvents));
@@ -281,6 +287,7 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
             fs.writeFileSync(`nyc/testData-${seed}/actions.json`, JSON.stringify(actionsList));
             fs.writeFileSync(`nyc/testData-${seed}/stats.json`, JSON.stringify(stats));
             fs.writeFileSync(`nyc/testData-${seed}/errors.json`, JSON.stringify(errorList));
+            fs.writeFileSync(`nyc/testData-${seed}/runData.json`, JSON.stringify(runData));
 
             // Check that we don't have errors and print the debug object
             assert(errorList.length === 0, `${errorList.length} errors occurred! Check the nyc/testData-${seed}/errors.json`);

--- a/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
+++ b/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
@@ -263,15 +263,9 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
              * At this point the test has finished, we might want to store a list of all the actions at this point and await them all to make sure they finish.
              * Feel free to put anything in the debug object. It's likely to get big. You can also put a range of actions if you're just trying to hone in on
              * what changed.
+             *
+             * This is the validation and data storage part of the test.
              */
-            const debugObject = {
-                actionCount: actionsList.length,
-                actionsList,
-                errorCount: errorList.length,
-                errorList,
-                ...actionStats,
-                handleRecord: handleTracker.handleActionRecord,
-            };
 
             const stats = {
                 ...actionStats,
@@ -289,13 +283,13 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
             fs.writeFileSync(`nyc/testData-${seed}/errors.json`, JSON.stringify(errorList));
 
             // Check that we don't have errors and print the debug object
-            assert(errorList.length === 0, `${errorList} errors occurred! Check the nyc/testData-${seed}/errors.json`);
+            assert(errorList.length === 0, `${errorList.length} errors occurred! Check the nyc/testData-${seed}/errors.json`);
 
             // Check that we don't have any error logs
             assert(overrideLogger.errorEvents.length === 0, `${overrideLogger.errorEvents.length} error events have been logged! Check the nyc/testData-${seed}/errorEvents.json`);
 
             /**
-             * This is just some heuristic expectations
+             * This is just some heuristic expectations and validations
              * - expect some number of actions.
              * - expect some number of each action type.
              *
@@ -303,7 +297,7 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
              */
             const minimumExpectedActions = 100;
             const minimumExpectedActionsPerActionType = minimumExpectedActions / 10;
-            assert(actionsList.length > minimumExpectedActions, `Very few actions!\nDebug: ${JSON.stringify(debugObject)}`);
+            assert(actionsList.length > minimumExpectedActions, `Very few actions!`);
             Object.entries(actionStats).forEach(([name, stat]) => {
                 assert(stat >= minimumExpectedActionsPerActionType, `There are less than ${minimumExpectedActionsPerActionType} calls to ${name}!`);
             });


### PR DESCRIPTION
[AB#1797](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1797)

Enable InactiveObject_X errors and log those errors and other information to a few files for easier debugging.