### PR TITLE
[build-tools] Add release report command

### DIFF
--- a/build-tools/lerna-package-lock.json
+++ b/build-tools/lerna-package-lock.json
@@ -4594,6 +4594,11 @@
 			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
 			"integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA=="
 		},
+		"@types/sort-json": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/sort-json/-/sort-json-2.0.1.tgz",
+			"integrity": "sha512-HAeJLCXpLg9aMSCJVQcMR3yU0y2PwJUtWv7vogaz0mEhuK1bhvDX/DeDxl4spPUYpnK7PM7hmX2bU5lsghOJNQ=="
+		},
 		"@types/source-list-map": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -9612,6 +9617,94 @@
 				}
 			}
 		},
+		"inquirer-table-prompt": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/inquirer-table-prompt/-/inquirer-table-prompt-0.2.1.tgz",
+			"integrity": "sha512-0nc7X2L/8Ek4V//v+uYMatWZRzM7UvWkpExdAf+v+/+WQPeLyiWyVoOEc7GjHVW96TG0Fv3IoqHZGpcN/2eHsQ==",
+			"requires": {
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-table": "^0.3.1",
+				"figures": "^3.1.0",
+				"inquirer": "^7.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"inquirer": {
+					"version": "7.3.3",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+					"integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+					"requires": {
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.1.0",
+						"cli-cursor": "^3.1.0",
+						"cli-width": "^3.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^3.0.0",
+						"lodash": "^4.17.19",
+						"mute-stream": "0.0.8",
+						"run-async": "^2.4.0",
+						"rxjs": "^6.6.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0",
+						"through": "^2.3.6"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "4.1.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+							"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"int64-buffer": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
@@ -14584,7 +14677,6 @@
 			"version": "6.6.7",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
 			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			},
@@ -14592,8 +14684,7 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -14846,6 +14937,28 @@
 					"requires": {
 						"debug": "4"
 					}
+				}
+			}
+		},
+		"sort-json": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
+			"integrity": "sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==",
+			"requires": {
+				"detect-indent": "^5.0.0",
+				"detect-newline": "^2.1.0",
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"detect-indent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+					"integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g=="
+				},
+				"detect-newline": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+					"integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg=="
 				}
 			}
 		},

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -126,6 +126,7 @@ USAGE
 * [`flub help [COMMAND]`](#flub-help-command)
 * [`flub info`](#flub-info)
 * [`flub release`](#flub-release)
+* [`flub release report`](#flub-release-report)
 * [`flub run bundleStats`](#flub-run-bundlestats)
 * [`flub version VERSION`](#flub-version-version)
 * [`flub version latest`](#flub-version-latest)
@@ -384,15 +385,42 @@ DESCRIPTION
   The release command ensures that a release branch is in good condition, then walks the user through releasing a
   package or release group.
 
-  The command runs a number of checks automatically to make sure . If any of the dependencies are also in the repo, then
-  they're checked for the latest release version. If the dependencies have not yet been released, then the command
-  prompts to perform the release of the dependency, then run the release command again.
+  The command runs a number of checks automatically to make sure the branch is in a good state for a release. If any of
+  the dependencies are also in the repo, then they're checked for the latest release version. If the dependencies have
+  not yet been released, then the command prompts to perform the release of the dependency, then run the release command
+  again.
 
   This process is continued until all the dependencies have been released, after which the release group itself is
   released.
 ```
 
 _See code: [dist/commands/release.ts](https://github.com/microsoft/FluidFramework/blob/v0.4.5000/dist/commands/release.ts)_
+
+## `flub release report`
+
+Generate a release report.
+
+```
+USAGE
+  $ flub release report [--json] [-d <value>] [-s | -r] [-o <value>] [-f] [-v]
+
+FLAGS
+  -d, --days=<value>    [default: 10] The number of days to look back for releases to report.
+  -f, --full            Output a full report.
+  -o, --output=<value>  Output a JSON report file to this location.
+  -r, --mostRecent      Always pick the most recent version as the latest (ignore semver version sorting).
+  -s, --highest         Always pick the greatest semver version as the latest (ignore dates).
+  -v, --verbose         Verbose logging.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Generate a release report.
+
+EXAMPLES
+  $ flub release report
+```
 
 ## `flub run bundleStats`
 

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -398,15 +398,16 @@ _See code: [dist/commands/release.ts](https://github.com/microsoft/FluidFramewor
 
 ## `flub release report`
 
-Generate a release report.
+Generates a report of Fluid Framework releases.
 
 ```
 USAGE
-  $ flub release report [--json] [-d <value>] [-s | -r] [-o <value>] [-f] [-v]
+  $ flub release report [--json] [-d <value>] [-s | -r] [-f -o <value>] [-v]
 
 FLAGS
   -d, --days=<value>    [default: 10] The number of days to look back for releases to report.
-  -f, --full            Output a full report.
+  -f, --full            Output a full report. A full report includes additional metadata for each package, including the
+                        time of the release, the type of release (patch, minor, major), and whether the release is new.
   -o, --output=<value>  Output a JSON report file to this location.
   -r, --mostRecent      Always pick the most recent version as the latest (ignore semver version sorting).
   -s, --highest         Always pick the greatest semver version as the latest (ignore dates).
@@ -416,10 +417,31 @@ GLOBAL FLAGS
   --json  Format output as json.
 
 DESCRIPTION
-  Generate a release report.
+  Generates a report of Fluid Framework releases.
+
+  The release report command is used to produce a report of all the packages that were released and their current
+  version. After a release, it is useful to generate this report to provide to customers, so they can update their
+  dependencies to the most recent version.
+
+  The command will prompt you to select versions for a package or release group in the event that multiple versions have
+  recently been released.
 
 EXAMPLES
-  $ flub release report
+  Generate a minimal release report and display it in the terminal.
+
+    $ flub release report
+
+  Generate a minimal release report and output it to stdout as JSON.
+
+    $ flub release report --json
+
+  Output a release report to 'report.json'.
+
+    $ flub release report -o report.json
+
+  Output a full release report to 'report.json'.
+
+    $ flub release report -f -o report.json
 ```
 
 ## `flub run bundleStats`

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -84,10 +84,12 @@
     "date-fns": "^2.29.1",
     "fs-extra": "^9.0.1",
     "inquirer": "^8.0.0",
+    "inquirer-table-prompt": "^0.2.1",
     "jssm": "^5.79.18",
     "jssm-viz-cli": "^5.83.0",
     "npm-check-updates": "^16.0.0",
     "semver": "^7.3.7",
+    "sort-json": "^2.0.1",
     "table": "^6.8.0"
   },
   "devDependencies": {
@@ -100,6 +102,7 @@
     "@types/node": "^14.18.0",
     "@types/semver": "^7.3.10",
     "@types/semver-utils": "^1.1.1",
+    "@types/sort-json": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",
     "chai": "^4.2.0",

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -109,7 +109,7 @@ export abstract class BaseCommand<T extends typeof BaseCommand.flags>
     async getContext(): Promise<Context> {
         if (this._context === undefined) {
             const resolvedRoot = await getResolvedFluidRoot();
-            const gitRepo = new GitRepo(resolvedRoot);
+            const gitRepo = new GitRepo(resolvedRoot, this.logger);
             const branch = await gitRepo.getCurrentBranchName();
 
             this.verbose(`Repo: ${resolvedRoot}`);

--- a/build-tools/packages/build-cli/src/commands/release.ts
+++ b/build-tools/packages/build-cli/src/commands/release.ts
@@ -18,10 +18,9 @@ import { ReleaseGroup, ReleasePackage } from "../releaseGroups";
 import { StateMachineCommand } from "../stateMachineCommand";
 
 /**
- * First the release group's dependencies are checked. If any of the dependencies are also in the repo, then they're
- * checked for the latest release version. If the dependencies have not yet been released, then the command prompts to
- * perform the release of the dependency, then run the releae command again.
- *
+ * Releases a package or release group. This command is mostly scaffolding and setting up the state machine, handlers,
+ * and the data to pass to the handlers. Most of the logic for handling the release is contained in the
+ * {@link FluidReleaseStateHandler} itself.
  */
 
 export class ReleaseCommand<T extends typeof ReleaseCommand.flags> extends StateMachineCommand<T> {
@@ -35,15 +34,6 @@ export class ReleaseCommand<T extends typeof ReleaseCommand.flags> extends State
     machine = FluidReleaseMachine;
     handler: StateHandler | undefined;
     data: FluidReleaseStateHandlerData = {};
-    releaseGroup: ReleaseGroup | ReleasePackage | undefined;
-    versionScheme: VersionScheme | undefined;
-    releaseVersion: string | undefined;
-
-    shouldCheckPolicy = true;
-    shouldCheckBranch = true;
-
-    shouldCommit = true;
-    shouldInstall = true;
 
     static flags = {
         releaseGroup: releaseGroupFlag({
@@ -70,7 +60,6 @@ export class ReleaseCommand<T extends typeof ReleaseCommand.flags> extends State
 
         this.handler = new FluidReleaseStateHandler(this.machine, this.logger);
         this.data.context = context;
-        // this.data.promptWriter = handler; // The BaseHandler extends PromptWriter
         this.data.promptWriter = new PromptWriter(this.logger);
         this.data.releaseGroup = flags.releaseGroup ?? flags.package!;
         this.data.releaseVersion = context.getVersion(this.data.releaseGroup);

--- a/build-tools/packages/build-cli/src/commands/release.ts
+++ b/build-tools/packages/build-cli/src/commands/release.ts
@@ -10,29 +10,40 @@ import {
     packageSelectorFlag,
     releaseGroupFlag,
     skipCheckFlag,
-    versionSchemeFlag,
 } from "../flags";
 import { FluidReleaseStateHandler, FluidReleaseStateHandlerData, StateHandler } from "../handlers";
 import { PromptWriter } from "../instructionalPromptWriter";
-import { StateMachineCommand, FluidReleaseMachine } from "../machines";
+import { FluidReleaseMachine } from "../machines";
+import { ReleaseGroup, ReleasePackage } from "../releaseGroups";
+import { StateMachineCommand } from "../stateMachineCommand";
 
 /**
- * Releases a package or release group. This command is mostly scaffolding and setting up the state machine, handlers,
- * and the data to pass to the handlers. Most of the logic for handling the release is contained in the
- * {@link FluidReleaseStateHandler} itself.
+ * First the release group's dependencies are checked. If any of the dependencies are also in the repo, then they're
+ * checked for the latest release version. If the dependencies have not yet been released, then the command prompts to
+ * perform the release of the dependency, then run the releae command again.
+ *
  */
 
 export class ReleaseCommand<T extends typeof ReleaseCommand.flags> extends StateMachineCommand<T> {
-    machine = FluidReleaseMachine;
-    data: FluidReleaseStateHandlerData = {};
-    handler: StateHandler | undefined;
-
     static summary = "Releases a package or release group.";
     static description = `The release command ensures that a release branch is in good condition, then walks the user through releasing a package or release group.
 
-    The command runs a number of checks automatically to make sure . If any of the dependencies are also in the repo, then they're checked for the latest release version. If the dependencies have not yet been released, then the command prompts to perform the release of the dependency, then run the release command again.
+    The command runs a number of checks automatically to make sure the branch is in a good state for a release. If any of the dependencies are also in the repo, then they're checked for the latest release version. If the dependencies have not yet been released, then the command prompts to perform the release of the dependency, then run the release command again.
 
     This process is continued until all the dependencies have been released, after which the release group itself is released.`;
+
+    machine = FluidReleaseMachine;
+    handler: StateHandler | undefined;
+    data: FluidReleaseStateHandlerData = {};
+    releaseGroup: ReleaseGroup | ReleasePackage | undefined;
+    versionScheme: VersionScheme | undefined;
+    releaseVersion: string | undefined;
+
+    shouldCheckPolicy = true;
+    shouldCheckBranch = true;
+
+    shouldCommit = true;
+    shouldInstall = true;
 
     static flags = {
         releaseGroup: releaseGroupFlag({
@@ -59,6 +70,7 @@ export class ReleaseCommand<T extends typeof ReleaseCommand.flags> extends State
 
         this.handler = new FluidReleaseStateHandler(this.machine, this.logger);
         this.data.context = context;
+        // this.data.promptWriter = handler; // The BaseHandler extends PromptWriter
         this.data.promptWriter = new PromptWriter(this.logger);
         this.data.releaseGroup = flags.releaseGroup ?? flags.package!;
         this.data.releaseVersion = context.getVersion(this.data.releaseGroup);

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -32,13 +32,32 @@ const DEFAULT_MIN_VERSION = "0.0.0";
  * released.
  */
 export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseReportCommand.flags> {
-    static description = "Generate a release report.";
-    static examples = ["<%= config.bin %> <%= command.id %>"];
+    static summary = "Generates a report of Fluid Framework releases.";
+    static description = `The release report command is used to produce a report of all the packages that were released and their current version. After a release, it is useful to generate this report to provide to customers, so they can update their dependencies to the most recent version.
+
+    The command will prompt you to select versions for a package or release group in the event that multiple versions have recently been released.`;
+
+    static examples = [
+        {
+            description: "Generate a minimal release report and display it in the terminal.",
+            command: "<%= config.bin %> <%= command.id %> ",
+        },
+        {
+            description: "Generate a minimal release report and output it to stdout as JSON.",
+            command: "<%= config.bin %> <%= command.id %> --json",
+        },
+        {
+            description: "Output a release report to 'report.json'.",
+            command: "<%= config.bin %> <%= command.id %> -o report.json",
+        },
+        {
+            description: "Output a full release report to 'report.json'.",
+            command: "<%= config.bin %> <%= command.id %> -f -o report.json",
+        },
+    ];
+
     static enableJsonFlag = true;
     static flags = {
-        // previous: Flags.boolean({
-        //     description: "Report the previous release versions instead of the latest.",
-        // }),
         days: Flags.integer({
             char: "d",
             description: "The number of days to look back for releases to report.",
@@ -61,7 +80,9 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
         }),
         full: Flags.boolean({
             char: "f",
-            description: "Output a full report.",
+            description:
+                "Output a full report. A full report includes additional metadata for each package, including the time of the release, the type of release (patch, minor, major), and whether the release is new.",
+            dependsOn: ["output"],
         }),
         ...BaseCommand.flags,
     };
@@ -115,7 +136,6 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
         /* eslint-enable no-await-in-loop */
 
         const report: ReleaseReport = await this.generateReleaseReport(versionData);
-        // const minReport: MinimalReleaseReport = this.generateMinimalReport(versionData);
         const packageList: PackageVersionList = await this.generatePackageList(versionData);
         const tableData = this.generateReleaseTable(versionData);
 

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -1,0 +1,437 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { Context, writeFileAsync } from "@fluidframework/build-tools";
+import { detectBumpType, isVersionBumpType, VersionBumpType } from "@fluid-tools/version-tools";
+import { Flags } from "@oclif/core";
+import chalk from "chalk";
+import { differenceInBusinessDays, formatDistanceToNow, formatISO9075 } from "date-fns";
+import inquirer from "inquirer";
+import sortJson from "sort-json";
+import { table } from "table";
+import { BaseCommand } from "../../base";
+import { getAllVersions, sortVersions, VersionDetails } from "../../lib";
+import { isReleaseGroup, ReleaseGroup, ReleasePackage } from "../../releaseGroups";
+
+const MAX_BUSINESS_DAYS_TO_CONSIDER_RECENT = 10;
+const DEFAULT_MIN_VERSION = "0.0.0";
+
+/**
+ * Releases a release group recursively.
+ *
+ * @remarks
+ *
+ * First the release group's dependencies are checked. If any of the dependencies are also in the repo, then they're
+ * checked for the latest release version. If the dependencies have not yet been released, then the command prompts to
+ * perform the release of the dependency, then run the releae command again.
+ *
+ * This process is continued until all the dependencies have been released, after which the release group itself is
+ * released.
+ */
+export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseReportCommand.flags> {
+    static description = "Generate a release report.";
+    static examples = ["<%= config.bin %> <%= command.id %>"];
+    static enableJsonFlag = true;
+    static flags = {
+        // previous: Flags.boolean({
+        //     description: "Report the previous release versions instead of the latest.",
+        // }),
+        days: Flags.integer({
+            char: "d",
+            description: "The number of days to look back for releases to report.",
+            default: MAX_BUSINESS_DAYS_TO_CONSIDER_RECENT,
+        }),
+        highest: Flags.boolean({
+            char: "s",
+            description: "Always pick the greatest semver version as the latest (ignore dates).",
+            exclusive: ["mostRecent"],
+        }),
+        mostRecent: Flags.boolean({
+            char: "r",
+            description:
+                "Always pick the most recent version as the latest (ignore semver version sorting).",
+            exclusive: ["highest"],
+        }),
+        output: Flags.file({
+            char: "o",
+            description: "Output a JSON report file to this location.",
+        }),
+        full: Flags.boolean({
+            char: "f",
+            description: "Output a full report.",
+        }),
+        ...BaseCommand.flags,
+    };
+
+    releaseGroup: ReleaseGroup | ReleasePackage | undefined;
+    releaseVersion: string | undefined;
+
+    public async run(): Promise<ReleaseReport | PackageVersionList> {
+        const context = await this.getContext();
+        const flags = this.processedFlags;
+        const versionData: PackageReleaseData = {};
+
+        const mode = flags.highest ? "version" : flags.mostRecent ? "date" : "interactive";
+
+        this.log(`Collecting version data for release groups...`);
+        /* eslint-disable no-await-in-loop */
+        // collect version data for each release group
+        for (const rg of context.repo.releaseGroups.keys()) {
+            const name = rg;
+            const repoVersion = context.getVersion(rg);
+
+            const data = await this.collectReleaseData(
+                context,
+                name,
+                repoVersion,
+                flags.days,
+                mode,
+            );
+            if (data !== undefined) {
+                versionData[name] = data;
+            }
+        }
+
+        this.log(`Collecting version data for independent packages...`);
+        // collect version data for each release package (independent packages)
+        for (const pkg of context.independentPackages) {
+            const name = pkg.name;
+            const repoVersion = pkg.version;
+
+            const data = await this.collectReleaseData(
+                context,
+                name,
+                repoVersion,
+                flags.days,
+                mode,
+            );
+            if (data !== undefined) {
+                versionData[name] = data;
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+
+        const report: ReleaseReport = await this.generateReleaseReport(versionData);
+        // const minReport: MinimalReleaseReport = this.generateMinimalReport(versionData);
+        const packageList: PackageVersionList = await this.generatePackageList(versionData);
+        const tableData = this.generateReleaseTable(versionData);
+
+        const finalReport = flags.full ? report : packageList;
+
+        tableData.sort((a, b) => {
+            if (a[0] > b[0]) {
+                return 1;
+            }
+
+            if (a[0] < b[0]) {
+                return -1;
+            }
+
+            return 0;
+        });
+
+        const output = table(tableData, {
+            // columns: [{ alignment: "left" }, { alignment: "left" }, { alignment: "center" }, { alignment: "left" }, { alignment: "left" }],
+            singleLine: true,
+        });
+
+        this.log(`Release Report\n\n${output}`);
+
+        if (flags.output !== undefined) {
+            await writeFileAsync(flags.output, JSON.stringify(finalReport));
+            // Sort the JSON in-place
+            sortJson.overwrite(flags.output, { indentSize: 2 });
+            this.info(`Wrote output file: ${flags.output}`);
+        }
+
+        // When the --json flag is passed, the command will return the raw data as JSON.
+        return finalReport;
+    }
+
+    /**
+     * Collects the releases of a given release group or package.
+     *
+     * @param context - The {@link Context}.
+     * @param releaseGroupOrPackage - The release group or package to collect release data for.
+     * @param repoVersion - The version of the release group or package in the repo.
+     * @param numberBusinessDaysToConsiderRecent - If a release is within this number of business days, it will be
+     * considered recent.
+     * @param mode - Controls which release is considered the latest. The default, `"interactive"`, prompts the user to
+     * select the version.
+     * @returns The collected release data.
+     */
+    private async collectReleaseData(
+        context: Context,
+        releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
+        repoVersion: string,
+        numberBusinessDaysToConsiderRecent: number,
+        mode: "interactive" | "date" | "version" = "interactive",
+    ): Promise<RawReleaseData | undefined> {
+        // const tags = await getTagsForReleaseGroup(context, releaseGroup);
+        const versions = await getAllVersions(context, releaseGroupOrPackage);
+
+        if (versions === undefined) {
+            return undefined;
+        }
+
+        const sortedByVersion = await sortVersions(versions, "version");
+        const sortedByDate = await sortVersions(versions, "date");
+        const versionCount = sortedByVersion.length;
+
+        if (sortedByDate === undefined) {
+            this.error(`sortedByDate is undefined.`);
+        }
+
+        let latestReleasedVersion: VersionDetails | undefined;
+
+        switch (mode) {
+            case "interactive": {
+                let answer: inquirer.Answers | undefined;
+
+                const recentReleases = sortedByDate.filter((v) => {
+                    const diff =
+                        v.date === undefined ? 0 : differenceInBusinessDays(Date.now(), v.date);
+                    return diff <= numberBusinessDaysToConsiderRecent;
+                });
+
+                // No recent releases, so set the latest to the highest semver
+                if (recentReleases.length === 0) {
+                    if (sortedByVersion.length > 0) {
+                        latestReleasedVersion = sortedByVersion[0];
+                    } else {
+                        console.log(
+                            `error: no recent releases, and no releases at all! ${releaseGroupOrPackage}`,
+                        );
+                    }
+                }
+
+                if (recentReleases.length === 1) {
+                    latestReleasedVersion = recentReleases[0];
+                } else if (recentReleases.length > 1) {
+                    const question: inquirer.ListQuestion = {
+                        type: "list",
+                        name: "selectedPackageVersion",
+                        message: `Multiple versions of ${releaseGroupOrPackage} were released in the last ${numberBusinessDaysToConsiderRecent} business days. Select the one you want to include in the release report.`,
+                        choices: recentReleases.map((v) => {
+                            return {
+                                name: `${v.version} (${formatDistanceToNow(v.date ?? 0)} ago)`,
+                                value: v.version,
+                                short: v.version,
+                            };
+                        }),
+                    };
+
+                    answer = await inquirer.prompt(question);
+                    const selectedVersion =
+                        answer === undefined
+                            ? recentReleases[0].version
+                            : (answer.selectedPackageVersion as string);
+                    latestReleasedVersion = recentReleases.find(
+                        (v) => v.version === selectedVersion,
+                    );
+                }
+
+                break;
+            }
+
+            case "date": {
+                latestReleasedVersion = sortedByDate[0];
+                break;
+            }
+
+            case "version": {
+                latestReleasedVersion = sortedByVersion[0];
+                break;
+            }
+
+            default: {
+                throw new Error(`Unhandled mode: ${mode}`);
+            }
+        }
+
+        assert(latestReleasedVersion !== undefined, "latestReleasedVersion is undefined");
+
+        const vIndex = sortedByVersion.findIndex(
+            (v) =>
+                v.version === latestReleasedVersion?.version &&
+                v.date === latestReleasedVersion.date,
+        );
+        const previousReleasedVersion =
+            vIndex + 1 <= versionCount
+                ? sortedByVersion[vIndex + 1]
+                : { version: DEFAULT_MIN_VERSION };
+
+        return {
+            repoVersion: {
+                version: repoVersion,
+            },
+            latestReleasedVersion,
+            previousReleasedVersion,
+            versions,
+        };
+    }
+
+    private async generateReleaseReport(reportData: PackageReleaseData): Promise<ReleaseReport> {
+        const context = await this.getContext();
+        const report: ReleaseReport = {};
+
+        for (const [pkgName, verDetails] of Object.entries(reportData)) {
+            if (verDetails.previousReleasedVersion === undefined) {
+                this.warning(`No previous version for ${pkgName}.`);
+            }
+
+            const { version: latestVer, date: latestDate } = verDetails.latestReleasedVersion;
+            const { version: prevVer } = verDetails.previousReleasedVersion ?? {
+                version: DEFAULT_MIN_VERSION,
+            };
+
+            const bumpType = detectBumpType(prevVer, latestVer);
+            if (!isVersionBumpType(bumpType)) {
+                this.error(
+                    `Invalid bump type (${bumpType}) detected in package ${pkgName}. ${prevVer} => ${latestVer}`,
+                );
+            }
+
+            const isNewRelease = this.isRecentRelease(verDetails);
+
+            // Expand the release group to its constituent packages.
+            if (isReleaseGroup(pkgName)) {
+                for (const pkg of context.packagesInReleaseGroup(pkgName)) {
+                    report[pkg.name] = {
+                        version: latestVer,
+                        date: latestDate,
+                        releaseType: bumpType,
+                        isNewRelease,
+                    };
+                }
+            } else {
+                report[pkgName] = {
+                    version: latestVer,
+                    date: latestDate,
+                    releaseType: bumpType,
+                    isNewRelease,
+                };
+            }
+        }
+
+        return report;
+    }
+
+    private generateMinimalReport(reportData: PackageReleaseData): MinimalReleaseReport {
+        const newObj: MinimalReleaseReport = {};
+        for (const [pkg, data] of Object.entries(reportData)) {
+            newObj[pkg] = data.latestReleasedVersion;
+        }
+
+        return newObj;
+    }
+
+    private async generatePackageList(reportData: PackageReleaseData): Promise<PackageVersionList> {
+        const context = await this.getContext();
+        const newObj: PackageVersionList = {};
+
+        for (const [pkg, data] of Object.entries(reportData)) {
+            if (isReleaseGroup(pkg)) {
+                for (const p of context.packagesInReleaseGroup(pkg)) {
+                    newObj[p.name] = data.latestReleasedVersion.version;
+                }
+            } else {
+                newObj[pkg] = data.latestReleasedVersion.version;
+            }
+        }
+
+        return newObj;
+    }
+
+    private generateReleaseTable(reportData: PackageReleaseData): string[][] {
+        const tableData: string[][] = [];
+
+        for (const [pkgName, verDetails] of Object.entries(reportData)) {
+            const { date: latestDate, version: latestVer } = verDetails.latestReleasedVersion;
+
+            const displayDate =
+                latestDate === undefined
+                    ? "--no date--"
+                    : formatISO9075(latestDate, { representation: "date" });
+
+            const highlight = this.isRecentRelease(verDetails) ? chalk.green : chalk.white;
+
+            let displayRelDate: string;
+            if (latestDate === undefined) {
+                displayRelDate = "";
+            } else {
+                const relDate = `${formatDistanceToNow(latestDate)} ago`;
+                displayRelDate = highlight(relDate);
+            }
+
+            const displayPreviousVersion =
+                verDetails.previousReleasedVersion?.version === undefined
+                    ? DEFAULT_MIN_VERSION
+                    : verDetails.previousReleasedVersion.version;
+
+            const bumpType = detectBumpType(
+                verDetails.previousReleasedVersion?.version ?? DEFAULT_MIN_VERSION,
+                latestVer,
+            );
+            const displayBumpType = highlight(`${bumpType}`);
+
+            const displayVersionSection = chalk.grey(
+                `${highlight(latestVer)} <= ${displayPreviousVersion}`,
+            );
+
+            tableData.push([
+                pkgName,
+                displayBumpType,
+                displayRelDate,
+                displayDate,
+                displayVersionSection,
+            ]);
+        }
+
+        return tableData;
+    }
+
+    private isRecentRelease(data: RawReleaseData): boolean {
+        const latestDate = data.latestReleasedVersion.date;
+
+        return latestDate === undefined
+            ? false
+            : differenceInBusinessDays(Date.now(), latestDate) < this.processedFlags.days;
+    }
+}
+
+interface RawReleaseData {
+    repoVersion: VersionDetails;
+    latestReleasedVersion: VersionDetails;
+    previousReleasedVersion?: VersionDetails;
+    versions: readonly VersionDetails[];
+}
+
+interface ReleaseDetails {
+    version: string;
+    date?: Date;
+    releaseType: VersionBumpType;
+    isNewRelease: boolean;
+    releaseGroup?: ReleaseGroup;
+}
+
+interface PackageReleaseData {
+    [packageName: string]: RawReleaseData;
+}
+
+interface ReleaseReport {
+    [packageName: string]: ReleaseDetails;
+}
+
+interface MinimalReleaseReport {
+    [packageName: string]: VersionDetails;
+}
+
+interface PackageVersionList {
+    [packageName: string]: string;
+}
+
+export type { PackageVersionList, ReleaseReport };

--- a/build-tools/packages/build-cli/src/machines/index.ts
+++ b/build-tools/packages/build-cli/src/machines/index.ts
@@ -4,5 +4,4 @@
  */
 
 export { FluidReleaseMachine } from "./fluidReleaseMachine";
-export { StateMachineCommand } from "../stateMachineCommand";
 export type { MachineState } from "./types";

--- a/build-tools/packages/build-cli/src/stateMachineCommand.ts
+++ b/build-tools/packages/build-cli/src/stateMachineCommand.ts
@@ -130,9 +130,6 @@ export abstract class StateMachineCommand<
                 if (this.machine.state_is_final(state)) {
                     this.verbose(`Exiting. Final state: ${state}`);
                     this.exit();
-
-                    // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
-                    // process.exit();
                 }
 
                 // eslint-disable-next-line no-constant-condition

--- a/build-tools/packages/build-tools/src/bumpVersion/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/gitRepo.ts
@@ -189,7 +189,7 @@ export class GitRepo {
         const results = pattern === undefined || pattern.length === 0
             ? await this.exec(`tag -l --sort=-committerdate`, `get all tags`)
             : await this.exec(`tag -l "${pattern}" --sort=-committerdate`, `get tags ${pattern}`);
-        const tags = results.split("\n").filter(t => t !== undefined && t !== "" && t !== null).splice(0, 100);
+        const tags = results.split("\n").filter(t => t !== undefined && t !== "" && t !== null);
 
         this.log?.verbose(`Found ${tags.length} tags.`)
         return tags;

--- a/build-tools/packages/build-tools/src/bumpVersion/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/gitRepo.ts
@@ -4,10 +4,11 @@
  */
 
 import { parseISO } from "date-fns";
+import { Logger } from "../common/logging";
 import { exec, execNoError } from "./utils";
 
 export class GitRepo {
-    constructor(public readonly resolvedRoot: string) {
+    constructor(public readonly resolvedRoot: string, protected readonly log?: Logger) {
     }
 
     private async getRemotes() {
@@ -180,8 +181,18 @@ export class GitRepo {
      * @param pattern - Pattern of tags to get.
      */
     public async getAllTags(pattern?: string): Promise<string[]> {
-        const results = pattern === undefined ? await this.exec(`tag -l`, `get all tags`) : await this.exec(`tag -l "${pattern}"`, `get tags ${pattern}`);
-        return results.split("\n").filter(t => t !== undefined && t !== "" && t !== null);
+        if(pattern === undefined || pattern.length === 0) {
+            this.log?.verbose(`Reading git tags from repo.`)
+        } else {
+            this.log?.verbose(`Reading git tags from repo using pattern: '${pattern}'`);
+        }
+        const results = pattern === undefined || pattern.length === 0
+            ? await this.exec(`tag -l --sort=-committerdate`, `get all tags`)
+            : await this.exec(`tag -l "${pattern}" --sort=-committerdate`, `get tags ${pattern}`);
+        const tags = results.split("\n").filter(t => t !== undefined && t !== "" && t !== null).splice(0, 100);
+
+        this.log?.verbose(`Found ${tags.length} tags.`)
+        return tags;
     }
 
     /**

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -20,7 +20,7 @@ export function detectBumpType(v1: semver.SemVer | string | null, v2: semver.Sem
 export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): VersionScheme;
 
 // @public
-export function fromInternalScheme(internalVersion: semver.SemVer | string): [publicVersion: semver.SemVer, internalVersion: semver.SemVer];
+export function fromInternalScheme(internalVersion: semver.SemVer | string, allowPrereleases?: boolean): [publicVersion: semver.SemVer, internalVersion: semver.SemVer];
 
 // @public
 export function fromVirtualPatchScheme(virtualPatchVersion: semver.SemVer | string): semver.SemVer;
@@ -50,7 +50,7 @@ export function isVersionScheme(scheme: string): scheme is VersionScheme;
 export function sortVersions(versionList: string[], allowPrereleases?: boolean): string[];
 
 // @public
-export function toInternalScheme(publicVersion: semver.SemVer | string, version: semver.SemVer | string): semver.SemVer;
+export function toInternalScheme(publicVersion: semver.SemVer | string, version: semver.SemVer | string, allowPrereleases?: boolean): semver.SemVer;
 
 // @public
 export function toVirtualPatchScheme(version: semver.SemVer | string): semver.SemVer;

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -46,17 +46,24 @@ const REQUIRED_PRERELEASE_IDENTIFIER = "internal";
  *
  * a.b.c-internal.x.y.z
  *
- * @param internalVersion - a version in the Fluid internal version scheme.
+ * @param internalVersion - A version in the Fluid internal version scheme.
+ * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
  * @returns A tuple of [publicVersion, internalVersion]
  */
 export function fromInternalScheme(
     internalVersion: semver.SemVer | string,
+    allowPrereleases = false,
 ): [publicVersion: semver.SemVer, internalVersion: semver.SemVer] {
     const parsedVersion = semver.parse(internalVersion);
-    validateVersionScheme(parsedVersion);
+    validateVersionScheme(parsedVersion, allowPrereleases);
 
     assert(parsedVersion !== null);
-    const newSemVerString = parsedVersion.prerelease.slice(1).join(".");
+    const prereleaseSections = parsedVersion.prerelease;
+
+    const newSemVerString =
+        prereleaseSections.length > 4
+            ? `${prereleaseSections.slice(1, 4).join(".")}-${prereleaseSections.slice(4).join(".")}`
+            : prereleaseSections.slice(1).join(".");
     const newSemVer = semver.parse(newSemVerString);
     if (newSemVer === null) {
         throw new Error(`Couldn't convert ${internalVersion} to a standard semver.`);
@@ -93,30 +100,36 @@ export function fromInternalScheme(
 
  * @param publicVersion - The public version.
  * @param version - The internal version.
+ * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
  * @returns A version in the Fluid internal version scheme.
  */
 export function toInternalScheme(
     publicVersion: semver.SemVer | string,
     version: semver.SemVer | string,
+    allowPrereleases = false,
 ): semver.SemVer {
     const parsedVersion = semver.parse(version);
     if (parsedVersion === null) {
         throw new Error(`Couldn't parse ${version} as a semver.`);
     }
 
-    if (parsedVersion.prerelease.length !== 0) {
+    if (!allowPrereleases && parsedVersion.prerelease.length !== 0) {
         throw new Error(
             `Input version already has a pre-release component (${parsedVersion.prerelease}), which is not expected.`,
         );
     }
 
-    const newSemVerString = `${publicVersion}-internal.${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch}`;
+    const prereleaseSections = parsedVersion.prerelease;
+    const newPrerelease = prereleaseSections.length > 0 ? `.${prereleaseSections.join(".")}` : "";
+    const newSemVerString = `${publicVersion}-internal.${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch}${newPrerelease}`;
     const newSemVer = semver.parse(newSemVerString);
     if (newSemVer === null) {
-        throw new Error(`Couldn't convert ${version} to the internal version scheme.`);
+        throw new Error(
+            `Couldn't convert ${version} to the internal version scheme. Tried parsing: '${newSemVerString}'`,
+        );
     }
 
-    if (!isInternalVersionScheme(newSemVer)) {
+    if (!isInternalVersionScheme(newSemVer, allowPrereleases)) {
         throw new Error(`Converted version is not a valid Fluid internal version: ${newSemVer}`);
     }
 

--- a/build-tools/packages/version-tools/src/semver.ts
+++ b/build-tools/packages/version-tools/src/semver.ts
@@ -5,7 +5,12 @@
 
 import * as semver from "semver";
 import { VersionBumpTypeExtended, VersionBumpType } from "./bumpTypes";
-import { bumpInternalVersion, getVersionRange } from "./internalVersionScheme";
+import {
+    bumpInternalVersion,
+    fromInternalScheme,
+    getVersionRange,
+    isInternalVersionScheme,
+} from "./internalVersionScheme";
 import { bumpVersionScheme, detectVersionScheme } from "./schemes";
 
 /**
@@ -91,7 +96,8 @@ export function detectConstraintType(range: string): "minor" | "patch" {
 }
 
 /**
- * Given a first and second version, returns the bump type
+ * Given a first and second version, returns the bump type. Works correctly for Fluid internal versions.
+ *
  * @param v1 - The first version to compare.
  * @param v2 - The second version to compare.
  * @returns The bump type, or undefined if it can't be determined.
@@ -102,14 +108,26 @@ export function detectBumpType(
     // eslint-disable-next-line @rushstack/no-new-null
     v2: semver.SemVer | string | null,
 ): VersionBumpType | undefined {
-    const v1Parsed = semver.parse(v1);
-    if (v1Parsed === null) {
+    let v1Parsed = semver.parse(v1);
+    if (v1Parsed === null || v1 === null) {
         throw new Error(`Invalid version: ${v1}`);
     }
 
-    const v2Parsed = semver.parse(v2);
-    if (v2Parsed === null) {
+    let v2Parsed = semver.parse(v2);
+    if (v2Parsed === null || v2 === null) {
         throw new Error(`Invalid version: ${v2}`);
+    }
+
+    // const scheme = detectVersionScheme(v1Parsed);
+    // let publicVer: semver.SemVer;
+    if (isInternalVersionScheme(v1, true)) {
+        const [, internalVer] = fromInternalScheme(v1, true);
+        v1Parsed = internalVer;
+    }
+
+    if (isInternalVersionScheme(v2, true)) {
+        const [, internalVer] = fromInternalScheme(v2, true);
+        v2Parsed = internalVer;
     }
 
     if (semver.compareBuild(v1Parsed, v2Parsed) >= 0) {

--- a/build-tools/packages/version-tools/src/semver.ts
+++ b/build-tools/packages/version-tools/src/semver.ts
@@ -118,8 +118,6 @@ export function detectBumpType(
         throw new Error(`Invalid version: ${v2}`);
     }
 
-    // const scheme = detectVersionScheme(v1Parsed);
-    // let publicVer: semver.SemVer;
     if (isInternalVersionScheme(v1, true)) {
         const [, internalVer] = fromInternalScheme(v1, true);
         v1Parsed = internalVer;

--- a/build-tools/packages/version-tools/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/test/internalVersionScheme.test.ts
@@ -93,6 +93,15 @@ describe("internalScheme", () => {
             assert.strictEqual(calculated.version, expected);
         });
 
+        it("parses 2.0.0-internal.1.1.0.12345", () => {
+            const input = `2.0.0-internal.1.1.0.12345`;
+            const expected = `1.1.0-12345`;
+            const [_, calculated] = fromInternalScheme(input, true);
+            assert.strictEqual(calculated.version, expected);
+
+            assert.throws(() => fromInternalScheme(input));
+        });
+
         it("throws on 2.0.0-alpha.1.0.0 (must use internal)", () => {
             const input = `2.0.0-alpha.1.0.0`;
             assert.throws(() => fromInternalScheme(input));
@@ -114,6 +123,13 @@ describe("internalScheme", () => {
             const input = `1.0.0`;
             const expected = `2.2.2-internal.1.0.0`;
             const calculated = toInternalScheme("2.2.2", input);
+            assert.strictEqual(calculated.version, expected);
+        });
+
+        it("converts 1.1.0-12345.12 to internal version with public version 2.0.0", () => {
+            const input = `1.1.0-12345.12`;
+            const expected = `2.0.0-internal.1.1.0.12345.12`;
+            const calculated = toInternalScheme("2.0.0", input, true);
             assert.strictEqual(calculated.version, expected);
         });
 

--- a/build-tools/packages/version-tools/test/semver.test.ts
+++ b/build-tools/packages/version-tools/test/semver.test.ts
@@ -38,7 +38,7 @@ describe("semver", () => {
         });
     });
 
-    describe("semverDiff", () => {
+    describe("detectBumpType semver", () => {
         it("major", () => {
             assert.equal(detectBumpType("0.0.1", "1.0.0"), "major");
         });
@@ -65,6 +65,54 @@ describe("semver", () => {
 
         it("prerelease", () => {
             assert.isUndefined(detectBumpType("0.0.1-foo", "0.0.1-foo.bar"));
+        });
+
+        it("v1 >= v2 throws", () => {
+            assert.throws(() => detectBumpType("0.0.1", "0.0.1"));
+            assert.throws(() => detectBumpType("0.0.2", "0.0.1"));
+            assert.throws(() => detectBumpType("0.0.1+0", "0.0.1"));
+            assert.throws(() => detectBumpType("0.0.1+2", "0.0.1+2"));
+            assert.throws(() => detectBumpType("0.0.1+3", "0.0.1+2"));
+            assert.throws(() => detectBumpType("0.0.1+2.0", "0.0.1+2"));
+            assert.throws(() => detectBumpType("0.0.1+2.a", "0.0.1+2.0"));
+        });
+    });
+
+    describe("detectBumpType internal version scheme", () => {
+        it("major", () => {
+            assert.equal(detectBumpType("2.0.0-internal.1.0.0", "2.0.0-internal.2.0.0"), "major");
+        });
+
+        it("minor", () => {
+            assert.equal(detectBumpType("2.0.0-internal.1.0.0", "2.0.0-internal.1.1.0"), "minor");
+        });
+
+        it("patch", () => {
+            assert.equal(detectBumpType("2.0.0-internal.1.0.0", "2.0.0-internal.1.0.1"), "patch");
+        });
+
+        it("premajor", () => {
+            assert.equal(
+                detectBumpType("2.0.0-internal.1.0.0.82134", "2.0.0-internal.2.0.0"),
+                "major",
+            );
+        });
+
+        it("preminor", () => {
+            assert.equal(
+                detectBumpType("2.0.0-internal.1.1.0.82134", "2.0.0-internal.1.2.0"),
+                "minor",
+            );
+        });
+
+        it("prepatch", () => {
+            assert.equal(detectBumpType("1.1.1-foo", "1.1.2"), "patch");
+        });
+
+        it("prerelease", () => {
+            assert.isUndefined(
+                detectBumpType("2.0.0-internal.1.0.0.82134", "2.0.0-internal.1.0.0"),
+            );
         });
 
         it("v1 >= v2 throws", () => {

--- a/build-tools/packages/version-tools/test/semver.test.ts
+++ b/build-tools/packages/version-tools/test/semver.test.ts
@@ -91,25 +91,25 @@ describe("semver", () => {
             assert.equal(detectBumpType("2.0.0-internal.1.0.0", "2.0.0-internal.1.0.1"), "patch");
         });
 
-        it("premajor", () => {
+        it("premajor bump type returns major", () => {
             assert.equal(
                 detectBumpType("2.0.0-internal.1.0.0.82134", "2.0.0-internal.2.0.0"),
                 "major",
             );
         });
 
-        it("preminor", () => {
+        it("preminor bump type returns minor", () => {
             assert.equal(
                 detectBumpType("2.0.0-internal.1.1.0.82134", "2.0.0-internal.1.2.0"),
                 "minor",
             );
         });
 
-        it("prepatch", () => {
+        it("prepatch bump type returns patch", () => {
             assert.equal(detectBumpType("1.1.1-foo", "1.1.2"), "patch");
         });
 
-        it("prerelease", () => {
+        it("prerelease bump type returns undefined", () => {
             assert.isUndefined(
                 detectBumpType("2.0.0-internal.1.0.0.82134", "2.0.0-internal.1.0.0"),
             );
@@ -123,6 +123,14 @@ describe("semver", () => {
             assert.throws(() => detectBumpType("0.0.1+3", "0.0.1+2"));
             assert.throws(() => detectBumpType("0.0.1+2.0", "0.0.1+2"));
             assert.throws(() => detectBumpType("0.0.1+2.a", "0.0.1+2.0"));
+        });
+
+        it("invalid semver v1 throws", () => {
+            assert.throws(() => detectBumpType("bad semver", "0.0.1"));
+        });
+
+        it("invalid semver v2 throws", () => {
+            assert.throws(() => detectBumpType("0.0.1", "bad semver"));
         });
     });
 


### PR DESCRIPTION
Adds a `release report` command to the build-cli. This command is used to collect version information for release groups and packages and produce a JSON file with data about the release. After a release, it is useful to generate this report to provide to customers, so they can update their dependencies to the most recent version.

The command will prompt you to select versions for a package or release group in the event that multiple versions have recently been released.