### PR TITLE
Add cursor benchmarks

### DIFF
--- a/packages/dds/tree/src/forest/cursor.ts
+++ b/packages/dds/tree/src/forest/cursor.ts
@@ -90,3 +90,22 @@ export function mapCursorField<T>(cursor: ITreeCursor, key: FieldKey, f: (cursor
     cursor.up();
     return output;
 }
+
+export function reduceField<T>(
+    cursor: ITreeCursor, key: FieldKey, initial: T, f: (cursor: ITreeCursor, initial: T) => T): T {
+    let output: T = initial;
+    let result = cursor.down(key, 0);
+    if (result !== TreeNavigationResult.Ok) {
+        assert(result === TreeNavigationResult.NotFound, "pending not supported in reduceField");
+        // This has to be special cased (and not fall through the code below)
+        // since the call to `up` needs to be skipped.
+        return output;
+    }
+    while (result === TreeNavigationResult.Ok) {
+        output = (f(cursor, output));
+        result = cursor.seek(1);
+    }
+    assert(result === TreeNavigationResult.NotFound, "expected enumeration to end at end of field");
+    cursor.up();
+    return output;
+}

--- a/packages/dds/tree/src/forest/index.ts
+++ b/packages/dds/tree/src/forest/index.ts
@@ -8,6 +8,7 @@ export {
     TreeNavigationResult,
     mapCursorField,
     SynchronousNavigationResult,
+    reduceField,
 } from "./cursor";
 export * from "./forest";
 export {

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITreeCursor, mapCursorField, TreeNavigationResult } from "../../../forest";
+import { ITreeCursor, mapCursorField, reduceField } from "../../../forest";
 
 export function sum(cursor: ITreeCursor): number {
     let total = 0;
@@ -11,26 +11,8 @@ export function sum(cursor: ITreeCursor): number {
     if (typeof value === "number") {
         total += value;
     }
-    for (const field of cursor.keys) {
-        for (let i = 0; i < cursor.length(field); i++) {
-            if (cursor.down(field, i) === TreeNavigationResult.Ok) {
-                total += sum(cursor);
-            }
-
-            cursor.up();
-        }
-    }
-    return total;
-}
-
-export function sumMap(cursor: ITreeCursor): number {
-    let total = 0;
-    const value = cursor.value;
-    if (typeof value === "number") {
-        total += value;
-    }
-    for (const field of cursor.keys) {
-        mapCursorField(cursor, field, sumMap);
+    for (const key of cursor.keys) {
+        total += reduceField(cursor, key, total, sum);
     }
     return total;
 }

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -19,21 +19,21 @@ export function sum(cursor: ITreeCursor): number {
     return total;
 }
 
-export function mahattanPerimeter(
+export function averageLocation(
     cursor: ITreeCursor,
     extractCoordinates: (cursor: ITreeCursor, calculate: (x: number, y: number) => void) => number,
-): number {
-    let total = 0;
-    let current: [number, number] | undefined;
+): [number, number] {
+    let count = 0;
+    let xTotal = 0;
+    let yTotal = 0;
 
     const calculate = (x: number, y: number) => {
-        if (current !== undefined) {
-            total += Math.abs(current[0] - x) + Math.abs(current[1] - y);
-        }
-        current = [x, y];
+        count += 1;
+        xTotal += x;
+        yTotal += y;
     };
 
     extractCoordinates(cursor, calculate);
 
-    return total;
+    return [xTotal / count, yTotal / count];
 }

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITreeCursor, mapCursorField, TreeNavigationResult } from "../../../forest";
+
+export function sum(cursor: ITreeCursor): number {
+    let total = 0;
+    const value = cursor.value;
+    if (typeof value === "number") {
+        total += value;
+    }
+    for (const field of cursor.keys) {
+        for (let i = 0; i < cursor.length(field); i++) {
+            if (cursor.down(field, i) === TreeNavigationResult.Ok) {
+                total += sum(cursor);
+            }
+
+            cursor.up();
+        }
+    }
+    return total;
+}
+
+export function sumMap(cursor: ITreeCursor): number {
+    let total = 0;
+    const value = cursor.value;
+    if (typeof value === "number") {
+        total += value;
+    }
+    for (const field of cursor.keys) {
+        mapCursorField(cursor, field, sumMap);
+    }
+    return total;
+}

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { ITreeCursor, mapCursorField, reduceField } from "../../../forest";
+import { fail } from "assert";
+import { assert } from "console";
+import { ITreeCursor, mapCursorField, reduceField, TreeNavigationResult } from "../../../forest";
+import { FieldKey } from "../../../tree";
 
 export function sum(cursor: ITreeCursor): number {
     let total = 0;
@@ -14,5 +17,41 @@ export function sum(cursor: ITreeCursor): number {
     for (const key of cursor.keys) {
         total += reduceField(cursor, key, total, sum);
     }
+    return total;
+}
+
+export function mahattanPerimeter(cursor: ITreeCursor): number {
+    let total = 0;
+    let current: [number, number] | undefined;
+
+    let result = cursor.down(key, 0);
+    if (result !== TreeNavigationResult.Ok) {
+        assert(result === TreeNavigationResult.NotFound, "pending not supported in reduceField");
+        // This has to be special cased (and not fall through the code below)
+        // since the call to `up` needs to be skipped.
+        return output;
+    }
+    while (result === TreeNavigationResult.Ok) {
+        output = (f(cursor, output));
+        result = cursor.seek(1);
+    }
+
+    // Read x and y values
+    if (cursor.down("" as FieldKey, 0) !== TreeNavigationResult.Ok) {
+        fail("no x");
+    }
+    const x = cursor.value;
+    cursor.up();
+    if (cursor.down("" as FieldKey, 1) !== TreeNavigationResult.Ok) {
+        fail("no y");
+    }
+    const y = cursor.value;
+    cursor.up();
+
+    if (current !== undefined) {
+        total += Math.abs(current[0] - x) + Math.abs(current[1] - y);
+    }
+    current = [x, y];
+
     return total;
 }

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -21,18 +21,19 @@ export function sum(cursor: ITreeCursor): number {
 
 export function mahattanPerimeter(
     cursor: ITreeCursor,
-    extractCoordinates: (cursor: ITreeCursor) => Generator<[number, number]>,
+    extractCoordinates: (cursor: ITreeCursor, calculate: (x: number, y: number) => void) => number,
 ): number {
     let total = 0;
-    // let count = 0;
     let current: [number, number] | undefined;
 
-    for (const [x, y] of extractCoordinates(cursor)) {
+    const calculate = (x: number, y: number) => {
         if (current !== undefined) {
             total += Math.abs(current[0] - x) + Math.abs(current[1] - y);
         }
         current = [x, y];
-    }
+    };
+
+    extractCoordinates(cursor, calculate);
 
     return total;
 }

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { fail } from "assert";
-import { assert } from "console";
-import { ITreeCursor, mapCursorField, reduceField, TreeNavigationResult } from "../../../forest";
-import { FieldKey } from "../../../tree";
+import { fail, strict as assert } from "assert";
+import { ITreeCursor, reduceField, TreeNavigationResult } from "../../../forest";
+import { EmptyKey, FieldKey } from "../../../tree";
 
 export function sum(cursor: ITreeCursor): number {
     let total = 0;
@@ -20,38 +19,20 @@ export function sum(cursor: ITreeCursor): number {
     return total;
 }
 
-export function mahattanPerimeter(cursor: ITreeCursor): number {
+export function mahattanPerimeter(
+    cursor: ITreeCursor,
+    extractCoordinates: (cursor: ITreeCursor) => Generator<[number, number]>,
+): number {
     let total = 0;
+    // let count = 0;
     let current: [number, number] | undefined;
 
-    let result = cursor.down(key, 0);
-    if (result !== TreeNavigationResult.Ok) {
-        assert(result === TreeNavigationResult.NotFound, "pending not supported in reduceField");
-        // This has to be special cased (and not fall through the code below)
-        // since the call to `up` needs to be skipped.
-        return output;
+    for (const [x, y] of extractCoordinates(cursor)) {
+        if (current !== undefined) {
+            total += Math.abs(current[0] - x) + Math.abs(current[1] - y);
+        }
+        current = [x, y];
     }
-    while (result === TreeNavigationResult.Ok) {
-        output = (f(cursor, output));
-        result = cursor.seek(1);
-    }
-
-    // Read x and y values
-    if (cursor.down("" as FieldKey, 0) !== TreeNavigationResult.Ok) {
-        fail("no x");
-    }
-    const x = cursor.value;
-    cursor.up();
-    if (cursor.down("" as FieldKey, 1) !== TreeNavigationResult.Ok) {
-        fail("no y");
-    }
-    const y = cursor.value;
-    cursor.up();
-
-    if (current !== undefined) {
-        total += Math.abs(current[0] - x) + Math.abs(current[1] - y);
-    }
-    current = [x, y];
 
     return total;
 }

--- a/packages/dds/tree/src/test/domains/json/json.ts
+++ b/packages/dds/tree/src/test/domains/json/json.ts
@@ -4,6 +4,8 @@
  */
 
 import { makeRandom } from "@fluid-internal/stochastic-test-utils";
+import { FieldKey } from "../../../tree";
+import { brand } from "../../../util";
 
 interface Canada {
     type: "FeatureCollection";
@@ -16,6 +18,11 @@ interface Canada {
         };
     }];
 }
+
+// Keys used by the Canada dataset
+export const FeatureKey: FieldKey = brand("features");
+export const GeometryKey: FieldKey = brand("geometry");
+export const CoordinatesKey: FieldKey = brand("coordinates");
 
 // The geometry of 'canada.json' is encoded as 480 segments of varying length.
 const originalSegmentLengths = [

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -14,7 +14,7 @@ import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor
 import { defaultSchemaPolicy } from "../../../feature-libraries";
 import { SchemaData, StoredSchemaRepository } from "../../../schema-stored";
 import { generateCanada } from "./json";
-import { sum, sumMap } from "./benchmarks";
+import { sum } from "./benchmarks";
 
 // IIRC, extracting this helper from clone() encourages V8 to inline the terminal case at
 // the leaves, but this should be verified.
@@ -86,7 +86,6 @@ function bench(name: string, getJson: () => any) {
         ["cursorToJsonObject", cursorToJsonObject],
         ["jsonableTreeFromCursor", jsonableTreeFromCursor],
         ["sum", sum],
-        ["sum-map", sumMap],
         // TODO: benchmarks that access fields by name (ex: canada perminater)
     ];
 

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -14,6 +14,7 @@ import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor
 import { defaultSchemaPolicy } from "../../../feature-libraries";
 import { SchemaData, StoredSchemaRepository } from "../../../schema-stored";
 import { generateCanada } from "./json";
+import { sum, sumMap } from "./benchmarks";
 
 // IIRC, extracting this helper from clone() encourages V8 to inline the terminal case at
 // the leaves, but this should be verified.
@@ -84,6 +85,9 @@ function bench(name: string, getJson: () => any) {
     const consumers: [string, (cursor: ITreeCursor) => void][] = [
         ["cursorToJsonObject", cursorToJsonObject],
         ["jsonableTreeFromCursor", jsonableTreeFromCursor],
+        ["sum", sum],
+        ["sum-map", sumMap],
+        // TODO: benchmarks that access fields by name (ex: canada perminater)
     ];
 
     for (const [consumerName, consumer] of consumers) {

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -51,12 +51,7 @@ function clone<T>(value: Jsonable<T>): Jsonable<T> {
         : cloneObject(value);
 }
 
-function* noopDataConsumer(cursor: ITreeCursor) {
-    yield undefined;
-}
-
-// Helper that measures an optimized 'deepClone()' vs. using ITreeCursor to extract an
-// equivalent clone of the source data.
+// Helper that measures a variety of access patterns using ITreeCursor.
 function bench(
     data: {
         name: string;

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -61,7 +61,7 @@ function bench(
     data: {
         name: string;
         getJson: () => any;
-        dataConsumer: (cursor: ITreeCursor) => Generator<any>;
+        dataConsumer: (cursor: ITreeCursor, calculate: (...operands: any[]) => void) => any;
     }[],
 ) {
     for (const { name, getJson, dataConsumer } of data) {
@@ -102,7 +102,9 @@ function bench(
 
         const consumers: [
             string,
-            (cursor: ITreeCursor, dataConsumer: (cursor: ITreeCursor) => Generator<any>) => void,
+            (cursor: ITreeCursor,
+                dataConsumer: (cursor: ITreeCursor, calculate: (...operands: any[]) => void) => any
+            ) => void,
         ][] = [
             ["cursorToJsonObject", cursorToJsonObject],
             ["jsonableTreeFromCursor", jsonableTreeFromCursor],
@@ -137,7 +139,7 @@ const canada = generateCanada(
         ? undefined
         : [2, 10]);
 
-function* extractCoordinatesFromCanada(cursor: ITreeCursor): Generator<[number, number]> {
+function extractCoordinatesFromCanada(cursor: ITreeCursor, calculate: (x: number, y: number) => void): void {
     cursor.down(FeatureKey, 0);
     cursor.down(EmptyKey, 0);
     cursor.down(GeometryKey, 0);
@@ -161,7 +163,7 @@ function* extractCoordinatesFromCanada(cursor: ITreeCursor): Generator<[number, 
             const y = cursor.value as number;
             cursor.up();
 
-            yield [x, y];
+            calculate(x, y);
             resultInner = cursor.seek(1);
         }
         cursor.up();

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -105,9 +105,9 @@ function bench(
             string,
             (cursor: ITreeCursor, dataConsumer: (cursor: ITreeCursor) => Generator<any>) => void,
         ][] = [
-            // ["cursorToJsonObject", cursorToJsonObject],
-            // ["jsonableTreeFromCursor", jsonableTreeFromCursor],
-            // ["sum", sum],
+            ["cursorToJsonObject", cursorToJsonObject],
+            ["jsonableTreeFromCursor", jsonableTreeFromCursor],
+            ["sum", sum],
             ["manhattanPerimeter", mahattanPerimeter],
         ];
 
@@ -145,18 +145,20 @@ function* extractCoordinatesFromCanada(cursor: ITreeCursor): Generator<[number, 
     cursor.down("coordinates" as FieldKey, 0);
 
     let result = cursor.down(EmptyKey, 0);
-    // assert.equal(result, TreeNavigationResult.Ok, "Unexpected shape for Canada dataset");
-    let resultInner = cursor.down(EmptyKey, 0);
-    // assert.equal(resultInner, TreeNavigationResult.Ok, "Unexpected shape for Canada dataset");
+    assert.equal(result, TreeNavigationResult.Ok, "Unexpected shape for Canada dataset");
 
     while (result === TreeNavigationResult.Ok) {
+        let resultInner = cursor.down(EmptyKey, 0);
+        assert.equal(resultInner, TreeNavigationResult.Ok, "Unexpected shape for Canada dataset");
+
         while (resultInner === TreeNavigationResult.Ok) {
             // Read x and y values
-            // assert.equal(cursor.down(EmptyKey, 0), TreeNavigationResult.Ok, "No X field");
+            assert.equal(cursor.down(EmptyKey, 0), TreeNavigationResult.Ok, "No X field");
             const x = cursor.value as number;
             cursor.up();
 
-            // assert.equal(cursor.down(EmptyKey, 1), TreeNavigationResult.Ok, "No Y field");
+            assert.equal(cursor.down(EmptyKey, 1), TreeNavigationResult.Ok, "No Y field");
+            // const yResult = cursor.down(EmptyKey, 1);
             const y = cursor.value as number;
             cursor.up();
 
@@ -165,7 +167,6 @@ function* extractCoordinatesFromCanada(cursor: ITreeCursor): Generator<[number, 
         }
         cursor.up();
         result = cursor.seek(1);
-        resultInner = cursor.down(EmptyKey, 0);
     }
 }
 

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { fail, strict as assert } from "assert";
+import { strict as assert } from "assert";
 import { benchmark, BenchmarkType, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
 import { Jsonable } from "@fluidframework/datastore-definitions";
 import {
@@ -12,7 +12,6 @@ import {
     jsonableTreeFromCursor,
     singleTextCursor,
     jsonTypeSchema,
-    FieldKey,
     EmptyKey,
 } from "../../..";
 import { initializeForest, TreeNavigationResult } from "../../../forest";
@@ -21,7 +20,7 @@ import { initializeForest, TreeNavigationResult } from "../../../forest";
 import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor";
 import { defaultSchemaPolicy } from "../../../feature-libraries";
 import { SchemaData, StoredSchemaRepository } from "../../../schema-stored";
-import { generateCanada } from "./json";
+import { CoordinatesKey, FeatureKey, generateCanada, GeometryKey } from "./json";
 import { mahattanPerimeter, sum } from "./benchmarks";
 
 // IIRC, extracting this helper from clone() encourages V8 to inline the terminal case at
@@ -139,10 +138,10 @@ const canada = generateCanada(
         : [2, 10]);
 
 function* extractCoordinatesFromCanada(cursor: ITreeCursor): Generator<[number, number]> {
-    cursor.down("features" as FieldKey, 0);
+    cursor.down(FeatureKey, 0);
     cursor.down(EmptyKey, 0);
-    cursor.down("geometry" as FieldKey, 0);
-    cursor.down("coordinates" as FieldKey, 0);
+    cursor.down(GeometryKey, 0);
+    cursor.down(CoordinatesKey, 0);
 
     let result = cursor.down(EmptyKey, 0);
     assert.equal(result, TreeNavigationResult.Ok, "Unexpected shape for Canada dataset");

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -51,7 +51,9 @@ function clone<T>(value: Jsonable<T>): Jsonable<T> {
         : cloneObject(value);
 }
 
-// Helper that measures a variety of access patterns using ITreeCursor.
+/**
+ * Performance test suite that measures a variety of access patterns using ITreeCursor.
+ */
 function bench(
     data: {
         name: string;

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -159,7 +159,6 @@ function extractCoordinatesFromCanada(cursor: ITreeCursor, calculate: (x: number
             cursor.up();
 
             assert.equal(cursor.down(EmptyKey, 1), TreeNavigationResult.Ok, "No Y field");
-            // const yResult = cursor.down(EmptyKey, 1);
             const y = cursor.value as number;
             cursor.up();
 

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -168,6 +168,12 @@ function* extractCoordinatesFromCanada(cursor: ITreeCursor): Generator<[number, 
         cursor.up();
         result = cursor.seek(1);
     }
+
+    // Reset the cursor state
+    cursor.up();
+    cursor.up();
+    cursor.up();
+    cursor.up();
 }
 
 describe.only("ITreeCursor", () => {

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -177,6 +177,6 @@ function extractCoordinatesFromCanada(cursor: ITreeCursor, calculate: (x: number
     cursor.up();
 }
 
-describe.only("ITreeCursor", () => {
+describe("ITreeCursor", () => {
     bench([{ name: "canada", getJson: () => canada, dataConsumer: extractCoordinatesFromCanada }]);
 });

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -21,7 +21,7 @@ import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor
 import { defaultSchemaPolicy } from "../../../feature-libraries";
 import { SchemaData, StoredSchemaRepository } from "../../../schema-stored";
 import { CoordinatesKey, FeatureKey, generateCanada, GeometryKey } from "./json";
-import { mahattanPerimeter, sum } from "./benchmarks";
+import { averageLocation, sum } from "./benchmarks";
 
 // IIRC, extracting this helper from clone() encourages V8 to inline the terminal case at
 // the leaves, but this should be verified.
@@ -109,7 +109,7 @@ function bench(
             ["cursorToJsonObject", cursorToJsonObject],
             ["jsonableTreeFromCursor", jsonableTreeFromCursor],
             ["sum", sum],
-            ["manhattanPerimeter", mahattanPerimeter],
+            ["averageLocation", averageLocation],
         ];
 
         for (const [consumerName, consumer] of consumers) {

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -10,6 +10,8 @@ import { FieldKey } from "../../../tree";
 /* eslint-disable-next-line import/no-internal-modules */
 import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor";
 import { brand } from "../../../util";
+import { generateCanada } from "./json";
+import { mahattanPerimeter } from "./benchmarks";
 
 describe("JsonCursor", () => {
     // This tests that test data roundtrips via extract.
@@ -194,3 +196,44 @@ describe("JsonCursor", () => {
         });
     });
 });
+
+describe.only("manhattan perimeter", () => {
+    const canada = generateCanada([2, 10]);
+    it("can be computed", () => {
+        const cursor = new JsonCursor(canada);
+        cursor.down("features" as FieldKey, 0);
+        cursor.down("" as FieldKey, 0);
+        cursor.down("geometry" as FieldKey, 0);
+        cursor.down("coordinates" as FieldKey, 0);
+
+        const perimeter = mahattanPerimeter(cursor);
+        assert.equal(perimeter, getPerimeter(canada));
+    });
+});
+
+interface Canada {
+    type: "FeatureCollection";
+    features: [{
+        type: "Feature";
+        properties: { name: "Canada"; };
+        geometry: {
+            type: "Polygon";
+            coordinates: [number, number][][];
+        };
+    }];
+}
+function getPerimeter(data: Canada): number {
+    let total = 0;
+    let current: [number, number] | undefined;
+
+    for (const outer of data.features[0].geometry.coordinates) {
+        for (const coordinate of outer) {
+            if (current !== undefined) {
+                total += Math.abs(current[0] - coordinate[0]) + Math.abs(current[1] - coordinate[1]);
+            }
+            current = coordinate;
+        }
+    }
+
+    return total;
+}

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -9,7 +9,7 @@ import { FieldKey } from "../../../tree";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor";
-import { brand } from "../../../util";
+import { brand, fail } from "../../../util";
 import { generateCanada } from "./json";
 import { mahattanPerimeter } from "./benchmarks";
 
@@ -196,44 +196,3 @@ describe("JsonCursor", () => {
         });
     });
 });
-
-describe.only("manhattan perimeter", () => {
-    const canada = generateCanada([2, 10]);
-    it("can be computed", () => {
-        const cursor = new JsonCursor(canada);
-        cursor.down("features" as FieldKey, 0);
-        cursor.down("" as FieldKey, 0);
-        cursor.down("geometry" as FieldKey, 0);
-        cursor.down("coordinates" as FieldKey, 0);
-
-        const perimeter = mahattanPerimeter(cursor);
-        assert.equal(perimeter, getPerimeter(canada));
-    });
-});
-
-interface Canada {
-    type: "FeatureCollection";
-    features: [{
-        type: "Feature";
-        properties: { name: "Canada"; };
-        geometry: {
-            type: "Polygon";
-            coordinates: [number, number][][];
-        };
-    }];
-}
-function getPerimeter(data: Canada): number {
-    let total = 0;
-    let current: [number, number] | undefined;
-
-    for (const outer of data.features[0].geometry.coordinates) {
-        for (const coordinate of outer) {
-            if (current !== undefined) {
-                total += Math.abs(current[0] - coordinate[0]) + Math.abs(current[1] - coordinate[1]);
-            }
-            current = coordinate;
-        }
-    }
-
-    return total;
-}

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -9,9 +9,7 @@ import { FieldKey } from "../../../tree";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor";
-import { brand, fail } from "../../../util";
-import { generateCanada } from "./json";
-import { mahattanPerimeter } from "./benchmarks";
+import { brand } from "../../../util";
 
 describe("JsonCursor", () => {
     // This tests that test data roundtrips via extract.


### PR DESCRIPTION
This adds a sum benchmark that is being split out from this PR: https://github.com/microsoft/FluidFramework/pull/11610. Also adds a perimeter benchmark for measuring access to known fields rather than enumeration.