### PR TITLE
Protect against potential double-call to attachRuntime (?)

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -1008,7 +1008,10 @@ export class LocalDetachedFluidDataStoreContext
         registry: IProvideFluidDataStoreFactory,
         dataStoreChannel: IFluidDataStoreChannel) {
         assert(this.detachedRuntimeCreation, 0x154 /* "runtime creation is already attached" */);
+        this.detachedRuntimeCreation = false;
+
         assert(this.channelDeferred === undefined, 0x155 /* "channel deferral is already set" */);
+        this.channelDeferred = new Deferred<IFluidDataStoreChannel>();
 
         const factory = registry.IFluidDataStoreFactory;
 
@@ -1017,9 +1020,6 @@ export class LocalDetachedFluidDataStoreContext
 
         assert(this.registry === undefined, 0x157 /* "datastore registry already attached" */);
         this.registry = entry.registry;
-
-        this.detachedRuntimeCreation = false;
-        this.channelDeferred = new Deferred<IFluidDataStoreChannel>();
 
         super.bindRuntime(dataStoreChannel);
 


### PR DESCRIPTION
## Description

Disclaimer: I have little context about this code, I'm submitting the PR for review purely based on first-principles reasoning, but there might be something I don't know about or am not seeing. Happy to close if that's the case.

I ran into this code and thought the new location seems like a better place for those lines. So if a first call to `attachRuntime` hits its `await` on line 1015/1016 and cedes execution, a second call to `attachRuntime` before the first call completes will correctly error out in one of the `assert()` lines. Otherwise the second call might not see `detachedRuntimeCreation === false` or `channelDeferred !== undefined`.

`factoryFromPackagePath()` does not seem to access `channelDeferred` nor `detachedRuntimeCreation` so assigning them before that function call shouldn't impact the function call.

## Reviewer Guidance

Ideally I'd like someone with more context (@vladsud you seem to have been the only one to touch this function in a meaningful way, a while back) to chime in.