### PR TITLE
Investigate if enforcing named exports have any impact on bundle sizes

### DIFF
--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export * from "./base";
-export * from "./client";
+export { IIntegerRange } from "./base";
+export { Client } from "./client";
 
 export 	{
     ConflictAction,
@@ -22,20 +22,139 @@ export 	{
     SortedDictionary,
     Stack,
 } from "./collections";
-export * from "./constants";
+export {
+    UniversalSequenceNumber,
+    UnassignedSequenceNumber,
+    TreeMaintenanceSequenceNumber,
+    LocalClientId,
+    NonCollabClient,
+} from "./constants";
 export {
     createDetachedLocalReferencePosition,
     LocalReferencePosition,
     LocalReferenceCollection,
  } from "./localReference";
-export * from "./mergeTreeNodes";
-export * from "./mergeTreeDeltaCallback";
-export * from "./mergeTreeTracking";
-export * from "./opBuilder";
-export * from "./ops";
-export * from "./properties";
-export * from "./segmentGroupCollection";
-export * from "./segmentPropertiesManager";
-export * from "./sortedSegmentSet";
-export * from "./textSegment";
-export * from "./referencePositions";
+export {
+    IMergeNodeCommon,
+    IMergeNode,
+    IMergeBlock,
+    IHierBlock,
+    IRemovalInfo,
+    toRemovalInfo,
+    ISegment,
+    IMarkerModifiedAction,
+    ISegmentAction,
+    ISegmentChanges,
+    BlockAction,
+    NodeAction,
+    IncrementalSegmentAction,
+    IncrementalBlockAction,
+    BlockUpdateActions,
+    InsertContext,
+    SegmentActions,
+    IncrementalSegmentActions,
+    SearchResult,
+    MergeTreeStats,
+    SegmentGroup,
+    MergeNode,
+    ordinalToArray,
+    MaxNodesInBlock,
+    MergeBlock,
+    BaseSegment,
+    reservedMarkerIdKey,
+    reservedMarkerSimpleTypeKey,
+    IJSONMarkerSegment,
+    Marker,
+    IncrementalExecOp,
+    IncrementalMapState,
+    CollaborationWindow,
+    compareNumbers,
+    compareStrings,
+    internedSpaces,
+    IConsensusInfo,
+    SegmentAccumulator,
+    MinListener,
+    debugMarkerToString,
+} from "./mergeTreeNodes";
+export {
+    MergeTreeDeltaOperationType,
+    MergeTreeDeltaOperationTypes,
+    IMergeTreeDeltaCallbackArgs,
+    MergeTreeMaintenanceType,
+    IMergeTreeSegmentDelta,
+    IMergeTreeDeltaOpArgs,
+    IMergeTreeClientSequenceArgs,
+    MergeTreeDeltaCallback,
+    IMergeTreeMaintenanceCallbackArgs,
+    MergeTreeMaintenanceCallback,
+} from "./mergeTreeDeltaCallback";
+export {
+    TrackingGroup,
+    TrackingGroupCollection,
+} from "./mergeTreeTracking";
+export {
+    createAnnotateMarkerOp,
+    createAnnotateRangeOp,
+    createRemoveRangeOp,
+    createInsertSegmentOp,
+    createInsertOp,
+    createGroupOp,
+} from "./opBuilder";
+export {
+    ReferenceType,
+    IMarkerDef,
+    MergeTreeDeltaType,
+    IMergeTreeDelta,
+    IRelativePosition,
+    IMergeTreeInsertMsg,
+    IMergeTreeRemoveMsg,
+    ICombiningOp,
+    IMergeTreeAnnotateMsg,
+    IMergeTreeGroupMsg,
+    IJSONSegment,
+    IMergeTreeDeltaOp,
+    IMergeTreeOp,
+} from "./ops";
+export {
+    MapLike,
+    PropertySet,
+    IConsensusValue,
+    combine,
+    matchProperties,
+    extend,
+    clone,
+    addProperties,
+    extendIfUndefined,
+    createMap,
+} from "./properties";
+export { SegmentGroupCollection } from "./segmentGroupCollection";
+export {
+    PropertiesRollback,
+    PropertiesManager,
+} from "./segmentPropertiesManager";
+export {
+    SortedSegmentSet,
+    SortedSegmentSetItem,
+} from "./sortedSegmentSet";
+export {
+    IJSONTextSegment,
+    TextSegment,
+    IMergeTreeTextHelper,
+} from "./textSegment";
+export {
+    reservedTileLabelsKey,
+    reservedRangeLabelsKey,
+    refTypeIncludesFlag,
+    refGetTileLabels,
+    refGetRangeLabels,
+    refHasTileLabel,
+    refHasRangeLabel,
+    refHasTileLabels,
+    refHasRangeLabels,
+    ReferencePosition,
+    RangeStackMap,
+    DetachedReferencePosition,
+    minReferencePosition,
+    maxReferencePosition,
+    compareReferencePositions,
+} from "./referencePositions";

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -36,10 +36,34 @@ export {
     IMapMessageLocalMetadata,
     IValueOpEmitter,
 } from "./defaultMapInterfaces";
-export * from "./sharedString";
-export * from "./sequence";
-export * from "./sequenceFactory";
-export * from "./sequenceDeltaEvent";
-export * from "./sharedSequence";
-export * from "./sharedIntervalCollection";
-export { IInterval, IntervalConflictResolver } from "./intervalTree";
+export {
+    ISharedString,
+    SharedStringSegment,
+    SharedString,
+    getTextAndMarkers,
+} from "./sharedString";
+export {
+    SharedSegmentSequence,
+    ISharedSegmentSequenceEvents,
+} from "./sequence";
+export { SharedStringFactory } from "./sequenceFactory";
+export {
+    SequenceEvent,
+    SequenceDeltaEvent,
+    SequenceMaintenanceEvent,
+    ISequenceDeltaRange,
+} from "./sequenceDeltaEvent";
+export {
+    IJSONRunSegment,
+    SubSequence,
+    SharedSequence,
+} from "./sharedSequence";
+export {
+    SharedIntervalCollectionFactory,
+    ISharedIntervalCollection,
+    SharedIntervalCollection,
+} from "./sharedIntervalCollection";
+export {
+    IInterval,
+    IntervalConflictResolver,
+} from "./intervalTree";

--- a/packages/framework/aqueduct/src/container-runtime-factories/index.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./baseContainerRuntimeFactory";
-export * from "./containerRuntimeFactoryWithDefaultDataStore";
+export { BaseContainerRuntimeFactory } from "./baseContainerRuntimeFactory";
+export { ContainerRuntimeFactoryWithDefaultDataStore } from "./containerRuntimeFactoryWithDefaultDataStore";

--- a/packages/framework/aqueduct/src/container-services/index.ts
+++ b/packages/framework/aqueduct/src/container-services/index.ts
@@ -3,4 +3,9 @@
  * Licensed under the MIT License.
  */
 
-export * from "./containerServices";
+export {
+    serviceRoutePathRoot,
+    ContainerServiceRegistryEntries,
+    BaseContainerService,
+    generateContainerServicesRequestHandler,
+} from "./containerServices";

--- a/packages/framework/aqueduct/src/data-object-factories/index.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/index.ts
@@ -3,5 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export * from "./dataObjectFactory";
-export * from "./pureDataObjectFactory";
+export {
+    DataObjectFactory,
+} from "./dataObjectFactory";
+export {
+    IRootDataObjectFactory,
+    PureDataObjectFactory,
+} from "./pureDataObjectFactory";

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -18,9 +18,35 @@
  * @packageDocumentation
  */
 
-export * from "./data-object-factories";
-export * from "./data-objects";
-export * from "./container-runtime-factories";
-export * from "./container-services";
-export * from "./request-handlers";
-export * from "./utils";
+export {
+    DataObjectFactory,
+    PureDataObjectFactory,
+    IRootDataObjectFactory,
+} from "./data-object-factories";
+export {
+    DataObject,
+    PureDataObject,
+    DataObjectTypes,
+    IDataObjectProps,
+} from "./data-objects";
+export {
+    BaseContainerRuntimeFactory,
+    ContainerRuntimeFactoryWithDefaultDataStore,
+} from "./container-runtime-factories";
+export {
+    serviceRoutePathRoot,
+    ContainerServiceRegistryEntries,
+    BaseContainerService,
+    generateContainerServicesRequestHandler,
+} from "./container-services";
+export {
+    mountableViewRequestHandler,
+    defaultRouteRequestHandler,
+    defaultFluidObjectRequestHandler,
+} from "./request-handlers";
+export {
+    waitForAttach,
+    getDefaultObjectFromContainer,
+    getObjectWithIdFromContainer,
+    getObjectFromContainer,
+} from "./utils";

--- a/packages/framework/aqueduct/src/request-handlers/index.ts
+++ b/packages/framework/aqueduct/src/request-handlers/index.ts
@@ -3,4 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export * from "./requestHandlers";
+export {
+    mountableViewRequestHandler,
+    defaultRouteRequestHandler,
+    defaultFluidObjectRequestHandler,
+} from "./requestHandlers";

--- a/packages/framework/aqueduct/src/utils/index.ts
+++ b/packages/framework/aqueduct/src/utils/index.ts
@@ -3,5 +3,9 @@
  * Licensed under the MIT License.
  */
 
-export * from "./attachUtils";
-export * from "./containerInteractions";
+export { waitForAttach } from "./attachUtils";
+export {
+    getDefaultObjectFromContainer,
+    getObjectWithIdFromContainer,
+    getObjectFromContainer,
+} from "./containerInteractions";


### PR DESCRIPTION
This is a test branch to see if there is any change in bundle size if we enforce named exports vs `export *`. 

Issue: https://github.com/microsoft/FluidFramework/issues/10062