### PR TITLE
Misc. cleanup in `fluid-framework` package

### DIFF
--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -15,7 +15,7 @@
   "module": "lib/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "concurrently npm:build:compile npm:lint",
+    "build": "concurrently npm:build:compile npm:lint && npm run build:docs",
     "build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",
     "build:compile": "concurrently npm:build:commonjs npm:build:esnext",
     "build:docs": "api-extractor run --local --typescript-compiler-folder ../../../node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -24,7 +24,7 @@
     "build:full:compile": "npm run build:compile",
     "build:test": "tsc --project ./src/test/tsconfig.json",
     "ci:build:docs": "api-extractor run --typescript-compiler-folder ../../../node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/* ../../../_api-extractor-temp/",
-    "clean": "rimraf dist *.tsbuildinfo *.build.log",
+    "clean": "rimraf _api-extractor-temp dist lib *.tsbuildinfo *.build.log",
     "eslint": "eslint --format stylish src",
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",

--- a/packages/framework/fluid-framework/src/containerDefinitions.ts
+++ b/packages/framework/fluid-framework/src/containerDefinitions.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export { AttachState } from "@fluidframework/container-definitions";

--- a/packages/framework/fluid-framework/src/containerLoader.ts
+++ b/packages/framework/fluid-framework/src/containerLoader.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export { ConnectionState } from "@fluidframework/container-loader";

--- a/packages/framework/fluid-framework/src/fluidStatic.ts
+++ b/packages/framework/fluid-framework/src/fluidStatic.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export * from "@fluidframework/fluid-static";

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -11,8 +11,8 @@
  * @packageDocumentation
  */
 
-export * from "./containerDefinitions";
-export * from "./containerLoader";
-export * from "./fluidStatic";
-export * from "./map";
-export * from "./sequence";
+export { AttachState } from "@fluidframework/container-definitions";
+export { ConnectionState } from "@fluidframework/container-loader";
+export * from "@fluidframework/fluid-static";
+export * from "@fluidframework/map";
+export * from "@fluidframework/sequence";

--- a/packages/framework/fluid-framework/src/map.ts
+++ b/packages/framework/fluid-framework/src/map.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export * from "@fluidframework/map";

--- a/packages/framework/fluid-framework/src/sequence.ts
+++ b/packages/framework/fluid-framework/src/sequence.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export * from "@fluidframework/sequence";


### PR DESCRIPTION
Specifically:
- Add missing files and directories to package's "clean" script
- Add missing docs build step to package's "build" script
- Simplify code structure by moving re-exports into `index.ts` file