### PR TITLE
Tree: cleanup shared-tree test and fix double editing bug

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -323,6 +323,7 @@ export interface IEditableForest extends IForestSubscription {
 // @public
 export interface IForestSubscription extends Dependee {
     allocateCursor(): ITreeSubscriptionCursor;
+    forgetAnchor(anchor: Anchor): void;
     root(range: DetachedField): Anchor;
     // (undocumented)
     readonly rootField: DetachedField;

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -52,6 +52,10 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         );
     }
 
+    public forgetAnchor(anchor: Anchor): void {
+        this.anchors.forget(anchor);
+    }
+
     applyDelta(delta: Delta.Root): void {
         // TODO: refactor object forest to use root node above detached fields, like how PathNode works.
         // Then factor out this editing code to work on any such JsonableTree.

--- a/packages/dds/tree/src/forest/forest.ts
+++ b/packages/dds/tree/src/forest/forest.ts
@@ -46,8 +46,14 @@ export interface IForestSubscription extends Dependee {
 
     /**
      * Anchor at the beginning of a root field.
+     * Will incur cost to maintain across edits until freed.
      */
     root(range: DetachedField): Anchor;
+
+    /**
+     * Frees an Anchor, stopping tracking its position across edits.
+     */
+    forgetAnchor(anchor: Anchor): void;
 
     /**
      * If observer is provided, it will be invalidated if the value returned from this changes

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -24,8 +24,11 @@ describe("SharedTree", () => {
             const readCursor = tree.forest.allocateCursor();
             const destination = tree.forest.root(tree.forest.rootField);
             const cursorResult = tree.forest.tryMoveCursorTo(destination, readCursor);
-            assert(cursorResult === TreeNavigationResult.Ok);
-            assert(readCursor.value === value);
+            assert.equal(cursorResult, TreeNavigationResult.Ok);
+            assert.equal(readCursor.seek(1), TreeNavigationResult.NotFound);
+            assert.equal(readCursor.value, value);
+            readCursor.free();
+            tree.forest.forgetAnchor(destination);
         }
 
         // Apply an edit to the first tree which inserts a node with a value

--- a/packages/dds/tree/src/transaction/transaction.ts
+++ b/packages/dds/tree/src/transaction/transaction.ts
@@ -40,7 +40,10 @@ export function runSynchronousTransaction<TEditor extends ProgressiveEditBuilder
     const result = command(checkout.forest, t.editor);
     const changes = t.editor.getChanges();
     const edit = checkout.changeFamily.rebaser.compose(changes);
-    if (result === TransactionResult.Abort) {
+
+    // TODO: in the non-abort case, optimize this to not rollback the edit,
+    // then reapply it (when the local edit is added) when possible.
+    {
         // Roll back changes
         const inverse = checkout.changeFamily.rebaser.invert(edit);
 
@@ -48,11 +51,11 @@ export function runSynchronousTransaction<TEditor extends ProgressiveEditBuilder
         // TODO: update schema in addition to anchors and tree data (in both places).
         checkout.changeFamily.rebaser.rebaseAnchors(checkout.forest.anchors, inverse);
         checkout.forest.applyDelta(checkout.changeFamily.intoDelta(inverse));
-
-        return result;
     }
 
-    checkout.submitEdit(edit);
+    if (result === TransactionResult.Apply) {
+        checkout.submitEdit(edit);
+    }
 
     return result;
 }


### PR DESCRIPTION
## Description

This fixes the bug found in #11838, and cleans up the test to actually be able to catch the bug. Also fixes a leak (which does not really matter in that test, but its good practice not to leak things, especially in tests people use as example usage).

This fix works by having transaction roll back its change after temporarily applying it during the transaction. The edit then gets reapplied when the local edit is added.

Also included is a fix that aborted edits would have gotten applied and submitted.