### PR TITLE
Tree: Use symbols for global field keys

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -267,8 +267,8 @@ export interface FieldEditor<TChangeset> {
     buildChildChange(childIndex: number, change: NodeChangeset): TChangeset;
 }
 
-// @public (undocumented)
-export type FieldKey = LocalFieldKey | GlobalFieldKey;
+// @public
+export type FieldKey = LocalFieldKey | GlobalFieldKeySymbol;
 
 // @public @sealed
 export class FieldKind {
@@ -338,6 +338,14 @@ export interface FieldSchema {
     readonly types?: TreeTypeSet;
 }
 
+// @public (undocumented)
+export const enum FieldScope {
+    // (undocumented)
+    global = "fields",
+    // (undocumented)
+    local = "fields"
+}
+
 // @public
 const forbidden: FieldKind;
 
@@ -355,7 +363,9 @@ export type GapCount = number;
 // @public
 export interface GenericTreeNode<TChild> extends NodeData {
     // (undocumented)
-    fields?: FieldMap<TChild>;
+    [FieldScope.local]?: FieldMap<TChild>;
+    // (undocumented)
+    [FieldScope.global]?: FieldMap<TChild>;
 }
 
 // @public
@@ -365,8 +375,10 @@ export function getEditableTree(forest: IEditableForest): [EditableTreeContext, 
 export const getTypeSymbol: unique symbol;
 
 // @public
-export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKey">> {
-}
+export type GlobalFieldKey = Brand<string, "tree.GlobalFieldKey">;
+
+// @public
+export type GlobalFieldKeySymbol = Brand<symbol, "GlobalFieldKeySymbol">;
 
 // @public (undocumented)
 export interface HasOpId {
@@ -857,7 +869,7 @@ export interface RootField {
 }
 
 // @public
-export const rootFieldKey: BrandedType<string, "tree.GlobalFieldKey">;
+export const rootFieldKey: GlobalFieldKey;
 
 // @public
 export interface SchemaData extends SchemaDataReader {
@@ -960,6 +972,9 @@ export class StoredSchemaRepository<TPolicy extends SchemaPolicy = SchemaPolicy>
     updateFieldSchema(identifier: GlobalFieldKey, schema: FieldSchema): void;
     updateTreeSchema(identifier: TreeSchemaIdentifier, schema: TreeSchema): void;
 }
+
+// @public (undocumented)
+export function symbolFromKey(key: GlobalFieldKey): GlobalFieldKeySymbol;
 
 // @public
 export type SynchronousNavigationResult = TreeNavigationResult.Ok | TreeNavigationResult.NotFound;

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -338,7 +338,7 @@ export interface FieldSchema {
     readonly types?: TreeTypeSet;
 }
 
-// @public (undocumented)
+// @public
 export const enum FieldScope {
     // (undocumented)
     global = "fields",

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -551,6 +551,9 @@ export const jsonString: NamedTreeSchema;
 // @public (undocumented)
 export const jsonTypeSchema: Map<TreeSchemaIdentifier, NamedTreeSchema>;
 
+// @public (undocumented)
+export function keyFromSymbol(key: GlobalFieldKeySymbol): GlobalFieldKey;
+
 // @public
 function lastWriteWinsRebaser<TChange>(data: {
     noop: TChange;

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 import { assert } from "@fluidframework/common-utils";
-import { Value, Anchor } from "../../tree";
+import { Value, Anchor, rootFieldKey } from "../../tree";
 import {
     IEditableForest, TreeNavigationResult, mapCursorField, ITreeSubscriptionCursor, ITreeSubscriptionCursorState,
 } from "../../forest";
 import { brand } from "../../util";
 import {
-    FieldSchema, rootFieldKey, LocalFieldKey, TreeSchemaIdentifier, TreeSchema, ValueSchema,
+    FieldSchema, LocalFieldKey, TreeSchemaIdentifier, TreeSchema, ValueSchema,
 } from "../../schema-stored";
 import { FieldKind, Multiplicity } from "../modular-schema";
 import {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/typedSchema.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/typedSchema.ts
@@ -5,12 +5,13 @@
 
 import { Invariant } from "../../util";
 import {
-    fieldSchema, treeSchema, TreeSchemaBuilder,
+    fieldSchema, TreeSchemaBuilder,
     FieldSchema,
     LocalFieldKey,
-    TreeSchema,
     ValueSchema,
     TreeSchemaIdentifier,
+    namedTreeSchema,
+    NamedTreeSchema,
 } from "../../schema-stored";
 import { FieldKind } from "./fieldKind";
 
@@ -22,7 +23,8 @@ import { FieldKind } from "./fieldKind";
 /**
  * Type implemented by schema to allow compile time schema access via type checking.
  */
-interface TreeSchemaTypeInfo extends TreeSchemaBuilder {
+export interface TreeSchemaTypeInfo extends TreeSchemaBuilder {
+    readonly name: TreeSchemaIdentifier;
     readonly local: { [key: string]: LabeledFieldSchema<any>; };
     readonly global: { [key: string]: unknown; };
     readonly extraLocalFields: LabeledFieldSchema<any>;
@@ -40,7 +42,7 @@ interface FieldSchemaTypeInfo {
  * typescript type to allow for deriving schema aware APIs.
  */
 export function typedTreeSchema<T extends TreeSchemaTypeInfo>(t: T): LabeledTreeSchema<T> {
-    return treeSchema(t) as LabeledTreeSchema<T>;
+    return namedTreeSchema(t) as LabeledTreeSchema<T>;
 }
 
 /**
@@ -60,8 +62,7 @@ export type TypeInfo<T extends LabeledTreeSchema<any>> = T extends LabeledTreeSc
 export type FieldInfo<T extends LabeledFieldSchema<any>> =
     T extends LabeledFieldSchema<infer R> ? R : unknown;
 
-export interface LabeledTreeSchema<T extends TreeSchemaTypeInfo>
-    extends TreeSchema {
+export interface LabeledTreeSchema<T extends TreeSchemaTypeInfo> extends NamedTreeSchema {
     readonly typeCheck?: Invariant<T>;
 
     // Allow reading localFields through the normal map, but without losing type information.

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -15,6 +15,7 @@ import {
     detachedFieldAsKey,
     FieldKey,
     FieldMap,
+    FieldScope,
     getGenericTreeField,
     getGenericTreeFieldMap,
     JsonableTree,
@@ -99,7 +100,8 @@ export class TextCursor implements ITreeCursor<SynchronousNavigationResult> {
     }
 
     get keys(): Iterable<FieldKey> {
-        return Object.getOwnPropertyNames(getGenericTreeFieldMap(this.getNode(), false)) as Iterable<FieldKey>;
+        return Object.getOwnPropertyNames(
+            getGenericTreeFieldMap(this.getNode(), FieldScope.local, false)) as Iterable<FieldKey>;
     }
 
     down(key: FieldKey, index: number): SynchronousNavigationResult {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -12,7 +12,7 @@ export {
     EmptyKey, FieldKey, TreeType, Value, TreeValue, AnchorSet, DetachedField,
     UpPath, Anchor, RootField, ChildCollection,
     ChildLocation, FieldMap, NodeData, GenericTreeNode, PlaceholderTree, JsonableTree,
-    Delta,
+    Delta, rootFieldKey, FieldScope, GlobalFieldKeySymbol, symbolFromKey, keyFromSymbol,
 } from "./tree";
 
 export { ITreeCursor, TreeNavigationResult, IEditableForest,
@@ -29,7 +29,7 @@ export {
     LocalFieldKey, GlobalFieldKey, TreeSchemaIdentifier, NamedTreeSchema, Named,
     FieldSchema, ValueSchema, TreeSchema,
     StoredSchemaRepository, FieldKindIdentifier,
-    rootFieldKey, TreeTypeSet, SchemaData, SchemaPolicy, SchemaDataReader,
+    TreeTypeSet, SchemaData, SchemaPolicy, SchemaDataReader,
 } from "./schema-stored";
 
 export {

--- a/packages/dds/tree/src/schema-stored/builders.ts
+++ b/packages/dds/tree/src/schema-stored/builders.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { brand, brandOpaque } from "../util";
+import { brand } from "../util";
 import {
     FieldKindIdentifier,
-    FieldSchema, GlobalFieldKey, LocalFieldKey, Named, NamedTreeSchema, TreeSchema, TreeSchemaIdentifier, ValueSchema,
+    FieldSchema, GlobalFieldKey, Named, NamedTreeSchema, TreeSchema, TreeSchemaIdentifier, ValueSchema,
 } from "./schema";
 
 /**
@@ -25,19 +25,6 @@ export const emptySet: ReadonlySet<never> = new Set();
  * Empty readonly map.
  */
 export const emptyMap: ReadonlyMap<never, never> = new Map<never, never>();
-
-/**
- * LocalFieldKey to use for when there is a collection of items under a tree node
- * that makes up the logical primary significant of that tree.
- */
-export const itemsKey: LocalFieldKey = brand("items");
-
-/**
- * GlobalFieldKey to use for the root of documents.
- * TODO: if we do want to standardize on a single value for this,
- * it likely should be namespaced or a UUID to avoid risk of collisions.
- */
-export const rootFieldKey = brandOpaque<GlobalFieldKey>("rootFieldKey");
 
 /**
  * Helper for building {@link FieldSchema}.

--- a/packages/dds/tree/src/schema-stored/index.ts
+++ b/packages/dds/tree/src/schema-stored/index.ts
@@ -11,5 +11,5 @@ export {
 } from "./schema";
 export { StoredSchemaRepository, SchemaData } from "./storedSchemaRepository";
 export {
-    treeSchema, fieldSchema, rootFieldKey, emptyMap, emptySet, TreeSchemaBuilder, namedTreeSchema,
+    treeSchema, fieldSchema, emptyMap, emptySet, TreeSchemaBuilder, namedTreeSchema,
 } from "./builders";

--- a/packages/dds/tree/src/schema-stored/schema.ts
+++ b/packages/dds/tree/src/schema-stored/schema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Brand, Opaque } from "../util";
+import { Brand } from "../util";
 
 /**
  * Example internal schema representation types.
@@ -44,16 +44,11 @@ export type LocalFieldKey = Brand<string, "tree.LocalFieldKey">;
 export type FieldKindIdentifier = Brand<string, "tree.FieldKindIdentifier">;
 
 /**
- * SchemaIdentifier for a Field "global field",
+ * SchemaIdentifier for a "global field",
  * meaning a field which has the same meaning for all usages within the document
  * (not scoped to a specific TreeSchema like LocalFieldKey).
- *
- * Note that the implementations should ensure that GlobalFieldKeys can never collide with LocalFieldKeys.
- * This can be done in several ways
- * (keeping the two classes of fields separate, name-spacing/escaping,
- * compressing one into numbers and leaving the other strings, etc.)
  */
-export interface GlobalFieldKey extends Opaque<Brand<string, "tree.GlobalFieldKey">>{}
+export type GlobalFieldKey = Brand<string, "tree.GlobalFieldKey">;
 
 /**
  * Example for how we might want to handle values.

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -146,18 +146,18 @@ describe("JsonCursor", () => {
 
         function expectFound(cursor: ITreeCursor, key: FieldKey, index = 0) {
             assert(0 <= index && index < cursor.length(key),
-                `.length() must include index of existing child '${key}[${index}]'.`);
+                `.length() must include index of existing child '${String(key)}[${index}]'.`);
 
             assert.equal(cursor.down(key, index), TreeNavigationResult.Ok,
-                `Must navigate to child '${key}[${index}]'.`);
+                `Must navigate to child '${String(key)}[${index}]'.`);
         }
 
         function expectNotFound(cursor: ITreeCursor, key: FieldKey, index = 0) {
             assert(!(index >= 0) || index >= cursor.length(key),
-                `.length() must exclude index of missing child '${key}[${index}]'.`);
+                `.length() must exclude index of missing child '${String(key)}[${index}]'.`);
 
             assert.equal(cursor.down(key, index), TreeNavigationResult.NotFound,
-                `Must return 'NotFound' for missing child '${key}[${index}]'`);
+                `Must return 'NotFound' for missing child '${String(key)}[${index}]'`);
         }
 
         it("Missing key in map returns NotFound", () => {

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -9,10 +9,10 @@
 import { fail, strict as assert } from "assert";
 import {
     NamedTreeSchema, StoredSchemaRepository, namedTreeSchema, ValueSchema, fieldSchema, SchemaData,
-    TreeSchemaIdentifier, rootFieldKey,
+    TreeSchemaIdentifier,
 } from "../../../schema-stored";
 import { IEditableForest, initializeForest } from "../../../forest";
-import { JsonableTree, EmptyKey, Value } from "../../../tree";
+import { JsonableTree, EmptyKey, Value, rootFieldKey } from "../../../tree";
 import { brand, Brand, clone } from "../../../util";
 import {
     defaultSchemaPolicy, getEditableTree, EditableTree, buildForest, getTypeSymbol, UnwrappedEditableField,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -122,10 +122,10 @@ describe("Schema Comparison", () => {
             value: ValueSchema.Nothing,
         }));
         assert(isNeverTree(defaultSchemaPolicy, repo, neverTree2));
-        repo.updateFieldSchema(brandOpaque<GlobalFieldKey>("never"), neverField);
+        repo.updateFieldSchema(brand("never"), neverField);
         assert(isNeverTree(defaultSchemaPolicy, repo, {
             localFields: emptyMap,
-            globalFields: new Set([brandOpaque<GlobalFieldKey>("never")]),
+            globalFields: new Set([brand("never")]),
             extraLocalFields: emptyField,
             extraGlobalFields: true,
             value: ValueSchema.Serializable,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../feature-libraries/modular-schema";
 
 import {
-    treeSchema, fieldSchema, rootFieldKey,
+    treeSchema, fieldSchema,
     FieldSchema,
     GlobalFieldKey, TreeSchema, TreeSchemaIdentifier, ValueSchema, StoredSchemaRepository, SchemaData,
 } from "../../../schema-stored";
@@ -22,6 +22,7 @@ import {
 } from "../../../schema-view";
 import { brand } from "../../../util";
 import { defaultSchemaPolicy, emptyField, FieldKinds } from "../../../feature-libraries";
+import { rootFieldKey } from "../../../tree";
 
 // Allow importing specific example files:
 /* eslint-disable-next-line import/no-internal-modules */

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/typedSchema.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/typedSchema.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../feature-libraries/modular-schema/typedSchema";
 
 import { ValueSchema } from "../../../schema-stored";
-import { requireTrue } from "../../../util";
+import { brand, requireTrue } from "../../../util";
 import { FieldKinds } from "../../../feature-libraries";
 
 // These tests currently just cover the type checking, so its all compile time.
@@ -27,6 +27,7 @@ const testField = typedFieldSchema({
 });
 
 export const testTreeSchema = typedTreeSchema({
+    name: brand("testTreeSchema"),
     local: { localKey1Name: testField },
     global: {},
     extraLocalFields: testField,

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -10,14 +10,14 @@ import { strict as assert } from "assert";
 import { ObjectForest } from "../feature-libraries/object-forest";
 
 import {
-    fieldSchema, rootFieldKey,
+    fieldSchema,
     SchemaData,
     StoredSchemaRepository,
 } from "../schema-stored";
 import { IEditableForest, initializeForest, TreeNavigationResult } from "../forest";
 import { JsonCursor, cursorToJsonObject, jsonTypeSchema, jsonNumber, jsonObject } from "../domains";
 import { recordDependency } from "../dependency-tracking";
-import { clonePath, Delta, detachedFieldAsKey, JsonableTree, UpPath } from "../tree";
+import { clonePath, Delta, detachedFieldAsKey, JsonableTree, UpPath, rootFieldKey } from "../tree";
 import { jsonableTreeFromCursor } from "..";
 import { brand } from "../util";
 import { defaultSchemaPolicy, FieldKinds, isNeverField } from "../feature-libraries";

--- a/packages/dds/tree/src/tree/globalFieldKeySymbol.ts
+++ b/packages/dds/tree/src/tree/globalFieldKeySymbol.ts
@@ -1,0 +1,36 @@
+import { GlobalFieldKey } from "../schema-stored";
+import { brand, Brand, fail } from "../util";
+
+/**
+ * Symbol which can be used to lookup a global field.
+ * Using a symbol here avoids the need to use the full string version of the key,
+ * and avoids the possibility of colliding with local field keys.
+ *
+ * Must only be produced using {@link symbolFromKey}.
+ */
+export type GlobalFieldKeySymbol = Brand<symbol, "GlobalFieldKeySymbol">;
+
+// These maps are used instead of `Symbol.for` and `Symbol.keyFor` to avoid colliding with unrelated symbols.
+const symbolMap: Map<GlobalFieldKey, GlobalFieldKeySymbol> = new Map();
+const keyMap: Map<GlobalFieldKeySymbol, GlobalFieldKey> = new Map();
+
+/**
+ * @returns a symbol to use for `key`.
+ */
+export function symbolFromKey(key: GlobalFieldKey): GlobalFieldKeySymbol {
+    const sym = symbolMap.get(key);
+    if (sym !== undefined) {
+        return sym;
+    }
+    const newSym: GlobalFieldKeySymbol = brand(Symbol(key));
+    symbolMap.set(key, newSym);
+    keyMap.set(newSym, key);
+    return newSym;
+}
+
+/**
+ * @returns the original {@link GlobalFieldKey} for the symbol.
+ */
+export function keyFromSymbol(key: GlobalFieldKeySymbol): GlobalFieldKey {
+    return keyMap.get(key) ?? fail("missing key for symbol");
+}

--- a/packages/dds/tree/src/tree/globalFieldKeySymbol.ts
+++ b/packages/dds/tree/src/tree/globalFieldKeySymbol.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { GlobalFieldKey } from "../schema-stored";
 import { brand, Brand, fail } from "../util";
 

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -15,12 +15,14 @@ export {
     TreeValue,
     detachedFieldAsKey,
     keyAsDetachedField,
+    rootFieldKey,
 } from "./types";
 
 export * from "./pathTree";
 export * from "./anchorSet";
 export * from "./treeTextFormat";
 export * from "./visitDelta";
+export * from "./globalFieldKeySymbol";
 
 // Split this up into separate import and export for compatibility with API-Extractor.
 import * as Delta from "./delta";

--- a/packages/dds/tree/src/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/tree/treeTextFormat.ts
@@ -75,6 +75,9 @@ export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderT
  */
 export interface JsonableTree extends PlaceholderTree {}
 
+/**
+ * Derives the scope using the type of `key`.
+ */
 export function scopeFromKey(key: FieldKey): FieldScope {
     return typeof key === "symbol" ? FieldScope.global : FieldScope.local;
 }

--- a/packages/dds/tree/src/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/tree/treeTextFormat.ts
@@ -101,9 +101,13 @@ export function getGenericTreeField<T>(node: GenericTreeNode<T>, key: FieldKey, 
     return newField;
 }
 
+/**
+ * The scope of a {@link FieldKey}.
+ */
 export const enum FieldScope {
     local = "fields",
     // TODO: separate this from local fields by giving it a different name.
+    // For now these are the same meaning GenericTreeNode actually only has one field.
     global = "fields",
 }
 

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -3,11 +3,25 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { Serializable } from "@fluidframework/datastore-definitions";
 import { GlobalFieldKey, LocalFieldKey, TreeSchemaIdentifier } from "../schema-stored";
 import { brand, Brand, extractFromOpaque, Opaque } from "../util";
+import { GlobalFieldKeySymbol, symbolFromKey } from "./globalFieldKeySymbol";
 
-export type FieldKey = LocalFieldKey | GlobalFieldKey;
+/**
+ * Either LocalFieldKey or GlobalFieldKey.
+ *
+ * To avoid collisions, we can not abstract over local and global field keys using the same format for each
+ * (that would make telling them apart impossible).
+ * Thus global field keys are using their symbols instead.
+ */
+export type FieldKey = LocalFieldKey | GlobalFieldKeySymbol;
+
+export function isLocalKey(key: FieldKey): key is LocalFieldKey {
+    return typeof key === "string";
+}
+
 export type TreeType = TreeSchemaIdentifier;
 
 /**
@@ -23,6 +37,14 @@ export type TreeType = TreeSchemaIdentifier;
  * that this intention may be better conveyed by metadata on the TreeViewSchema.
  */
 export const EmptyKey: LocalFieldKey = brand("");
+
+/**
+ * GlobalFieldKey to use for the root of documents.
+ * TODO: if we do want to standardize on a single value for this,
+ * it likely should be namespaced or a UUID to avoid risk of collisions.
+ */
+export const rootFieldKey: GlobalFieldKey = brand("rootFieldKey");
+export const rootFieldKeySymbol: GlobalFieldKeySymbol = symbolFromKey(rootFieldKey);
 
 /**
  * Location of a tree relative to is parent container (which can be a tree or forest).
@@ -80,7 +102,12 @@ export function detachedFieldAsKey(field: DetachedField): LocalFieldKey {
  * and with the same scope (ex: forest) as the detachedFieldAsKey was originally from.
  */
 export function keyAsDetachedField(key: FieldKey): DetachedField {
-    return brand(extractFromOpaque(key));
+    if (isLocalKey(key)) {
+        assert(key !== rootFieldKey as string, "Root is field key must be a global field key");
+        return brand(key);
+    }
+    assert(key === rootFieldKeySymbol, "Root is only allowed global field key as detached field");
+    return brand(rootFieldKey);
 }
 
 /**


### PR DESCRIPTION
## Description

This is a first step of a longer process to resolve the potential for local and global field key to collide.

This makes the "FieldKey" type separate the two by using symbols for global field keys, but does not yet update the implementations to use this to avoid conflicts.
