### PR TITLE
Track reference Sequence number for batched messages

### DIFF
--- a/packages/runtime/container-runtime/src/batchManager.ts
+++ b/packages/runtime/container-runtime/src/batchManager.ts
@@ -9,7 +9,11 @@ import { ContainerRuntimeMessage } from "./containerRuntime";
 /**
  * Message type used by BatchManager
  */
-export type BatchMessage = IBatchMessage & { localOpMetadata: unknown; deserializedContent: ContainerRuntimeMessage; };
+export type BatchMessage = IBatchMessage & {
+    localOpMetadata: unknown;
+    deserializedContent: ContainerRuntimeMessage;
+    referenceSequenceNumber: number;
+};
 
 /**
  * Helper class that manages partial batch & rollback.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1772,7 +1772,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             // Sending ops while processing ops is not good idea - it's not defined when
             // referenceSequenceNumber changes in op processing sequence (at the beginning or end of op processing),
             // If we send ops in response to processing multiple ops, then we for sure hit this assert!
-            // This issue should be looked into!
+            // Tracked via ADO #1834
             // assert(batch[0].referenceSequenceNumber === batch[length - 1].referenceSequenceNumber,
             //    "Batch should be generated synchronously, without processing ops in the middle!");
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1765,9 +1765,18 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         if (length > 1) {
             batch[0].metadata = { ...batch[0].metadata, batch: true };
             batch[length - 1].metadata = { ...batch[length - 1].metadata, batch: false };
+
+            // This assert fires for the following reason (there might be more cases like that):
+            // AgentScheduler will send ops in response to ConsensusRegisterCollection's "atomicChanged" event handler,
+            // i.e. in the middle of op processing!
+            // Sending ops while processing ops is not good idea - it's not defined when
+            // referenceSequenceNumber changes in op processing sequence (at the beginning or end of op processing),
+            // If we send ops in response to processing multiple ops, then we for sure hit this assert!
+            // This issue should be looked into!
+            // assert(batch[0].referenceSequenceNumber === batch[length - 1].referenceSequenceNumber,
+            //    "Batch should be generated synchronously, without processing ops in the middle!");
         }
 
-        const refSeqNumber = this.deltaManager.lastSequenceNumber;
         let clientSequenceNumber: number = -1;
 
         // Did we disconnect in the middle of turn-based batch?
@@ -1805,7 +1814,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.pendingStateManager.onSubmitMessage(
                 message.deserializedContent.type,
                 clientSequenceNumber,
-                refSeqNumber,
+                message.referenceSequenceNumber,
                 message.deserializedContent.contents,
                 message.localOpMetadata,
                 message.metadata,
@@ -2599,10 +2608,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             deserializedContent,
             metadata,
             localOpMetadata,
+            referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
         });
         if (this._flushMode !== FlushMode.TurnBased) {
             this.flush();
         } else if (!this.flushTrigger) {
+            this.flushTrigger = true;
             // Use Promise.resolve().then() to queue a microtask to detect the end of the turn and force a flush.
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             Promise.resolve().then(() => {


### PR DESCRIPTION
Addressing https://dev.azure.com/fluidframework/internal/_queries/edit/1848/?triage=true (sort of)
Updated https://dev.azure.com/fluidframework/internal/_queries/edit/1834 as serious follow is required IMHO.
Thanks @agarwal-navin for pointing out, my original assumption was wrong, and assert (that is commented here) points to serious issues in how we process ops.
