### PR TITLE
Fix walkAllSegments to only walk descendant nodes

### DIFF
--- a/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
@@ -173,12 +173,20 @@ export function walkAllChildSegments(
     if (startBlock.childCount === 0) {
         return true;
     }
+
+    // undefined shouldn't actually be added, but this allows subsequent check for `node.parent` to typecheck
+    // without further runtime work.
+    const ancestors = new Set<IMergeBlock | undefined>();
+    for (let cur = startBlock.parent; cur !== undefined; cur = cur.parent) {
+        ancestors.add(cur);
+    }
+
     return depthFirstNodeWalk(
         startBlock,
         startBlock.children[0],
-        startBlock.parent === undefined
+        ancestors.size === 0
             ? undefined
-            : (node) => node.parent === startBlock.parent ? NodeAction.Exit : NodeAction.Continue,
+            : (node) => ancestors.has(node.parent) ? NodeAction.Exit : NodeAction.Continue,
         leafAction,
     );
 }

--- a/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
@@ -178,7 +178,7 @@ export function walkAllChildSegments(
         startBlock.children[0],
         startBlock.parent === undefined
             ? undefined
-            : (node) => node === startBlock.parent ? NodeAction.Exit : NodeAction.Continue,
+            : (node) => node.parent === startBlock.parent ? NodeAction.Exit : NodeAction.Continue,
         leafAction,
     );
 }

--- a/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
@@ -45,7 +45,7 @@ describe("MergeTree walks", () => {
         }
     });
 
-    describe.only("walkAllChildSegments", () => {
+    describe("walkAllChildSegments", () => {
         function* getAllDescendantBlocks(block: IMergeBlock): Iterable<IMergeBlock> {
             yield block;
             for (let i = 0; i < block.childCount; i++) {

--- a/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
@@ -1,0 +1,63 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    MaxNodesInBlock,
+} from "../mergeTreeNodes";
+import {
+    TextSegment,
+} from "../textSegment";
+import { LocalClientId, UniversalSequenceNumber } from "../constants";
+import { MergeTree } from "../mergeTree";
+import { walkAllChildSegments } from "../mergeTreeNodeWalk";
+import { insertText } from "./testUtils";
+
+const localClientId = 17;
+
+describe("MergeTree walks", () => {
+    let mergeTree: MergeTree;
+    beforeEach(() => {
+        let initialText = "0";
+        mergeTree = new MergeTree();
+        mergeTree.insertSegments(
+            0,
+            [TextSegment.make(initialText)],
+            UniversalSequenceNumber,
+            LocalClientId,
+            UniversalSequenceNumber,
+            undefined);
+        for (let i = 1; i < MaxNodesInBlock * 4; i++) {
+            const text = i.toString();
+            insertText(
+                mergeTree,
+                mergeTree.getLength(UniversalSequenceNumber, localClientId),
+                UniversalSequenceNumber,
+                localClientId,
+                UniversalSequenceNumber,
+                text,
+                undefined,
+                undefined);
+            initialText += text;
+        }
+    });
+
+    describe("walkAllChildSegments", () => {
+        it("visits only descendants", () => {
+            for (let i = 0; i < mergeTree.root.childCount; i++) {
+                const block = mergeTree.root.children[i];
+                assert(!block.isLeaf(), "Expected multi-layer tree");
+                walkAllChildSegments(block, (seg) => {
+                    let current = seg.parent;
+                    while (current !== block && current !== undefined) {
+                        current = current.parent;
+                    }
+                    assert(current === block, "Expected all visited segments to be descendants");
+                    return true;
+                });
+            }
+        });
+    });
+});


### PR DESCRIPTION
The conditional on `downAction` didn't correctly cause the function to exit. So previous behavior would continue the walk past descendant nodes, acting more like a right excursion.

This doesn't matter in any existing production codepath, but isn't a great latent bug to have.