### PR TITLE
[lint-config] Enable import/no-nodejs-modules rule

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -265,7 +265,10 @@ module.exports = {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
 
-        // By default libraries should not take dependencies on node libraries
+        /**
+         * By default libraries should not take dependencies on node libraries. This rule can be disabled at the project
+         * level for libraries that are intended to be used only in node.
+         */
         "import/no-nodejs-modules": "warn",
     },
     overrides: [

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -264,6 +264,9 @@ module.exports = {
         "@typescript-eslint/prefer-includes": "error",
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
+
+        // By default libraries should not take dependencies on node libraries
+        "import/no-nodejs-modules": "warn",
     },
     overrides: [
         {

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -468,6 +468,9 @@
         "import/no-named-as-default-member": [
             1
         ],
+        "import/no-nodejs-modules": [
+            "warn"
+        ],
         "import/no-unassigned-import": [
             "error"
         ],

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -468,6 +468,9 @@
         "import/no-named-as-default-member": [
             1
         ],
+        "import/no-nodejs-modules": [
+            "warn"
+        ],
         "import/no-unassigned-import": [
             "error"
         ],

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -503,6 +503,9 @@
         "import/no-named-as-default-member": [
             1
         ],
+        "import/no-nodejs-modules": [
+            "warn"
+        ],
         "import/no-unassigned-import": [
             "error"
         ],

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -521,6 +521,9 @@
         "import/no-named-as-default-member": [
             1
         ],
+        "import/no-nodejs-modules": [
+            "warn"
+        ],
         "import/no-unassigned-import": [
             "error"
         ],

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -468,6 +468,9 @@
         "import/no-named-as-default-member": [
             1
         ],
+        "import/no-nodejs-modules": [
+            "warn"
+        ],
         "import/no-unassigned-import": [
             "error"
         ],


### PR DESCRIPTION
Related to #11350. This lint rule helps prevent taking dependencies on node libraries, and given our browser-first focus, we should enable it in our default config. I made it a warning to make it easier to adopt.