### PR TITLE
Reorder attach ops to exclude them from batch

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -13,6 +13,7 @@ import { FluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { FlushMode } from '@fluidframework/runtime-definitions';
 import { IAudience } from '@fluidframework/container-definitions';
+import { IBatchMessage } from '@fluidframework/container-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IContainerContext } from '@fluidframework/container-definitions';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
@@ -111,6 +112,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     readonly enqueueSummarize: ISummarizer["enqueueSummarize"];
     // (undocumented)
     flush(): void;
+    // Warning: (ae-forgotten-export) The symbol "BatchMessage" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected flushBatch(batch: BatchMessage[]): void;
     // (undocumented)
     get flushMode(): FlushMode;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/batchManager.ts
+++ b/packages/runtime/container-runtime/src/batchManager.ts
@@ -77,6 +77,7 @@ export class BatchManager {
                 for (let i = this.pendingBatch.length; i > startPoint;) {
                     i--;
                     const message = this.pendingBatch[i];
+                    this.batchContentSize -= message.contents.length;
                     process(message);
                 }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1792,7 +1792,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             0x24c /* "Cannot call `flush()` from `orderSequentially`'s callback" */);
 
         const batch = this.batchManager.popBatch();
+        this.flushBatch(batch);
 
+        assert(this.batchManager.empty, "reentrancy");
+    }
+
+    protected flushBatch(batch: BatchMessage[]): void {
         const length = batch.length;
 
         if (length > 1) {
@@ -1854,8 +1859,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             );
             clientSequenceNumber++;
         }
-
-        assert(this.batchManager.empty, "reentrancy");
 
         this.pendingStateManager.onFlush();
     }
@@ -2638,28 +2641,52 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.logger.sendErrorEvent({ eventName: "SubmitOpInReadonly" });
         }
 
+        const message: BatchMessage = {
+            contents: serializedContent,
+            deserializedContent,
+            metadata,
+            localOpMetadata,
+            referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
+        };
+
         try {
-            this.batchManager.push({
-                contents: serializedContent,
-                deserializedContent,
-                metadata,
-                localOpMetadata,
-                referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
-            });
+            // If this is attach message for new data store, and we are in a batch, send this op out of order
+            // Is it safe:
+            //    Yes, this should be safe reordering. Newly created data stores are not visible through API surface.
+            //    They become visible only when aliased, or handle to some sub-element of newly created datastore
+            //    is stored in some DDS, i.e. only after some other op.
+            // Why:
+            //    Attach ops are large, and expensive to process. Plus there are scenarios where a lot of new data
+            //    stores are created, causing issues like relay service throttling (too many ops) and catastrophic
+            //    failure (batch is too large). Pushing them earlier and outside of main batch should alleviate
+            //    these issues.
+            // Cons:
+            //    With large batches, relay service may throttle clients. Clients may disconnect while throttled.
+            //    This change creates new possibility of a lot of newly created data stores never being referenced
+            //    because client died before it had a change to submit the rest of the ops. This will create more
+            //    garbage that needs to be collected leveraging GC (Garbage Collection) feature.
+            // Please note that this does not change file format, so it can be disabled in the future if this
+            // optimization no longer makes sense (for example, batch compression may make it less appealing).
+            if (this._flushMode === FlushMode.TurnBased && type === ContainerMessageType.Attach &&
+                    this.mc.config.getBoolean("Fluid.ContainerRuntime.disableAttachOpReorder") !== true) {
+                this.flushBatch([message]);
+            } else {
+                this.batchManager.push(message);
+                if (this._flushMode !== FlushMode.TurnBased) {
+                    this.flush();
+                } else if (!this.flushTrigger) {
+                    this.flushTrigger = true;
+                    // Queue a microtask to detect the end of the turn and force a flush.
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    Promise.resolve().then(() => {
+                        this.flushTrigger = false;
+                        this.flush();
+                    });
+                }
+            }
         } catch (error) {
             this.closeFn(error as GenericError);
             throw error;
-        }
-        if (this._flushMode !== FlushMode.TurnBased) {
-            this.flush();
-        } else if (!this.flushTrigger) {
-            this.flushTrigger = true;
-            // Use Promise.resolve().then() to queue a microtask to detect the end of the turn and force a flush.
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            Promise.resolve().then(() => {
-                this.flushTrigger = false;
-                this.flush();
-            });
         }
 
         if (this.isContainerMessageDirtyable(type, contents)) {


### PR DESCRIPTION
Curious, what you think about it?

Based on Loop data of failed copy / paste scenarios (involving table cells), attach ops in large batches (4.5Mb payloads) represent roughly 1/3rd in op counts, and 2/3rds in op size. Splitting attached ops out allows substantially reduce batch size and thus reduce chances of hitting 1Mb limit.

I'm thinking this is rather temporary. I.e. once compression is enabled, we probably do not want to send attach ops one by one.
Instead, we could wait for whole batch to accumulate, and then send 0-N separate batch(es) of attached ops (with SOLID compression), followed by one batch of regular ops (also with SOLID compression). If original batch of ops is small, we may leave it as is, i.e. do no reordering. Or rather reorder, start compressing attached ops and keep flushing them as soon as result approaches 1Mb limit. If it never does, then we keep sending just one batch, but with attach ops at the beginning of that batch, preceding all other ops (bonus - do so dynamically as ops accumulate, flushing batches sooner to improve latency).

Correctness of that change relies on a fact that the only way to create root data store is through aliasing, i.e. through "regular op". I.e. attach op should not change visibility of data store (as it used to be, when data store can be created as root in one go).

Plus fixing small bug with rollback and batch size counting.