### PR TITLE
remove breaking while keeping overlap fix

### DIFF
--- a/docs/themes/thxvscode/assets/scss/includes/_docs.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_docs.scss
@@ -122,6 +122,7 @@
 }
 #docs-navbar > .nav {
   max-height: calc(100vh - 140px);
+  overflow: hidden;
 }
 #docs-navbar::-webkit-scrollbar {
   width: 0 !important;

--- a/docs/themes/thxvscode/layouts/partials/apiNav.html
+++ b/docs/themes/thxvscode/layouts/partials/apiNav.html
@@ -22,7 +22,7 @@
 {{ printf "%#v" $in_api_section }} -->
 
 <nav id="docs-navbar" aria-label="Topics" class="docs-nav visible-md visible-lg">
-    <ul class="nav" id="main-nav" style="overflow: hidden;">
+    <ul class="nav" id="main-nav">
 
         <li {{ if $ref_home_active }} class="active" {{ end }}>
             <a class="docs-home" href="/docs/" {{ if $ref_home_active }}

--- a/docs/themes/thxvscode/layouts/partials/apiNav.html
+++ b/docs/themes/thxvscode/layouts/partials/apiNav.html
@@ -22,7 +22,7 @@
 {{ printf "%#v" $in_api_section }} -->
 
 <nav id="docs-navbar" aria-label="Topics" class="docs-nav visible-md visible-lg">
-    <ul class="nav" id="main-nav">
+    <ul class="nav" id="main-nav" style="overflow: hidden;">
 
         <li {{ if $ref_home_active }} class="active" {{ end }}>
             <a class="docs-home" href="/docs/" {{ if $ref_home_active }}
@@ -53,7 +53,7 @@
                     {{- range ((where $current.Site.RegularPages "Params.area" "==" $menuArea).ByParam "menuPosition") }}
                     {{ $isCurrentPage := eq .RelPermalink $current.RelPermalink }}
 
-                    <li {{ if $isCurrentPage }}class="active" {{ end }} style="padding-top:5px;">
+                    <li {{ if $isCurrentPage }}class="active" {{ end }}>
                         <a href="{{ .RelPermalink }}"
                             {{ if $isCurrentPage }}aria-label="Current Page: {{ (default .Name .Title) | safeHTML }} " {{ end }}>
                             {{ .Title }} </a>

--- a/docs/themes/thxvscode/layouts/partials/docNav.html
+++ b/docs/themes/thxvscode/layouts/partials/docNav.html
@@ -11,7 +11,7 @@
 {{/* printf "%#v" $menu */}}
 
 <nav id="docs-navbar" aria-label="Topics" class="docs-nav visible-md visible-lg">
-    <ul class="nav" id="main-nav">
+    <ul class="nav" id="main-nav" style="overflow: hidden;">
         {{ if $sectionTitle }}
         <li {{ if eq .Kind "section" }} class="active" {{ end }}>
             <a class="docs-home" href="/{{ $mainURL }}" {{ if eq .Kind "section" }}
@@ -37,7 +37,7 @@
                 <!-- list all pages in area -->
                 {{- range ((where $current.Site.RegularPages "Params.area" "==" $menuArea).ByParam "menuPosition") }}
                 {{ $isCurrentPage := eq .RelPermalink $current.RelPermalink }}
-                <li {{ if $isCurrentPage }}class="active" {{ end }} style="padding-top:5px;">
+                <li {{ if $isCurrentPage }}class="active" {{ end }}>
                     <a href="{{ .RelPermalink }}" {{ if $isCurrentPage }}aria-label="Current Page: {{ (default .Name .Title) | safeHTML }} " {{ end }}>
                         {{ .Title }} </a>
                 </li>

--- a/docs/themes/thxvscode/layouts/partials/docNav.html
+++ b/docs/themes/thxvscode/layouts/partials/docNav.html
@@ -11,7 +11,7 @@
 {{/* printf "%#v" $menu */}}
 
 <nav id="docs-navbar" aria-label="Topics" class="docs-nav visible-md visible-lg">
-    <ul class="nav" id="main-nav" style="overflow: hidden;">
+    <ul class="nav" id="main-nav">
         {{ if $sectionTitle }}
         <li {{ if eq .Kind "section" }} class="active" {{ end }}>
             <a class="docs-home" href="/{{ $mainURL }}" {{ if eq .Kind "section" }}


### PR DESCRIPTION
## Description

> To reproduce this bug, decrease your resolution such that when you click on a drop down link the sub links overlap but not too low that the navbar moves to the top
> Adding padding to the links seem to solve this issue

## Any relevant logs or outputs
<img width="150" alt="MicrosoftTeams-image (1)" src="https://user-images.githubusercontent.com/107130183/189151213-6f1b8ea8-bab4-440f-a1e8-c834cb81fef6.png">

![MicrosoftTeams-image](https://user-images.githubusercontent.com/107130183/188661580-e79e6569-9f3e-4a12-b091-bc43d3cae1b1.png)

## Other information or known dependencies

> [AB#1444](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1444)
