### PR TITLE
Read data store base summary during creation and update summarizer node.

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -307,11 +307,10 @@ export interface ISummarizerNode {
     // (undocumented)
     getChild(id: string): ISummarizerNode | undefined;
     invalidate(sequenceNumber: number): void;
-    loadBaseSummary(snapshot: ISnapshotTree, readAndParseBlob: <T>(id: string) => Promise<T>): Promise<ISnapshotTree>;
-    loadBaseSummaryWithoutDifferential(snapshot: ISnapshotTree): void;
     recordChange(op: ISequencedDocumentMessage): void;
     readonly referenceSequenceNumber: number;
     summarize(fullTree: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
+    updateBaseSummaryState(snapshot: ISnapshotTree): void;
 }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1035,7 +1035,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         );
 
         if (baseSnapshot) {
-            this.summarizerNode.loadBaseSummaryWithoutDifferential(baseSnapshot);
+            this.summarizerNode.updateBaseSummaryState(baseSnapshot);
         }
 
         this.dataStores = new DataStores(

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -79,8 +79,13 @@
         "backCompat": false,
         "forwardCompat": false
       },
+      "InterfaceDeclaration_ISummarizerNode": {
+        "backCompat": false,
+        "forwardCompat": false
+      },
       "InterfaceDeclaration_ISummarizerNodeWithGC": {
-        "backCompat": false
+        "backCompat": false,
+        "forwardCompat": false
       }
     }
   }

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -165,20 +165,7 @@ export interface ISummarizerNode {
      * path is "/a/.channels/b", then the additional path part is ".channels".
      * @param snapshot - the base summary to parse
      */
-    loadBaseSummaryWithoutDifferential(snapshot: ISnapshotTree): void;
-    /**
-     * Does all the work of loadBaseSummaryWithoutDifferential. Additionally if
-     * the base summary is a differential summary containing handle + outstanding ops blob,
-     * then this will return the innermost base summary, and update the state by
-     * tracking the outstanding ops.
-     * @param snapshot - the base summary to parse
-     * @param readAndParseBlob - function to read and parse blobs from storage
-     * @returns the base summary to be used
-     */
-    loadBaseSummary(
-        snapshot: ISnapshotTree,
-        readAndParseBlob: <T>(id: string) => Promise<T>,
-    ): Promise<ISnapshotTree>;
+    updateBaseSummaryState(snapshot: ISnapshotTree): void;
     /**
      * Records an op representing a change to this node/subtree.
      * @param op - op of change to record

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.ts
@@ -835,6 +835,7 @@ declare function get_old_InterfaceDeclaration_ISummarizerNode():
 declare function use_current_InterfaceDeclaration_ISummarizerNode(
     use: TypeOnly<current.ISummarizerNode>);
 use_current_InterfaceDeclaration_ISummarizerNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISummarizerNode());
 
 /*
@@ -847,6 +848,7 @@ declare function get_current_InterfaceDeclaration_ISummarizerNode():
 declare function use_old_InterfaceDeclaration_ISummarizerNode(
     use: TypeOnly<old.ISummarizerNode>);
 use_old_InterfaceDeclaration_ISummarizerNode(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummarizerNode());
 
 /*
@@ -907,6 +909,7 @@ declare function get_old_InterfaceDeclaration_ISummarizerNodeWithGC():
 declare function use_current_InterfaceDeclaration_ISummarizerNodeWithGC(
     use: TypeOnly<current.ISummarizerNodeWithGC>);
 use_current_InterfaceDeclaration_ISummarizerNodeWithGC(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISummarizerNodeWithGC());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -97,8 +97,13 @@
   "typeValidation": {
     "version": "2.0.0",
     "broken": {
+      "InterfaceDeclaration_IRootSummarizerNode": {
+        "backCompat": false,
+        "forwardCompat": false
+      },
       "InterfaceDeclaration_IRootSummarizerNodeWithGC": {
-        "backCompat": false
+        "backCompat": false,
+        "forwardCompat": false
       }
     }
   }

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -353,30 +353,13 @@ export class SummarizerNode implements IRootSummarizerNode {
         }
     }
 
-    public loadBaseSummaryWithoutDifferential(snapshot: ISnapshotTree) {
+    public updateBaseSummaryState(snapshot: ISnapshotTree) {
         // Check base summary to see if it has any additional path parts
         // separating child SummarizerNodes. Checks for .channels subtrees.
         const { childrenPathPart } = parseSummaryForSubtrees(snapshot);
         if (childrenPathPart !== undefined && this._latestSummary !== undefined) {
             this._latestSummary.additionalPath = EscapedPath.create(childrenPathPart);
         }
-    }
-
-    public async loadBaseSummary(
-        snapshot: ISnapshotTree,
-        readAndParseBlob: ReadAndParseBlob,
-    ): Promise<ISnapshotTree> {
-        const pathParts: string[] = [];
-        const { childrenPathPart } = parseSummaryForSubtrees(snapshot);
-        if (childrenPathPart !== undefined) {
-            pathParts.push(childrenPathPart);
-        }
-
-        if (pathParts.length > 0 && this._latestSummary !== undefined) {
-            this._latestSummary.additionalPath = EscapedPath.createAndConcat(pathParts);
-        }
-
-        return snapshot;
     }
 
     public recordChange(op: ISequencedDocumentMessage): void {

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -175,31 +175,9 @@ describe("Runtime", () => {
             });
 
             describe("Load Base Summary", () => {
-                it("Load base summary without differential should do nothing for simple snapshot", async () => {
-                    createRoot({ refSeq: 1 });
-                    rootNode.loadBaseSummaryWithoutDifferential(simpleSnapshot);
-
-                    const latestSummary = (rootNode as SummarizerNode).latestSummary;
-                    assert(latestSummary !== undefined, "latest summary should exist");
-                    assert.strictEqual(latestSummary.additionalPath?.path, undefined,
-                        "should not have any path parts for children");
-                });
-
-                it("Load base summary without differential should strip channels subtree", async () => {
-                    createRoot({ refSeq: 1 });
-                    rootNode.loadBaseSummaryWithoutDifferential(channelsSnapshot);
-
-                    const latestSummary = (rootNode as SummarizerNode).latestSummary;
-                    assert(latestSummary !== undefined, "latest summary should exist");
-                    assert.strictEqual(latestSummary.additionalPath?.path, channelsTreeName,
-                        "should have channels path for children");
-                });
-
                 it("Load base summary should do nothing for simple snapshot", async () => {
                     createRoot({ refSeq: 1 });
-                    const baseSummary = await rootNode.loadBaseSummary(simpleSnapshot, readAndParseBlob);
-                    assert.strictEqual(Object.keys(baseSummary.trees).length, 2, "only 2 subtrees");
-                    assert(baseSummary.trees[ids[1]] !== undefined, "mid subtree");
+                    rootNode.updateBaseSummaryState(simpleSnapshot);
 
                     const latestSummary = (rootNode as SummarizerNode).latestSummary;
                     assert(latestSummary !== undefined, "latest summary should exist");
@@ -209,9 +187,7 @@ describe("Runtime", () => {
 
                 it("Load base summary should strip channels subtree", async () => {
                     createRoot({ refSeq: 1 });
-                    const baseSummary = await rootNode.loadBaseSummary(channelsSnapshot, readAndParseBlob);
-                    assert.strictEqual(Object.keys(baseSummary.trees).length, 2, "only 2 subtrees");
-                    assert(baseSummary.trees[channelsTreeName] !== undefined, "channels subtree");
+                    rootNode.updateBaseSummaryState(channelsSnapshot);
 
                     const latestSummary = (rootNode as SummarizerNode).latestSummary;
                     assert(latestSummary !== undefined, "latest summary should exist");

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.ts
@@ -455,6 +455,7 @@ declare function get_old_InterfaceDeclaration_IRootSummarizerNode():
 declare function use_current_InterfaceDeclaration_IRootSummarizerNode(
     use: TypeOnly<current.IRootSummarizerNode>);
 use_current_InterfaceDeclaration_IRootSummarizerNode(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRootSummarizerNode());
 
 /*
@@ -467,6 +468,7 @@ declare function get_current_InterfaceDeclaration_IRootSummarizerNode():
 declare function use_old_InterfaceDeclaration_IRootSummarizerNode(
     use: TypeOnly<old.IRootSummarizerNode>);
 use_old_InterfaceDeclaration_IRootSummarizerNode(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IRootSummarizerNode());
 
 /*
@@ -479,6 +481,7 @@ declare function get_old_InterfaceDeclaration_IRootSummarizerNodeWithGC():
 declare function use_current_InterfaceDeclaration_IRootSummarizerNodeWithGC(
     use: TypeOnly<current.IRootSummarizerNodeWithGC>);
 use_current_InterfaceDeclaration_IRootSummarizerNodeWithGC(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRootSummarizerNodeWithGC());
 
 /*


### PR DESCRIPTION
## Description
This change does couple of things:
1. Removes the compat code in remote data store context that reads and converts base summary in "string" format. All the call sites (in dataStores.ts) pass in ISnapshotTree or undefined so its not possible for this to a string anymore.
2. When a data store is created, it updates the summarizer node with its base summary. Here's why this is needed:

When a data store is realized, it reads the base summary it loaded from and updates state from it in the summarizer node. For instance, it reads whether the base summary has DDSes under ".channels" sub-tree and updates this state which is later used when generating a SummaryHandle for this data store.

If application code as part of data store realization, it's possible that data stores are realized out-of-order. What this means is that a data store can be realized after it has been summarized. Consider the following scenario and how this affects the state of the data store (and eventually its children):
- A container with 2 data stores is loaded from a summary. A new summary process starts.
- Data store 1 is summarized. It does not have any changes so it is not realized as part of the summary process. It's ".channels" state is not updated, i.e., it does not know whether in the previous summary, its childern are under ".channels" sub-tree or not. This non-updated state is cached as the work-in-progress state for this summary.
- Data store 2 is summarized and as part of running the application code, it loads data store 1 resulting in its realization. Data store 1's children nodes are created.
- The summary is uploaded to the server and "completeSummary" is called with the summaryHandle. Data store 1's work-in-progress state is stored in a pending queue as pending summary state. It updates the pending state of its children state with its pending state which was not updated with the ".channels" information.
- Summary ack is received and pending summary state becomes latest summary state for data store 1 and its children nodes.
- In the next summary, if any child nodes of data store 1 did not change, they end up sending SummaryHandle with incorrect ".channels" information encoded resulting in the summary being rejected.

The scenario described above is repro'd in the tests added by this PR which fixes this bug as well - https://github.com/microsoft/FluidFramework/pull/11697. Although the bug was fixed, this has the potential to cause other issues because the data store's base summary state is not updated when it its summarized.
A data store's base summary should always be read and its summarizer node's state be updated from it.

## Does this introduce a breaking change?
Althought this changes APIs in the summarizer node, it is confined to the container runtime package. Only container runtime and data store context calls the API that is changed so there are no back-compat concerns here.

[AB#1817](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1817)