### PR TITLE
Fix index summary loading in SharedTree

### DIFF
--- a/packages/dds/tree/src/feature-libraries/schemaIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaIndex.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IsoBuffer } from "@fluidframework/common-utils";
+import { bufferToString, IsoBuffer } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/datastore-definitions";
 import {
@@ -106,10 +106,9 @@ export class SchemaIndex implements Index<unknown>, SummaryElement {
 
     public async load(services: IChannelStorageService, parse: SummaryElementParser): Promise<void> {
         if (await services.contains(schemaBlobKey)) {
-            // const schemaBuffer = await services.readBlob(schemaBlobKey);
-            // TODO: use schema to initialize this.schema
-            // const schema = parse(bufferToString(_schemaBuffer, "utf8")) as string;
-            throw new Error("Method not implemented.");
+            const blob = await services.readBlob(schemaBlobKey);
+            parse(bufferToString(blob, "utf-8")) as string;
+            // TODO: use parsed results to rehydrate the schema
         }
     }
 }

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -111,8 +111,10 @@ export class SharedTreeCore<TChange, TChangeFamily extends ChangeFamily<any, TCh
 
     protected async loadCore(services: IChannelStorageService): Promise<void> {
         const loadIndexes = this.summaryElements
-            // eslint-disable-next-line @typescript-eslint/promise-function-async
-            .map((summaryElement) => summaryElement.load(services, (contents) => this.serializer.parse(contents)));
+            .map(async (summaryElement) => summaryElement.load(
+                scopeStorageService(services, "indexes", summaryElement.key),
+                (contents) => this.serializer.parse(contents),
+            ));
 
         await Promise.all(loadIndexes);
     }
@@ -242,11 +244,12 @@ export interface SummaryElement {
     getGCData(fullGC?: boolean): IGarbageCollectionData;
 
     /**
-     * Allows the index to perform custom loading
-     * @param services - Storage used by the index
+     * Allows the index to perform custom loading. The storage service is scoped to this index and therefore
+     * paths in this index will not collide with those in other indexes, even if they are the same string.
+     * @param service - Storage used by the index
      * @param parse - Parses serialized data from storage into runtime objects for the index
      */
-    load(services: IChannelStorageService, parse: SummaryElementParser): Promise<void>;
+    load(service: IChannelStorageService, parse: SummaryElementParser): Promise<void>;
 }
 
 /**
@@ -258,4 +261,23 @@ export type SummaryElementStringifier = (contents: unknown) => string;
 /**
  * Parses a serialized/summarized string into an object, rehydrating any Fluid handles as necessary
  */
- export type SummaryElementParser = (contents: string) => unknown;
+export type SummaryElementParser = (contents: string) => unknown;
+
+/** Compose an {@link IChannelStorageService} which prefixes all paths before forwarding them to the original service */
+function scopeStorageService(service: IChannelStorageService, ...pathElements: string[]): IChannelStorageService {
+    function scopePath(path: string): string {
+        return `${pathElements.join("/")}/${path}`;
+    }
+
+    return {
+        async readBlob(path: string): Promise<ArrayBufferLike> {
+            return service.readBlob(scopePath(path));
+        },
+        async contains(path) {
+            return service.contains(scopePath(path));
+        },
+        async list(path) {
+            return service.list(scopePath(path));
+        },
+    };
+}

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -263,21 +263,21 @@ export type SummaryElementStringifier = (contents: unknown) => string;
  */
 export type SummaryElementParser = (contents: string) => unknown;
 
-/** Compose an {@link IChannelStorageService} which prefixes all paths before forwarding them to the original service */
+/**
+ * Compose an {@link IChannelStorageService} which prefixes all paths before forwarding them to the original service
+ */
 function scopeStorageService(service: IChannelStorageService, ...pathElements: string[]): IChannelStorageService {
-    function scopePath(path: string): string {
-        return `${pathElements.join("/")}/${path}`;
-    }
+    const scope = `${pathElements.join("/")}/`;
 
     return {
         async readBlob(path: string): Promise<ArrayBufferLike> {
-            return service.readBlob(scopePath(path));
+            return service.readBlob(`${scope}${path}`);
         },
         async contains(path) {
-            return service.contains(scopePath(path));
+            return service.contains(`${scope}${path}`);
         },
         async list(path) {
-            return service.list(scopePath(path));
+            return service.list(`${scope}${path}`);
         },
     };
 }

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -197,21 +197,6 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
             assert(forest.anchors.isEmpty());
         });
 
-        it("reads only one node", async () => {
-            // This is a regression test for a scenario in which the
-            // cursor would allow navigation past the end of the field
-            const forest = factory(new StoredSchemaRepository(defaultSchemaPolicy));
-            const content: JsonableTree[] = [{ type: jsonObject.name }];
-            initializeForest(forest, content);
-            const readCursor = forest.allocateCursor();
-            const destination = forest.root(forest.rootField);
-            const cursorResult = forest.tryMoveCursorTo(destination, readCursor);
-            assert.equal(cursorResult, TreeNavigationResult.Ok);
-            assert.equal(readCursor.seek(1), TreeNavigationResult.NotFound);
-            readCursor.free();
-            forest.forgetAnchor(destination);
-        });
-
         // TODO: test more kinds of deltas, including moves.
 
         describe("top level invalidation", () => {

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -197,6 +197,21 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
             assert(forest.anchors.isEmpty());
         });
 
+        it("reads only one node", async () => {
+            // This is a regression test for a scenario in which the
+            // cursor would allow navigation past the end of the field
+            const forest = factory(new StoredSchemaRepository(defaultSchemaPolicy));
+            const content: JsonableTree[] = [{ type: jsonObject.name }];
+            initializeForest(forest, content);
+            const readCursor = forest.allocateCursor();
+            const destination = forest.root(forest.rootField);
+            const cursorResult = forest.tryMoveCursorTo(destination, readCursor);
+            assert.equal(cursorResult, TreeNavigationResult.Ok);
+            assert.equal(readCursor.seek(1), TreeNavigationResult.NotFound);
+            readCursor.free();
+            forest.forgetAnchor(destination);
+        });
+
         // TODO: test more kinds of deltas, including moves.
 
         describe("top level invalidation", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -5,7 +5,7 @@
 import { strict as assert } from "assert";
 import { singleTextCursor } from "../../feature-libraries";
 import { brand } from "../../util";
-import { detachedFieldAsKey } from "../../tree";
+import { detachedFieldAsKey, TreeValue } from "../../tree";
 import { TreeNavigationResult } from "../../forest";
 import { TestTreeProvider } from "../utils";
 import { ISharedTree } from "../../shared-tree";
@@ -19,38 +19,29 @@ describe("SharedTree", () => {
 
         const value = "42";
 
-        // Validate that the given tree has the state we create in this test
-        function validateTree(tree: ISharedTree): void {
-            const readCursor = tree.forest.allocateCursor();
-            const destination = tree.forest.root(tree.forest.rootField);
-            const cursorResult = tree.forest.tryMoveCursorTo(destination, readCursor);
-            assert.equal(cursorResult, TreeNavigationResult.Ok);
-            assert.equal(readCursor.seek(1), TreeNavigationResult.NotFound);
-            assert.equal(readCursor.value, value);
-            readCursor.free();
-            tree.forest.forgetAnchor(destination);
-        }
-
         // Apply an edit to the first tree which inserts a node with a value
-        provider.trees[0].runTransaction((forest, editor) => {
-            const writeCursor = singleTextCursor({ type: brand("Test"), value });
-            editor.insert({
-                parent: undefined,
-                parentField: detachedFieldAsKey(forest.rootField),
-                parentIndex: 0,
-            }, writeCursor);
-
-            return TransactionResult.Apply;
-        });
+        insertTestValue(provider.trees[0], value);
 
         // Ensure that the first tree has the state we expect
-        validateTree(provider.trees[0]);
+        assert.equal(getTestValue(provider.trees[0]), value);
         // Ensure that the second tree receives the expected state from the first tree
         await provider.ensureSynchronized();
-        validateTree(provider.trees[1]);
+        assert.equal(getTestValue(provider.trees[1]), value);
         // Ensure that a tree which connects after the edit has already happened also catches up
         const joinedLaterTree = await provider.createTree();
-        validateTree(joinedLaterTree);
+        assert.equal(getTestValue(joinedLaterTree), value);
+    });
+
+    it("can summarize and load", async () => {
+        const provider = await TestTreeProvider.create(1);
+        const [summarizingTree] = provider.trees;
+        const summarize = await provider.enableManualSummarization();
+        const value = 42;
+        insertTestValue(summarizingTree, value);
+        await summarize();
+        await provider.ensureSynchronized();
+        const loadingTree = await provider.createTree();
+        assert.equal(getTestValue(loadingTree), value);
     });
 
     describe("Editing", () => {
@@ -60,29 +51,12 @@ describe("SharedTree", () => {
             const [tree1, tree2] = provider.trees;
 
             // Insert node
-            tree1.runTransaction((forest, editor) => {
-                const writeCursor = singleTextCursor({ type: brand("Test"), value });
-                editor.insert({
-                    parent: undefined,
-                    parentField: detachedFieldAsKey(forest.rootField),
-                    parentIndex: 0,
-                }, writeCursor);
-                return TransactionResult.Apply;
-            });
+            insertTestValue(tree1, value);
 
             await provider.ensureSynchronized();
 
             // Validate insertion
-            {
-                const readCursor = tree2.forest.allocateCursor();
-                const destination = tree2.forest.root(tree2.forest.rootField);
-                const cursorResult = tree2.forest.tryMoveCursorTo(destination, readCursor);
-                assert.equal(cursorResult, TreeNavigationResult.Ok);
-                assert.equal(readCursor.seek(1), TreeNavigationResult.NotFound);
-                assert.equal(readCursor.value, value);
-                readCursor.free();
-                tree2.forest.forgetAnchor(destination);
-            }
+            assert.equal(getTestValue(tree2), value);
 
             // Delete node
             tree1.runTransaction((forest, editor) => {
@@ -108,3 +82,38 @@ describe("SharedTree", () => {
         });
     });
 });
+
+/**
+ * Inserts a single node under the root of the tree with the given value.
+ * Use {@link getTestValue} to read the value.
+ */
+function insertTestValue(tree: ISharedTree, value: TreeValue): void {
+    // Apply an edit to the first tree which inserts a node with a value
+    tree.runTransaction((forest, editor) => {
+        const writeCursor = singleTextCursor({ type: brand("TestValue"), value });
+        editor.insert({
+            parent: undefined,
+            parentField: detachedFieldAsKey(forest.rootField),
+            parentIndex: 0,
+        }, writeCursor);
+
+        return TransactionResult.Apply;
+    });
+}
+
+/**
+ * Reads a value in a tree set by {@link insertTestValue} if it exists
+ */
+function getTestValue(tree: ISharedTree): TreeValue | undefined {
+    const readCursor = tree.forest.allocateCursor();
+    const destination = tree.forest.root(tree.forest.rootField);
+    const cursorResult = tree.forest.tryMoveCursorTo(destination, readCursor);
+    const { value } = readCursor;
+    readCursor.free();
+    tree.forest.forgetAnchor(destination);
+    if (cursorResult === TreeNavigationResult.Ok) {
+        return value;
+    }
+
+    return undefined;
+}

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -20,7 +20,7 @@ describe("SharedTree", () => {
         const value = "42";
 
         // Apply an edit to the first tree which inserts a node with a value
-        insertTestValue(provider.trees[0], value);
+        setTestValue(provider.trees[0], value);
 
         // Ensure that the first tree has the state we expect
         assert.equal(getTestValue(provider.trees[0]), value);
@@ -37,7 +37,7 @@ describe("SharedTree", () => {
         const [summarizingTree] = provider.trees;
         const summarize = await provider.enableManualSummarization();
         const value = 42;
-        insertTestValue(summarizingTree, value);
+        setTestValue(summarizingTree, value);
         await summarize();
         await provider.ensureSynchronized();
         const loadingTree = await provider.createTree();
@@ -51,7 +51,7 @@ describe("SharedTree", () => {
             const [tree1, tree2] = provider.trees;
 
             // Insert node
-            insertTestValue(tree1, value);
+            setTestValue(tree1, value);
 
             await provider.ensureSynchronized();
 
@@ -87,8 +87,8 @@ describe("SharedTree", () => {
  * Inserts a single node under the root of the tree with the given value.
  * Use {@link getTestValue} to read the value.
  */
-function insertTestValue(tree: ISharedTree, value: TreeValue): void {
-    // Apply an edit to the first tree which inserts a node with a value
+function setTestValue(tree: ISharedTree, value: TreeValue): void {
+    // Apply an edit to the tree which inserts a node with a value
     tree.runTransaction((forest, editor) => {
         const writeCursor = singleTextCursor({ type: brand("TestValue"), value });
         editor.insert({
@@ -102,15 +102,15 @@ function insertTestValue(tree: ISharedTree, value: TreeValue): void {
 }
 
 /**
- * Reads a value in a tree set by {@link insertTestValue} if it exists
+ * Reads a value in a tree set by {@link setTestValue} if it exists
  */
-function getTestValue(tree: ISharedTree): TreeValue | undefined {
-    const readCursor = tree.forest.allocateCursor();
-    const destination = tree.forest.root(tree.forest.rootField);
-    const cursorResult = tree.forest.tryMoveCursorTo(destination, readCursor);
+function getTestValue({ forest }: ISharedTree): TreeValue | undefined {
+    const readCursor = forest.allocateCursor();
+    const destination = forest.root(forest.rootField);
+    const cursorResult = forest.tryMoveCursorTo(destination, readCursor);
     const { value } = readCursor;
     readCursor.free();
-    tree.forest.forgetAnchor(destination);
+    forest.forgetAnchor(destination);
     if (cursorResult === TreeNavigationResult.Ok) {
         return value;
     }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -619,10 +619,7 @@ export class MockObjectStorageService implements IChannelStorageService {
 export class MockSharedObjectServices implements IChannelServices {
     public static createFromSummary(summaryTree: ISummaryTree) {
         const contents: { [key: string]: string; } = {};
-        for (const [key, value] of Object.entries(summaryTree.tree)) {
-            assert(value.type === SummaryType.Blob, "Unexpected summary type on mock createFromSummary");
-            contents[key] = value.content as string;
-        }
+        setContentsFromSummaryTree(summaryTree, "", contents);
         return new MockSharedObjectServices(contents);
     }
 
@@ -631,5 +628,22 @@ export class MockSharedObjectServices implements IChannelServices {
 
     public constructor(contents: { [key: string]: string; }) {
         this.objectStorage = new MockObjectStorageService(contents);
+    }
+}
+
+/** Populate the given `contents` object with all paths/values in a summary tree */
+function setContentsFromSummaryTree({ tree }: ISummaryTree, path: string, contents: { [key: string]: string; }): void {
+    for (const [key, value] of Object.entries(tree)) {
+        switch (value.type) {
+            case SummaryType.Blob:
+                assert(typeof value.content === "string", "Unexpected blob value on mock createFromSummary");
+                contents[`${path}${key}`] = value.content;
+                break;
+            case SummaryType.Tree:
+                setContentsFromSummaryTree(value, `${path}${key}/`, contents);
+                break;
+            default:
+                assert(false, "Unexpected summary type on mock createFromSummary");
+        }
     }
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -631,7 +631,9 @@ export class MockSharedObjectServices implements IChannelServices {
     }
 }
 
-/** Populate the given `contents` object with all paths/values in a summary tree */
+/**
+ * Populate the given `contents` object with all paths/values in a summary tree
+ */
 function setContentsFromSummaryTree({ tree }: ISummaryTree, path: string, contents: { [key: string]: string; }): void {
     for (const [key, value] of Object.entries(tree)) {
         switch (value.type) {


### PR DESCRIPTION
SharedTree's indexes currently allow for custom loading, but they are not able to actually retrieve blobs from the storage service without knowing the path element above them. This PR "scopes" the service object passed to each index with the path preemptively so that each index can work within a local namespace and not worry about collisions with other indexes. Also:

* Add tests for the loading of indexes and summarizing of SharedTree
* Stub out SchemaIndex loading so that it doesn't cause failures when testing summarization
* Upgrade `MockObjectStorageService` to respect summary elements that are more than one-deep in a summary tree.
* Factor out some test utilities in sharedTreeCore.spec.ts