### PR TITLE
feat(merge-tree): add basic obliterate tests

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1044,6 +1044,8 @@ export class MergeTree {
     // (undocumented)
     mergeTreeMaintenanceCallback?: MergeTreeMaintenanceCallback;
     // (undocumented)
+    obliterateRange(start: number, end: number, refSeq: number, clientId: number, seq: number, overwrite: boolean | undefined, opArgs: IMergeTreeDeltaOpArgs): void;
+    // (undocumented)
     options?: PropertySet | undefined;
     // (undocumented)
     static readonly options: {

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1044,8 +1044,6 @@ export class MergeTree {
     // (undocumented)
     mergeTreeMaintenanceCallback?: MergeTreeMaintenanceCallback;
     // (undocumented)
-    obliterateRange(start: number, end: number, refSeq: number, clientId: number, seq: number, overwrite: boolean | undefined, opArgs: IMergeTreeDeltaOpArgs): void;
-    // (undocumented)
     options?: PropertySet | undefined;
     // (undocumented)
     static readonly options: {

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1930,18 +1930,6 @@ export class MergeTree {
         }
     }
 
-    public obliterateRange(
-        start: number,
-        end: number,
-        refSeq: number,
-        clientId: number,
-        seq: number,
-        overwrite = false,
-        opArgs: IMergeTreeDeltaOpArgs,
-    ): void {
-        this.markRangeRemoved(start, end, refSeq, clientId, seq, overwrite, opArgs);
-    }
-
     public markRangeRemoved(
         start: number,
         end: number,

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1930,6 +1930,18 @@ export class MergeTree {
         }
     }
 
+    public obliterateRange(
+        start: number,
+        end: number,
+        refSeq: number,
+        clientId: number,
+        seq: number,
+        overwrite = false,
+        opArgs: IMergeTreeDeltaOpArgs,
+    ): void {
+        this.markRangeRemoved(start, end, refSeq, clientId, seq, overwrite, opArgs);
+    }
+
     public markRangeRemoved(
         start: number,
         end: number,
@@ -1938,7 +1950,7 @@ export class MergeTree {
         seq: number,
         overwrite = false,
         opArgs: IMergeTreeDeltaOpArgs,
-    ) {
+    ): void {
         let _overwrite = overwrite;
         this.ensureIntervalBoundary(start, refSeq, clientId);
         this.ensureIntervalBoundary(end, refSeq, clientId);

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -1,0 +1,161 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { MergeTreeDeltaType } from "../ops";
+import { TestClient } from "./testClient";
+import { insertText } from "./testUtils";
+
+describe("obliterate", () => {
+    let client: TestClient;
+    let refSeq: number;
+    const localClientId = 17;
+    const remoteClientId = 18;
+
+    beforeEach(() => {
+        client = new TestClient();
+        client.startOrUpdateCollaboration("local");
+        for (const char of "hello world") {
+            client.applyMsg(
+                client.makeOpMessage(
+                    client.insertTextLocal(client.getLength(), char),
+                    client.getCurrentSeq() + 1));
+        }
+        assert.equal(client.getText(), "hello world");
+        refSeq = client.getCurrentSeq();
+    });
+
+    it("removes text", () => {
+        client.mergeTree.obliterateRange(
+            0,
+            client.getLength(),
+            refSeq,
+            localClientId,
+            refSeq + 1,
+            false,
+            undefined as any,
+        );
+        assert.equal(client.getText(), "");
+    });
+
+    describe("concurrent obliterate and insert", () => {
+        it("removes text for obliterate then insert", () => {
+            client.mergeTree.obliterateRange(
+                0,
+                client.getLength(),
+                refSeq,
+                remoteClientId,
+                refSeq + 1,
+                false,
+                undefined as any,
+            );
+            insertText(
+                client.mergeTree,
+                0,
+                refSeq,
+                remoteClientId + 1,
+                refSeq + 2,
+                "more ",
+                undefined,
+                { op: { type: MergeTreeDeltaType.INSERT } },
+            );
+            assert.equal(client.getText(), "");
+        });
+        it("removes text for insert then obliterate", () => {
+            insertText(
+                client.mergeTree,
+                0,
+                refSeq,
+                remoteClientId + 1,
+                refSeq + 1,
+                "more ",
+                undefined,
+                { op: { type: MergeTreeDeltaType.INSERT } },
+            );
+            client.mergeTree.obliterateRange(
+                0,
+                "hello world".length,
+                refSeq,
+                remoteClientId,
+                refSeq + 2,
+                false,
+                undefined as any,
+            );
+            assert.equal(client.getText(), "");
+        });
+    });
+
+    describe("endpoint behavior", () => {
+        it("does not expand to include text inserted at start", () => {
+            client.mergeTree.obliterateRange(
+                5,
+                client.getLength(),
+                refSeq,
+                remoteClientId,
+                refSeq + 1,
+                false,
+                undefined as any,
+            );
+            insertText(
+                client.mergeTree,
+                5,
+                refSeq,
+                remoteClientId + 1,
+                refSeq + 2,
+                " world",
+                undefined,
+                { op: { type: MergeTreeDeltaType.INSERT } },
+            );
+            assert.equal(client.getText(), "hello world");
+        });
+        it("does not expand to include text inserted at end", () => {
+            client.mergeTree.obliterateRange(
+                0,
+                5,
+                refSeq,
+                remoteClientId,
+                refSeq + 1,
+                false,
+                undefined as any,
+            );
+            insertText(
+                client.mergeTree,
+                5,
+                refSeq,
+                remoteClientId + 1,
+                refSeq + 2,
+                "hello",
+                undefined,
+                { op: { type: MergeTreeDeltaType.INSERT } },
+            );
+            assert.equal(client.getText(), "hello world");
+        });
+    });
+
+    describe("local obliterate with concurrent inserts", () => {
+        it("removes range when pending local obliterate op", () => {
+            client.mergeTree.obliterateRange(
+                0,
+                "hello world".length,
+                refSeq,
+                localClientId,
+                refSeq + 1,
+                false,
+                undefined as any,
+            );
+            insertText(
+                client.mergeTree,
+                0,
+                refSeq,
+                remoteClientId,
+                refSeq + 2,
+                "more ",
+                undefined,
+                { op: { type: MergeTreeDeltaType.INSERT } },
+            );
+            assert.equal(client.getText(), "");
+        });
+    });
+});

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { UnassignedSequenceNumber } from "../constants";
 import { MergeTreeDeltaType } from "../ops";
 import { TestClient } from "./testClient";
 import { insertText } from "./testUtils";
@@ -141,7 +142,7 @@ describe.skip("obliterate", () => {
                 "hello world".length,
                 refSeq,
                 localClientId,
-                refSeq + 1,
+                UnassignedSequenceNumber,
                 false,
                 undefined as any,
             );

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -29,7 +29,7 @@ describe.skip("obliterate", () => {
     });
 
     it("removes text", () => {
-        client.mergeTree.obliterateRange(
+        client.obliterateRange(
             0,
             client.getLength(),
             refSeq,
@@ -43,7 +43,7 @@ describe.skip("obliterate", () => {
 
     describe("concurrent obliterate and insert", () => {
         it("removes text for obliterate then insert", () => {
-            client.mergeTree.obliterateRange(
+            client.obliterateRange(
                 0,
                 client.getLength(),
                 refSeq,
@@ -75,7 +75,7 @@ describe.skip("obliterate", () => {
                 undefined,
                 { op: { type: MergeTreeDeltaType.INSERT } },
             );
-            client.mergeTree.obliterateRange(
+            client.obliterateRange(
                 0,
                 "hello world".length,
                 refSeq,
@@ -90,7 +90,7 @@ describe.skip("obliterate", () => {
 
     describe("endpoint behavior", () => {
         it("does not expand to include text inserted at start", () => {
-            client.mergeTree.obliterateRange(
+            client.obliterateRange(
                 5,
                 client.getLength(),
                 refSeq,
@@ -112,7 +112,7 @@ describe.skip("obliterate", () => {
             assert.equal(client.getText(), "hello world");
         });
         it("does not expand to include text inserted at end", () => {
-            client.mergeTree.obliterateRange(
+            client.obliterateRange(
                 0,
                 5,
                 refSeq,
@@ -137,7 +137,7 @@ describe.skip("obliterate", () => {
 
     describe("local obliterate with concurrent inserts", () => {
         it("removes range when pending local obliterate op", () => {
-            client.mergeTree.obliterateRange(
+            client.obliterateRange(
                 0,
                 "hello world".length,
                 refSeq,

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -8,7 +8,7 @@ import { MergeTreeDeltaType } from "../ops";
 import { TestClient } from "./testClient";
 import { insertText } from "./testUtils";
 
-describe("obliterate", () => {
+describe.skip("obliterate", () => {
     let client: TestClient;
     let refSeq: number;
     const localClientId = 17;

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -23,6 +23,7 @@ import { SnapshotLegacy } from "../snapshotlegacy";
 import { TextSegment } from "../textSegment";
 import { MergeTree } from "../mergeTree";
 import { MergeTreeTextHelper } from "../MergeTreeTextHelper";
+import { IMergeTreeDeltaOpArgs } from "../mergeTreeDeltaCallback";
 import { TestSerializer } from "./testSerializer";
 import { nodeOrdinalsHaveIntegrity } from "./testUtils";
 
@@ -115,6 +116,21 @@ export class TestClient extends Client {
                 }
             });
         };
+    }
+
+    /**
+     * @internal
+     */
+    public obliterateRange(
+        start: number,
+        end: number,
+        refSeq: number,
+        clientId: number,
+        seq: number,
+        overwrite = false,
+        opArgs: IMergeTreeDeltaOpArgs,
+    ): void {
+        this.mergeTree.markRangeRemoved(start, end, refSeq, clientId, seq, overwrite, opArgs);
     }
 
     public getText(start?: number, end?: number): string {


### PR DESCRIPTION
## Description

Creates basic functionality tests for [obliterate](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/merge-tree/docs/Obliterate.md).

[ado 1760](https://dev.azure.com/fluidframework/internal/_workitems/edit/1760/)
