### PR TITLE
Add accessViolationError to ContainerErrorType

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -56,6 +56,7 @@ export type ConnectionState = ConnectionState.Disconnected | ConnectionState.Est
 
 // @public
 export enum ContainerErrorType {
+    accessViolationError = "accessViolationError",
     clientSessionExpiredError = "clientSessionExpiredError",
     dataCorruptionError = "dataCorruptionError",
     dataProcessingError = "dataProcessingError",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -83,6 +83,18 @@
       },
       "InterfaceDeclaration_IContainerContext": {
         "forwardCompat": false
+      },
+      "EnumDeclaration_ContainerErrorType": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IGenericError": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IThrottlingWarning": {
+        "backCompat": false
+      },
+      "InterfaceDeclaration_IUsageError": {
+        "backCompat": false
       }
     }
   }

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -39,7 +39,12 @@ export enum ContainerErrorType {
      * aids in safely deleting unused objects.
      */
     clientSessionExpiredError = "clientSessionExpiredError",
-}
+
+    /**
+     * Error indicating access was attempted for an object that is no longer available.
+     */
+     accessViolationError = "accessViolationError",
+    }
 
 /**
  * Base interface for all errors and warnings at container level

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.ts
@@ -203,6 +203,7 @@ declare function get_current_EnumDeclaration_ContainerErrorType():
 declare function use_old_EnumDeclaration_ContainerErrorType(
     use: TypeOnly<old.ContainerErrorType>);
 use_old_EnumDeclaration_ContainerErrorType(
+    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_ContainerErrorType());
 
 /*
@@ -961,6 +962,7 @@ declare function get_current_InterfaceDeclaration_IGenericError():
 declare function use_old_InterfaceDeclaration_IGenericError(
     use: TypeOnly<old.IGenericError>);
 use_old_InterfaceDeclaration_IGenericError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IGenericError());
 
 /*
@@ -1393,6 +1395,7 @@ declare function get_current_InterfaceDeclaration_IThrottlingWarning():
 declare function use_old_InterfaceDeclaration_IThrottlingWarning(
     use: TypeOnly<old.IThrottlingWarning>);
 use_old_InterfaceDeclaration_IThrottlingWarning(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IThrottlingWarning());
 
 /*
@@ -1417,6 +1420,7 @@ declare function get_current_InterfaceDeclaration_IUsageError():
 declare function use_old_InterfaceDeclaration_IUsageError(
     use: TypeOnly<old.IUsageError>);
 use_old_InterfaceDeclaration_IUsageError(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IUsageError());
 
 /*


### PR DESCRIPTION
This is the errorType we'll use for GC when app code attempts to use an unreferenced object that has been swept (deleted).

In the short term (while Sweep is still being implemented), we'll close the container with this error if a SweepReady object is used. Then when Sweep is implemented we'll throw or return this error on codepaths that attempt to use a Tombstoned or Deleted object.

Some follow-ups this brings to mind, I might open work items for these:
- Create new set of Runtime errors defined in the container-runtime-definitions package (e.g. this, sessionExpiry, maybe other)
- We would like to move away from enums and use union of string literal types.
