### PR TITLE
[website] pick first line from package description

### DIFF
--- a/docs/themes/thxvscode/layouts/apis/list.html
+++ b/docs/themes/thxvscode/layouts/apis/list.html
@@ -30,7 +30,10 @@
                         {{ range where $packagePages "Params.package" . }}
                         <tr>
                             <td><a href="{{ .RelPermalink | safeURL }}" title="{{ .Title }}">{{ .Title }}</a></td>
-                            <td>{{ truncate 170 (.Params.Summary | markdownify) }}</td>
+                            <td>
+                                {{ $firstLine := index (split .Params.Summary "\n\n") 0 }}
+                                {{ $firstLine | markdownify }}
+                            </td>
                         </tr>
                         {{ end }}
                         {{ end }}

--- a/docs/themes/thxvscode/layouts/apis/list.html
+++ b/docs/themes/thxvscode/layouts/apis/list.html
@@ -26,16 +26,15 @@
                     </thead>
                     <tbody>
                         {{ range $names }}
-
-                        {{ range where $packagePages "Params.package" . }}
+                        {{- range where $packagePages "Params.package" . -}}
                         <tr>
                             <td><a href="{{ .RelPermalink | safeURL }}" title="{{ .Title }}">{{ .Title }}</a></td>
                             <td>
                                 {{ $firstLine := index (split .Params.Summary "\n\n") 0 }}
-                                {{ $firstLine | markdownify }}
+                                {{- $firstLine | .RenderString -}}
                             </td>
                         </tr>
-                        {{ end }}
+                        {{- end -}}
                         {{ end }}
                     </tbody>
                 </table>


### PR DESCRIPTION
Currently we truncate the package description on the API overview page to 170 characters. It results with broken html syntax in several places.

The proposed solution is to pick the first line from the package description block rather than truncating the description block with an arbitrary character count.

### Before
![image](https://user-images.githubusercontent.com/8239356/187994521-91a817b7-e19e-4091-ab54-02faa930a8c4.png)

### After
![image](https://user-images.githubusercontent.com/8239356/187994584-2b1fdd02-4945-47aa-93a3-4ffbf5506c2d.png)


