### PR TITLE
Increase timeouts of CLI tests

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -54,7 +54,7 @@
     "test:jest:report": "assign-test-ports && lerna run test:jest --concurrency 4 --stream --no-bail --no-sort -- -- --ci --reporters=default --reporters=jest-junit",
     "test:mocha": "lerna run test:mocha --stream --no-bail --no-sort -- -- --color",
     "test:mocha:bail": "lerna run test:mocha --stream",
-    "test:mocha:report": "lerna run test:mocha --stream --no-bail --no-sort -- -- --timeout 4s --reporter xunit --reporter-option output=nyc/mocha-junit-report.xml",
+    "test:mocha:report": "lerna run test:mocha --stream --no-bail --no-sort -- -- --reporter xunit --reporter-option output=nyc/mocha-junit-report.xml",
     "test:realsvc": "lerna run test:realsvc --stream --no-bail --no-sort",
     "test:realsvc:report": "lerna run test:realsvc:report --stream --no-bail --no-sort",
     "test:report": "npm run test:mocha:report && npm run test:jest:report && npm run test:realsvc:report",

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -17,7 +17,8 @@ const test_tags = [
 ];
 
 describe("generate:buildVersion", () => {
-    test.stdout()
+    test.timeout(10000)
+        .stdout()
         .command([
             "generate:buildVersion",
             "--build",
@@ -35,9 +36,10 @@ describe("generate:buildVersion", () => {
             expect(ctx.stdout).to.contain("version=0.4.0-12345");
         });
 
-    test.env({
-        VERSION_BUILDNUMBER: "88802",
-    })
+    test.timeout(10000)
+        .env({
+            VERSION_BUILDNUMBER: "88802",
+        })
         .stdout()
         .command([
             "generate:buildVersion",


### PR DESCRIPTION
The CLI tests can take longer than the 4 second timeout, so updating tests to use a longer timeout.