### PR TITLE
Aliasing older datastores

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1760,7 +1760,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         await this.dataStores.waitIfPendingAlias(id);
         const internalId = this.internalId(id);
         const context = await this.dataStores.getDataStore(internalId, wait);
-        assert(await context.isRoot(), 0x12b /* "did not get root data store" */);
+        assert(this.dataStores.isIdAliased(internalId), 0x12b /* "did not get root data store" */);
         return context.realize();
     }
 

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -163,12 +163,12 @@ export class DataStoreContexts
     }
 
     private async waitIfTrackedForAliasConversion(id: string) {
-        const deferred = this.pendingLegacyRootContexts.get(id);
-        if (deferred === undefined) {
+        const marker = this.pendingLegacyRootContexts.get(id);
+        if (marker === undefined) {
             return;
         }
 
-        return deferred.promise.then(() => {
+        return marker.promise.then(() => {
             this.pendingLegacyRootContexts.delete(id);
         });
     }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -110,7 +110,7 @@ export class DataStores implements IDisposable {
 
         // back-compat
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        contexts.on("add", this.maybeAliasLegacyRootDataStore);
+        contexts.on("boundContextAdded", this.maybeAliasLegacyRootDataStore);
 
         const baseGCDetailsP = new LazyPromise(async () => {
             return getBaseGCDetails();

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -465,7 +465,6 @@ export class DataStores implements IDisposable {
             throw responseToException(create404Response(request), request);
         }
 
-        await this.contexts.waitIfTracked(id);
         return context;
     }
 

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -396,8 +396,10 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
     });
 
     describe("Legacy root datastores to aliased datastores conversion", () => {
-        const oldVersion = "0.59.0";
-        beforeEach(async () => ensurePackageInstalled(oldVersion, 0, /* force */ true));
+        const oldVersion = "1.0.0";
+        beforeEach(async () => {
+            await ensurePackageInstalled(oldVersion, 0, /* force */ false);
+        });
         afterEach(async () => reset());
 
         const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -427,12 +427,9 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
         const createOldContainer = async (): Promise<IContainer> => provider.createContainer(oldRuntimeFactory);
 
-        let oldContainer: IContainer;
-        let oldDataObject: ITestFluidObject;
-
         it("Old document with root datastores, new runtime will alias them", async () => {
-            oldContainer = await createOldContainer();
-            oldDataObject = await requestFluidObject<ITestFluidObject>(oldContainer, "/");
+            const oldContainer = await createOldContainer();
+            const oldDataObject = await requestFluidObject<ITestFluidObject>(oldContainer, "/");
             const sc = new SummaryCollection(container1.deltaManager, new TelemetryNullLogger());
             await (runtimeOf(oldDataObject) as any).createRootDataStore(packageName, "1");
             await provider.ensureSynchronized();
@@ -450,7 +447,15 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
         });
 
         it("New document, old runtime creates root datastores, new runtime will alias them", async () => {
+            const oldContainer = await createOldContainer();
+            const oldDataObject = await requestFluidObject<ITestFluidObject>(oldContainer, "/");
+            const newContainer = await provider.loadTestContainer(testContainerConfig);
+            const newDataObject = await requestFluidObject<ITestFluidObject>(newContainer, "/");
 
+            await (runtimeOf(oldDataObject) as any).createRootDataStore(packageName, "1");
+            await provider.ensureSynchronized();
+
+            assert.ok(await getRootDataStore(newDataObject, "1"));
         });
     });
 });


### PR DESCRIPTION
The goal here is to move existing root datastores to aliasing, by aliasing their ids to themselves. This way, the root property of a datastore can have a single source of truth, the alias map.