### PR TITLE
Create the baseDataObject with a counter

### DIFF
--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -4,10 +4,10 @@
  */
 
 import { IRandom } from "@fluid-internal/stochastic-test-utils";
+import { DataObject } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
-import { BaseTestDataObject } from "./testDataObjects";
 
 /**
  * DataObjectWithCounter increments a SharedCounter as a way of sending ops.
@@ -15,7 +15,7 @@ import { BaseTestDataObject } from "./testDataObjects";
  * The SharedCounter is retrieved via handle
  */
 const counterKey = "counter";
-export class DataObjectWithCounter extends BaseTestDataObject {
+export class DataObjectWithCounter extends DataObject {
     private _counterHandle?: IFluidHandle<SharedCounter>;
     public isRunning: boolean = false;
     public static get type(): string {

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -32,7 +32,7 @@ export class DataObjectWithCounter extends DataObject {
         this.counter = await handle.get();
     }
 
-    public async sendOp(_count: number, _random: IRandom) {
+    public async sendOp() {
         assert(this.counter !== undefined, "Can't send ops when the counter isn't initialized!");
         assert(this.isRunning === true, `The DataObject should be running in order to generate ops!`);
         this.counter.increment(1);

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -9,6 +9,11 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
 import { BaseTestDataObject } from "./testDataObjects";
 
+/**
+ * DataObjectWithCounter increments a SharedCounter as a way of sending ops.
+ *
+ * The SharedCounter is retrieved via handle
+ */
 const counterKey = "counter";
 export class DataObjectWithCounter extends BaseTestDataObject {
     private _counterHandle?: IFluidHandle<SharedCounter>;
@@ -27,7 +32,6 @@ export class DataObjectWithCounter extends BaseTestDataObject {
     }
 
     protected async hasInitialized(): Promise<void> {
-        // Use this to determine the local change count
         this._counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
     }
 

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IRandom } from "@fluid-internal/stochastic-test-utils";
 import { DataObject } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IRandom } from "@fluid-internal/stochastic-test-utils";
+import { assert } from "@fluidframework/common-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { SharedCounter } from "@fluidframework/counter";
+import { BaseTestDataObject } from "./testDataObjects";
+
+const counterKey = "counter";
+export class DataObjectWithCounter extends BaseTestDataObject {
+    private _counterHandle?: IFluidHandle<SharedCounter>;
+    public isRunning: boolean = false;
+    public static get type(): string {
+        return "OpSendingDataObject";
+    }
+
+    public get counterHandle(): IFluidHandle<SharedCounter> {
+        assert(this._counterHandle !== undefined, `CounterHandle should always be defined!`);
+        return this._counterHandle;
+    }
+
+    protected async initializingFirstTime(props?: any): Promise<void> {
+        this.root.set<IFluidHandle>(counterKey, SharedCounter.create(this.runtime).handle);
+    }
+
+    protected async hasInitialized(): Promise<void> {
+        // Use this to determine the local change count
+        this._counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
+    }
+
+    public async sendOp(_count: number, _random: IRandom) {
+        assert(this.counterHandle !== undefined, "Can't send ops when counter handle isn't set!");
+        const counter = await this.counterHandle.get();
+        counter.increment(1);
+    }
+
+    public stop() {
+        this.isRunning = false;
+    }
+}


### PR DESCRIPTION
Part of [AB#1847](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1847)

As a part of https://github.com/microsoft/FluidFramework/pull/11928/files#

`DataObjectWithCounter` is a DataObject containing a `SharedCounter` and a way of retrieving that `SharedCounter` via a handle. It generates ops by incrementing the counter.