### PR TITLE
Tree: use sealed

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -11,7 +11,7 @@ import { Serializable } from '@fluidframework/datastore-definitions';
 // @public
 export type Anchor = Brand<number, "rebaser.Anchor">;
 
-// @public
+// @public @sealed
 export class AnchorSet {
     applyDelta(delta: Delta.Root): void;
     // (undocumented)
@@ -28,7 +28,7 @@ export type Brand<ValueType, Name extends string> = ValueType & BrandedType<Valu
 // @public
 export function brand<T extends Brand<any, string>>(value: T extends BrandedType<infer ValueType, string> ? ValueType : never): T;
 
-// @public
+// @public @sealed
 export abstract class BrandedType<ValueType, Name extends string> {
     protected readonly _type_brand: Name;
     // (undocumented)
@@ -106,7 +106,7 @@ export interface Covariant<T> {
 }
 
 // @public
-export function cursorToJsonObject(reader: ITreeCursor): unknown;
+export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible;
 
 // @public
 export const defaultSchemaPolicy: FullSchemaPolicy;
@@ -225,7 +225,7 @@ export type FieldChangeset = Brand<unknown, "FieldChangeset">;
 // @public (undocumented)
 export type FieldKey = LocalFieldKey | GlobalFieldKey;
 
-// @public
+// @public @sealed
 export class FieldKind {
     constructor(identifier: FieldKindIdentifier, multiplicity: Multiplicity, changeHandler: FieldChangeHandler<any>, allowsTreeSupersetOf: (originalTypes: ReadonlySet<TreeSchemaIdentifier> | undefined, superset: FieldSchema) => boolean, handlesEditsFrom: ReadonlySet<FieldKindIdentifier>);
     // (undocumented)
@@ -430,7 +430,7 @@ export type JsonCompatibleReadOnly = string | number | boolean | null | readonly
     readonly [P in string]: JsonCompatibleReadOnly | undefined;
 };
 
-// @public
+// @public @sealed
 export class JsonCursor<T> implements ITreeCursor<SynchronousNavigationResult> {
     constructor(root: Jsonable<T>);
     // (undocumented)
@@ -559,7 +559,7 @@ interface ModifyMovedOut {
     type: typeof MarkType.Modify;
 }
 
-// @public
+// @public @sealed
 export class ModularChangeFamily implements ChangeFamily<ModularEditBuilder, FieldChangeMap>, ChangeRebaser<FieldChangeMap> {
     constructor(fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>);
     // (undocumented)
@@ -580,7 +580,7 @@ export class ModularChangeFamily implements ChangeFamily<ModularEditBuilder, Fie
     get rebaser(): ChangeRebaser<FieldChangeMap>;
 }
 
-// @public (undocumented)
+// @public @sealed (undocumented)
 export class ModularEditBuilder extends ProgressiveEditBuilder<FieldChangeMap> {
     constructor(family: ModularChangeFamily, deltaReceiver: (delta: Delta.Root) => void, anchors: AnchorSet);
 }
@@ -693,15 +693,16 @@ export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderT
 // @public (undocumented)
 export abstract class ProgressiveEditBuilder<TChange> {
     constructor(changeFamily: ChangeFamily<unknown, TChange>, deltaReceiver: (delta: Delta.Root) => void, anchorSet: AnchorSet);
+    // @sealed
     protected applyChange(change: TChange): void;
-    // (undocumented)
+    // @sealed (undocumented)
     getChanges(): TChange[];
 }
 
 // @public
 type ProtoNode = JsonableTree;
 
-// @public
+// @public @sealed
 export class Rebaser<TChangeRebaser extends ChangeRebaser<any>> {
     constructor(rebaser: TChangeRebaser);
     discardRevision(revision: RevisionTag): void;
@@ -778,7 +779,7 @@ export class SimpleDependee implements Dependee {
     // (undocumented)
     readonly computationName: string;
     invalidateDependents(): void;
-    // (undocumented)
+    // @sealed (undocumented)
     listDependents(): Set<Dependent>;
     // (undocumented)
     registerDependent(dependent: Dependent): boolean;
@@ -792,7 +793,7 @@ export function singleTextCursor(root: JsonableTree): TextCursor;
 // @public
 type Skip = number;
 
-// @public
+// @public @sealed
 export class StoredSchemaRepository<TPolicy extends SchemaPolicy = SchemaPolicy> extends SimpleDependee implements SchemaData {
     constructor(policy: TPolicy, data?: SchemaData);
     // (undocumented)
@@ -894,7 +895,7 @@ export type TreeTypeSet = ReadonlySet<TreeSchemaIdentifier> | undefined;
 export interface TreeValue extends Serializable {
 }
 
-// @public
+// @public @sealed
 class UnitEncoder extends ChangeEncoder<0> {
     // (undocumented)
     decodeBinary(formatVersion: number, change: IsoBuffer): 0;
@@ -920,7 +921,7 @@ export type Value = undefined | TreeValue;
 // @public
 const value: FieldKind;
 
-// @public
+// @public @sealed
 class ValueEncoder<T extends JsonCompatibleReadOnly> extends ChangeEncoder<T> {
     // (undocumented)
     decodeJson(formatVersion: number, change: JsonCompatibleReadOnly): T;

--- a/packages/dds/tree/src/change-family/changeEncoder.ts
+++ b/packages/dds/tree/src/change-family/changeEncoder.ts
@@ -4,6 +4,7 @@
  */
 
 import { bufferToString, IsoBuffer } from "@fluidframework/common-utils";
+import { JsonCompatibleReadOnly } from "../util";
 
 /**
  * Serializes and deserializes changes.
@@ -46,27 +47,3 @@ export abstract class ChangeEncoder<TChange> {
         return this.decodeJson(formatVersion, jsonable);
     }
 }
-
-/**
- * Use for Json compatible data.
- *
- * Note that this does not robustly forbid non json comparable data via type checking,
- * but instead mostly restricts access to it.
- */
-// eslint-disable-next-line @rushstack/no-new-null
-export type JsonCompatible = string | number | boolean | null | JsonCompatible[] | { [P in string]: JsonCompatible; };
-
-/**
- * Use for readonly view of Json compatible data.
- *
- * Note that this does not robustly forbid non json comparable data via type checking,
- * but instead mostly restricts access to it.
- */
-export type JsonCompatibleReadOnly =
-    | string
-    | number
-    | boolean
-    // eslint-disable-next-line @rushstack/no-new-null
-    | null
-    | readonly JsonCompatibleReadOnly[]
-    | { readonly [P in string]: JsonCompatibleReadOnly | undefined; };

--- a/packages/dds/tree/src/change-family/fence.json
+++ b/packages/dds/tree/src/change-family/fence.json
@@ -1,5 +1,5 @@
 {
     "tags": [ "change-family" ],
     "exports": [ "index" ],
-    "imports": [ "rebase", "tree" ]
+    "imports": [ "rebase", "tree", "util" ]
 }

--- a/packages/dds/tree/src/change-family/progressiveEditBuilder.ts
+++ b/packages/dds/tree/src/change-family/progressiveEditBuilder.ts
@@ -15,6 +15,8 @@ export abstract class ProgressiveEditBuilder<TChange> {
 
     /**
      * Subclasses add editing methods which call this with their generated edits.
+     *
+     * @sealed
      */
     protected applyChange(change: TChange): void {
         this.changes.push(change);
@@ -25,6 +27,7 @@ export abstract class ProgressiveEditBuilder<TChange> {
 
     /**
      * @returns a copy of the internal change list so far.
+     * @sealed
      */
     public getChanges(): TChange[] {
         return [...this.changes];

--- a/packages/dds/tree/src/dependency-tracking/simpleDependee.ts
+++ b/packages/dds/tree/src/dependency-tracking/simpleDependee.ts
@@ -36,6 +36,9 @@ export class SimpleDependee implements Dependee {
 		}
 	}
 
+    /**
+     * @sealed
+     */
 	public listDependents() {
 		return this.dependents;
 	}

--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { Jsonable } from "@fluidframework/datastore-definitions";
-import { JsonCompatible } from "../../change-family";
+import { JsonCompatible } from "../../util";
 import {
     ITreeCursor,
     mapCursorField,

--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -5,6 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { Jsonable } from "@fluidframework/datastore-definitions";
+import { JsonCompatible } from "../../change-family";
 import {
     ITreeCursor,
     mapCursorField,
@@ -24,6 +25,8 @@ import {
 
 /**
  * An ITreeCursor implementation used to read a Jsonable tree for testing and benchmarking.
+ *
+ * @sealed
  */
 export class JsonCursor<T> implements ITreeCursor<SynchronousNavigationResult> {
     // PERF: JsonCursor maintains a stack of nodes/edges traversed.  This stack is
@@ -189,20 +192,20 @@ export class JsonCursor<T> implements ITreeCursor<SynchronousNavigationResult> {
  * Extract a JS object tree from the contents of the given ITreeCursor.
  * Assumes that ITreeCursor contains only unaugmented JsonTypes.
  */
-export function cursorToJsonObject(reader: ITreeCursor): unknown {
+export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
     const type = reader.type;
 
     switch (type) {
         case jsonNumber.name:
         case jsonBoolean.name:
         case jsonString.name:
-            return reader.value;
+            return reader.value as number | boolean | string;
         case jsonArray.name: {
             const result = mapCursorField(reader, EmptyKey, cursorToJsonObject);
             return result;
         }
         case jsonObject.name: {
-            const result: any = {};
+            const result: JsonCompatible = {};
             for (const key of reader.keys) {
                 assert(reader.down(key, 0) === TreeNavigationResult.Ok, 0x360 /* expected navigation ok */);
                 result[key as string] = cursorToJsonObject(reader);

--- a/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
@@ -22,6 +22,8 @@ import {
 
 /**
  * Encoder for changesets which carry no information.
+ *
+ * @sealed
  */
 export class UnitEncoder extends ChangeEncoder<0> {
     public encodeForJson(formatVersion: number, change: 0): JsonCompatible {
@@ -43,6 +45,8 @@ export class UnitEncoder extends ChangeEncoder<0> {
 
 /**
  * Encoder for changesets which are just a json compatible value.
+ *
+ * @sealed
  */
 export class ValueEncoder<T extends JsonCompatibleReadOnly> extends ChangeEncoder<T> {
     public encodeForJson(formatVersion: number, change: T): JsonCompatibleReadOnly {

--- a/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
@@ -4,10 +4,10 @@
  */
 
 import { assert, IsoBuffer } from "@fluidframework/common-utils";
-import { ChangeEncoder, JsonCompatible, JsonCompatibleReadOnly } from "../change-family";
+import { ChangeEncoder } from "../change-family";
 import { FieldKindIdentifier } from "../schema-stored";
 import { AnchorSet, Delta, JsonableTree } from "../tree";
-import { brand } from "../util";
+import { brand, JsonCompatible, JsonCompatibleReadOnly } from "../util";
 import {
     FieldKind,
     Multiplicity,

--- a/packages/dds/tree/src/feature-libraries/defaultRebaser.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultRebaser.ts
@@ -5,8 +5,8 @@
 
 import { AnchorSet, Delta, UpPath, Value } from "../tree";
 import { ChangeRebaser } from "../rebase";
-import { Contravariant, Covariant, Invariant } from "../util";
-import { ChangeEncoder, ChangeFamily, JsonCompatible } from "../change-family";
+import { Contravariant, Covariant, Invariant, JsonCompatible } from "../util";
+import { ChangeEncoder, ChangeFamily } from "../change-family";
 
 export class DefaultChangeFamily implements ChangeFamily<DefaultEditor, DefaultChangeset> {
     readonly encoder = defaultChangeEncoder;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { JsonCompatibleReadOnly } from "../../change-family";
 import { FieldKindIdentifier } from "../../schema-stored";
 import { Delta, FieldKey } from "../../tree";
-import { Brand, Invariant } from "../../util";
+import { Brand, Invariant, JsonCompatibleReadOnly } from "../../util";
 
 /**
  * Functionality provided by a field kind which will be composed with other `FieldChangeHandler`s to

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldKind.ts
@@ -20,6 +20,8 @@ import { FieldChangeHandler } from "./fieldChangeHandler";
  * All behavior must be deterministic, and not change across versions of the app/library.
  *
  * These policies include the data encoding, change encoding, change rebase and change application.
+ *
+ * @sealed
  */
 export class FieldKind {
     /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -15,6 +15,8 @@ import { FieldKind } from "./fieldKind";
 /**
  * Implementation of ChangeFamily which delegates work in a given field to the appropriate FieldKind
  * as determined by the schema.
+ *
+ * @sealed
  */
 export class ModularChangeFamily implements
     ChangeFamily<ModularEditBuilder, FieldChangeMap>,
@@ -183,6 +185,9 @@ interface EncodedFieldChange {
     change: JsonCompatibleReadOnly;
 }
 
+/**
+ * @sealed
+ */
 export class ModularEditBuilder extends ProgressiveEditBuilder<FieldChangeMap> {
     constructor(
         family: ModularChangeFamily,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -4,11 +4,11 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { ChangeEncoder, ChangeFamily, JsonCompatibleReadOnly, ProgressiveEditBuilder } from "../../change-family";
+import { ChangeEncoder, ChangeFamily, ProgressiveEditBuilder } from "../../change-family";
 import { ChangeRebaser } from "../../rebase";
 import { FieldKindIdentifier } from "../../schema-stored";
 import { AnchorSet, Delta, FieldKey } from "../../tree";
-import { brand, getOrAddEmptyToMap } from "../../util";
+import { brand, getOrAddEmptyToMap, JsonCompatibleReadOnly } from "../../util";
 import { FieldChangeHandler, FieldChangeMap, FieldChange } from "./fieldChangeHandler";
 import { FieldKind } from "./fieldKind";
 

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeset.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeset.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ChangeEncoder, JsonCompatible } from "../../change-family";
+import { ChangeEncoder } from "../../change-family";
 import { Transposed as T } from "../../changeset";
+import { JsonCompatible } from "../../util";
 
 export type SequenceChangeset = T.LocalChangeset;
 

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -47,14 +47,14 @@ export {
     brandOpaque,
     ValueFromBranded,
     NameFromBranded,
+    JsonCompatibleReadOnly,
+    JsonCompatible,
 } from "./util";
 
 export {
     ChangeEncoder,
     ChangeFamily,
     ProgressiveEditBuilder,
-    JsonCompatibleReadOnly,
-    JsonCompatible,
 } from "./change-family";
 
 export {

--- a/packages/dds/tree/src/rebase/rebaser.ts
+++ b/packages/dds/tree/src/rebase/rebaser.ts
@@ -13,6 +13,8 @@ export type RevisionTag = Brand<number, "rebaser.RevisionTag">;
 
 /**
  * A collection of branches which can rebase changes between them.
+ *
+ * @sealed
  */
 export class Rebaser<TChangeRebaser extends ChangeRebaser<any>> {
     private lastRevision = 0;

--- a/packages/dds/tree/src/schema-stored/storedSchemaRepository.ts
+++ b/packages/dds/tree/src/schema-stored/storedSchemaRepository.ts
@@ -49,6 +49,8 @@ import {
  * it is not the focus of this design since such users have strictly less implementation constraints.
  *
  * TODO: could implement more fine grained dependency tracking.
+ *
+ * @sealed
  */
 export class StoredSchemaRepository<TPolicy extends SchemaPolicy = SchemaPolicy>
     extends SimpleDependee implements SchemaData {

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -5,11 +5,11 @@
 
 import { fail, strict as assert } from "assert";
 import { unreachableCase } from "@fluidframework/common-utils";
-import { ChangeEncoder, ChangeFamily, JsonCompatible } from "../../change-family";
+import { ChangeEncoder, ChangeFamily } from "../../change-family";
 import { Commit, EditManager, SessionId } from "../../edit-manager";
 import { ChangeRebaser } from "../../rebase";
 import { AnchorSet, Delta, FieldKey } from "../../tree";
-import { brand, makeArray, RecursiveReadonly } from "../../util";
+import { brand, makeArray, RecursiveReadonly, JsonCompatible } from "../../util";
 
 interface NonEmptyTestChangeset {
     /**

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { JsonCompatibleReadOnly } from "../../../change-family";
 import {
     FieldChangeEncoder,
     FieldChangeHandler,
@@ -17,7 +16,7 @@ import {
 } from "../../../feature-libraries";
 import { FieldKindIdentifier } from "../../../schema-stored";
 import { Delta, FieldKey } from "../../../tree";
-import { brand } from "../../../util";
+import { brand, JsonCompatibleReadOnly } from "../../../util";
 
 type ValueChangeset = FieldKinds.ReplaceOp<number>;
 

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -21,6 +21,8 @@ const NeverAnchor: Anchor = brand(0);
  * Collection of Anchors at a specific revision.
  *
  * See {@link Rebaser} for how to update across revisions.
+ *
+ * @sealed
  */
 export class AnchorSet {
     /**

--- a/packages/dds/tree/src/util/brand.ts
+++ b/packages/dds/tree/src/util/brand.ts
@@ -31,6 +31,8 @@ export type Brand<ValueType, Name extends string> = ValueType &
  *
  * Do not use this class with `instanceof`: this will always be false at runtime,
  * but the compiler may think its true in some cases.
+ *
+ * @sealed
  */
 export abstract class BrandedType<ValueType, Name extends string> {
     protected _typeCheck?: Invariant<ValueType>;

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -106,3 +106,27 @@ export function compareSets<T>({ a, b, aExtra, bExtra, same }: {
 	}
 	return collection;
 }
+
+/**
+ * Use for Json compatible data.
+ *
+ * Note that this does not robustly forbid non json comparable data via type checking,
+ * but instead mostly restricts access to it.
+ */
+// eslint-disable-next-line @rushstack/no-new-null
+export type JsonCompatible = string | number | boolean | null | JsonCompatible[] | { [P in string]: JsonCompatible; };
+
+/**
+ * Use for readonly view of Json compatible data.
+ *
+ * Note that this does not robustly forbid non json comparable data via type checking,
+ * but instead mostly restricts access to it.
+ */
+export type JsonCompatibleReadOnly =
+    | string
+    | number
+    | boolean
+    // eslint-disable-next-line @rushstack/no-new-null
+    | null
+    | readonly JsonCompatibleReadOnly[]
+    | { readonly [P in string]: JsonCompatibleReadOnly | undefined; };


### PR DESCRIPTION
## Description

Use api-extractor sealed in tree where appropriate.

Also avoids one use of undefined where a more specific type is possible.