### PR TITLE
Allow `Promise<T>` in `FluidObjectHandle`

### DIFF
--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -124,7 +124,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
 
 // @public (undocumented)
 export class FluidObjectHandle<T extends FluidObject = FluidObject> implements IFluidHandle {
-    constructor(value: T, path: string, routeContext: IFluidHandleContext);
+    constructor(value: T | Promise<T>, path: string, routeContext: IFluidHandleContext);
     // (undocumented)
     readonly absolutePath: string;
     // (undocumented)
@@ -142,7 +142,7 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
     // (undocumented)
     readonly routeContext: IFluidHandleContext;
     // (undocumented)
-    protected readonly value: T;
+    protected readonly value: T | Promise<T>;
 }
 
 // @public (undocumented)

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -32,7 +32,7 @@ export class SharedObjectHandle extends FluidObjectHandle<ISharedObject> {
      * @param routeContext - The parent IFluidHandleContext that has a route to this handle.
      */
     constructor(
-        value: ISharedObject,
+        protected readonly value: ISharedObject,
         path: string,
         routeContext: IFluidHandleContext,
     ) {

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -47,7 +47,7 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
      * @param routeContext - The parent IFluidHandleContext that has a route to this handle.
      */
     constructor(
-        protected readonly value: T,
+        protected readonly value: T | Promise<T>,
         public readonly path: string,
         public readonly routeContext: IFluidHandleContext,
     ) {
@@ -55,6 +55,7 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
     }
 
     public async get(): Promise<any> {
+        // Note that this return works whether we received a T or a Promise<T> for this.value in the constructor.
         return this.value;
     }
 


### PR DESCRIPTION
## Description

- Allow `Promise<T>` for the `value` parameter of `FluidObjectHandle`'s constructor, in addition to the current `T`.
- Make the visibility + mutability of the corresponding parameter in the `SharedObjectHandle` subclass match the one in the parent class.

The first bullet point only makes the constructor more permissive, and the class in the second bullet point is not exported out of its package so it's not part of any public API surface, thus neither change should be breaking === both should be safe to do in `main`.

This capability is just preparation for a bigger change that builds on it, based on [previous proof-of-concept work](https://github.com/microsoft/FluidFramework/pull/9048/files) by @anthony-murphy , related to having fluid handles be a first-class-citizen way of interacting with data stores and other internal pieces of the framework, and eventually making the request pattern an application-level concern, instead of the only way to interact with some things inside the framework.