### PR TITLE
FF.com: Expanding Nav dropdown, text is getting overlapped

### DIFF
--- a/docs/themes/thxvscode/layouts/partials/apiNav.html
+++ b/docs/themes/thxvscode/layouts/partials/apiNav.html
@@ -53,7 +53,7 @@
                     {{- range ((where $current.Site.RegularPages "Params.area" "==" $menuArea).ByParam "menuPosition") }}
                     {{ $isCurrentPage := eq .RelPermalink $current.RelPermalink }}
 
-                    <li {{ if $isCurrentPage }}class="active" {{ end }}>
+                    <li {{ if $isCurrentPage }}class="active" {{ end }} style="padding-top:5px;">
                         <a href="{{ .RelPermalink }}"
                             {{ if $isCurrentPage }}aria-label="Current Page: {{ (default .Name .Title) | safeHTML }} " {{ end }}>
                             {{ .Title }} </a>

--- a/docs/themes/thxvscode/layouts/partials/docNav.html
+++ b/docs/themes/thxvscode/layouts/partials/docNav.html
@@ -37,7 +37,7 @@
                 <!-- list all pages in area -->
                 {{- range ((where $current.Site.RegularPages "Params.area" "==" $menuArea).ByParam "menuPosition") }}
                 {{ $isCurrentPage := eq .RelPermalink $current.RelPermalink }}
-                <li {{ if $isCurrentPage }}class="active" {{ end }}>
+                <li {{ if $isCurrentPage }}class="active" {{ end }} style="padding-top:5px;">
                     <a href="{{ .RelPermalink }}" {{ if $isCurrentPage }}aria-label="Current Page: {{ (default .Name .Title) | safeHTML }} " {{ end }}>
                         {{ .Title }} </a>
                 </li>


### PR DESCRIPTION
## Description

> To reproduce this bug, decrease your resolution such that when you click on a drop down link the sub links overlap but not too low that the navbar moves to the top
> Adding padding to the links seem to solve this issue

## Any relevant logs or outputs
![MicrosoftTeams-image](https://user-images.githubusercontent.com/107130183/188661580-e79e6569-9f3e-4a12-b091-bc43d3cae1b1.png)

## Other information or known dependencies

> [AB#1444](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1444)
