### PR TITLE
Change how summary-related service messages are processed.

### DIFF
--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -310,13 +310,12 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
                 // back-compat: ADO #1385: remove cast when ISequencedDocumentMessage changes are propagated
                 if ((op as any).data !== undefined) {
                     op.contents = JSON.parse((op as any).data);
-                    if (op.type === MessageType.SummaryAck) {
-                        return this.handleSummaryAck(op as ISummaryAckMessage);
-                    } else {
-                        return this.handleSummaryNack(op as ISummaryNackMessage);
-                    }
                 }
-                break;
+                if (op.type === MessageType.SummaryAck) {
+                    return this.handleSummaryAck(op as ISummaryAckMessage);
+                } else {
+                    return this.handleSummaryNack(op as ISummaryNackMessage);
+                }
             default: {
                 // If the difference between timestamp of current op and last summary op is greater than
                 // the maxAckWaitTime, then we need to inform summarizer to not wait and summarize

--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -239,9 +239,7 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
         private readonly logger: ITelemetryLogger,
     ) {
         super();
-        this.deltaManager.on(
-            "op",
-            (op) => this.handleOp(op));
+        this.deltaManager.on("op", (op) => this.handleOp(op));
     }
 
     /**
@@ -299,20 +297,26 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
      * Handler for ops; only handles ops relating to summaries.
      * @param op - op message to handle
      */
-    private handleOp(op: ISequencedDocumentMessage) {
+    private handleOp(opArg: ISequencedDocumentMessage) {
+        const op = { ...opArg };
         switch (op.type) {
             case MessageType.Summarize: {
                 this.handleSummaryOp(op as ISummaryOpMessage);
                 return;
             }
-            case MessageType.SummaryAck: {
-                this.handleSummaryAck(op as ISummaryAckMessage);
-                return;
-            }
-            case MessageType.SummaryNack: {
-                this.handleSummaryNack(op as ISummaryNackMessage);
-                return;
-            }
+            case MessageType.SummaryAck:
+            case MessageType.SummaryNack:
+                // Old files (prior to PR #10077) may not contain this info
+                // back-compat: ADO #1385: remove cast when ISequencedDocumentMessage changes are propagated
+                if ((op as any).data !== undefined) {
+                    op.contents = JSON.parse((op as any).data);
+                    if (op.type === MessageType.SummaryAck) {
+                        return this.handleSummaryAck(op as ISummaryAckMessage);
+                    } else {
+                        return this.handleSummaryNack(op as ISummaryNackMessage);
+                    }
+                }
+                break;
             default: {
                 // If the difference between timestamp of current op and last summary op is greater than
                 // the maxAckWaitTime, then we need to inform summarizer to not wait and summarize

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -117,7 +117,7 @@ describe("Runtime", () => {
                     summaryProposal,
                 };
                 mockDeltaManager.emit("op", {
-                    contents,
+                    data: JSON.stringify(contents),
                     type: MessageType.SummaryAck,
                     sequenceNumber: ++lastRefSeq,
                 });
@@ -135,7 +135,7 @@ describe("Runtime", () => {
                     message: "test-nack",
                 };
                 mockDeltaManager.emit("op", {
-                    contents,
+                    data: JSON.stringify(contents),
                     type: MessageType.SummaryNack,
                     sequenceNumber: ++lastRefSeq,
                 });
@@ -757,7 +757,7 @@ describe("Runtime", () => {
                     assert(!ackNackResult.success, "on-demand summary should fail");
                     assert(ackNackResult.data?.summaryNackOp.type === MessageType.SummaryNack,
                         "should be nack");
-                    assert(ackNackResult.data.summaryNackOp.contents.message === "test-nack",
+                    assert(JSON.parse((ackNackResult.data.summaryNackOp as any).data).message === "test-nack",
                         "summary nack error should be test-nack");
                 });
 

--- a/packages/runtime/container-runtime/src/test/summaryCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryCollection.spec.ts
@@ -8,7 +8,7 @@ import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
 import { IDocumentMessage, ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
-import { ISummaryAckMessage, ISummaryNackMessage, ISummaryOpMessage, SummaryCollection } from "../summaryCollection";
+import { ISummaryOpMessage, SummaryCollection } from "../summaryCollection";
 
 const summaryOp: ISummaryOpMessage = {
     clientId: "cliendId",
@@ -27,7 +27,11 @@ const summaryOp: ISummaryOpMessage = {
     },
 };
 
-const summaryAck: ISummaryAckMessage = {
+const summaryAckContents = {
+    handle: "AckHandle",
+    summaryProposal: { summarySequenceNumber: summaryOp.sequenceNumber },
+};
+const summaryAck: ISequencedDocumentMessage & { data: string; } = {
     clientId: "cliendId",
     clientSequenceNumber: summaryOp.clientSequenceNumber + 1,
     minimumSequenceNumber: summaryOp.sequenceNumber,
@@ -36,13 +40,15 @@ const summaryAck: ISummaryAckMessage = {
     term: 0,
     timestamp: summaryOp.timestamp + 1,
     type: MessageType.SummaryAck,
-    contents: {
-        handle: "AckHandle",
-        summaryProposal: { summarySequenceNumber: summaryOp.sequenceNumber },
-    },
+    contents: summaryAckContents,
+    data: JSON.stringify(summaryAckContents),
 };
 
-const summaryNack: ISummaryNackMessage = {
+const summaryNackContents = {
+    message: "Nack",
+    summaryProposal: { summarySequenceNumber: summaryOp.sequenceNumber },
+};
+const summaryNack: ISequencedDocumentMessage & { data: string; } = {
     clientId: "cliendId",
     clientSequenceNumber: summaryOp.clientSequenceNumber + 1,
     minimumSequenceNumber: summaryOp.sequenceNumber,
@@ -51,10 +57,8 @@ const summaryNack: ISummaryNackMessage = {
     term: 0,
     timestamp: summaryOp.timestamp + 1,
     type: MessageType.SummaryNack,
-    contents: {
-        message: "Nack",
-        summaryProposal: { summarySequenceNumber: summaryOp.sequenceNumber },
-    },
+    contents: summaryNackContents,
+    data: JSON.stringify(summaryNackContents),
 };
 
 describe("Summary Collection", () => {


### PR DESCRIPTION
Content property on messages is only for client messages.
All service messages communicate info in the `data` property.
That was not the case for summary ack & nack, and it was fixed in https://github.com/microsoft/FluidFramework/pull/10077
Client must to move to using data property, and once it's done - service can stop sending us json in content property.

I made this change in least invasive way - we can do more clearing later if we want to
