### PR TITLE
fix: Omit "index" file names from links between documents.

### DIFF
--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test.md
@@ -1,6 +1,6 @@
 # simple-suite-test
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test)
 
 Test package
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testabstractclass-class.md
@@ -1,6 +1,6 @@
 # TestAbstractClass
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestAbstractClass](./simple-suite-test/testabstractclass-class)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestAbstractClass](./simple-suite-test/testabstractclass-class)
 
 A test abstract class.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testclass-class.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestClass](./simple-suite-test/testclass-class)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestClass](./simple-suite-test/testclass-class)
 
 Test class
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testemptyinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testemptyinterface-interface.md
@@ -1,6 +1,6 @@
 # TestEmptyInterface
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestEmptyInterface](./simple-suite-test/testemptyinterface-interface)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestEmptyInterface](./simple-suite-test/testemptyinterface-interface)
 
 An empty interface
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterface](./simple-suite-test/testinterface-interface)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterface](./simple-suite-test/testinterface-interface)
 
 Test interface
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfaceextendingotherinterfaces-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfaceextendingotherinterfaces-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceExtendingOtherInterfaces
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterfaceExtendingOtherInterfaces](./simple-suite-test/testinterfaceextendingotherinterfaces-interface)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterfaceExtendingOtherInterfaces](./simple-suite-test/testinterfaceextendingotherinterfaces-interface)
 
 Test interface that extends other interfaces
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithtypeparameter-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithtypeparameter-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithTypeParameter
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterfaceWithTypeParameter](./simple-suite-test/testinterfacewithtypeparameter-interface)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestInterfaceWithTypeParameter](./simple-suite-test/testinterfacewithtypeparameter-interface)
 
 Test interface with generic type parameter
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testmodule-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testmodule-namespace.md
@@ -1,6 +1,6 @@
 # TestModule
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestModule](./simple-suite-test/testmodule-namespace)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestModule](./simple-suite-test/testmodule-namespace)
 
 ## Variables
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace-namespace.md
@@ -1,6 +1,6 @@
 # TestNamespace
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace)
 
 Test Namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testclass-class.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestClass](./simple-suite-test/testnamespace/testclass-class)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestClass](./simple-suite-test/testnamespace/testclass-class)
 
 Test class
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testinterface-interface.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestInterface](./simple-suite-test/testnamespace/testinterface-interface)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestInterface](./simple-suite-test/testnamespace/testinterface-interface)
 
 Test interface
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testsubnamespace-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testnamespace/testsubnamespace-namespace.md
@@ -1,6 +1,6 @@
 # TestSubNamespace
 
-[Packages](./index) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestSubNamespace](./simple-suite-test/testnamespace/testsubnamespace-namespace)
+[Packages](./) &gt; [simple-suite-test](./simple-suite-test) &gt; [TestNamespace](./simple-suite-test/testnamespace-namespace) &gt; [TestSubNamespace](./simple-suite-test/testnamespace/testsubnamespace-namespace)
 
 Test sub-namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/flat-config/simple-suite-test.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/flat-config/simple-suite-test.md
@@ -1,4 +1,4 @@
-[Packages](docs/index) &gt; [simple-suite-test](docs/simple-suite-test)
+[Packages](docs/) &gt; [simple-suite-test](docs/simple-suite-test)
 
 Test package
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/sparse-config/simple-suite-test.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/sparse-config/simple-suite-test.md
@@ -1,6 +1,6 @@
 # simple-suite-test
 
-[Packages](docs/index) &gt; [simple-suite-test](docs/simple-suite-test)
+[Packages](docs/) &gt; [simple-suite-test](docs/simple-suite-test)
 
 Test package
 

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -174,7 +174,14 @@ export function getLinkUrlForApiItem(
     config: Required<MarkdownDocumenterConfiguration>,
 ): string {
     const uriBase = config.uriBaseOverridePolicy(apiItem) ?? config.uriRoot;
-    const documentPath = getFilePathForApiItem(apiItem, config, /* includeExtension: */ false);
+    let documentPath = getFilePathForApiItem(apiItem, config, /* includeExtension: */ false);
+
+    // Omit "index" file name from path generated in links.
+    // This can be considered an optimization in most cases, but some documentation systems also special-case
+    // "index" files, so this can also prevent issues in some cases.
+    if (documentPath === "index" || documentPath.endsWith("/index")) {
+        documentPath = documentPath.slice(0, documentPath.length - "index".length);
+    }
 
     // Don't bother with heading ID if we are linking to the root item of a document
     let headingPostfix = "";


### PR DESCRIPTION
See the source-code comment for more details, but this is required to work around Hugo's "_index.md" file pattern oddities (Hugo's build transforms these file names, so the resulting HTML file names do not match the Markdown filenames we provide.

Fortunately, this is also a change I wanted to make to clean up generated links anyways, this Hugo requirement just made the change more urgent.