### PR TITLE
Fix a couple of issues introduced in recent website build changes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -307,13 +307,13 @@ This shortcode can be found in `layouts/shortcodes/apiref.html`.
 `Markdown` like the following:
 
 ```markdown
-The {{< apiref FluidContainer >}} class can be used to...
+The {{< apiref "FluidContainer" "class" >}} class can be used to...
 ```
 
 will generate something like:
 
 ```markdown
-The <a href="{{ relref /docs/apis/fluid-static/fluidcontainer.md }}"><code>FluidContainer</code></a> class can be used to...
+The <a href="{{ relref /docs/apis/fluid-static/fluidcontainer-class.md }}"><code>FluidContainer</code></a> class can be used to...
 ```
 
 ## Working on the template

--- a/docs/layouts/shortcodes/apiref.html
+++ b/docs/layouts/shortcodes/apiref.html
@@ -6,8 +6,8 @@
 {{/* - (optional) unscopedPackageName: The *unscoped* name of the package to which the API member belongs. */}}
 {{/*   default value: "fluid-framework" */}}
 
-{{- $name := default "index" (.Get 0) -}}
-{{- $kind := default "index" (.Get 1) -}}
+{{- $name := .Get 0 -}}
+{{- $kind := .Get 1 -}}
 {{- $unscopedPackageName := default "fluid-framework" (.Get 2) -}}
 
 {{- $fileNameWithoutExtension := lower (delimit (slice $name $kind) "-") -}}

--- a/docs/markdown-emitter.js
+++ b/docs/markdown-emitter.js
@@ -83,7 +83,7 @@ class HugoMarkdownEmitter extends MarkdownEmitter {
         writer.ensureNewLine();
 
         const title = docNoteBox.title ?? "";
-        const type = docNoteBox.title.toLowerCase() === "deprecated" ? "warning" : tip;
+        const type = title.toLowerCase() === "deprecated" ? "warning" : "tip";
 
         writer.writeLine(`{{% callout ${type} ${title} %}}`);
 

--- a/docs/markdown-emitter.js
+++ b/docs/markdown-emitter.js
@@ -83,7 +83,7 @@ class HugoMarkdownEmitter extends MarkdownEmitter {
         writer.ensureNewLine();
 
         const title = docNoteBox.title ?? "";
-        const type = title.toLowerCase() === "deprecated" ? "warning" : "tip";
+        const type = title.toLowerCase() === "deprecated" ? "warning" : "note";
 
         writer.writeLine(`{{% callout ${type} ${title} %}}`);
 

--- a/docs/markdown-emitter.js
+++ b/docs/markdown-emitter.js
@@ -82,7 +82,10 @@ class HugoMarkdownEmitter extends MarkdownEmitter {
 
         writer.ensureNewLine();
 
-        writer.writeLine(`{{% callout ${docNoteBox.type} ${docNoteBox.title ? docNoteBox.title : ""} %}}`);
+        const title = docNoteBox.title ?? "";
+        const type = docNoteBox.title.toLowerCase() === "deprecated" ? "warning" : tip;
+
+        writer.writeLine(`{{% callout ${type} ${title} %}}`);
 
         this.writeNode(docNoteBox.content, context, false);
         writer.ensureNewLine();


### PR DESCRIPTION
Fixes:
 - apiref was incorrectly providing default values that didn't make sense (also updated the example usage in the README)
 - markdown-emitter.js was incorrectly assuming `DocNoteBox` was providing a "type" parameter.