### PR TITLE
Add tagName to pipelines that don't have it

### DIFF
--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -60,7 +60,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: tools/api-markdown-documenter
-    tagName:
+    tagName: api-markdown-documenter
     taskBuild: build
     taskBuildDocs: true
     taskLint: true

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -65,7 +65,7 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: tools/benchmark
-    tagName:
+    tagName: benchmark
     taskBuild: build
     taskBuildDocs: true
     taskLint: true


### PR DESCRIPTION
## Description

Without a value for tagName, releases of these 2 packages (`@fluid-tools/benchmark` and `@fluid-tools/api-markdown-documenter`) don't get tagged in the git repo, and the published npm packages are tagged as canary instead of latest.

In short, this is because the `fluid-build-version` tool [expects a non-empty value](https://github.com/microsoft/FluidFramework/blob/328879891a632a9deb931688100fb2b023a8cecb/build-tools/packages/build-tools/src/buildVersion/buildVersion.ts#L119-L127) in order to update the `isLatest` variable during the build/publish pipeline run, and [only if that variable is set](https://github.com/microsoft/FluidFramework/blob/1999ba6b5a55df0257aca696aace1c9d18bc19c0/tools/pipelines/templates/include-publish-npm-package-steps.yml#L74-L82) (plus other conditions), will the npm package be tagged as latest.

## Other information or known dependencies

[AB1864](https://dev.azure.com/fluidframework/internal/_workitems/edit/1864)