### PR TITLE
Fix `@deprecated` comments

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -619,17 +619,17 @@ export interface ISummaryOpMessage extends ISequencedDocumentMessage {
 
 // @public (undocumented)
 export interface ISummaryRuntimeOptions {
-    // @deprecated (undocumented)
+    // @deprecated
     disableSummaries?: boolean;
-    // @deprecated (undocumented)
+    // @deprecated
     initialSummarizerDelayMs?: number;
     // @deprecated (undocumented)
     maxOpsSinceLastSummary?: number;
-    // @deprecated (undocumented)
+    // @deprecated
     summarizerClientElection?: boolean;
     // Warning: (ae-forgotten-export) The symbol "ISummarizerOptions" needs to be exported by the entry point index.d.ts
     //
-    // @deprecated (undocumented)
+    // @deprecated
     summarizerOptions?: Readonly<Partial<ISummarizerOptions>>;
     summaryConfigOverrides?: ISummaryConfiguration;
 }

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -179,7 +179,7 @@ export function parseCompactSnapshotResponse(buffer: ReadBuffer): ISnapshotConte
 
 // Warning: (ae-forgotten-export) The symbol "SnapshotFormatSupportType" needs to be exported by the entry point index.d.ts
 //
-// @public @deprecated
+// @public
 export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, forceAccessTokenViaAuthorizationHeader: boolean, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, fetchBinarySnapshotFormat?: boolean, snapshotFormatFetchType?: SnapshotFormatSupportType): Promise<boolean>;
 
 // @public

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -129,7 +129,7 @@ export interface IEnvelope {
 export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
-    // @deprecated (undocumented)
+    // @deprecated
     attachGraph(): void;
     readonly attachState: AttachState;
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
@@ -345,7 +345,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     // (undocumented)
     getChild(id: string): ISummarizerNodeWithGC | undefined;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    // @deprecated (undocumented)
+    // @deprecated
     getGCSummaryDetails(): IGarbageCollectionSummaryDetails;
     isReferenced(): boolean;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;

--- a/build-tools/packages/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
+++ b/build-tools/packages/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * @deprecated -- in favor build-tools/packages/build-cli/src/genMonoRepoPackageJson.ts
+ * @deprecated In favor `build-tools/packages/build-cli/src/genMonoRepoPackageJson.ts`.
  */
 
 import { FluidRepo } from "../common/fluidRepo";

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -31,8 +31,8 @@ export interface ITableDocumentEvents extends IEvent {
 }
 
 /**
- * @deprecated - TableDocument is an abandoned prototype.  Please use SharedMatrix with
- *               the IMatrixProducer/Consumer interfaces instead.
+ * @deprecated `TableDocument` is an abandoned prototype.
+ * Please use {@link @fluidframework/matrix#SharedMatrix} with the `IMatrixProducer`/`Consumer` interfaces instead.
  */
 export class TableDocument extends DataObject<{ Events: ITableDocumentEvents; }> implements ITable {
     public static getFactory() { return TableDocument.factory; }

--- a/examples/data-objects/table-document/src/table.ts
+++ b/examples/data-objects/table-document/src/table.ts
@@ -8,8 +8,8 @@ import { ICombiningOp, PropertySet } from "@fluidframework/merge-tree";
 export type TableDocumentItem = any;
 
 /**
- * @deprecated - ITable is an abandoned prototype.  Please use SharedMatrix with
- *               the IMatrixProducer/Consumer interfaces instead.
+ * @deprecated `ITable` is an abandoned prototype.
+ * Please use {@link @fluidframework/matrix#SharedMatrix} with the `IMatrixProducer`/`Consumer` interfaces instead.
  */
 export interface ITable {
     readonly numRows: number;

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -128,7 +128,7 @@ export interface IContainerContext extends IDisposable {
     readonly storage: IDocumentStorageService;
     readonly connected: boolean;
     readonly baseSnapshot: ISnapshotTree | undefined;
-    /** @deprecated - please use submitBatchFn & submitSummaryFn */
+    /** @deprecated Please use submitBatchFn & submitSummaryFn */
     readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
     /** @returns clientSequenceNumber of last message in a batch */
     readonly submitBatchFn: (batch: IBatchMessage[]) => number;

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -56,7 +56,7 @@ export interface IFluidHandle<
     > extends IProvideFluidHandle {
 
     /**
-     * @deprecated - Do not use handle's path for routing. Use `get` to get the underlying object.
+     * @deprecated Do not use handle's path for routing. Use `get` to get the underlying object.
      *
      * The absolute path to the handle context from the root.
      */

--- a/packages/dds/merge-tree/src/snapshotChunks.ts
+++ b/packages/dds/merge-tree/src/snapshotChunks.ts
@@ -63,7 +63,8 @@ export interface IJSONSegmentWithMergeInfo {
     client?: string;
     seq?: number;
     /**
-     * @deprecated - use removedClientIds instead. this only exists for back-compat
+     * @deprecated Use {@link IJSONSegmentWithMergeInfo.removedClientIds} instead.
+     * This only exists for backwards compatability.
      */
     removedClient?: string;
     removedClientIds?: string[];

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -122,7 +122,7 @@ export class TextSegment extends BaseSegment {
 
 export interface IMergeTreeTextHelper{
     /**
-     * @deprecated - If consuming via sequence, use `getTextAndMarkers` exported from \@fluidframework/sequence.
+     * @deprecated If consuming via sequence, use `getTextAndMarkers` exported from `\@fluidframework/sequence`.
      * Otherwise, define your own accumulation model and use `Client.walkSegments`.
      */
     getTextAndMarkers(refSeq: number, clientId: number, label: string, start?: number, end?: number): {

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -408,8 +408,8 @@ export abstract class SharedSegmentSequence<T extends ISegment>
     }
 
     /**
-     * @deprecated - IntervalCollections are created on a first-write wins basis, and concurrent creates
-     * are supported. Use `getIntervalCollection` instead.
+     * @deprecated `IntervalCollection`s are created on a first-write wins basis, and concurrent creates
+     * are supported. Use {@link SharedSegmentSequence.getIntervalCollection} instead.
      */
     public async waitIntervalCollection(
         label: string,

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -31,8 +31,8 @@ import { IMapMessageLocalMetadata } from "./defaultMapInterfaces";
 const snapshotFileName = "header";
 
 /**
- * The factory that defines the SharedIntervalCollection
- * @deprecated - SharedIntervalCollection is not maintained and is planned to be removed.
+ * The factory that defines the SharedIntervalCollection.
+ * @deprecated `SharedIntervalCollection` is not maintained and is planned to be removed.
  */
 export class SharedIntervalCollectionFactory implements IChannelFactory {
     public static readonly Type = "https://graph.microsoft.com/types/sharedIntervalCollection";
@@ -82,7 +82,7 @@ export interface ISharedIntervalCollection<TInterval extends ISerializableInterv
 }
 
 /**
- * @deprecated - SharedIntervalCollection is not maintained and is planned to be removed.
+ * @deprecated `SharedIntervalCollection` is not maintained and is planned to be removed.
  */
 export class SharedIntervalCollection
     extends SharedObject implements ISharedIntervalCollection<Interval> {
@@ -128,8 +128,8 @@ export class SharedIntervalCollection
     }
 
     /**
-     * @deprecated - IntervalCollections are created on a first-write wins basis, and concurrent creates
-     * are supported. Use `getIntervalCollection` instead.
+     * @deprecated `IntervalCollection`s are created on a first-write wins basis, and concurrent creates
+     * are supported. Use {@link SharedIntervalCollection.getIntervalCollection} instead.
      */
     public async waitIntervalCollection(
         label: string,

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -224,7 +224,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * @deprecated - use the free function `getTextAndMarkers` exported by this package instead.
+     * @deprecated Use the free function {@link getTextAndMarkers} exported by this package instead.
      */
     public getTextAndMarkers(label: string) {
         const segmentWindow = this.client.getCollabWindow();
@@ -251,7 +251,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * @deprecated - use `getTextWithPlaceholders` instead.
+     * @deprecated Use {@link SharedString.getTextWithPlaceholders} instead.
      */
     public getTextRangeWithPlaceholders(start: number, end: number) {
         return this.getTextWithPlaceholders(start, end);

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -81,14 +81,16 @@ export class DocumentDeltaConnection
         assert(this._disposed || this.socket.connected, 0x244 /* "Socket is closed, but connection is not!" */);
         return this._disposed;
     }
+
     /**
      * Flag to indicate whether the DocumentDeltaConnection is expected to still be capable of sending messages.
      * After disconnection, we flip this to prevent any stale messages from being emitted.
      */
     protected _disposed: boolean = false;
     private readonly mc: MonitoringContext;
+
     /**
-     * @deprecated - Implementors should manage their own logger or monitoring context
+     * @deprecated Implementors should manage their own logger or monitoring context
      */
     protected get logger(): ITelemetryLogger {
         return this.mc.logger;

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -57,7 +57,7 @@ export interface ICollabSessionOptions {
      */
     unauthenticatedUserDisplayName?: string;
     /**
-     * @deprecated - Due to security reasons we will be passing the token via Authorization header only.
+     * @deprecated Due to security reasons we will be passing the token via Authorization header only.
      * Value indicating session preference to always pass access token via Authorization header.
      * Default behavior is to pass access token via query parameter unless overall href string
      * length exceeds 2048 characters. Using query param is performance optimization which results
@@ -98,7 +98,7 @@ export interface HostStoragePolicy {
     sessionOptions?: ICollabSessionOptions;
 
     /**
-     * @deprecated - This field will be always set to true after removal.
+     * @deprecated This field will be always set to true after removal.
      * True to have the sharing link redeem fallback in case the Trees Latest/Redeem 1RT call fails with redeem error.
      * During fallback it will first redeem the sharing link and then make the Trees latest call.
      */
@@ -110,7 +110,7 @@ export interface HostStoragePolicy {
     cacheCreateNewSummary?: boolean;
 
     /**
-     * @deprecated - This will be replaced with feature gate snapshotFormatFetchType.
+     * @deprecated This will be replaced with feature gate snapshotFormatFetchType.
      * Policy controlling if we want to fetch binary format snapshot.
      */
     fetchBinarySnapshotFormat?: boolean;

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -28,6 +28,7 @@ import { IVersionedValueWithEpoch } from "./contracts";
 /**
  * Function to prefetch the snapshot and cached it in the persistant cache, so that when the container is loaded
  * the cached latest snapshot could be used and removes the network call from the critical path.
+ *
  * @param resolvedUrl - Resolved url to fetch the snapshot.
  * @param getStorageToken - function that can provide the storage token for a given site. This is
  *  is also referred to as the "VROOM" token in SPO.
@@ -36,11 +37,12 @@ import { IVersionedValueWithEpoch } from "./contracts";
  * @param logger - Logger to have telemetry events.
  * @param hostSnapshotFetchOptions - Options to fetch the snapshot if any. Otherwise default will be used.
  * @param enableRedeemFallback - True to have the sharing link redeem fallback in case the Trees Latest/Redeem
- *  1RT call fails with redeem error. During fallback it will first redeem the sharing link and then make
- *  the Trees latest call.
- *  @deprecated - This will be replaced with snapshotFormatFetchType.
+ * 1RT call fails with redeem error. During fallback it will first redeem the sharing link and then make
+ * the Trees latest call.
+ * Note: this can be considered deprecated - it will be replaced with `snapshotFormatFetchType`.
  * @param fetchBinarySnapshotFormat - Control if we want to fetch binary format snapshot.
  * @param snapshotFormatFetchType - Snapshot format to fetch.
+ *
  * @returns - True if the snapshot is cached, false otherwise.
  */
 export async function prefetchLatestSnapshot(

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -79,7 +79,7 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
         return false;
     }
     /**
-     * @deprecated - Needed for back compat
+     * @deprecated Needed for backwards compatability.
      */
     private getProvider(provider: string & keyof TMap) {
         // this was removed, but some partners have trouble with back compat where they

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -198,9 +198,10 @@ export class ContainerContext implements IContainerContext {
     }
 
     /**
-     * @deprecated - Temporary migratory API, to be removed when customers no longer need it.  When removed,
-     * ContainerContext should only take an IQuorumClients rather than an IQuorum.  See IContainerContext for more
-     * details.
+     * @deprecated Temporary migratory API, to be removed when customers no longer need it.
+     * When removed, `ContainerContext` should only take an {@link @fluidframework/container-definitions#IQuorumClients}
+     * rather than an {@link @fluidframework/protocol-definitions#IQuorum}.
+     * See {@link @fluidframework/container-definitions#IContainerContext} for more details.
      */
     public getSpecifiedCodeDetails(): IFluidCodeDetails | undefined {
         return (this._quorum.get("code") ?? this._quorum.get("code2")) as IFluidCodeDetails | undefined;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -31,16 +31,16 @@ import {
 } from "@fluidframework/runtime-definitions";
 
 /**
- * @deprecated - This will be removed in a later release.
+ * @deprecated This will be removed in a later release.
  */
 export const IContainerRuntime: keyof IProvideContainerRuntime = "IContainerRuntime";
 
 /**
- * @deprecated - This will be removed in a later release.
+ * @deprecated This will be removed in a later release.
  */
 export interface IProvideContainerRuntime {
     /**
-     * @deprecated - This will be removed in a later release.
+     * @deprecated This will be removed in a later release.
      */
     IContainerRuntime: IContainerRuntime;
 }
@@ -100,8 +100,8 @@ export interface IContainerRuntime extends
 
     /**
      * Flushes any ops currently being batched to the loader
-     * @deprecated - This will be removed in a later release. If a more manual flushing process is needed,
-     * move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
+     * @deprecated This will be removed in a later release. If a more manual flushing process is needed,
+     * move all usage to {@link IContainerRuntimeBase.orderSequentially} if possible.
      */
     flush(): void;
 

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -99,9 +99,11 @@ export interface IContainerRuntime extends
     readonly isDirty: boolean;
 
     /**
-     * Flushes any ops currently being batched to the loader
-     * @deprecated This will be removed in a later release. If a more manual flushing process is needed,
-     * move all usage to {@link IContainerRuntimeBase.orderSequentially} if possible.
+     * Flushes any ops currently being batched to the loader.
+     *
+     * @deprecated This will be removed in a later release.
+     * If a more manual flushing process is needed, move all usage to
+     * {@link @fluidframework/runtime-definitions#IContainerRuntimeBase.orderSequentially} if possible.
      */
     flush(): void;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -379,7 +379,7 @@ export interface ISummaryRuntimeOptions {
      * Delay before first attempt to spawn summarizing container.
      *
      * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
-     * {@link ISummaryConfiguration.initialSummarizerDelayMs} instead.
+     * {@link ISummaryBaseConfiguration.initialSummarizerDelayMs} instead.
      */
     initialSummarizerDelayMs?: number;
 
@@ -387,7 +387,7 @@ export interface ISummaryRuntimeOptions {
      * Flag that disables summaries if it is set to true.
      *
      * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
-     * {@link ISummaryConfiguration.disableSummaries} instead.
+     * {@link ISummaryConfigurationDisableSummarizer.state} instead.
      */
     disableSummaries?: boolean;
 
@@ -395,7 +395,7 @@ export interface ISummaryRuntimeOptions {
      * @defaultValue 7000 operations (ops)
      *
      * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
-     * {@link ISummaryConfiguration.maxOpsSinceLastSummary} instead.
+     * {@link ISummaryBaseConfiguration.maxOpsSinceLastSummary} instead.
      */
     maxOpsSinceLastSummary?: number;
 
@@ -405,7 +405,7 @@ export interface ISummaryRuntimeOptions {
      * @defaultValue `false` (disabled) and must be explicitly set to true to enable.
      *
      * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
-     * {@link ISummaryConfiguration.summarizerClientElection} instead.
+     * {@link ISummaryBaseConfiguration.summarizerClientElection} instead.
      */
     summarizerClientElection?: boolean;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -230,7 +230,8 @@ export interface ISummaryBaseConfiguration {
 export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
     state: "enabled";
     /**
-     * @deprecated - please move all implementation to minIdleTime and maxIdleTime
+     * @deprecated Please move all implementations to {@link ISummaryConfigurationHeuristics.minIdleTime} and
+     * {@link ISummaryConfigurationHeuristics.maxIdleTime} instead.
      */
     idleTime: number;
     /**
@@ -375,33 +376,45 @@ export interface ISummaryRuntimeOptions {
     summaryConfigOverrides?: ISummaryConfiguration;
 
     /**
-     *  @deprecated - use `summaryConfigOverrides.initialSummarizerDelayMs` instead.
-     *  Delay before first attempt to spawn summarizing container.
-    */
+     * Delay before first attempt to spawn summarizing container.
+     *
+     * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
+     * {@link ISummaryConfiguration.initialSummarizerDelayMs} instead.
+     */
     initialSummarizerDelayMs?: number;
 
     /**
-     * @deprecated - use `summaryConfigOverrides.disableSummaries` instead.
      * Flag that disables summaries if it is set to true.
+     *
+     * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
+     * {@link ISummaryConfiguration.disableSummaries} instead.
      */
     disableSummaries?: boolean;
 
     /**
-     * @deprecated - use `summaryConfigOverrides.maxOpsSinceLastSummary` instead.
-     * Defaults to 7000 ops
+     * @defaultValue 7000 operations (ops)
+     *
+     * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
+     * {@link ISummaryConfiguration.maxOpsSinceLastSummary} instead.
      */
     maxOpsSinceLastSummary?: number;
 
     /**
-    * @deprecated - use `summaryConfigOverrides.summarizerClientElection` instead.
-    * Flag that will enable changing elected summarizer client after maxOpsSinceLastSummary.
-    * This defaults to false (disabled) and must be explicitly set to true to enable.
-    */
+     * Flag that will enable changing elected summarizer client after maxOpsSinceLastSummary.
+     *
+     * @defaultValue `false` (disabled) and must be explicitly set to true to enable.
+     *
+     * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
+     * {@link ISummaryConfiguration.summarizerClientElection} instead.
+     */
     summarizerClientElection?: boolean;
 
     /**
-     * @deprecated - use `summaryConfigOverrides.state = "DisableHeuristics"` instead.
-     *  Options that control the running summarizer behavior. */
+     * Options that control the running summarizer behavior.
+     *
+     * @deprecated Use {@link ISummaryRuntimeOptions.summaryConfigOverrides}'s
+     * `{@link ISummaryConfiguration.state} = "DisableHeuristics"` instead.
+     * */
     summarizerOptions?: Readonly<Partial<ISummarizerOptions>>;
 }
 

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -700,7 +700,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     public abstract getInitialSnapshotDetails(): Promise<ISnapshotDetails>;
 
     /**
-     * @deprecated - Sets the datastore as root, for aliasing purposes: #7948
+     * @deprecated Sets the datastore as root, for aliasing purposes: #7948
      * This method should not be used outside of the aliasing context.
      * It will be removed, as the source of truth for this flag will be the aliasing blob.
      */
@@ -709,7 +709,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     }
 
     /**
-     * @deprecated - Renamed to getBaseGCDetails().
+     * @deprecated Renamed to `{@link FluidDataStoreContext.getBaseGCDetails}()`.
      */
     public abstract getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
 
@@ -851,7 +851,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
     }
 
     /**
-     * @deprecated - Renamed to getBaseGCDetails.
+     * @deprecated Renamed to {@link RemoteFluidDataStoreContext.getBaseGCDetails}.
      */
     public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
         return this.getBaseGCDetails();
@@ -965,7 +965,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
     }
 
     /**
-     * @deprecated - Renamed to getBaseGCDetails.
+     * @deprecated Renamed to {@link LocalFluidDataStoreContextBase.getBaseGCDetails}.
      */
     public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
         // Local data store does not have initial summary.

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -25,16 +25,16 @@ import { SummarizeReason } from "./summaryGenerator";
 import { ISummaryConfigurationHeuristics } from ".";
 
 /**
- * @deprecated - This will be removed in a later release.
+ * @deprecated This will be removed in a later release.
  */
 export const ISummarizer: keyof IProvideSummarizer = "ISummarizer";
 
 /**
- * @deprecated - This will be removed in a later release.
+ * @deprecated This will be removed in a later release.
  */
 export interface IProvideSummarizer {
     /**
-     * @deprecated - This will be removed in a later release.
+     * @deprecated This will be removed in a later release.
      */
     readonly ISummarizer: ISummarizer;
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -134,7 +134,7 @@ export interface IContainerRuntimeBase extends
 
     /**
      * Sets the flush mode for operations on the document.
-     * @deprecated - Will be removed in 0.60. See #9480.
+     * @deprecated Will be removed in 0.60. See #9480.
      */
     setFlushMode(mode: FlushMode): void;
 
@@ -215,8 +215,8 @@ export interface IFluidDataStoreChannel extends
     readonly visibilityState?: VisibilityState;
 
     /**
-     * @deprecated - This will be removed in favor of makeVisibleAndAttachGraph.
      * Runs through the graph and attaches the bound handles. Then binds this runtime to the container.
+     * @deprecated This will be removed in favor of {@link IFluidDataStoreChannel.makeVisibleAndAttachGraph}.
      */
     attachGraph(): void;
 
@@ -414,7 +414,7 @@ export interface IFluidDataStoreContext extends
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 
     /**
-     * @deprecated - Renamed to getBaseGCDetails.
+     * @deprecated Renamed to {@link IFluidDataStoreContext.getBaseGCDetails}.
      */
     getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
 

--- a/packages/runtime/runtime-definitions/src/garbageCollection.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollection.ts
@@ -28,6 +28,6 @@ export interface IGarbageCollectionDetailsBase {
 }
 
 /**
- * @deprecated - Kept for back-compat. This has been renamed to {@link IGarbageCollectionDetailsBase}.
+ * @deprecated Kept for backwards-compatabiliy. This has been renamed to {@link IGarbageCollectionDetailsBase}.
  */
 export type IGarbageCollectionSummaryDetails = IGarbageCollectionDetailsBase;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -266,8 +266,9 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
 
     /**
-     * @deprecated - Renamed to getBaseGCDetails.
      * Returns the GC details that may be added to this node's summary.
+     *
+     * @deprecated Renamed to {@link ISummarizerNodeWithGC.getBaseGCDetails}.
      */
     getGCSummaryDetails(): IGarbageCollectionSummaryDetails;
 

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -121,7 +121,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     }
 
     /**
-     * @deprecated - Renamed to getBaseGCDetails.
+     * @deprecated Renamed to {@link SummarizerNodeWithGC.getBaseGCDetails}.
      */
     public getGCSummaryDetails(): IGarbageCollectionSummaryDetails {
         return this.getBaseGCDetails();


### PR DESCRIPTION
Fix syntax issues (mainly usage of `-` delimiters, which are not desired with `@deprecated` comments), and adding API reference links where appropriate.

For more on `@deprecated` usage, see: https://github.com/microsoft/FluidFramework/wiki/TSDoc-Guidelines#deprecated