### PR TITLE
Check for read-mode in test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -245,6 +245,8 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
 
             await provider.ensureSynchronized();
 
+            assert.strict(!container1.deltaManager.active, "Expected read mode");
+
             // Since we start in read mode, we shouldn't be able to successfully get the task even after volunteering
             assert.strict(!taskSubscription.haveTask(), "Got task in read mode");
 


### PR DESCRIPTION
## Description

Add assert in test to validate that container is in read mode when it's expected to be.

## Reviewer Guidance

@anthony-murphy, I just extracted this from the old branch, do you recall more context around it? Did you hit the problem?
