### PR TITLE
Allow deli to maintain op batches when passing them forward

### DIFF
--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -19,6 +19,9 @@ export interface IDeliServerConfiguration {
     // Enables creating join/leave signals for write clients
     enableWriteClientSignals: boolean;
 
+    // Enables deli to maintain batches as it produces them to the next lambdas
+    maintainBatches: boolean;
+
     // Enables deli to check for idle clients when it starts
     checkForIdleClientsOnStartup: boolean;
 
@@ -167,6 +170,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         enableOpHashing: true,
         enableAutoDSNUpdate: false,
         checkForIdleClientsOnStartup: false,
+        maintainBatches: false,
         enableWriteClientSignals: false,
         clientTimeout: 5 * 60 * 1000,
         activityTimeout: 30 * 1000,

--- a/server/routerlicious/packages/test-utils/src/messageFactory.ts
+++ b/server/routerlicious/packages/test-utils/src/messageFactory.ts
@@ -40,7 +40,6 @@ export class KafkaMessageFactory {
     }
 
     public sequenceMessage(value: any | any[], key: string): IQueuedMessage {
-        const valueArray = Array.isArray(value) ? value : [value];
         const partition = this.getPartition(key);
         const offset = this.offsets[partition]++;
 
@@ -49,9 +48,9 @@ export class KafkaMessageFactory {
             partition,
             topic: this.topic,
             value: this.stringify
-                ? JSON.stringify(valueArray)
+                ? JSON.stringify(value)
                 : ({
-                    contents: valueArray,
+                    contents: Array.isArray(value) ? value : [value],
                     documentId: this.documentId,
                     tenantId: this.tenantId,
                     type: BoxcarType,

--- a/server/routerlicious/packages/test-utils/src/messageFactory.ts
+++ b/server/routerlicious/packages/test-utils/src/messageFactory.ts
@@ -39,7 +39,8 @@ export class KafkaMessageFactory {
         }
     }
 
-    public sequenceMessage(value: any, key: string): IQueuedMessage {
+    public sequenceMessage(value: any | any[], key: string): IQueuedMessage {
+        const valueArray = Array.isArray(value) ? value : [value];
         const partition = this.getPartition(key);
         const offset = this.offsets[partition]++;
 
@@ -48,9 +49,9 @@ export class KafkaMessageFactory {
             partition,
             topic: this.topic,
             value: this.stringify
-                ? JSON.stringify(value)
+                ? JSON.stringify(valueArray)
                 : ({
-                    contents: [value],
+                    contents: valueArray,
                     documentId: this.documentId,
                     tenantId: this.tenantId,
                     type: BoxcarType,


### PR DESCRIPTION
When a client submits an op batch:
1. The frontend (alfred) produces that op batch to the `rawdeltas` kafka topic in a single `Boxcar` message
2. Deli consumes that `Boxcar` and sequences each op
3. Deli produces each sequenced op to the `deltas` topic _separately_
     -  the op batch has now been broken up into 1 `Boxcar` per op!
5. From this point on, the `broadcaster` lambda (redis pubsub), `scribe` (summary handling), and `scriptorium` (op storage) will be consuming each op one by one.

This change allows deli to maintain the op batch when inserting the sequenced ops into the `deltas` topic. So all the sequenced ops will be sent in a single `Boxcar` message. This lets op batches be maintained when being pubsub'd to the clients and when the ops are inserted into storage / persisted.
This functionality can be enabled via the `maintainBatches` deli service configuration option. Defaulting to false, pending some testing.