### PR TITLE
Add logging when uploading Summary

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2485,6 +2485,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             let handle: string;
             try {
+                // Logging removal tracked by task 1884.
                 this.logger.sendTelemetryEvent({ eventName: "uploadSummaryWithContext",
                     proposalHandle: summaryContext.proposalHandle,
                     ackHandle: summaryContext.ackHandle,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2485,6 +2485,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             let handle: string;
             try {
+                this.logger.sendTelemetryEvent({ eventName: "uploadSummaryWithContext",
+                    proposalHandle: summaryContext.proposalHandle,
+                    ackHandle: summaryContext.ackHandle,
+                    referenceSequenceNumber: summaryContext.referenceSequenceNumber });
                 handle = await this.storage.uploadSummaryWithContext(summarizeResult.summary, summaryContext);
             } catch (error) {
                 return { stage: "generate", ...generateSummaryData, error };


### PR DESCRIPTION
In order to properly address [ bug1871](https://fluidframework.visualstudio.com/internal/_workitems/edit/1871) we need to understand whether FRS is getting the correct proposal handle when we upload it.  This will exclude the possibility of having AFR sending the same proposal handle 2x and will allow us to understand why we are processing a previous handle at all. Once we log the telemetry on our stress tests, the plan is to remove this logging.