### PR TITLE
No data store factory export

### DIFF
--- a/examples/apps/collaborative-textarea/src/fluid-object/index.ts
+++ b/examples/apps/collaborative-textarea/src/fluid-object/index.ts
@@ -46,6 +46,3 @@ export class CollaborativeText extends DataObject {
         this._text = await this.root.get<IFluidHandle<SharedString>>(this.textKey)?.get();
     }
 }
-
-// Export the CollaborativeText factory as fluidExport for the dynamic component loading scenario
-export const fluidExport = CollaborativeText.getFactory();

--- a/examples/data-objects/codemirror/src/codeMirror.ts
+++ b/examples/data-objects/codemirror/src/codeMirror.ts
@@ -117,5 +117,3 @@ export class SmdeFactory implements IFluidDataStoreFactory {
         return runtime;
     }
 }
-
-export const fluidExport = new SmdeFactory();

--- a/examples/data-objects/prosemirror/src/index.ts
+++ b/examples/data-objects/prosemirror/src/index.ts
@@ -11,11 +11,13 @@ import { buildRuntimeRequestHandler } from "@fluidframework/request-handler";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { requestFluidObject, RequestParser, RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
 import { MountableView } from "@fluidframework/view-adapters";
-import { fluidExport as smde, ProseMirror, ProseMirrorView } from "./prosemirror";
+import { ProseMirror, ProseMirrorFactory, ProseMirrorView } from "./prosemirror";
 
 export { ProseMirror, ProseMirrorFactory, ProseMirrorView } from "./prosemirror";
 
 const defaultComponentId = "default";
+
+const smde = new ProseMirrorFactory();
 
 const viewRequestHandler = async (request: RequestParser, runtime: IContainerRuntime) => {
     if (request.pathParts.length === 0) {

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -195,5 +195,3 @@ export class ProseMirrorFactory implements IFluidDataStoreFactory {
         return runtime;
     }
 }
-
-export const fluidExport = new ProseMirrorFactory();

--- a/examples/data-objects/smde/src/index.ts
+++ b/examples/data-objects/smde/src/index.ts
@@ -9,9 +9,11 @@ import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { buildRuntimeRequestHandler } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import { RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
-import { fluidExport as smde } from "./smde";
+import { SmdeFactory } from "./smde";
 
 const defaultComponentId = "default";
+
+const smde = new SmdeFactory();
 
 class SmdeContainerFactory extends RuntimeFactoryHelper {
     public async instantiateFirstTime(runtime: ContainerRuntime): Promise<void> {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -192,7 +192,7 @@ export class Smde extends EventEmitter implements
     }
 }
 
-class SmdeFactory implements IFluidDataStoreFactory {
+export class SmdeFactory implements IFluidDataStoreFactory {
     public static readonly type = "@fluid-example/smde";
     public readonly type = SmdeFactory.type;
 
@@ -218,5 +218,3 @@ class SmdeFactory implements IFluidDataStoreFactory {
         return runtime;
     }
 }
-
-export const fluidExport = new SmdeFactory();

--- a/examples/data-objects/vltava/src/fluidObjects/tabs/newTabButton.tsx
+++ b/examples/data-objects/vltava/src/fluidObjects/tabs/newTabButton.tsx
@@ -14,7 +14,7 @@ import {
     IIconProps,
     IContextualMenuItem,
 } from "office-ui-fabric-react";
-import { fluidExport as pmfe } from "@fluid-example/prosemirror/dist/prosemirror";
+import { ProseMirrorFactory } from "@fluid-example/prosemirror";
 
 import { ITabsTypes } from "./dataModel";
 
@@ -41,6 +41,8 @@ const customSplitButtonStyles: IButtonStyles = {
 };
 
 const addIcon: IIconProps = { iconName: "Add" };
+
+const pmfe = new ProseMirrorFactory();
 
 export const NewTabButton: React.FC<IButtonExampleProps> =
     (props: IButtonExampleProps) => {

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -62,7 +62,6 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/aqueduct": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
     "@fluidframework/common-utils": "^1.0.0",
     "@fluidframework/container-definitions": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
     "@fluidframework/container-loader": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
@@ -75,7 +74,6 @@
     "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
     "@fluidframework/protocol-definitions": "^1.0.0",
     "@fluidframework/routerlicious-driver": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
-    "@fluidframework/runtime-definitions": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
     "@fluidframework/server-local-server": "^0.1037.2000-91174",
     "@fluidframework/server-services-client": "^0.1037.2000-91174",


### PR DESCRIPTION
Data store factories haven't been permissible fluidExports since #9769 when IFluidObject augmentation was taken off.  This change would remove a few remaining places in the repo where we call a data store factory a "fluidExport" and also remove the wrapping functionality from webpack-fluid-loader.

This doesn't change LocalCodeLoader which does the same thing, but I think it at least covers the public-facing examples.

Note - prosemirror is already broken in main.