### PR TITLE
Tree: export SharedTreeFactory and ISharedTree

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -4,6 +4,12 @@
 
 ```ts
 
+import { IChannel } from '@fluidframework/datastore-definitions';
+import { IChannelAttributes } from '@fluidframework/datastore-definitions';
+import { IChannelFactory } from '@fluidframework/datastore-definitions';
+import { IChannelServices } from '@fluidframework/datastore-definitions';
+import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
+import { ISharedObject } from '@fluidframework/shared-object-base';
 import { IsoBuffer } from '@fluidframework/common-utils';
 import { Jsonable } from '@fluidframework/datastore-definitions';
 import { Serializable } from '@fluidframework/datastore-definitions';
@@ -76,6 +82,9 @@ export interface ChangeRebaser<TChangeset> {
 // @public (undocumented)
 export type ChangesetFromChangeRebaser<TChangeRebaser extends ChangeRebaser<any>> = TChangeRebaser extends ChangeRebaser<infer TChangeset> ? TChangeset : never;
 
+// @public (undocumented)
+export type ChangesetTag = number | string;
+
 // @public
 export type ChildCollection = FieldKey | RootField;
 
@@ -128,7 +137,7 @@ declare namespace Delta {
         OuterMark,
         InnerModify,
         MarkList,
-        Skip,
+        Skip_2 as Skip,
         Modify,
         ModifyDeleted,
         ModifyMovedOut,
@@ -142,7 +151,7 @@ declare namespace Delta {
         MoveInAndModify,
         Insert,
         InsertAndModify,
-        ProtoNode,
+        ProtoNode_2 as ProtoNode,
         MoveId,
         Offset,
         FieldMap_2 as FieldMap,
@@ -183,6 +192,18 @@ export interface EditableTreeContext {
 
 // @public
 export type EditableTreeOrPrimitive = EditableTree | PrimitiveValue;
+
+// @public (undocumented)
+export enum Effects {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Delete = "Delete",
+    // (undocumented)
+    Move = "Move",
+    // (undocumented)
+    None = "None"
+}
 
 // @public (undocumented)
 const empty: Root;
@@ -328,6 +349,9 @@ export interface FullSchemaPolicy extends SchemaPolicy {
     readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>;
 }
 
+// @public (undocumented)
+export type GapCount = number;
+
 // @public
 export interface GenericTreeNode<TChild> extends NodeData {
     // (undocumented)
@@ -342,6 +366,17 @@ export const getTypeSymbol: unique symbol;
 
 // @public
 export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKey">> {
+}
+
+// @public (undocumented)
+export interface HasOpId {
+    id: OpId;
+}
+
+// @public (undocumented)
+export interface ICheckout<TEditBuilder> {
+    readonly forest: IForestSubscription;
+    runTransaction(transaction: (forest: IForestSubscription, editor: TEditBuilder) => TransactionResult): TransactionResult;
 }
 
 // @public
@@ -370,7 +405,7 @@ function inputLength(mark: Mark): number;
 // @public
 interface Insert {
     // (undocumented)
-    content: ProtoNode[];
+    content: ProtoNode_2[];
     // (undocumented)
     type: typeof MarkType.Insert;
 }
@@ -378,9 +413,9 @@ interface Insert {
 // @public
 interface InsertAndModify {
     // (undocumented)
-    content: ProtoNode;
+    content: ProtoNode_2;
     // (undocumented)
-    fields: FieldMarks<Skip | ModifyInserted | MoveIn | MoveInAndModify>;
+    fields: FieldMarks<Skip_2 | ModifyInserted | MoveIn | MoveInAndModify>;
     // (undocumented)
     type: typeof MarkType.InsertAndModify;
 }
@@ -402,6 +437,10 @@ export interface Invariant<T> extends Contravariant<T>, Covariant<T> {
 
 // @public
 export type isAny<T> = boolean extends (T extends {} ? true : false) ? true : false;
+
+// @public
+export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObject {
+}
 
 // @public (undocumented)
 export function isNeverField(policy: FullSchemaPolicy, originalData: SchemaData, field: FieldSchema): boolean;
@@ -545,7 +584,7 @@ interface Modify {
 // @public
 interface ModifyAndDelete {
     // (undocumented)
-    fields: FieldMarks<Skip | ModifyDeleted | MoveOut>;
+    fields: FieldMarks<Skip_2 | ModifyDeleted | MoveOut>;
     // (undocumented)
     type: typeof MarkType.ModifyAndDelete;
 }
@@ -553,7 +592,7 @@ interface ModifyAndDelete {
 // @public
 interface ModifyAndMoveOut {
     // (undocumented)
-    fields?: FieldMarks<Skip | ModifyMovedOut | Delete | MoveOut>;
+    fields?: FieldMarks<Skip_2 | ModifyMovedOut | Delete | MoveOut>;
     moveId: MoveId;
     // (undocumented)
     setValue?: Value;
@@ -564,7 +603,7 @@ interface ModifyAndMoveOut {
 // @public
 interface ModifyDeleted {
     // (undocumented)
-    fields: FieldMarks<Skip | ModifyDeleted | ModifyAndMoveOut | MoveOut>;
+    fields: FieldMarks<Skip_2 | ModifyDeleted | ModifyAndMoveOut | MoveOut>;
     // (undocumented)
     type: typeof MarkType.Modify;
 }
@@ -572,7 +611,7 @@ interface ModifyDeleted {
 // @public
 interface ModifyInserted {
     // (undocumented)
-    fields: FieldMarks<Skip | ModifyInserted | MoveIn | MoveInAndModify>;
+    fields: FieldMarks<Skip_2 | ModifyInserted | MoveIn | MoveInAndModify>;
     // (undocumented)
     type: typeof MarkType.Modify;
 }
@@ -580,7 +619,7 @@ interface ModifyInserted {
 // @public
 interface ModifyMovedIn {
     // (undocumented)
-    fields: FieldMarks<Skip | ModifyMovedIn | MoveIn | MoveInAndModify | Insert | InsertAndModify>;
+    fields: FieldMarks<Skip_2 | ModifyMovedIn | MoveIn | MoveInAndModify | Insert | InsertAndModify>;
     // (undocumented)
     type: typeof MarkType.Modify;
 }
@@ -588,7 +627,7 @@ interface ModifyMovedIn {
 // @public
 interface ModifyMovedOut {
     // (undocumented)
-    fields?: FieldMarks<Skip | ModifyMovedOut | Delete | ModifyAndDelete | ModifyAndMoveOut | MoveOut>;
+    fields?: FieldMarks<Skip_2 | ModifyMovedOut | Delete | ModifyAndDelete | ModifyAndMoveOut | MoveOut>;
     // (undocumented)
     setValue?: Value;
     // (undocumented)
@@ -638,7 +677,7 @@ interface MoveIn {
 // @public
 interface MoveInAndModify {
     // (undocumented)
-    fields: FieldMarks<Skip | ModifyMovedIn | MoveIn | Insert>;
+    fields: FieldMarks<Skip_2 | ModifyMovedIn | MoveIn | Insert>;
     moveId: MoveId;
     // (undocumented)
     type: typeof MarkType.MoveInAndModify;
@@ -701,10 +740,17 @@ export type NodeChangeInverter = (change: FieldChangeMap) => FieldChangeMap;
 // @public (undocumented)
 export type NodeChangeRebaser = (change: FieldChangeMap, baseChange: FieldChangeMap) => FieldChangeMap;
 
+// @public (undocumented)
+export type NodeCount = number;
+
 // @public
 export interface NodeData {
     readonly type: TreeSchemaIdentifier;
     value?: TreeValue;
+}
+
+// @public
+export interface NodePath extends UpPath {
 }
 
 // @public
@@ -721,13 +767,20 @@ type Offset = number;
 export type Opaque<T extends Brand<any, string>> = T extends Brand<infer ValueType, infer Name> ? BrandedType<ValueType, Name> : never;
 
 // @public
+export type OpId = number;
+
+// @public
 const optional: FieldKind;
 
 // @public
-type OuterMark = Skip | Modify | Delete | MoveOut | MoveIn | Insert | ModifyAndDelete | ModifyAndMoveOut | MoveInAndModify | InsertAndModify;
+type OuterMark = Skip_2 | Modify | Delete | MoveOut | MoveIn | Insert | ModifyAndDelete | ModifyAndMoveOut | MoveInAndModify | InsertAndModify;
 
 // @public
 export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
+
+// @public
+export interface PlacePath extends UpPath {
+}
 
 // @public (undocumented)
 export type PrimitiveValue = string | boolean | number;
@@ -742,7 +795,10 @@ export abstract class ProgressiveEditBuilder<TChange> {
 }
 
 // @public
-type ProtoNode = JsonableTree;
+export type ProtoNode = JsonableTree;
+
+// @public
+type ProtoNode_2 = JsonableTree;
 
 // @public
 export const proxyTargetSymbol: unique symbol;
@@ -818,6 +874,34 @@ export interface SchemaPolicy {
 // @public
 const sequence: FieldKind;
 
+// @public (undocumented)
+export type SequenceChangeset = Transposed.LocalChangeset;
+
+// @public (undocumented)
+export class SequenceEditBuilder extends ProgressiveEditBuilder<SequenceChangeset> {
+    constructor(deltaReceiver: (delta: Delta.Root) => void, anchorSet: AnchorSet);
+    // (undocumented)
+    delete(place: PlacePath, count: number): void;
+    // (undocumented)
+    insert(place: PlacePath, cursor: ITreeCursor): void;
+    // (undocumented)
+    move(source: PlacePath, count: number, destination: PlacePath): void;
+    // (undocumented)
+    setValue(node: NodePath, value: Value): void;
+}
+
+// @public
+export class SharedTreeFactory implements IChannelFactory {
+    // (undocumented)
+    attributes: IChannelAttributes;
+    // (undocumented)
+    create(runtime: IFluidDataStoreRuntime, id: string): ISharedTree;
+    // (undocumented)
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<IChannel>;
+    // (undocumented)
+    type: string;
+}
+
 // @public
 export class SimpleDependee implements Dependee {
     constructor(computationName?: string);
@@ -835,8 +919,11 @@ export class SimpleDependee implements Dependee {
 // @public (undocumented)
 export function singleTextCursor(root: JsonableTree): TextCursor;
 
+// @public (undocumented)
+export type Skip = number;
+
 // @public
-type Skip = number;
+type Skip_2 = number;
 
 // @public @sealed
 export class StoredSchemaRepository<TPolicy extends SchemaPolicy = SchemaPolicy> extends SimpleDependee implements SchemaData {
@@ -901,7 +988,241 @@ export class TextCursor implements ITreeCursor<SynchronousNavigationResult> {
 }
 
 // @public (undocumented)
+export enum Tiebreak {
+    // (undocumented)
+    Left = 0,
+    // (undocumented)
+    Right = 1
+}
+
+// @public (undocumented)
 export type ToDelta = (child: FieldChangeMap) => Delta.Root;
+
+// @public (undocumented)
+export enum TransactionResult {
+    // (undocumented)
+    Abort = 0,
+    // (undocumented)
+    Apply = 1
+}
+
+// @public
+export namespace Transposed {
+    // (undocumented)
+    export type Attach = Insert | ModifyInsert | MoveIn | ModifyMoveIn | Bounce | Intake;
+    export interface Bounce extends HasOpId, HasPlaceFields {
+        // (undocumented)
+        type: "Bounce";
+    }
+    // (undocumented)
+    export interface Detach extends HasOpId {
+        // (undocumented)
+        count: NodeCount;
+        // (undocumented)
+        gaps?: GapEffect[];
+        // (undocumented)
+        tomb?: ChangesetTag;
+        // (undocumented)
+        type: "Delete" | "MoveOut";
+    }
+    // (undocumented)
+    export interface FieldMarks {
+        // (undocumented)
+        [key: string]: MarkList;
+    }
+    // (undocumented)
+    export interface Forward extends HasOpId, GapEffectPolicy {
+        // (undocumented)
+        type: "Forward";
+    }
+    // (undocumented)
+    export type GapEffect = Scorch | Forward | Heal | Unforward;
+    // (undocumented)
+    export interface GapEffectPolicy {
+        excludePriorInsertions?: true;
+        includePosteriorInsertions?: true;
+    }
+    // (undocumented)
+    export interface GapEffectSegment {
+        // (undocumented)
+        count: GapCount;
+        stack: GapEffect[];
+        // (undocumented)
+        tomb?: ChangesetTag;
+        // (undocumented)
+        type: "Gap";
+    }
+    // (undocumented)
+    export type GapEffectType = GapEffect["type"];
+    // (undocumented)
+    export interface HasPlaceFields {
+        heed?: Effects | [Effects, Effects];
+        scorch?: PriorOp;
+        src?: PriorOp;
+        tiebreak?: Tiebreak;
+    }
+    // (undocumented)
+    export interface Heal extends HasOpId, GapEffectPolicy {
+        // (undocumented)
+        type: "Heal";
+    }
+    // (undocumented)
+    export interface Insert extends HasOpId, HasPlaceFields {
+        // (undocumented)
+        content: ProtoNode[];
+        // (undocumented)
+        type: "Insert";
+    }
+    export interface Intake extends PriorOp {
+        // (undocumented)
+        type: "Intake";
+    }
+    export interface LocalChangeset {
+        // (undocumented)
+        marks: FieldMarks;
+        // (undocumented)
+        moves?: MoveEntry<TreeForestPath>[];
+    }
+    // (undocumented)
+    export type Mark = SizedMark | Attach;
+    // (undocumented)
+    export type MarkList<TMark = Mark> = TMark[];
+    // (undocumented)
+    export interface Modify {
+        // (undocumented)
+        fields?: FieldMarks;
+        // (undocumented)
+        tomb?: ChangesetTag;
+        // (undocumented)
+        type: "Modify";
+        // (undocumented)
+        value?: SetValue;
+    }
+    // (undocumented)
+    export interface ModifyDetach extends HasOpId {
+        // (undocumented)
+        fields?: FieldMarks;
+        // (undocumented)
+        tomb?: ChangesetTag;
+        // (undocumented)
+        type: "MDelete" | "MMoveOut";
+        // (undocumented)
+        value?: SetValue;
+    }
+    // (undocumented)
+    export interface ModifyInsert extends HasOpId, HasPlaceFields {
+        // (undocumented)
+        content: ProtoNode;
+        // (undocumented)
+        fields?: FieldMarks;
+        // (undocumented)
+        type: "MInsert";
+        // (undocumented)
+        value?: SetValue;
+    }
+    // (undocumented)
+    export interface ModifyMoveIn extends HasOpId, HasPlaceFields {
+        // (undocumented)
+        fields?: FieldMarks;
+        // (undocumented)
+        type: "MMoveIn";
+        // (undocumented)
+        value?: SetValue;
+    }
+    // (undocumented)
+    export interface ModifyReattach extends HasOpId {
+        // (undocumented)
+        fields?: FieldMarks;
+        // (undocumented)
+        tomb: ChangesetTag;
+        // (undocumented)
+        type: "MRevive" | "MReturn";
+        // (undocumented)
+        value?: SetValue;
+    }
+    // (undocumented)
+    export interface MoveEntry<TPath = TreeRootPath> {
+        // (undocumented)
+        dst: TPath;
+        // (undocumented)
+        hops?: TPath[];
+        // (undocumented)
+        id: OpId;
+        // (undocumented)
+        src: TPath;
+    }
+    // (undocumented)
+    export interface MoveIn extends HasOpId, HasPlaceFields {
+        count: NodeCount;
+        // (undocumented)
+        type: "MoveIn";
+    }
+    // (undocumented)
+    export type NodeMark = Detach | Reattach;
+    // (undocumented)
+    export type ObjectMark = SizedObjectMark | Attach;
+    export interface PeerChangeset {
+        // (undocumented)
+        marks: MarkList;
+        // (undocumented)
+        moves?: MoveEntry[];
+    }
+    // (undocumented)
+    export interface PriorOp {
+        // (undocumented)
+        change: ChangesetTag;
+        // (undocumented)
+        id: OpId;
+    }
+    // (undocumented)
+    export interface Reattach extends HasOpId {
+        // (undocumented)
+        count: NodeCount;
+        // (undocumented)
+        tomb: ChangesetTag;
+        // (undocumented)
+        type: "Revive" | "Return";
+    }
+    // (undocumented)
+    export interface Scorch extends HasOpId, GapEffectPolicy {
+        // (undocumented)
+        type: "Scorch";
+    }
+    // (undocumented)
+    export interface SetValue extends HasOpId {
+        value?: TreeValue;
+    }
+    // (undocumented)
+    export type SizedMark = Skip | SizedObjectMark;
+    // (undocumented)
+    export type SizedObjectMark = Tomb | Modify | Detach | Reattach | ModifyReattach | ModifyDetach | GapEffectSegment;
+    // (undocumented)
+    export interface Tomb {
+        // (undocumented)
+        change: ChangesetTag;
+        // (undocumented)
+        count: number;
+        // (undocumented)
+        type: "Tomb";
+    }
+    export interface Tombstones {
+        // (undocumented)
+        change: ChangesetTag;
+        // (undocumented)
+        count: NodeCount;
+    }
+    // (undocumented)
+    export interface Unforward extends HasOpId, GapEffectPolicy {
+        // (undocumented)
+        type: "Unforward";
+    }
+}
+
+// @public (undocumented)
+export interface TreeForestPath {
+    // (undocumented)
+    [label: string]: TreeRootPath;
+}
 
 // @public (undocumented)
 export interface TreeLocation {
@@ -917,6 +1238,11 @@ export const enum TreeNavigationResult {
     Ok = 1,
     Pending = 0
 }
+
+// @public (undocumented)
+export type TreeRootPath = number | {
+    [label: number]: TreeForestPath;
+};
 
 // @public (undocumented)
 export interface TreeSchema {

--- a/packages/dds/tree/src/changeset/format.ts
+++ b/packages/dds/tree/src/changeset/format.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { JsonableTree } from "../tree";
+import { JsonableTree, TreeValue } from "../tree";
 
 // TODOs:
 // Clipboard
@@ -69,7 +69,7 @@ export namespace Transposed {
 		/**
 		 * Can be left unset to represent the value being cleared.
 		 */
-		value?: Value;
+		value?: TreeValue;
 	}
 
 	export interface Modify {
@@ -311,7 +311,6 @@ export type NodeCount = number;
 export type GapCount = number;
 export type Skip = number;
 export type ChangesetTag = number | string;
-export type Value = number | string | boolean;
 export type ClientId = number;
 export enum Tiebreak { Left, Right }
 export enum Effects {

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
@@ -211,8 +211,18 @@ function wrap1(marks: T.FieldMarks, node: UpPath): T.FieldMarks {
     return toFieldMarks({ type: "Modify", fields: marks }, node);
 }
 
-type NodePath = UpPath;
-type PlacePath = UpPath;
+/**
+ * Location of a Node in a tree relative to the root.
+ * Only valid for a specific revision of that tree.
+ */
+export interface NodePath extends UpPath{}
+
+/**
+ * Location of a "Place" in a tree relative to the root.
+ * This means a location where a node could be inserted, such as between nodes or an end of a field.
+ * Only valid for a specific revision of that tree.
+ */
+export interface PlacePath extends UpPath{}
 
 const ERR_UP_PATH_NOT_VALID
     = "If the two paths have the same key and the same index then they should have shared an UpPath earlier";

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -65,11 +65,31 @@ export {
 } from "./rebase";
 
 export {
+    ICheckout,
+    TransactionResult,
+} from "./checkout";
+
+export {
     cursorToJsonObject,
     JsonCursor,
     jsonTypeSchema,
     jsonArray, jsonBoolean, jsonNull, jsonNumber, jsonObject, jsonString,
 } from "./domains";
+
+export {
+    Transposed,
+    TreeForestPath,
+    TreeRootPath,
+    OpId,
+    Skip,
+    ChangesetTag,
+    Effects,
+    Tiebreak,
+    ProtoNode,
+    GapCount,
+    HasOpId,
+    NodeCount,
+} from "./changeset";
 
 export {
     buildForest,
@@ -112,4 +132,13 @@ export {
     proxyTargetSymbol,
     defaultSchemaPolicy,
     PrimitiveValue,
+    SequenceEditBuilder,
+    SequenceChangeset,
+    NodePath,
+    PlacePath,
 } from "./feature-libraries";
+
+export {
+    ISharedTree,
+    SharedTreeFactory,
+} from "./shared-tree";

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./sharedTree";
+export { ISharedTree, SharedTreeFactory } from "./sharedTree";

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -10,6 +10,7 @@ import {
     IChannelServices,
     IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
+import { ISharedObject } from "@fluidframework/shared-object-base";
 import { ICheckout, TransactionResult } from "../checkout";
 import {
     defaultSchemaPolicy,
@@ -27,14 +28,21 @@ import { Checkout as TransactionCheckout, runSynchronousTransaction } from "../t
 import { AnchorSet } from "../tree";
 
 /**
+ * Collaboratively editable tree distributed datastructure,
+ * powered by {@link @fluidframework/shared-object-base#ISharedObject}.
+ *
+ * See [the README](../../README.md) for details.
+ */
+export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObject{}
+
+/**
  * Shared tree, configured with a good set of indexes and field kinds which will maintain compatibility over time.
  * TODO: node identifier index.
  *
  * TODO: detail compatibility requirements.
  * TODO: expose or implement Checkout.
  */
-export class SharedTree extends SharedTreeCore<SequenceChangeset, SequenceChangeFamily>
-implements ICheckout<SequenceEditBuilder> {
+class SharedTree extends SharedTreeCore<SequenceChangeset, SequenceChangeFamily> implements ISharedTree {
     public readonly forest: IForestSubscription;
     /**
      * Rather than implementing TransactionCheckout, have a member that implements it.
@@ -76,7 +84,7 @@ implements ICheckout<SequenceEditBuilder> {
 }
 
 /**
- * A channel factory that creates {@link SharedTree}s.
+ * A channel factory that creates {@link ISharedTree}s.
  */
  export class SharedTreeFactory implements IChannelFactory {
     public type: string = "SharedTree";
@@ -98,7 +106,7 @@ implements ICheckout<SequenceEditBuilder> {
         return tree;
     }
 
-    public create(runtime: IFluidDataStoreRuntime, id: string): IChannel {
+    public create(runtime: IFluidDataStoreRuntime, id: string): ISharedTree {
         const tree = new SharedTree(id, runtime, this.attributes, "SharedTree");
         tree.initializeLocal();
         return tree;

--- a/packages/dds/tree/src/test/sequence-change-family/cases.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/cases.ts
@@ -5,8 +5,8 @@
 
 import { SequenceChangeset } from "../../feature-libraries";
 import { brand } from "../../util";
-import { Transposed as T, Value } from "../../changeset";
 import { TreeSchemaIdentifier } from "../../schema-stored";
+import { Value } from "../../tree";
 
 export function setRootValueTo(value: Value): SequenceChangeset {
     return {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -8,7 +8,7 @@ import { brand } from "../../util";
 import { detachedFieldAsKey } from "../../tree";
 import { TreeNavigationResult } from "../../forest";
 import { TestTreeProvider } from "../utils";
-import { SharedTree } from "../../shared-tree";
+import { ISharedTree } from "../../shared-tree";
 import { TransactionResult } from "../../checkout";
 
 describe("SharedTree", () => {
@@ -20,7 +20,7 @@ describe("SharedTree", () => {
         const value = "42";
 
         // Validate that the given tree has the state we create in this test
-        function validateTree(tree: SharedTree): void {
+        function validateTree(tree: ISharedTree): void {
             const readCursor = tree.forest.allocateCursor();
             const destination = tree.forest.root(tree.forest.rootField);
             const cursorResult = tree.forest.tryMoveCursorTo(destination, readCursor);

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -15,7 +15,7 @@ import {
     TestFluidObjectFactory,
     ITestFluidObject } from "@fluidframework/test-utils";
 import { InvalidationToken, SimpleObservingDependent } from "../dependency-tracking";
-import { SharedTree, SharedTreeFactory } from "../shared-tree";
+import { ISharedTree, SharedTreeFactory } from "../shared-tree";
 
 // Testing utilities
 
@@ -53,10 +53,10 @@ export class TestTreeProvider {
     private static readonly treeId = "TestSharedTree";
 
     private readonly provider: ITestObjectProvider;
-    private readonly _trees: SharedTree[] = [];
+    private readonly _trees: ISharedTree[] = [];
     private readonly _containers: IContainer[] = [];
 
-    public get trees(): readonly SharedTree[] {
+    public get trees(): readonly ISharedTree[] {
         return this._trees;
     }
 
@@ -86,20 +86,20 @@ export class TestTreeProvider {
     }
 
     /**
-     * Create and initialize a new {@link SharedTree} that is connected to all other trees from this provider.
+     * Create and initialize a new {@link ISharedTree} that is connected to all other trees from this provider.
      * @returns the tree that was created. For convenience, the tree can also be accessed via `this[i]` where
      * _i_ is the index of the tree in order of creation.
      */
-    public async createTree(): Promise<SharedTree> {
+    public async createTree(): Promise<ISharedTree> {
         const container = this.trees.length === 0
         ? await this.provider.makeTestContainer()
         : await this.provider.loadTestContainer();
 
         const dataObject = await requestFluidObject<ITestFluidObject>(container, "/");
-        return this._trees[this.trees.length] = await dataObject.getSharedObject<SharedTree>(TestTreeProvider.treeId);
+        return this._trees[this.trees.length] = await dataObject.getSharedObject<ISharedTree>(TestTreeProvider.treeId);
     }
 
-    public [Symbol.iterator](): IterableIterator<SharedTree> {
+    public [Symbol.iterator](): IterableIterator<ISharedTree> {
         return this.trees[Symbol.iterator]();
     }
 


### PR DESCRIPTION
## Description

Make an ISharedTree interface to allow exporting SharedTree without exposing the details of its class hierarchy-based implementation.

Export this new interface along with SharedTree factory (and the types they depend on) publicly from the package.

Also changes the "Value" type in `changeset` to use the one from `tree` (avoiding having to export two types with the same name for the same use-case). The one from tree is also more general (permits arbitrary serializable values).
