### PR TITLE
Fix nconf config for webpack-fluid-loader

### DIFF
--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -65,7 +65,7 @@ export const after = (
 ) => {
     const options: RouteOptions = { mode: "local", ...env, ...{ port: server.options.port } };
     const config: nconf.Provider = nconf
-        .env({ parseValules: true, inputSeparator: "__" })
+        .env({ parseValues: true, separator: "__" })
         .file(path.join(baseDir, "config.json"));
     const buildTokenConfig = (response, redirectUriCallback?): OdspTokenConfig => ({
         type: "browserLogin",


### PR DESCRIPTION
Nconf documentation of "inputSeparator" is for a newer version than has actually been released -- for now it's still "separator".  Looks like we'll need to update whenever 1.0.0 releases: https://github.com/indexzero/nconf/pull/337