### PR TITLE
Only fail passing tests due to log error

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -341,9 +341,6 @@ describeNoCompat("SharedMap orderSequentially", (getTestObjectProvider) => {
     beforeEach(() => {
         provider = getTestObjectProvider();
     });
-    afterEach(async () => reset());
-
-    const reset = async () => provider.reset();
 
     let container: Container;
     let dataObject: ITestFluidObject;
@@ -387,7 +384,6 @@ describeNoCompat("SharedMap orderSequentially", (getTestObjectProvider) => {
         let sharedMap2: SharedMap;
 
         beforeEach(async () => {
-            await reset();
             provider = getTestObjectProvider();
         });
 

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -384,6 +384,7 @@ describeNoCompat("SharedMap orderSequentially", (getTestObjectProvider) => {
         let sharedMap2: SharedMap;
 
         beforeEach(async () => {
+            provider.reset();
             provider = getTestObjectProvider();
         });
 

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -64,6 +64,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
         containerConfig: ITestContainerConfig = testContainerConfig,
         featureGates: Record<string, ConfigTypes> = {},
     ) => {
+        provider.reset();
         const configWithFeatureGates = {
             ...containerConfig,
             loaderProps: { configProvider: configProvider(featureGates) },
@@ -76,6 +77,8 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
         await provider.ensureSynchronized();
     };
+
+    const reset = async () => provider.reset();
 
     const allDataCorruption = async (containers: IContainer[]) => Promise.all(
         containers.map(async (c) => new Promise<boolean>((resolve) => c.once("closed", (error) => {
@@ -105,6 +108,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
     describe("Legacy APIs", () => {
         beforeEach(async () => setupContainers(testContainerConfig));
+        afterEach(async () => reset());
 
         it("Datastore creation with legacy API returns datastore which can be aliased", async () => {
             const ds = await createDataStoreWithProps(dataObject1, "1");
@@ -115,6 +119,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
     describe("Aliasing", () => {
         beforeEach(async () => setupContainers());
+        afterEach(async () => reset());
 
         const alias = "alias";
 

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -64,7 +64,6 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
         containerConfig: ITestContainerConfig = testContainerConfig,
         featureGates: Record<string, ConfigTypes> = {},
     ) => {
-        provider.reset();
         const configWithFeatureGates = {
             ...containerConfig,
             loaderProps: { configProvider: configProvider(featureGates) },
@@ -77,8 +76,6 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
         await provider.ensureSynchronized();
     };
-
-    const reset = async () => provider.reset();
 
     const allDataCorruption = async (containers: IContainer[]) => Promise.all(
         containers.map(async (c) => new Promise<boolean>((resolve) => c.once("closed", (error) => {
@@ -108,7 +105,6 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
     describe("Legacy APIs", () => {
         beforeEach(async () => setupContainers(testContainerConfig));
-        afterEach(async () => reset());
 
         it("Datastore creation with legacy API returns datastore which can be aliased", async () => {
             const ds = await createDataStoreWithProps(dataObject1, "1");
@@ -119,7 +115,6 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
     describe("Aliasing", () => {
         beforeEach(async () => setupContainers());
-        afterEach(async () => reset());
 
         const alias = "alias";
 

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -510,8 +510,4 @@ describeNoCompat("SingleCommit Summaries Tests", (getTestObjectProvider) => {
         const summary3ParentHandle = broadcastResult3.data.summarizeOp.contents.head;
         assert(summary3ParentHandle === summary2AckHandle, "Summary Parent should match ack handle of summary2");
     });
-
-    afterEach(async () => {
-        provider.reset();
-    });
 });

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -40,7 +40,7 @@ function createCompatSuite(
                         config.containerRuntime,
                         config.dataRuntime,
                     );
-                    // eslint-disable-next-line @typescript-eslint/no-invalid-this
+
                     Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
                 });
                 tests.bind(this)((options?: ITestObjectProviderOptions) => {
@@ -50,9 +50,17 @@ function createCompatSuite(
                     }
                     return provider;
                 });
-                // eslint-disable-next-line prefer-arrow-callback
+
                 afterEach(function(done: Mocha.Done) {
-                    done(getUnexpectedLogErrorException(provider.logger, "Use itExpects to specify expected errors. "));
+                    const logErrors = getUnexpectedLogErrorException(provider.logger);
+                    // if the test failed for another reason
+                    // then we don't need to check errors
+                    // and fail the after each as well
+                    if (this.currentTest?.state === "passed") {
+                        done(logErrors);
+                    } else {
+                        done();
+                    }
                     if (resetAfterEach) {
                         provider.reset();
                     }


### PR DESCRIPTION
## Description

Previously it was possible for a test to fail, and then the after each to also fail due to logging error. This change only fails a test in the after each if the test otherwise passed. This will make the logs easier to read, and the test results easier to understand, as the logs will only cause the test to fail if it hit no other errors.