### PR TITLE
Change class referenced in docs

### DIFF
--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -308,7 +308,7 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
  * and retrieving values that JavaScript developers are accustomed to with the
  * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map | Map} built-in object.
  * However, the keys of a SharedMap must be strings, and the values must either be a JSON-serializable object or a
- * {@link @fluidframework/shared-object-base#SharedObjectHandle}.
+ * {@link @fluidframework/datastore#FluidObjectHandle}.
  *
  * For more information, including example usages, see {@link https://fluidframework.com/docs/data-structures/map/}.
  */


### PR DESCRIPTION
## Description

`SharedObjectHandle` is not exported from `@fluidframework/shared-object-base` so it seems weird to have another package say "I expect one of these (among other possible things)".

## Reviewer Guidance

I'd like feedback on the best thing to point at in the docs instead of `SharedObjectHandle`, the two seemingly natural options are the parent class `@fluidframework/datastore#FluidObjectHandle`, or the interface that the parent class inherits from, `@fluidframework/core-interfaces#IFluidHandle`. I don't recall what the current consensus is on "are handles something we expect consumers to implement or not", which would inform if it's better to point to the interface (if custom handle implementations are expected) or the concrete class (if not).
