### PR TITLE
TreeDDS: avoid unnecessary rebasing

### DIFF
--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -263,10 +263,10 @@ interface Branch<TChangeset> {
     localChanges: Commit<TChangeset>[];
     refSeq: SeqNumber;
     /**
-     * A branch is divergent iff it has local changes and there is a change with a `seqNumber`
+     * A branch is divergent iff it has local changes and there is a change outside the branch with a `seqNumber`
      * between the branch's `refSeq` and the `seqNumber` of the last change in the branch.
      * In other words, the ref commit followed by the local changes
-     * do not from a contiguous block in the trunk or final sequence.
+     * do not form a contiguous block in the trunk or final sequence.
      *
      * Note that a commit whose ref number does not match the latest sequence number at the time of its
      * sequencing is not necessarily divergent: if the commit is from the peer who issued the preceding commit,

--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -111,7 +111,7 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
         if (lastCommit === undefined || newCommit.refNumber === lastCommit.seqNumber) {
             branch.isDivergent = false;
         } else {
-            branch.isDivergent ||= newCommit.sessionId !== lastCommit?.sessionId;
+            branch.isDivergent ||= newCommit.sessionId !== lastCommit.sessionId;
         }
     }
 
@@ -263,8 +263,10 @@ interface Branch<TChangeset> {
     localChanges: Commit<TChangeset>[];
     refSeq: SeqNumber;
     /**
-     * True iff the commits on the branch were not based on the commit at trunk tip at the time
-     * they were sequenced.
+     * A branch is divergent iff it has local changes and there is a change with a `seqNumber`
+     * between the branch's `refSeq` and the `seqNumber` of the last change in the branch.
+     * In other words, the ref commit followed by the local changes
+     * do not from a contiguous block in the trunk or final sequence.
      *
      * Note that a commit whose ref number does not match the latest sequence number at the time of its
      * sequencing is not necessarily divergent: if the commit is from the peer who issued the preceding commit,
@@ -274,13 +276,13 @@ interface Branch<TChangeset> {
      *
      * - A new commit `c`
      *
-     * - The function `prev(x)` that return the commit sequenced immediately before commit `x`:
+     * - The function `prev(x)` that returns the commit sequenced immediately before commit `x`:
      *
      * ```typescript
      * isDivergent(c) =
      *     prev(c) !== undefined
-     *     && c.ref != prev(c).seq
-     *     && (prev(c).peer != c.peer || isDivergent(prev(c)))
+     *     && c.refNumber !== prev(c).seqNumber
+     *     && (prev(c).sessionId !== c.sessionId || isDivergent(prev(c)))
      * ```
      */
     isDivergent: boolean;

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -175,10 +175,6 @@ class TestChangeRebaser implements ChangeRebaser<TestChangeset> {
 }
 
 class UnrebasableTestChangeRebaser extends TestChangeRebaser {
-    public invert(change: TestChangeset): TestChangeset {
-        assert.fail("Unexpected call to invert");
-    }
-
     public rebase(change: TestChangeset, over: TestChangeset): TestChangeset {
         assert.fail("Unexpected call to rebase");
     }
@@ -354,6 +350,13 @@ describe("EditManager", () => {
             { seq: 4, type: "Pull", ref: 2, from: peer1 },
             { seq: 5, type: "Pull", ref: 0, from: peer2 },
             { seq: 6, type: "Pull", ref: 0, from: peer2 },
+        ]);
+
+        runUnitTestScenario("Can rebase peer changes over a local change", [
+            { seq: 1, type: "Push" },
+            { seq: 1, type: "Ack" },
+            { seq: 2, type: "Pull", ref: 0, from: peer1 },
+            { seq: 3, type: "Pull", ref: 0, from: peer1 },
         ]);
 
         runUnitTestScenario("Can rebase multiple local changes", [


### PR DESCRIPTION
This PR adds a check in the `EditManager` to avoid some unnecessary rebasing.
In the long run, this is just a performance improvement (albeit a possibly important one).
In the short run, this helps avoid cases where our current lack of support for true inverses causes unexpected merge outcomes.