### PR TITLE
Disable pipeline runs for PRs for *Performance benchmarks* pipeline

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -23,6 +23,7 @@ trigger:
     - tools/telemetry-generator
     - tools/pipelines/test-perf-benchmarks.yml
     - tools/pipelines/templates/include-set-package-version.yml
+pr: none
 
 parameters:
 - name: taskBuild


### PR DESCRIPTION
## Description

Disables runs of the `Performance benchmarks` pipeline for PRs. Not sure why I haven't seen it triggering for PRs to `main`, but @dannimad pointed out to me that it ran in a PR to `next`. Missed that disabling for PRs needed to be done explicitly, it's not the default.