### PR TITLE
TreeDDS: Simplify Delta typing

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -134,15 +134,9 @@ declare namespace Delta {
         Root,
         empty,
         Mark,
-        OuterMark,
-        InnerModify,
         MarkList,
         Skip_2 as Skip,
         Modify,
-        ModifyDeleted,
-        ModifyMovedOut,
-        ModifyMovedIn,
-        ModifyInserted,
         Delete,
         ModifyAndDelete,
         MoveOut,
@@ -329,7 +323,7 @@ export interface FieldMap<TChild> {
 type FieldMap_2<T> = Map<FieldKey, T>;
 
 // @public (undocumented)
-type FieldMarks<TMark> = FieldMap_2<MarkList<TMark>>;
+type FieldMarks = FieldMap_2<MarkList>;
 
 // @public (undocumented)
 export interface FieldSchema {
@@ -397,9 +391,6 @@ export interface IForestSubscription extends Dependee {
 }
 
 // @public
-type InnerModify = ModifyDeleted | ModifyInserted | ModifyMovedIn | ModifyMovedOut;
-
-// @public
 function inputLength(mark: Mark): number;
 
 // @public
@@ -415,7 +406,7 @@ interface InsertAndModify {
     // (undocumented)
     content: ProtoNode_2;
     // (undocumented)
-    fields: FieldMarks<Skip_2 | ModifyInserted | MoveIn | MoveInAndModify>;
+    fields: FieldMarks;
     // (undocumented)
     type: typeof MarkType.InsertAndModify;
 }
@@ -553,10 +544,10 @@ export interface MakeNominal {
 }
 
 // @public
-type Mark = OuterMark | InnerModify;
+type Mark = Skip_2 | Modify | Delete | MoveOut | MoveIn | Insert | ModifyAndDelete | ModifyAndMoveOut | MoveInAndModify | InsertAndModify;
 
 // @public
-type MarkList<TMark = Mark> = TMark[];
+type MarkList = Mark[];
 
 // @public (undocumented)
 const MarkType: {
@@ -574,7 +565,7 @@ const MarkType: {
 // @public
 interface Modify {
     // (undocumented)
-    fields?: FieldMarks<OuterMark>;
+    fields?: FieldMarks;
     // (undocumented)
     setValue?: Value;
     // (undocumented)
@@ -584,7 +575,7 @@ interface Modify {
 // @public
 interface ModifyAndDelete {
     // (undocumented)
-    fields: FieldMarks<Skip_2 | ModifyDeleted | MoveOut>;
+    fields: FieldMarks;
     // (undocumented)
     type: typeof MarkType.ModifyAndDelete;
 }
@@ -592,46 +583,12 @@ interface ModifyAndDelete {
 // @public
 interface ModifyAndMoveOut {
     // (undocumented)
-    fields?: FieldMarks<Skip_2 | ModifyMovedOut | Delete | MoveOut>;
+    fields?: FieldMarks;
     moveId: MoveId;
     // (undocumented)
     setValue?: Value;
     // (undocumented)
     type: typeof MarkType.ModifyAndMoveOut;
-}
-
-// @public
-interface ModifyDeleted {
-    // (undocumented)
-    fields: FieldMarks<Skip_2 | ModifyDeleted | ModifyAndMoveOut | MoveOut>;
-    // (undocumented)
-    type: typeof MarkType.Modify;
-}
-
-// @public
-interface ModifyInserted {
-    // (undocumented)
-    fields: FieldMarks<Skip_2 | ModifyInserted | MoveIn | MoveInAndModify>;
-    // (undocumented)
-    type: typeof MarkType.Modify;
-}
-
-// @public
-interface ModifyMovedIn {
-    // (undocumented)
-    fields: FieldMarks<Skip_2 | ModifyMovedIn | MoveIn | MoveInAndModify | Insert | InsertAndModify>;
-    // (undocumented)
-    type: typeof MarkType.Modify;
-}
-
-// @public
-interface ModifyMovedOut {
-    // (undocumented)
-    fields?: FieldMarks<Skip_2 | ModifyMovedOut | Delete | ModifyAndDelete | ModifyAndMoveOut | MoveOut>;
-    // (undocumented)
-    setValue?: Value;
-    // (undocumented)
-    type: typeof MarkType.Modify;
 }
 
 // @public @sealed
@@ -679,7 +636,7 @@ interface MoveIn {
 // @public
 interface MoveInAndModify {
     // (undocumented)
-    fields: FieldMarks<Skip_2 | ModifyMovedIn | MoveIn | Insert>;
+    fields: FieldMarks;
     moveId: MoveId;
     // (undocumented)
     type: typeof MarkType.MoveInAndModify;
@@ -783,9 +740,6 @@ export type OpId = number;
 const optional: FieldKind;
 
 // @public
-type OuterMark = Skip_2 | Modify | Delete | MoveOut | MoveIn | Insert | ModifyAndDelete | ModifyAndMoveOut | MoveInAndModify | InsertAndModify;
-
-// @public
 export type PlaceholderTree<TPlaceholder = never> = GenericTreeNode<PlaceholderTree<TPlaceholder>> | TPlaceholder;
 
 // @public
@@ -848,7 +802,7 @@ function replaceRebaser<T>(): FieldChangeRebaser<ReplaceOp<T>>;
 export type RevisionTag = Brand<number, "rebaser.RevisionTag">;
 
 // @public
-type Root = FieldMarks<OuterMark>;
+type Root = FieldMarks;
 
 // @public
 export interface RootField {

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -18,11 +18,11 @@ import { isSkipMark } from "./utils";
  export function toDelta(changeset: T.LocalChangeset): Delta.Root {
     // Save result to a constant to work around linter bug:
     // https://github.com/typescript-eslint/typescript-eslint/issues/5014
-    const out: Delta.Root = convertFieldMarks<Delta.OuterMark>(changeset.marks);
+    const out: Delta.Root = convertFieldMarks(changeset.marks);
     return out;
 }
 
-function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
+function convertMarkList(marks: T.MarkList): Delta.MarkList {
     const out = new OffsetListFactory<Delta.Mark>();
     for (const mark of marks) {
         if (isSkipMark(mark)) {
@@ -74,7 +74,7 @@ function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
                     if (mark.tomb === undefined) {
                         out.pushContent({
                             type: Delta.MarkType.Modify,
-                            ...convertModify<Delta.OuterMark>(mark),
+                            ...convertModify(mark),
                         });
                     }
                     break;
@@ -88,7 +88,7 @@ function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
                     break;
                 }
                 case "MDelete": {
-                    const fields = convertModify<Delta.ModifyDeleted | Delta.MoveOut>(mark).fields;
+                    const fields = convertModify(mark).fields;
                     if (fields !== undefined) {
                         const deleteMark: Delta.ModifyAndDelete = {
                             type: Delta.MarkType.ModifyAndDelete,
@@ -145,8 +145,7 @@ function convertMarkList<TMarks>(marks: T.MarkList): Delta.MarkList<TMarks> {
             }
         }
     }
-    // TODO: add runtime checks
-    return out.list as unknown as Delta.MarkList<TMarks>;
+    return out.list;
 }
 
 const DUMMY_REVIVED_NODE_TYPE: TreeSchemaIdentifier = brand("RevivedNode");
@@ -185,14 +184,13 @@ interface DeltaInsertModification {
      * The modifications to make to the inserted subtree.
      * May be empty.
      */
-    fields: InsertedFieldsMarksMap;
+    fields: Delta.FieldMarks;
 }
 
 /**
  * A map of marks to be applied to inserted fields.
  */
-type InsertedFieldsMarksMap = Delta.FieldMarks<InsertedFieldsMark>;
-type InsertedFieldsMark = Delta.Skip | Delta.ModifyInserted | Delta.MoveIn | Delta.MoveInAndModify;
+type InsertedFieldsMark = Delta.Skip | Delta.Modify | Delta.MoveIn | Delta.MoveInAndModify;
 
 /**
  * Converts inserted content into the format expected in Delta instances.
@@ -211,8 +209,8 @@ type InsertedFieldsMark = Delta.Skip | Delta.ModifyInserted | Delta.MoveIn | Del
 function applyOrCollectModifications(
     node: Delta.ProtoNode,
     modify: ChangesetMods,
-): InsertedFieldsMarksMap {
-    const outFieldsMarks: InsertedFieldsMarksMap = new Map();
+): Delta.FieldMarks {
+    const outFieldsMarks: Delta.FieldMarks = new Map();
     if (modify.value !== undefined) {
         node.value = modify.value.value;
     }
@@ -340,30 +338,30 @@ interface ChangesetMods {
 /**
  * Modifications to a subtree as described by a Delta.
  */
- interface DeltaMods<TMark> {
-    fields?: Delta.FieldMarks<TMark>;
+ interface DeltaMods {
+    fields?: Delta.FieldMarks;
     setValue?: Value;
 }
 
 /**
  * Converts tree modifications from the Changeset to the Delta format.
  */
-function convertModify<TMarks>(modify: ChangesetMods): DeltaMods<TMarks> {
-    const out: DeltaMods<TMarks> = {};
+function convertModify(modify: ChangesetMods): DeltaMods {
+    const out: DeltaMods = {};
     if (modify.value !== undefined) {
         out.setValue = modify.value.value;
     }
     const fields = modify.fields;
     if (fields !== undefined) {
-        out.fields = convertFieldMarks<TMarks>(fields);
+        out.fields = convertFieldMarks(fields);
     }
     return out;
 }
 
-function convertFieldMarks<TMarks>(fields: T.FieldMarks): Delta.FieldMarks<TMarks> {
-    const outFields: Delta.FieldMarks<TMarks> = new Map();
+function convertFieldMarks(fields: T.FieldMarks): Delta.FieldMarks {
+    const outFields: Delta.FieldMarks = new Map();
     for (const key of Object.keys(fields)) {
-        const marks = convertMarkList<TMarks>(fields[key]);
+        const marks = convertMarkList(fields[key]);
         const brandedKey: FieldKey = brand(key);
         outFields.set(brandedKey, marks);
     }

--- a/packages/dds/tree/src/test/changeset/toDelta.spec.ts
+++ b/packages/dds/tree/src/test/changeset/toDelta.spec.ts
@@ -20,7 +20,7 @@ function toDelta(changeset: T.LocalChangeset): Delta.Root {
     return delta;
 }
 
-function toTreeDelta(list: T.MarkList): Delta.MarkList<Delta.OuterMark> {
+function toTreeDelta(list: T.MarkList): Delta.MarkList {
     const fullDelta = toDelta({ marks: { root: list } });
     return fullDelta.get(rootKey) ?? assert.fail("Expected changes under the root");
 }

--- a/packages/dds/tree/src/tree/visitDelta.ts
+++ b/packages/dds/tree/src/tree/visitDelta.ts
@@ -95,10 +95,10 @@ type Pass = (delta: Delta.MarkList, props: PassProps) => void;
 
 interface ModifyLike {
     setValue?: Value;
-    fields?: Delta.FieldMarks<Delta.Mark>;
+    fields?: Delta.FieldMarks;
 }
 
-function visitFieldMarks(fields: Delta.FieldMarks<Delta.Mark>, props: PassProps, func: Pass): void {
+function visitFieldMarks(fields: Delta.FieldMarks, props: PassProps, func: Pass): void {
     for (const [key, field] of fields) {
         props.visitor.enterField(key);
         func(field, { ...props, startIndex: 0 });


### PR DESCRIPTION
This PR relaxes some of the type constraints in the `Delta` structure.
Motivation: the cost in code complexity will be too high if we try to preserve these constraints while leveraging the recursive structure in `FieldChangeHandler`s.