### PR TITLE
Write the sendOps logic for DataObjectWithCounter

### DIFF
--- a/packages/test/test-gc-sweep-tests/src/sendOps.ts
+++ b/packages/test/test-gc-sweep-tests/src/sendOps.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IRandom } from "@fluid-internal/stochastic-test-utils";
+import { assert, delay } from "@fluidframework/common-utils";
+import { DataObjectWithCounter } from "./dataObjectWithCounter";
+
+export function start(dataObjectWithCounter: DataObjectWithCounter, count: number, random: IRandom) {
+    dataObjectWithCounter.isRunning = true;
+    sendOps(dataObjectWithCounter, count, random).catch((error) => { console.log(error); });
+}
+
+// The delay to wait between each created op
+const delayPerOpMs = 100;
+/**
+ * @param dataObjectWithCounter - the dataObject to send ops from
+ * @param count - number of ops performed
+ * @param random - used to control randomization consistently across all clients
+ *
+ * Perform 1000 ops and then do something interesting to GC as in reference and unreference datastores
+ */
+export async function sendOps(dataObjectWithCounter: DataObjectWithCounter, count: number, random: IRandom) {
+    assert(dataObjectWithCounter.isRunning === true, "Should be running to send ops");
+    let opsPerformed = 0;
+    while (opsPerformed < count && dataObjectWithCounter.isRunning && !dataObjectWithCounter.disposed) {
+        // This count is shared across dataObjects so this should reach clients * datastores * count
+        await dataObjectWithCounter.sendOp();
+        // This data is local and allows us to understand the number of changes a local client has created
+        opsPerformed++;
+        await delay(delayPerOpMs);
+    }
+}

--- a/packages/test/test-gc-sweep-tests/src/sendOps.ts
+++ b/packages/test/test-gc-sweep-tests/src/sendOps.ts
@@ -23,12 +23,15 @@ const delayPerOpMs = 100;
  */
 export async function sendOps(dataObjectWithCounter: DataObjectWithCounter, count: number, random: IRandom) {
     assert(dataObjectWithCounter.isRunning === true, "Should be running to send ops");
-    let opsPerformed = 0;
-    while (opsPerformed < count && dataObjectWithCounter.isRunning && !dataObjectWithCounter.disposed) {
-        // This count is shared across dataObjects so this should reach clients * datastores * count
-        await dataObjectWithCounter.sendOp();
-        // This data is local and allows us to understand the number of changes a local client has created
-        opsPerformed++;
-        await delay(delayPerOpMs);
+    while (dataObjectWithCounter.isRunning) {
+        let opsPerformed = 0;
+        while (opsPerformed < count && dataObjectWithCounter.isRunning && !dataObjectWithCounter.disposed) {
+            // This count is shared across dataObjects so this should reach clients * datastores * count
+            await dataObjectWithCounter.sendOp();
+            // This data is local and allows us to understand the number of changes a local client has created
+            opsPerformed++;
+            await delay(delayPerOpMs);
+        }
+        // TODO: Do something interesting
     }
 }

--- a/packages/test/test-gc-sweep-tests/src/sendOps.ts
+++ b/packages/test/test-gc-sweep-tests/src/sendOps.ts
@@ -19,7 +19,7 @@ const delayPerOpMs = 100;
  * @param count - number of ops performed
  * @param random - used to control randomization consistently across all clients
  *
- * Perform 1000 ops and then do something interesting to GC as in reference and unreference datastores
+ * Perform some count of ops and then potentially reference and unreference datastores
  */
 export async function sendOps(dataObjectWithCounter: DataObjectWithCounter, count: number, random: IRandom) {
     assert(dataObjectWithCounter.isRunning === true, "Should be running to send ops");
@@ -32,6 +32,7 @@ export async function sendOps(dataObjectWithCounter: DataObjectWithCounter, coun
             opsPerformed++;
             await delay(delayPerOpMs);
         }
-        // TODO: Do something interesting
+        // TODO: Do something interesting, here is where the randomization logic should go
+        random.integer(0, opsPerformed);
     }
 }


### PR DESCRIPTION
Part of [AB#1847](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1847) and [AB#1837](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1837)

As a part of https://github.com/microsoft/FluidFramework/pull/11928/files#

The goal of this PR is to write the send ops logic by incrementing the `dataObjectWithCounter` and to allow for the stoppage of sending ops as well. The start method is a way to allow clients to send ops regardless of what the other clients are doing.

This may be useful to put inside the `dataObjectWithCounter` class. 