### PR TITLE
[test-runtime-utils] Rm node assert library dep

### DIFF
--- a/packages/runtime/test-runtime-utils/.eslintrc.js
+++ b/packages/runtime/test-runtime-utils/.eslintrc.js
@@ -13,8 +13,8 @@ module.exports = {
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
 
-        // This library is used in the browser, so we don't want dependencies on node libraries.
-        "import/no-nodejs-modules": "error",
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", {"allow": ["events"]}],
     },
     "overrides": [
         {

--- a/packages/runtime/test-runtime-utils/.eslintrc.js
+++ b/packages/runtime/test-runtime-utils/.eslintrc.js
@@ -12,6 +12,9 @@ module.exports = {
     },
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
+
+        // This library is used in the browser, so we don't want dependencies on node libraries.
+        "import/no-nodejs-modules": "error",
     },
     "overrides": [
         {

--- a/packages/runtime/test-runtime-utils/src/validateAssertionError.ts
+++ b/packages/runtime/test-runtime-utils/src/validateAssertionError.ts
@@ -25,7 +25,6 @@ import { shortCodeMap } from "./assertionShortCodesMap";
 export function validateAssertionError(error: Error, expectedErrorMsg: string): boolean {
     const mappedMsg = shortCodeMap[error.message] as string ?? error.message;
     if (mappedMsg !== expectedErrorMsg) {
-        throw new AssertionError();
         // This throws an Error instead of an AssertionError because AssertionError would require a dependency on the
         // node assert library, which we don't want to do for this library because it's used in the browser.
         throw new Error(`Unexpected assertion thrown: ${error.message} ('${mappedMsg}')`);

--- a/packages/runtime/test-runtime-utils/src/validateAssertionError.ts
+++ b/packages/runtime/test-runtime-utils/src/validateAssertionError.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { AssertionError } from "assert";
 import { shortCodeMap } from "./assertionShortCodesMap";
 
 /**

--- a/packages/runtime/test-runtime-utils/src/validateAssertionError.ts
+++ b/packages/runtime/test-runtime-utils/src/validateAssertionError.ts
@@ -26,7 +26,10 @@ import { shortCodeMap } from "./assertionShortCodesMap";
 export function validateAssertionError(error: Error, expectedErrorMsg: string): boolean {
     const mappedMsg = shortCodeMap[error.message] as string ?? error.message;
     if (mappedMsg !== expectedErrorMsg) {
-        throw new AssertionError({ message: `Unexpected assertion thrown: ${error.message} ('${mappedMsg}')` });
+        throw new AssertionError();
+        // This throws an Error instead of an AssertionError because AssertionError would require a dependency on the
+        // node assert library, which we don't want to do for this library because it's used in the browser.
+        throw new Error(`Unexpected assertion thrown: ${error.message} ('${mappedMsg}')`);
     }
     return true;
 }


### PR DESCRIPTION
Fixes #11350.

This change removes the dependency on the node assert library in test-runtime-utils. It also enables the import/no-nodejs-modules rule to help prevent these types of bugs in the future.