### PR TITLE
Create gc sweep test data object with child data object

### DIFF
--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DataObjectFactory } from "@fluidframework/aqueduct";
+import { assert } from "@fluidframework/common-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { DataObjectWithCounter, dataObjectWithCounterFactory } from "./dataObjectWithCounter";
+import { allFactories } from "./testDataObjects";
+
+const childKey = "childKey";
+export class DataObjectWithChildDataObject extends DataObjectWithCounter {
+    private unrefTimeStampMs?: number;
+    private oldChild?: DataObjectWithCounter;
+    private child?: DataObjectWithCounter;
+
+    public static get type(): string {
+        return "DataObjectWithChildDataObject";
+    }
+
+    protected async initializingFirstTime(props?: any): Promise<void> {
+        await super.initializingFirstTime(props);
+        await this.referenceNewChild();
+    }
+
+    protected async hasInitialized(): Promise<void> {
+        await super.hasInitialized();
+        const childHandle = this.root.get<IFluidHandle<DataObjectWithCounter>>(childKey);
+        this.child = await childHandle?.get();
+    }
+
+    public stop() {
+        this.child?.stop();
+        this.isRunning = false;
+    }
+
+    public async unreferenceChild() {
+        assert(this.child !== undefined, `Child should be defined when unreferencing!`);
+        this.oldChild = this.child;
+        this.child.stop();
+        this.root.delete(childKey);
+        this.unrefTimeStampMs = Date.now();
+    }
+
+    public async referenceNewChild() {
+        this.child = await dataObjectWithCounterFactory.createInstance(this.context.containerRuntime);
+        await this.referenceChild(this.child.handle);
+    }
+
+    public async referenceChild(handle: IFluidHandle<DataObjectWithCounter>) {
+        this.oldChild = this.child;
+        this.root.set(childKey, handle);
+    }
+
+    // This should only be called when inactiveObjectX time isn't greater than unrefTimeStampMs
+    public async rereferenceChild() {
+        assert(this.oldChild !== undefined, `An old handle should exist when re referencing`);
+        assert(this.unrefTimeStampMs !== undefined, `An unreferenceTimestamp should exist when re referencing`);
+        await this.referenceChild(this.oldChild.handle);
+        this.oldChild = undefined;
+        this.unrefTimeStampMs = undefined;
+    }
+}
+
+export const dataObjectWithChildDataObjectFactory = new DataObjectFactory(
+    DataObjectWithChildDataObject.type,
+    DataObjectWithChildDataObject,
+    allFactories,
+    {},
+);

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
@@ -6,66 +6,63 @@
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { SharedCounter } from "@fluidframework/counter";
 import { DataObjectWithCounter, dataObjectWithCounterFactory } from "./dataObjectWithCounter";
-import { allFactories } from "./testDataObjects";
 
-const childKey = "childKey";
-export class DataObjectWithChildDataObject extends DataObjectWithCounter {
+export class RootDataObjectWithChildDataObject extends DataObjectWithCounter {
     private unrefTimeStampMs?: number;
-    private oldChild?: DataObjectWithCounter;
+    private unreferencedChild?: DataObjectWithCounter;
     private child?: DataObjectWithCounter;
-
-    public static get type(): string {
-        return "DataObjectWithChildDataObject";
+    private get childKey(): string {
+        assert(this.context.clientId !== undefined, `client id needs to be defined to retrieve the child key!`);
+        return `childKey:${this.context.clientId}`;
     }
 
-    protected async initializingFirstTime(props?: any): Promise<void> {
-        await super.initializingFirstTime(props);
-        await this.referenceNewChild();
+    public static get type(): string {
+        return "RootDataObjectWithChildDataObject";
     }
 
     protected async hasInitialized(): Promise<void> {
         await super.hasInitialized();
-        const childHandle = this.root.get<IFluidHandle<DataObjectWithCounter>>(childKey);
-        this.child = await childHandle?.get();
-    }
-
-    public stop() {
-        this.child?.stop();
-        this.isRunning = false;
+        await this.createAndReferenceChild();
+        // TODO: Start logic goes here after we agree on what it should be.
     }
 
     public async unreferenceChild() {
         assert(this.child !== undefined, `Child should be defined when unreferencing!`);
-        this.oldChild = this.child;
+        this.unreferencedChild = this.child;
         this.child.stop();
-        this.root.delete(childKey);
+        this.root.delete(this.childKey);
         this.unrefTimeStampMs = Date.now();
     }
 
-    public async referenceNewChild() {
+    public async createAndReferenceChild() {
         this.child = await dataObjectWithCounterFactory.createInstance(this.context.containerRuntime);
         await this.referenceChild(this.child.handle);
     }
 
     public async referenceChild(handle: IFluidHandle<DataObjectWithCounter>) {
-        this.oldChild = this.child;
-        this.root.set(childKey, handle);
+        this.unreferencedChild = this.child;
+        this.root.set(this.childKey, handle);
     }
 
     // This should only be called when inactiveObjectX time isn't greater than unrefTimeStampMs
-    public async rereferenceChild() {
-        assert(this.oldChild !== undefined, `An old handle should exist when re referencing`);
-        assert(this.unrefTimeStampMs !== undefined, `An unreferenceTimestamp should exist when re referencing`);
-        await this.referenceChild(this.oldChild.handle);
-        this.oldChild = undefined;
+    public async reviveChild() {
+        assert(this.unreferencedChild !== undefined, `An old handle should exist when reviving`);
+        assert(this.unrefTimeStampMs !== undefined, `An unreferenceTimestamp should exist when reviving`);
+        await this.referenceChild(this.unreferencedChild.handle);
+        this.unreferencedChild = undefined;
         this.unrefTimeStampMs = undefined;
+    }
+
+    public async doActivity() {
+        // This is a placeholder method, there is value in leaving this for a later discussion.
     }
 }
 
-export const dataObjectWithChildDataObjectFactory = new DataObjectFactory(
-    DataObjectWithChildDataObject.type,
-    DataObjectWithChildDataObject,
-    allFactories,
+export const rootDataObjectWithChildDataObjectFactory = new DataObjectFactory(
+    RootDataObjectWithChildDataObject.type,
+    RootDataObjectWithChildDataObject,
+    [SharedCounter.getFactory()],
     {},
 );

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
@@ -12,6 +12,7 @@ import { DataObjectWithCounter, dataObjectWithCounterFactory } from "./dataObjec
 export class RootDataObjectWithChildDataObject extends DataObjectWithCounter {
     private unrefTimeStampMs?: number;
     private unreferencedChild?: DataObjectWithCounter;
+    // TODO: logic to always keep a child referenced. A getter should retrieve this value and add some asserts
     private child?: DataObjectWithCounter;
     private get childKey(): string {
         assert(this.context.clientId !== undefined, `client id needs to be defined to retrieve the child key!`);
@@ -28,6 +29,7 @@ export class RootDataObjectWithChildDataObject extends DataObjectWithCounter {
         // TODO: Start logic goes here after we agree on what it should be.
     }
 
+    // TODO: Make private - left public so the build passes
     public async unreferenceChild() {
         assert(this.child !== undefined, `Child should be defined when unreferencing!`);
         this.unreferencedChild = this.child;
@@ -36,17 +38,18 @@ export class RootDataObjectWithChildDataObject extends DataObjectWithCounter {
         this.unrefTimeStampMs = Date.now();
     }
 
-    public async createAndReferenceChild() {
+    private async createAndReferenceChild() {
         this.child = await dataObjectWithCounterFactory.createInstance(this.context.containerRuntime);
         await this.referenceChild(this.child.handle);
     }
 
-    public async referenceChild(handle: IFluidHandle<DataObjectWithCounter>) {
+    private async referenceChild(handle: IFluidHandle<DataObjectWithCounter>) {
         this.unreferencedChild = this.child;
         this.root.set(this.childKey, handle);
     }
 
     // This should only be called when inactiveObjectX time isn't greater than unrefTimeStampMs
+    // TODO: Make private - left public so the build passes
     public async reviveChild() {
         assert(this.unreferencedChild !== undefined, `An old handle should exist when reviving`);
         assert(this.unrefTimeStampMs !== undefined, `An unreferenceTimestamp should exist when reviving`);
@@ -55,9 +58,7 @@ export class RootDataObjectWithChildDataObject extends DataObjectWithCounter {
         this.unrefTimeStampMs = undefined;
     }
 
-    public async doActivity() {
-        // This is a placeholder method, there is value in leaving this for a later discussion.
-    }
+    // TODO: create a doActivity method that does interesting GC tasks
 }
 
 export const rootDataObjectWithChildDataObjectFactory = new DataObjectFactory(

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -7,7 +7,6 @@ import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
-import { allFactories } from "./testDataObjects";
 
 /**
  * DataObjectWithCounter increments a SharedCounter as a way of sending ops.
@@ -46,6 +45,6 @@ export class DataObjectWithCounter extends DataObject {
 export const dataObjectWithCounterFactory = new DataObjectFactory(
     DataObjectWithCounter.type,
     DataObjectWithCounter,
-    allFactories,
+    [SharedCounter.getFactory()],
     {},
 );

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -3,10 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { DataObject } from "@fluidframework/aqueduct";
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
+import { allFactories } from "./testDataObjects";
 
 /**
  * DataObjectWithCounter increments a SharedCounter as a way of sending ops.
@@ -18,7 +19,7 @@ export class DataObjectWithCounter extends DataObject {
     private counter?: SharedCounter;
     public isRunning: boolean = false;
     public static get type(): string {
-        return "OpSendingDataObject";
+        return "DataObjectWithCounter";
     }
 
     protected async initializingFirstTime(props?: any): Promise<void> {
@@ -41,3 +42,10 @@ export class DataObjectWithCounter extends DataObject {
         this.isRunning = false;
     }
 }
+
+export const dataObjectWithCounterFactory = new DataObjectFactory(
+    DataObjectWithCounter.type,
+    DataObjectWithCounter,
+    allFactories,
+    {},
+);

--- a/packages/test/test-gc-sweep-tests/src/testDataObjects.ts
+++ b/packages/test/test-gc-sweep-tests/src/testDataObjects.ts
@@ -198,7 +198,7 @@ export class HandleManager {
 }
 
 // Factories for all the channels we support
-const allFactories: IChannelFactory[] = [
+export const allFactories: IChannelFactory[] = [
     ConsensusQueue.getFactory(),
     ConsensusRegisterCollection.getFactory(),
     Ink.getFactory(),

--- a/packages/test/test-gc-sweep-tests/src/testDataObjects.ts
+++ b/packages/test/test-gc-sweep-tests/src/testDataObjects.ts
@@ -198,7 +198,7 @@ export class HandleManager {
 }
 
 // Factories for all the channels we support
-export const allFactories: IChannelFactory[] = [
+const allFactories: IChannelFactory[] = [
     ConsensusQueue.getFactory(),
     ConsensusRegisterCollection.getFactory(),
     Ink.getFactory(),


### PR DESCRIPTION
Part of [AB#1847](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1847)

As a part of https://github.com/microsoft/FluidFramework/pull/11928/files#

Create a dataObject that has a child data object and the functionality to reference, re-reference, and unreference the child data object.