### PR TITLE
Assert serializeGCData is never called with local changes

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -298,6 +298,10 @@ export class Client {
         this.mergeTree.walkAllSegments(
             this.mergeTree.root,
             (seg) => {
+                assert(
+                    seg.seq !== UnassignedSequenceNumber && seg.removedSeq !== UnassignedSequenceNumber,
+                    "serializeGCData should never be invoked with local changes"
+                );
                 // Only serialize segments that have not been removed.
                 if (seg.removedSeq === undefined) {
                     handleCollectingSerializer.stringify(

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -300,7 +300,7 @@ export class Client {
             (seg) => {
                 assert(
                     seg.seq !== UnassignedSequenceNumber && seg.removedSeq !== UnassignedSequenceNumber,
-                    "serializeGCData should never be invoked with local changes"
+                    "serializeGCData should never be invoked with local changes",
                 );
                 // Only serialize segments that have not been removed.
                 if (seg.removedSeq === undefined) {


### PR DESCRIPTION
This adds an error event for misusage of `serializeGCData`, since the implementation has the potential to cause incorrect GC behavior if it's invoked with local changes (it has no special-casing for UnassignedSequenceNumber). Future changes to summarization process should make this convertible to an assert, but for now we'll use the event to attempt to root-cause GC bugs.