### PR TITLE
Shift responsibility to stringify message content from Loader to runtime layer

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -28,6 +28,7 @@ import { ISequencedProposal } from '@fluidframework/protocol-definitions';
 import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
+import { ISummaryContent } from '@fluidframework/protocol-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryProperties } from '@fluidframework/common-definitions';
@@ -179,9 +180,11 @@ export interface IContainerContext extends IDisposable {
     // (undocumented)
     readonly storage: IDocumentStorageService;
     // (undocumented)
-    readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
+    readonly submitFn: (type: MessageType, contents: string, batch: boolean, appData?: any) => number;
     // (undocumented)
     readonly submitSignalFn: (contents: any) => void;
+    // (undocumented)
+    readonly submitSummaryFn: (summaryOp: ISummaryContent) => number;
     // (undocumented)
     readonly taggedLogger: ITelemetryBaseLogger;
     // (undocumented)

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -80,6 +80,9 @@
       "RemovedEnumDeclaration_BindState": {
         "forwardCompat": false,
         "backCompat": false
+      },
+      "InterfaceDeclaration_IContainerContext": {
+        "forwardCompat": false
       }
     }
   }

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -20,6 +20,7 @@ import {
     IVersion,
     IDocumentMessage,
     IQuorumClients,
+    ISummaryContent,
 } from "@fluidframework/protocol-definitions";
 import { IAudience } from "./audience";
 import { IDeltaManager } from "./deltas";
@@ -119,7 +120,8 @@ export interface IContainerContext extends IDisposable {
     readonly storage: IDocumentStorageService;
     readonly connected: boolean;
     readonly baseSnapshot: ISnapshotTree | undefined;
-    readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
+    readonly submitFn: (type: MessageType, contents: string, batch: boolean, appData?: any) => number;
+    readonly submitSummaryFn: (summaryOp: ISummaryContent) => number;
     readonly submitSignalFn: (contents: any) => void;
     readonly closeFn: (error?: ICriticalContainerError) => void;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -372,6 +372,7 @@ declare function get_old_InterfaceDeclaration_IContainerContext():
 declare function use_current_InterfaceDeclaration_IContainerContext(
     use: TypeOnly<current.IContainerContext>);
 use_current_InterfaceDeclaration_IContainerContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerContext());
 
 /*

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -42,6 +42,7 @@ import {
     ISummaryTree,
     IVersion,
     MessageType,
+    ISummaryContent,
 } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { Container } from "./container";
@@ -58,7 +59,8 @@ export class ContainerContext implements IContainerContext {
         deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         quorum: IQuorum,
         loader: ILoader,
-        submitFn: (type: MessageType, contents: any, batch: boolean, appData: any) => number,
+        submitFn: (type: MessageType, contents: string, batch: boolean, appData: any) => number,
+        submitSummaryFn: (summaryOp: ISummaryContent) => number,
         submitSignalFn: (contents: any) => void,
         closeFn: (error?: ICriticalContainerError) => void,
         version: string,
@@ -76,6 +78,7 @@ export class ContainerContext implements IContainerContext {
             quorum,
             loader,
             submitFn,
+            submitSummaryFn,
             submitSignalFn,
             closeFn,
             version,
@@ -166,6 +169,7 @@ export class ContainerContext implements IContainerContext {
         quorum: IQuorum,
         public readonly loader: ILoader,
         public readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData: any) => number,
+        public readonly submitSummaryFn: (summaryOp: ISummaryContent) => number,
         public readonly submitSignalFn: (contents: any) => void,
         public readonly closeFn: (error?: ICriticalContainerError) => void,
         public readonly version: string,

--- a/packages/loader/container-loader/src/test/containerContext.spec.ts
+++ b/packages/loader/container-loader/src/test/containerContext.spec.ts
@@ -73,6 +73,7 @@ describe("ContainerContext Tests", () => {
             Sinon.fake(),
             Sinon.fake(),
             Sinon.fake(),
+            Sinon.fake(),
             Container.version,
             Sinon.fake(),
             existing,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2413,7 +2413,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             let clientSequenceNumber: number;
             try {
-                clientSequenceNumber = this.submitSystemMessage(MessageType.Summarize, summaryMessage);
+                clientSequenceNumber = this.submitSummaryMessage(summaryMessage);
             } catch (error) {
                 return { stage: "upload", ...uploadData, error };
             }
@@ -2575,40 +2575,44 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    private submitSystemMessage(
-        type: MessageType,
-        contents: any) {
+    private submitMessageCore(type: MessageType, contents: any, batch: boolean, metaData?: any) {
         this.verifyNotClosed();
         assert(this.connected, 0x133 /* "Container disconnected when trying to submit system message" */);
 
-        // System message should not be sent in the middle of the batch.
-        // That said, we can preserve existing behavior by not flushing existing buffer.
-        // That might be not what caller hopes to get, but we can look deeper if telemetry tells us it's a problem.
-        const middleOfBatch = this.flushMode === FlushMode.TurnBased && this.needsFlush;
-        if (middleOfBatch) {
-            this.mc.logger.sendErrorEvent({ eventName: "submitSystemMessageError", type });
-        }
-
         return this.context.submitFn(
             type,
-            contents,
-            middleOfBatch);
+            // back-compat: ADO #1385: remove this check in future and make unconditional
+            this.context.submitSummaryFn === undefined ? contents : JSON.stringify(contents),
+            batch,
+            metaData);
+    }
+
+    private submitSummaryMessage(contents: ISummaryContent) {
+        // System message should not be sent in the middle of the batch.
+        assert(this.flushMode !== FlushMode.TurnBased || !this.needsFlush, "System op in the middle of a batch");
+        // back-compat: ADO #1385: Make this call unconditional in the future
+        if (this.context.submitSummaryFn !== undefined) {
+            return this.context.submitSummaryFn(contents);
+        } else {
+            return this.submitMessageCore(
+                MessageType.Summarize,
+                contents,
+                false); // batch
+            }
     }
 
     private submitRuntimeMessage(
         type: ContainerMessageType,
         contents: any,
         batch: boolean,
-        appData?: any,
+        metaData?: any,
     ) {
-        this.verifyNotClosed();
-        assert(this.connected, 0x259 /* "Container disconnected when trying to submit system message" */);
         const payload: ContainerRuntimeMessage = { type, contents };
-        return this.context.submitFn(
+        return this.submitMessageCore(
             MessageType.Operation,
             payload,
             batch,
-            appData);
+            metaData);
     }
 
     /**


### PR DESCRIPTION
This (in future) will help us avoid double strigification for scenarios like chunked ops, compressed ops.
