### PR TITLE
Cleanup waitIntervalCollection and getTextRangeWithPlaceholders

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -107,6 +107,7 @@ bindToContext and related types](#remove-ifluiddatastorechannelbindtocontext-and
 - [Marker.toString simplified](#markertostring-simplified)
 - [Remove `IContainerRuntimeBase.setFlushMode`](#remove-icontainerruntimebasesetflushmode)
 - [`getTextAndMarkers` changed to be a free function](#gettextandmarkers-changed-to-be-a-free-function)
+- [waitIntervalCollection removed](#waitintervalcollection-removed)
 - [OldestClientObserver moved to @fluid-experimental/oldest-client-observer](#oldestclientobserver-moved-to-@fluid-experimental/oldest-client-observer)
 - [Creating root datastores using `IContainerRuntime.CreateRootDataStore` and `IContainerRuntimeBase._createDataStoreWithProps` is no longer supported](#Creating-root-datastores-using-IContainerRuntimeCreateRootDataStore-and-IContainerRuntimeBase_createDataStoreWithProps-is-no-longer-supported)
 - [Remove deprecated data structures from `@fluidframework/sequence`](#remove-deprecated-data-structures-from-fluidframeworksequence)
@@ -221,6 +222,11 @@ The `setFlushMode` has been removed from `IContainerRuntimeBase`. FlushMode is n
 `SharedString.getTextAndMarkers` involves a sizeable amount of model-specific logic.
 To improve bundle size, it will be converted to a free function so that this logic is tree-shakeable.
 The corresponding method on `IMergeTreeTexHelper` will also be removed.
+
+### `waitIntervalCollection` removed
+
+`SharedSegmentSequence.waitIntervalCollection` has been removed.
+Use `getIntervalCollection` instead, which has the same semantics but is synchronous.
 
 ### OldestClientObserver moved to @fluid-experimental/oldest-client-observer
 The `OldestClientObserver` class and its associated interfaces have been removed from @fluid-experimental/task-manager and moved to the new package @fluid-experimental/oldest-client-observer. Please migrate all imports to @fluid-experimental/oldest-client-observer.

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -280,8 +280,6 @@ export interface ISerializedIntervalCollectionV2 {
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
     // (undocumented)
     getIntervalCollection(label: string): IntervalCollection<TInterval>;
-    // (undocumented)
-    waitIntervalCollection(label: string): Promise<IntervalCollection<TInterval>>;
 }
 
 // @public
@@ -400,8 +398,6 @@ export class SharedIntervalCollection extends SharedObject implements ISharedInt
     protected reSubmitCore(content: any, localOpMetadata: unknown): void;
     // (undocumented)
     protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
-    // @deprecated (undocumented)
-    waitIntervalCollection(label: string): Promise<IntervalCollection<Interval>>;
 }
 
 // @public @deprecated
@@ -492,8 +488,6 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     submitSequenceMessage(message: IMergeTreeOp): void;
     // (undocumented)
     protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    // @deprecated (undocumented)
-    waitIntervalCollection(label: string): Promise<IntervalCollection<SequenceInterval>>;
     walkSegments<TClientData>(handler: ISegmentAction<TClientData>, start?: number, end?: number, accum?: TClientData, splitRange?: boolean): void;
 }
 
@@ -527,8 +521,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     getText(start?: number, end?: number): string;
     // (undocumented)
     getTextRangeWithMarkers(start: number, end: number): string;
-    // @deprecated (undocumented)
-    getTextRangeWithPlaceholders(start: number, end: number): string;
     getTextWithPlaceholders(start?: number, end?: number): string;
     // (undocumented)
     id: string;

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -111,6 +111,9 @@
   "typeValidation": {
     "version": "2.0.0",
     "broken": {
+      "InterfaceDeclaration_ISharedIntervalCollection": {
+        "backCompat": false
+      },
       "RemovedClassDeclaration_SharedNumberSequence": {
         "backCompat": false,
         "forwardCompat": false
@@ -192,6 +195,9 @@
         "backCompat": false
       },
       "ClassDeclaration_SequenceDeltaEvent": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SharedIntervalCollection": {
         "backCompat": false
       },
       "ClassDeclaration_SequenceMaintenanceEvent": {

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -406,16 +406,6 @@ export abstract class SharedSegmentSequence<T extends ISegment>
         }
     }
 
-    /**
-     * @deprecated - IntervalCollections are created on a first-write wins basis, and concurrent creates
-     * are supported. Use `getIntervalCollection` instead.
-     */
-    public async waitIntervalCollection(
-        label: string,
-    ): Promise<IntervalCollection<SequenceInterval>> {
-        return this.intervalCollections.get(label);
-    }
-
     public getIntervalCollection(label: string): IntervalCollection<SequenceInterval> {
         return this.intervalCollections.get(label);
     }

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -77,7 +77,6 @@ export class SharedIntervalCollectionFactory implements IChannelFactory {
 }
 
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
-    waitIntervalCollection(label: string): Promise<IntervalCollection<TInterval>>;
     getIntervalCollection(label: string): IntervalCollection<TInterval>;
 }
 
@@ -125,16 +124,6 @@ export class SharedIntervalCollection
             (op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
             new IntervalCollectionValueType(),
         );
-    }
-
-    /**
-     * @deprecated - IntervalCollections are created on a first-write wins basis, and concurrent creates
-     * are supported. Use `getIntervalCollection` instead.
-     */
-    public async waitIntervalCollection(
-        label: string,
-    ): Promise<IntervalCollection<Interval>> {
-        return this.intervalCollections.get(this.getIntervalCollectionPath(label));
     }
 
     public getIntervalCollection(label: string): IntervalCollection<Interval> {

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -244,13 +244,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
         return this.mergeTreeTextHelper.getText(segmentWindow.currentSeq, segmentWindow.clientId, " ", start, end);
     }
 
-    /**
-     * @deprecated - use `getTextWithPlaceholders` instead.
-     */
-    public getTextRangeWithPlaceholders(start: number, end: number) {
-        return this.getTextWithPlaceholders(start, end);
-    }
-
     public getTextRangeWithMarkers(start: number, end: number) {
         const segmentWindow = this.client.getCollabWindow();
         return this.mergeTreeTextHelper.getText(segmentWindow.currentSeq, segmentWindow.clientId, "*", start, end);

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.ts
@@ -373,6 +373,7 @@ declare function get_current_InterfaceDeclaration_ISharedIntervalCollection():
 declare function use_old_InterfaceDeclaration_ISharedIntervalCollection(
     use: TypeOnly<old.ISharedIntervalCollection<any>>);
 use_old_InterfaceDeclaration_ISharedIntervalCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISharedIntervalCollection());
 
 /*
@@ -690,6 +691,7 @@ declare function get_current_ClassDeclaration_SharedIntervalCollection():
 declare function use_old_ClassDeclaration_SharedIntervalCollection(
     use: TypeOnly<old.SharedIntervalCollection>);
 use_old_ClassDeclaration_SharedIntervalCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_SharedIntervalCollection());
 
 /*

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -66,6 +66,9 @@
       "ClassDeclaration_SequenceInterval": {
         "backCompat": false
       },
+      "InterfaceDeclaration_ISharedIntervalCollection": {
+        "backCompat": false
+      },
       "InterfaceDeclaration_ISharedString": {
         "backCompat": false
       },
@@ -73,6 +76,9 @@
         "backCompat": false
       },
       "ClassDeclaration_SequenceDeltaEvent": {
+        "backCompat": false
+      },
+      "ClassDeclaration_SharedIntervalCollection": {
         "backCompat": false
       },
       "ClassDeclaration_SequenceMaintenanceEvent": {

--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.ts
@@ -1142,6 +1142,7 @@ declare function get_current_InterfaceDeclaration_ISharedIntervalCollection():
 declare function use_old_InterfaceDeclaration_ISharedIntervalCollection(
     use: TypeOnly<old.ISharedIntervalCollection<any>>);
 use_old_InterfaceDeclaration_ISharedIntervalCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISharedIntervalCollection());
 
 /*
@@ -1771,6 +1772,7 @@ declare function get_current_ClassDeclaration_SharedIntervalCollection():
 declare function use_old_ClassDeclaration_SharedIntervalCollection(
     use: TypeOnly<old.SharedIntervalCollection>);
 use_old_ClassDeclaration_SharedIntervalCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_SharedIntervalCollection());
 
 /*


### PR DESCRIPTION
## Description

These APIs were deprecated in main in previous PRs and are straightforward to migrate off of, but were never removed in next. This remedies that.