### PR TITLE
Implement sweep v2 tests to avoid InactiveObjectX errors

### DIFF
--- a/packages/test/test-gc-sweep-tests/src/containerManager.ts
+++ b/packages/test/test-gc-sweep-tests/src/containerManager.ts
@@ -9,7 +9,6 @@ import { IContainer } from "@fluidframework/container-definitions";
 import { IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { IRandom } from "@fluid-internal/stochastic-test-utils";
-import { ContainerDataObjectManager } from "./containerDataObjectManager";
 
 /**
  * Responsible for tracking the lifetime of containers
@@ -34,11 +33,12 @@ export class ContainerManager {
         return container;
     }
 
-    public async loadContainer(): Promise<void> {
+    public async loadContainer(): Promise<IContainer> {
         const container = await this.provider.loadContainer(this.runtimeFactory, {
             configProvider: this.configProvider,
         });
         this.trackContainer(container);
+        return container;
     }
 
     private trackContainer(container: IContainer) {
@@ -64,12 +64,12 @@ export class ContainerManager {
         return this.connectedContainers.length;
     }
 
-    public async getRandomContainer(random: IRandom): Promise<ContainerDataObjectManager> {
+    public async getRandomContainer(random: IRandom): Promise<IContainer> {
         if (!this.hasConnectedContainers()) {
             await this.loadContainer();
         }
         const container = random.pick(this.connectedContainers);
         assert(!container.closed, "Picked container should not be closed!");
-        return new ContainerDataObjectManager(container);
+        return container;
     }
 }

--- a/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
+++ b/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
@@ -100,7 +100,7 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
     for (let i = 0; i < numberOfTests; i++) {
         const seed = Math.random();
         const random: IRandom = makeRandom(seed);
-        it(`GC Randomization Test with Seed: ${seed}`, async () => {
+        it.skip(`GC Randomization Test with Seed: ${seed}`, async () => {
             provider = getTestObjectProvider({
                 syncSummarizer: true,
             });
@@ -161,7 +161,8 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
 
             // After creating the DataObject, the handle must be stored for it to become live.
             const createDataStoreForRandomContainer = async () => {
-                const containerDataObjectManager = await containerManager.getRandomContainer(random);
+                const container = await containerManager.getRandomContainer(random);
+                const containerDataObjectManager = new ContainerDataObjectManager(container);
                 const dataObject = await containerDataObjectManager.createDataObject();
                 await referenceHandle(containerDataObjectManager, dataObject.handle);
                 fluidObjectTracker.trackDataObject(dataObject);
@@ -169,7 +170,8 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
 
             // Stores a handle of a DataStore or DDS into a DDS
             const referenceRandomHandle = async () => {
-                const containerDataObjectManager = await containerManager.getRandomContainer(random);
+                const container = await containerManager.getRandomContainer(random);
+                const containerDataObjectManager = new ContainerDataObjectManager(container);
                 const handlePath = fluidObjectTracker.getRandomFluidObject(random);
                 const handle = await containerDataObjectManager.getHandle(handlePath);
                 await referenceHandle(containerDataObjectManager, handle);
@@ -177,7 +179,8 @@ describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
 
             // Removes a handle of a DataStore or DDS from a DDS
             const unreferenceRandomHandle = async () => {
-                const containerDataObjectManager = await containerManager.getRandomContainer(random);
+                const container = await containerManager.getRandomContainer(random);
+                const containerDataObjectManager = new ContainerDataObjectManager(container);
                 // getChannelWithHandle only gets handles that aren't removed or getting removed
                 const channelPath = handleTracker.getRemovePath(random);
                 const removedHandle = await containerDataObjectManager.removeHandle(channelPath, random);

--- a/packages/test/test-gc-sweep-tests/src/test/gcSweepTestV2.spec.ts
+++ b/packages/test/test-gc-sweep-tests/src/test/gcSweepTestV2.spec.ts
@@ -1,0 +1,141 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable max-len */
+import * as fs from "fs";
+import { assert } from "console";
+import {
+    ContainerRuntimeFactoryWithDefaultDataStore,
+} from "@fluidframework/aqueduct";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
+import {
+    DefaultSummaryConfiguration,
+    IContainerRuntimeOptions,
+    ISummaryConfigurationHeuristics,
+} from "@fluidframework/container-runtime";
+import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { makeRandom, IRandom } from "@fluid-internal/stochastic-test-utils";
+import { delay } from "@fluidframework/common-utils";
+import { mockConfigProvider } from "../mockConfigProvider";
+import { IgnoreErrorLogger } from "../ignoreErrorLogger";
+import { ContainerManager } from "../containerManager";
+import { opSendingDataObjectFactory, ReferencingDataObject, referencingDataObjectFactory } from "../treeDataObject";
+
+describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+
+    const summaryOptions = DefaultSummaryConfiguration as ISummaryConfigurationHeuristics;
+    summaryOptions.summarizerClientElection = true;
+    // Summaries should run automatically
+    const runtimeOptions: IContainerRuntimeOptions = {
+        summaryOptions,
+        gcOptions: {
+            gcAllowed: true,
+        },
+    };
+    const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+        runtime.IFluidHandleContext.resolveHandle(request);
+    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+        referencingDataObjectFactory,
+        [
+            [referencingDataObjectFactory.type, Promise.resolve(referencingDataObjectFactory)],
+            [opSendingDataObjectFactory.type, Promise.resolve(opSendingDataObjectFactory)],
+        ],
+        undefined,
+        [innerRequestHandler],
+        runtimeOptions,
+    );
+
+    // const sessionExpiryDurationMs = 3000; // 3 seconds
+    const inactiveTimeoutMs = 3000; // 3 seconds
+
+    // Set settings here, may be useful to put everything in the mockConfigProvider
+    const settings = {
+        // "Fluid.GarbageCollection.RunSessionExpiry": "true",
+        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": inactiveTimeoutMs,
+        // "Fluid.GarbageCollection.TestOverride.SessionExpiryMs": sessionExpiryDurationMs,
+    };
+    const configProvider = mockConfigProvider(settings);
+
+    let overrideLogger: IgnoreErrorLogger;
+
+    // Test timeout
+    const testTimeout = 5 * 60 * 60 * 1000; // 5 hours
+
+    // Currently for GC Sweep testing only, run with npm run test. Should not be running in CI
+    // Note: can run with npm run test:build to build and run the test
+    // TODO: have this configurable via mocha cmd arguments
+    // TODO: setup test to run in CI
+    const numberOfTests = 1;
+    for (let i = 0; i < numberOfTests; i++) {
+        const seed = Math.random();
+        const random: IRandom = makeRandom(seed);
+
+        const liveContainers = 10;
+        const dataStoresInTree = 2;
+        const opsPerDataStorePerContainer = 500;
+        const opLimit = 200000;
+        const burstsTotal = opLimit / (liveContainers * dataStoresInTree * opsPerDataStorePerContainer);
+
+        it(`GC Ops Test with Seed: ${seed}, Containers: ${liveContainers}, Ops/DataStore/Container: ${opsPerDataStorePerContainer}, Ops Total: ${opLimit}, Bursts: ${burstsTotal}`, async () => {
+            provider = getTestObjectProvider({
+                syncSummarizer: true,
+            });
+
+            // Wrap the logger
+            overrideLogger = new IgnoreErrorLogger(provider.logger);
+            provider.logger = overrideLogger;
+
+            // Create the containerManager responsible for retrieving, creating, loading, and tracking the lifetime of containers.
+            const containerManager = new ContainerManager(runtimeFactory, configProvider, provider);
+            const mainContainer = await containerManager.createContainer();
+            const mainDataObject = await requestFluidObject<ReferencingDataObject>(mainContainer, "default");
+            mainDataObject.start(opsPerDataStorePerContainer, random);
+            // waits needs to be > 100
+            const waitsMs: number[] = [
+                inactiveTimeoutMs,
+                0,
+                summaryOptions.maxIdleTime,
+                summaryOptions.maxTime,
+                summaryOptions.maxAckWaitTime,
+            ];
+
+            // Ops per interesting gc event per client
+            // ops per interesting gc event
+            // ops per person
+            let bursts = 0;
+            while (bursts < burstsTotal) {
+                if (containerManager.connectedContainerCount < liveContainers) {
+                    const container = await containerManager.loadContainer();
+                    const rootDataObject = await requestFluidObject<ReferencingDataObject>(container, "default");
+                    rootDataObject.start(opsPerDataStorePerContainer, random);
+                } else {
+                    containerManager.closeRandomContainer(random);
+                }
+                const wait = random.pick(waitsMs);
+                await delay(wait);
+                bursts++;
+            }
+
+            fs.mkdirSync(`nyc/testData-${seed}`, { recursive: true });
+            fs.writeFileSync(`nyc/testData-${seed}/events.json`, JSON.stringify(overrideLogger.events));
+            fs.writeFileSync(`nyc/testData-${seed}/inactiveObjectEvents.json`, JSON.stringify(overrideLogger.inactiveObjectEvents));
+            fs.writeFileSync(`nyc/testData-${seed}/errorEvents.json`, JSON.stringify(overrideLogger.errorEvents));
+            fs.writeFileSync(`nyc/testData-${seed}/errorEventStats.json`, JSON.stringify(overrideLogger.errorEventStats));
+
+            const finalContainer = await containerManager.loadContainer();
+            const finalDataObject = await requestFluidObject<ReferencingDataObject>(finalContainer, "default");
+            const finalCounter = await finalDataObject.counterHandle.get();
+            const finalCount = finalCounter.value;
+            assert(finalCount === opLimit / dataStoresInTree, `Expected final count of ${finalCount} to be ${opLimit / dataStoresInTree}`);
+
+            assert(overrideLogger.inactiveObjectEvents.length === 0, `InactiveObject events occurred - look at nyc/testData-${seed}/inactiveObjectEvents.json`);
+            assert(overrideLogger.errorEvents.length === 0, `Error events occurred - look at nyc/testData-${seed}/errorEvents.json`);
+        }).timeout(testTimeout);
+    }
+});

--- a/packages/test/test-gc-sweep-tests/src/testDataObjects.ts
+++ b/packages/test/test-gc-sweep-tests/src/testDataObjects.ts
@@ -31,7 +31,7 @@ import {
 } from "./channelHandler";
 
 // The BaseTestDataObject has functionality that all other data objects should derive
-export class BaseTestDataObject extends DataObject {
+export abstract class BaseTestDataObject extends DataObject {
     public static get type(): string {
         return "TestDataObject";
     }
@@ -198,7 +198,7 @@ export class HandleManager {
 }
 
 // Factories for all the channels we support
-const allFactories: IChannelFactory[] = [
+export const allFactories: IChannelFactory[] = [
     ConsensusQueue.getFactory(),
     ConsensusRegisterCollection.getFactory(),
     Ink.getFactory(),
@@ -210,7 +210,6 @@ const allFactories: IChannelFactory[] = [
     SharedString.getFactory(),
 ];
 
-// The DataObjectFactory for DataObjectManyDDSes
 export const dataObjectWithManyDDSesFactory = new DataObjectFactory(
     DataObjectManyDDSes.type,
     DataObjectManyDDSes,

--- a/packages/test/test-gc-sweep-tests/src/treeDataObject.ts
+++ b/packages/test/test-gc-sweep-tests/src/treeDataObject.ts
@@ -1,0 +1,185 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IRandom } from "@fluid-internal/stochastic-test-utils";
+import { DataObjectFactory } from "@fluidframework/aqueduct";
+import { assert, delay } from "@fluidframework/common-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { SharedCounter } from "@fluidframework/counter";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { BaseTestDataObject, allFactories } from "./testDataObjects";
+
+const counterKey = "counter";
+const delayPerOp = 100;
+export abstract class BaseOpDataObject extends BaseTestDataObject {
+    protected isRunning: boolean = false;
+    public get counterHandle(): IFluidHandle<SharedCounter> {
+        const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
+        assert(counterHandle !== undefined, `CounterHandle should always be defined!`);
+        return counterHandle;
+    }
+    protected count?: number;
+    protected random?: IRandom;
+    private opsPerformed: number = 0;
+
+    protected async initializingFirstTime(props?: any): Promise<void> {
+        this.root.set<IFluidHandle>(counterKey, SharedCounter.create(this.runtime).handle);
+    }
+
+    protected async hasInitialized(): Promise<void> {
+        // Use this to determine the local change count
+        this.opsPerformed = 0;
+    }
+
+    public abstract sendOp(count: number, random: IRandom): Promise<void>;
+
+    public abstract stop(): void;
+
+    public start(count: number, random: IRandom) {
+        this.isRunning = true;
+        this.sendOps(count, random).catch((error) => { console.log(error); });
+    }
+
+    /**
+     * @param count - number of ops performed
+     * @param random - used to control randomization consistently across all clients
+     *
+     * Perform 1000 ops and then do something interesting to GC as in reference and unreference datastores
+     */
+    private async sendOps(count: number, random: IRandom) {
+        assert(this.counterHandle !== undefined, "Can't send ops when counter handle isn't set!");
+        assert(this.isRunning === true, "Should be running to send ops");
+        const counter = await this.counterHandle.get();
+        while (this.opsPerformed < count && this.isRunning && !this.disposed) {
+            // This count is shared across dataObjects so this should reach clients * datastores * count
+            counter.increment(1);
+            // This data is local and allows us to understand the number of changes a local client has created
+            this.opsPerformed++;
+            await delay(delayPerOp);
+        }
+        if (this.isRunning && !this.disposed) {
+            await this.sendOp(count, random);
+        }
+        this.stop();
+    }
+}
+
+export class OpSendingDataObject extends BaseOpDataObject {
+    public static get type(): string {
+        return "OpSendingDataObject";
+    }
+
+    public async sendOp(_count: number, _random: IRandom) {
+        assert(this.counterHandle !== undefined, "Can't send ops when counter handle isn't set!");
+        const counter = await this.counterHandle.get();
+        counter.increment(1);
+    }
+
+    public stop() {
+        this.isRunning = false;
+    }
+}
+
+const childKey = "childKey";
+export class ReferencingDataObject extends BaseOpDataObject {
+    private unrefTimeStampMs?: number;
+    private oldChildHandle?: IFluidHandle<OpSendingDataObject>;
+    private child?: OpSendingDataObject;
+
+    public static get type(): string {
+        return "ReferencingDataObject";
+    }
+
+    private get childHandle(): IFluidHandle<OpSendingDataObject> | undefined {
+        return this.root.get<IFluidHandle<OpSendingDataObject>>(childKey);
+    }
+
+    protected async initializingFirstTime(props?: any): Promise<void> {
+        const child = await opSendingDataObjectFactory.createInstance(this.containerRuntime);
+        this.root.set<IFluidHandle>(childKey, child.handle);
+    }
+
+    protected async hasInitialized(): Promise<void> {
+        await super.hasInitialized();
+        this.root.on("valueChanged", (change) => {
+            if (change.key === childKey) {
+                this.child?.stop();
+                this.child = this.root.get(change.key);
+            }
+        });
+    }
+
+    // do activity
+    public async sendOp(count: number, random: IRandom) {
+        assert(this.counterHandle !== undefined, "Can't send ops when counter handle isn't set!");
+        const availableOps: (() => Promise<void>)[] =
+        [
+            async () => { await this.referenceNew(count, random); },
+            async () => { /** no op */ },
+        ];
+        if (this.childHandle !== undefined) {
+           availableOps.push(async () => { await this.unreference(); });
+        }
+        if (this.oldChildHandle !== undefined) {
+            availableOps.push(async () => { await this.rereference(count, random); });
+        }
+        const op = random.pick(availableOps);
+        await op();
+    }
+
+    public stop() {
+        this.child?.stop();
+        this.isRunning = false;
+    }
+
+    public async createDataObject() {
+        const dataStore = await this.containerRuntime.createDataStore(OpSendingDataObject.type);
+        const dataObject = await requestFluidObject<OpSendingDataObject>(dataStore, "/");
+        return dataObject;
+    }
+
+    public async unreference() {
+        assert(this.childHandle !== undefined, `Child handle should be defined when unreferencing!`);
+        this.oldChildHandle = this.childHandle;
+        const child = await this.oldChildHandle.get();
+        child.stop();
+        this.root.delete(childKey);
+    }
+
+    public async referenceNew(count: number, random: IRandom) {
+        const child = await this.createDataObject();
+        await this.referenceAndStart(count, random, child.handle);
+    }
+
+    public async referenceAndStart(count: number, random: IRandom, handle: IFluidHandle<OpSendingDataObject>) {
+        this.oldChildHandle = this.childHandle;
+        this.root.set(childKey, handle);
+        this.unrefTimeStampMs = Date.now();
+        this.child = await handle.get();
+        this.child.start(count, random);
+    }
+
+    public async rereference(count: number, random: IRandom) {
+        assert(this.oldChildHandle !== undefined, `An old handle should exist when referencing`);
+        assert(this.unrefTimeStampMs !== undefined, `An unreferenceTimestamp`);
+        await this.referenceAndStart(count, random, this.oldChildHandle);
+        this.oldChildHandle = undefined;
+        this.unrefTimeStampMs = undefined;
+    }
+}
+
+export const referencingDataObjectFactory = new DataObjectFactory(
+    ReferencingDataObject.type,
+    ReferencingDataObject,
+    allFactories,
+    {},
+);
+
+export const opSendingDataObjectFactory = new DataObjectFactory(
+    OpSendingDataObject.type,
+    OpSendingDataObject,
+    allFactories,
+    {},
+);


### PR DESCRIPTION
[AB#1847](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1847)

The current GC Sweep tests do not support avoiding inactiveObjectX errors as they use the request pattern. Implement the sweep tests to run so that no inactiveObjectX errors should occur as proper handle usage is implemented.

This is the general direction of where the v2 tests will go.

Here is a table of the ops performed. A burst is considered a series of regular ops followed by an interesting GC op. The formula for a burst = live containers * datastores * ops per datastore. Each datastore on each container is individually performing 1000 ops or closing before then.

| Type | 1000 ops per datastore | 500 ops per datastore |
| --------------- | --------------- | --------------- |
| live containers | 10 | 10 |
| datastores | 2 | 2 |
| ops per datastore | 1000 | 500 |
| ops per burst | 20000 | 10000 |
| bursts total | 10 | 20 |





















































