### PR TITLE
Bugfix for applyChangeSet. String changes maintain value and oldValue

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
@@ -317,16 +317,14 @@ export class ChangeSet {
                 }
                 baseIsSetChange = true;
             }
-            let appliedChanges = in_appliedPropertyChanges[in_changedKey];
-            if (isObject(appliedChanges) && appliedChanges.hasOwnProperty("value")) {
-                appliedChanges = (appliedChanges as SerializedChangeSet).value;
-            }
+            const appliedChanges = in_appliedPropertyChanges[in_changedKey];
+            const appliedChangesValue = appliedChanges?.value ?? appliedChanges;
 
-            if (splitTypeid.typeid === "String" && isString(appliedChanges)) {
+            if (splitTypeid.typeid === "String" && isString(appliedChangesValue)) {
                 // we've got a 'set' command and just overwrite the changes
                 if (baseIsSetChange && oldValue !== undefined) {
                     in_baseChanges[in_changedKey] = {
-                        value: appliedChanges,
+                        value: appliedChangesValue,
                         oldValue,
                     };
                 } else {

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/squashReversible.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/squashReversible.spec.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @fileoverview In this file, we will test the squashing of two
+ *    reversible changesets.
+ */
+ import { expect } from 'chai';
+import { ChangeSet, SerializedChangeSet } from "../changeset";
+
+describe("Squash Reversible ChangeSets", function() {
+    it("Squashing artificial reversible changesets ", () => {
+        const cs1s: SerializedChangeSet = {
+            String: {
+                x: {
+                    oldValue: "a",
+                    value: "b",
+                },
+            },
+        };
+        const cs2s: SerializedChangeSet = {
+            String: {
+                y: {
+                    oldValue: "c",
+                    value: "d",
+                },
+            },
+        };
+        const ch1: ChangeSet = new ChangeSet(cs1s);
+        const ch2: ChangeSet = new ChangeSet(cs2s);
+        ch1.applyChangeSet(ch2);
+        expect(ch1._changes.String.y.oldValue).equal("c");
+    });
+});


### PR DESCRIPTION
This is the followup for #10766. The reversible ChangeSets are fabricated without modifier (insert, modify, delete). I am not sure whether such ChangeSet is legal. The code was copied from  #10766 (implemented by @pswillcock)  and the unit test was added.  @pswillcock, please, bring us some light how this fix works (was isObject(appliedChanges) && appliedChanges.hasOwnProperty("value") line incorrect?)
@dstanesc @ruiterr @nedalhy please, check, whether this was really a bug and whether this PR should be merged.