### PR TITLE
Copy previousProperties (for rollback of mergeTree annotations)

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1443,7 +1443,7 @@ export class SegmentGroupCollection {
     // (undocumented)
     get empty(): boolean;
     // (undocumented)
-    enqueue(segmentGroup: SegmentGroup): void;
+    enqueue(segmentGroup: SegmentGroup, sourceSegment?: ISegment): void;
     // (undocumented)
     pop?(): SegmentGroup | undefined;
     // (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1443,7 +1443,7 @@ export class SegmentGroupCollection {
     // (undocumented)
     get empty(): boolean;
     // (undocumented)
-    enqueue(segmentGroup: SegmentGroup, sourceSegment?: ISegment): void;
+    enqueue(segmentGroup: SegmentGroup): void;
     // (undocumented)
     pop?(): SegmentGroup | undefined;
     // (undocumented)

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -21,9 +21,16 @@ export class SegmentGroupCollection {
         return this.segmentGroups.empty();
     }
 
-    public enqueue(segmentGroup: SegmentGroup) {
+    public enqueue(segmentGroup: SegmentGroup, sourceSegment?: ISegment) {
         this.segmentGroups.enqueue(segmentGroup);
         segmentGroup.segments.push(this.segment);
+        if (segmentGroup.previousProps && sourceSegment) {
+            // duplicate the previousProps for the new segment if it's split from an existing one
+            const index = segmentGroup.segments.indexOf(sourceSegment);
+            if (index !== -1) {
+                segmentGroup.previousProps.push(segmentGroup.previousProps[index]);
+            }
+        }
     }
 
     public dequeue(): SegmentGroup | undefined {
@@ -39,6 +46,6 @@ export class SegmentGroupCollection {
     }
 
     public copyTo(segment: ISegment) {
-        this.segmentGroups.walk((sg) => segment.segmentGroups.enqueue(sg));
+        this.segmentGroups.walk((sg) => segment.segmentGroups.enqueue(sg, this.segment));
     }
 }

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -21,16 +21,9 @@ export class SegmentGroupCollection {
         return this.segmentGroups.empty();
     }
 
-    public enqueue(segmentGroup: SegmentGroup, sourceSegment?: ISegment) {
+    public enqueue(segmentGroup: SegmentGroup) {
         this.segmentGroups.enqueue(segmentGroup);
         segmentGroup.segments.push(this.segment);
-        if (segmentGroup.previousProps && sourceSegment) {
-            // duplicate the previousProps for the new segment if it's split from an existing one
-            const index = segmentGroup.segments.indexOf(sourceSegment);
-            if (index !== -1) {
-                segmentGroup.previousProps.push(segmentGroup.previousProps[index]);
-            }
-        }
     }
 
     public dequeue(): SegmentGroup | undefined {
@@ -46,6 +39,17 @@ export class SegmentGroupCollection {
     }
 
     public copyTo(segment: ISegment) {
-        this.segmentGroups.walk((sg) => segment.segmentGroups.enqueue(sg, this.segment));
+        this.segmentGroups.walk((sg) => segment.segmentGroups.enqueueOnCopy(sg, this.segment));
+    }
+
+    private enqueueOnCopy(segmentGroup: SegmentGroup, sourceSegment: ISegment) {
+        this.enqueue(segmentGroup);
+        if (segmentGroup.previousProps) {
+            // duplicate the previousProps for this segment
+            const index = segmentGroup.segments.indexOf(sourceSegment);
+            if (index !== -1) {
+                segmentGroup.previousProps.push(segmentGroup.previousProps[index]);
+            }
+        }
     }
 }

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -181,6 +181,59 @@ describe("client.rollback", () => {
             assert(props === undefined || props.foo === undefined);
         }
     });
+    it("Should rollback annotate that later gets split", () => {
+        client.insertTextLocal(0, "abfg");
+        client.annotateRangeLocal(0, 4, { foo: "bar" }, undefined);
+        client.insertTextLocal(1, "cde");
+        client.rollback?.({ type: MergeTreeDeltaType.INSERT }, client.peekPendingSegmentGroups());
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+
+        assert.equal(client.getText(), "abfg");
+        for (let i = 0; i < 4; i++) {
+            const props = client.getPropertiesAtPosition(i);
+            assert(props === undefined || props.foo === undefined);
+        }
+    });
+    it("Should rollback annotates with multiple previous property sets", () => {
+        client.insertTextLocal(0, "acde");
+        client.annotateRangeLocal(0, 3, { foo: "one" }, undefined);
+        client.annotateRangeLocal(2, 4, { foo: "two" }, undefined);
+        client.annotateRangeLocal(0, 3, { foo: "three" }, undefined);
+        client.insertTextLocal(1, "b");
+
+        client.rollback?.({ type: MergeTreeDeltaType.INSERT }, client.peekPendingSegmentGroups());
+        let props = client.getPropertiesAtPosition(3);
+        assert(props !== undefined && props.foo === "two");
+        for (let i = 0; i < 3; i++) {
+            props = client.getPropertiesAtPosition(i);
+            assert(props !== undefined && props.foo === "three");
+        }
+
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+        for (let i = 0; i < 2; i++) {
+            props = client.getPropertiesAtPosition(i);
+            assert(props !== undefined && props.foo === "one");
+        }
+        for (let i = 2; i < 4; i++) {
+            props = client.getPropertiesAtPosition(i);
+            assert(props !== undefined && props.foo === "two");
+        }
+
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+        props = client.getPropertiesAtPosition(3);
+        assert(props === undefined || props.foo === undefined);
+        for (let i = 0; i < 3; i++) {
+            props = client.getPropertiesAtPosition(i);
+            assert(props !== undefined && props.foo === "one");
+        }
+
+        client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
+        assert.equal(client.getText(), "acde");
+        for (let i = 0; i < 4; i++) {
+            props = client.getPropertiesAtPosition(i);
+            assert(props === undefined || props.foo === undefined);
+        }
+    });
     it("Should rollback annotate with same prop", () => {
         client.insertTextLocal(0, "abcde");
         client.annotateRangeLocal(2, 3, { foo: "bar" }, undefined);


### PR DESCRIPTION
The array of PropertySets in a SegmentGroup needs to match the array of segments so that rollback of annotations knows what properties to restore on each segment. But when a segment is split after an annotation, there was no corresponding property set for the new segment, causing rollback to crash. This change copies the property set of the original segment for the new split segment.