### PR TITLE
Expose container from loadContainer in ContainerManager

### DIFF
--- a/packages/test/test-gc-sweep-tests/src/containerManager.ts
+++ b/packages/test/test-gc-sweep-tests/src/containerManager.ts
@@ -34,11 +34,12 @@ export class ContainerManager {
         return container;
     }
 
-    public async loadContainer(): Promise<void> {
+    public async loadContainer(): Promise<IContainer> {
         const container = await this.provider.loadContainer(this.runtimeFactory, {
             configProvider: this.configProvider,
         });
         this.trackContainer(container);
+        return container;
     }
 
     private trackContainer(container: IContainer) {


### PR DESCRIPTION
Part of [AB#1847](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1847)

As a part of https://github.com/microsoft/FluidFramework/pull/11928/files#

Expose the container to use in ContainerManager.

Container manager is responsible for loading and creating containers and managing the lifetime of them. It keeps track of connected containers. When containers are closed, ContainerManager updates the number of connected containers.