### PR TITLE
[build-tools] Correct release branch names

### DIFF
--- a/build-tools/packages/build-cli/src/lib/branches.ts
+++ b/build-tools/packages/build-cli/src/lib/branches.ts
@@ -108,21 +108,36 @@ export function generateBumpDepsBranchName(
  * @internal
  */
 export function generateReleaseBranchName(releaseGroup: ReleaseGroup, version: string): string {
+    // An array of all the sections of a "path" branch -- a branch with slashes in the name.
+    const branchPath = ["release"];
+
     const scheme = detectVersionScheme(version);
-    const branchVersion =
-        scheme === "internal"
-            ? fromInternalScheme(version)[1].version
-            : scheme === "virtualPatch"
-            ? fromVirtualPatchScheme(version).version
-            : version;
+    const schemeIsInternal = scheme === "internal" || scheme === "internalPrerelease";
+
+    let branchVersion: string;
+    if (schemeIsInternal === true) {
+        branchVersion = fromInternalScheme(version)[1].version
+    } else if (scheme === "virtualPatch") {
+        branchVersion = fromVirtualPatchScheme(version).version
+    } else {
+        branchVersion = version;
+    }
+
+    if (releaseGroup === "client") {
+        if (schemeIsInternal) {
+            branchPath.push("v2int");
+        }
+    } else {
+        branchPath.push(releaseGroup);
+    }
+
     const releaseBranchVersion =
         scheme === "virtualPatch"
-            ? toVirtualPatchScheme(
-                  `${semver.major(branchVersion)}.${semver.minor(branchVersion)}.0`,
-              )
+            ? toVirtualPatchScheme(`${semver.major(branchVersion)}.${semver.minor(branchVersion)}.0`).version
             : `${semver.major(branchVersion)}.${semver.minor(branchVersion)}`;
-    const branchName = releaseGroup === "client" ? "v2int" : releaseGroup;
-    const releaseBranch = `release/${branchName}/${releaseBranchVersion}`;
+    branchPath.push(releaseBranchVersion);
+
+    const releaseBranch = branchPath.join("/");
     return releaseBranch;
 }
 

--- a/build-tools/packages/build-cli/src/lib/branches.ts
+++ b/build-tools/packages/build-cli/src/lib/branches.ts
@@ -116,9 +116,9 @@ export function generateReleaseBranchName(releaseGroup: ReleaseGroup, version: s
 
     let branchVersion: string;
     if (schemeIsInternal === true) {
-        branchVersion = fromInternalScheme(version)[1].version
+        branchVersion = fromInternalScheme(version)[1].version;
     } else if (scheme === "virtualPatch") {
-        branchVersion = fromVirtualPatchScheme(version).version
+        branchVersion = fromVirtualPatchScheme(version).version;
     } else {
         branchVersion = version;
     }
@@ -133,7 +133,9 @@ export function generateReleaseBranchName(releaseGroup: ReleaseGroup, version: s
 
     const releaseBranchVersion =
         scheme === "virtualPatch"
-            ? toVirtualPatchScheme(`${semver.major(branchVersion)}.${semver.minor(branchVersion)}.0`).version
+            ? toVirtualPatchScheme(
+                  `${semver.major(branchVersion)}.${semver.minor(branchVersion)}.0`,
+              ).version
             : `${semver.major(branchVersion)}.${semver.minor(branchVersion)}`;
     branchPath.push(releaseBranchVersion);
 

--- a/build-tools/packages/build-cli/test/lib/branches.test.ts
+++ b/build-tools/packages/build-cli/test/lib/branches.test.ts
@@ -115,6 +115,12 @@ describe("generateReleaseBranchName", () => {
         assert.equal(actual, expected);
     });
 
+    it("client using semver", () => {
+        const actual = generateReleaseBranchName(MonoRepoKind.Client, "1.2.3");
+        const expected = "release/1.2";
+        assert.equal(actual, expected);
+    });
+
     it("Fluid internal version scheme", () => {
         const actual = generateReleaseBranchName(MonoRepoKind.Client, "2.0.0-internal.1.0.0");
         const expected = "release/v2int/1.0";


### PR DESCRIPTION
The release branch name generation function didn't handle older releases of client that don't use the internal version scheme.