### PR TITLE
Remove MulitUrlResolver and MultiDocumentServiceFactory from webpack-fluid-loader

### DIFF
--- a/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
@@ -3,16 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import { MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
+import { assert } from "@fluidframework/common-utils";
+import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { getRandomName } from "@fluidframework/server-services-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
-import { assert } from "@fluidframework/common-utils";
+
 import { v4 as uuid } from "uuid";
+
 import { IDevServerUser, IRouterliciousRouteOptions, RouteOptions } from "./loader";
 
 export const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
@@ -22,7 +24,7 @@ export function getDocumentServiceFactory(
     options: RouteOptions,
     odspPersistantCache?: IPersistedCache,
     odspHostStoragePolicy?: HostStoragePolicy,
-) {
+): IDocumentServiceFactory {
     const deltaConn = deltaConns.get(documentId) ??
         LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory(documentId));
     deltaConns.set(documentId, deltaConn);
@@ -48,22 +50,31 @@ export function getDocumentServiceFactory(
             getUser());
     }
 
-    return MultiDocumentServiceFactory.create([
-        new LocalDocumentServiceFactory(deltaConn),
-        // TODO: web socket token
-        new OdspDocumentServiceFactory(
-            async () => options.mode === "spo" || options.mode === "spo-df" ? (options.odspAccessToken ?? null) : null,
-            async () => options.mode === "spo" || options.mode === "spo-df" ? (options.pushAccessToken ?? null) : null,
-            odspPersistantCache,
-            odspHostStoragePolicy,
-        ),
-        new RouterliciousDocumentServiceFactory(
-            routerliciousTokenProvider,
-            {
-                enableWholeSummaryUpload: options.mode === "r11s" || options.mode === "docker"
-                    ? options.enableWholeSummaryUpload
-                    : undefined,
-                enableDiscovery: options.mode === "r11s" && options.discoveryEndpoint !== undefined,
-            }),
-    ]);
+    switch (options.mode) {
+        case "docker":
+        case "r11s":
+        case "tinylicious":
+            return new RouterliciousDocumentServiceFactory(
+                routerliciousTokenProvider,
+                {
+                    enableWholeSummaryUpload: options.mode === "r11s" || options.mode === "docker"
+                        ? options.enableWholeSummaryUpload
+                        : undefined,
+                    enableDiscovery: options.mode === "r11s" && options.discoveryEndpoint !== undefined,
+                },
+            );
+
+        case "spo":
+        case "spo-df":
+            // TODO: web socket token
+            return new OdspDocumentServiceFactory(
+                async () => options.odspAccessToken ?? null,
+                async () => options.pushAccessToken ?? null,
+                odspPersistantCache,
+                odspHostStoragePolicy,
+            );
+
+        default: // Local
+            return new LocalDocumentServiceFactory(deltaConn);
+    }
 }

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -32,11 +32,12 @@ import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { RequestParser } from "@fluidframework/runtime-utils";
-import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
+import { ensureFluidResolvedUrl, InsecureUrlResolver } from "@fluidframework/driver-utils";
 import { Port } from "webpack-dev-server";
-import { MultiUrlResolver } from "./multiResolver";
+import { getUrlResolver } from "./multiResolver";
 import { deltaConns, getDocumentServiceFactory } from "./multiDocumentServiceFactory";
 import { OdspPersistentCache } from "./odspPersistantCache";
+import { OdspUrlResolver } from "./odspUrlResolver";
 
 export interface IDevServerUser extends IUser {
     name: string;
@@ -158,7 +159,7 @@ async function createWebLoader(
     documentId: string,
     fluidModule: IFluidModule,
     options: RouteOptions,
-    urlResolver: MultiUrlResolver,
+    urlResolver: InsecureUrlResolver | OdspUrlResolver | LocalResolver,
     codeDetails: IFluidCodeDetails,
     testOrderer: boolean = false,
     odspPersistantCache?: IPersistedCache,
@@ -174,7 +175,7 @@ async function createWebLoader(
     // Create the inner document service which will be wrapped inside local driver. The inner document service
     // will be used for ops(like delta connection/delta ops) while for storage, local storage would be used.
     if (testOrderer) {
-        const resolvedUrl = await urlResolver.resolve(await urlResolver.createRequestForCreateNew(documentId));
+        const resolvedUrl = await urlResolver.resolve(await urlResolver.createCreateNewRequest(documentId));
         assert(resolvedUrl !== undefined, 0x318 /* resolvedUrl is undefined */);
         const innerDocumentService = await documentServiceFactory.createDocumentService(
             resolvedUrl,
@@ -200,8 +201,7 @@ async function createWebLoader(
     );
 
     return new Loader({
-        urlResolver: testOrderer ?
-            new MultiUrlResolver(documentId, window.location.origin, options, true) : urlResolver,
+        urlResolver: testOrderer ? new LocalResolver() : urlResolver,
         documentServiceFactory,
         codeLoader,
     });
@@ -243,7 +243,7 @@ export async function start(
         config: {},
     };
 
-    const urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
+    const urlResolver = getUrlResolver(options);
     const odspPersistantCache = new OdspPersistentCache();
 
     // Create the loader that is used to load the Container.
@@ -393,7 +393,7 @@ async function attachContainer(
     loader: Loader,
     container: IContainer,
     fluidObjectUrl: string,
-    urlResolver: MultiUrlResolver,
+    urlResolver: InsecureUrlResolver | OdspUrlResolver | LocalResolver,
     documentId: string,
     url: string,
     leftDiv: HTMLDivElement,
@@ -425,7 +425,7 @@ async function attachContainer(
     // To test orderer, we use local driver as wrapper for actual document service. So create request
     // using local resolver.
     const attachUrl = testOrderer ? new LocalResolver().createCreateNewRequest(documentId)
-        : await urlResolver.createRequestForCreateNew(documentId);
+        : await urlResolver.createCreateNewRequest(documentId);
 
     if (manualAttach) {
         // Create an "Attach Container" button that the user can click when they want to attach the container.

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -34,8 +34,8 @@ import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/loca
 import { RequestParser } from "@fluidframework/runtime-utils";
 import { ensureFluidResolvedUrl, InsecureUrlResolver } from "@fluidframework/driver-utils";
 import { Port } from "webpack-dev-server";
-import { getUrlResolver } from "./multiResolver";
-import { deltaConns, getDocumentServiceFactory } from "./multiDocumentServiceFactory";
+import { getUrlResolver } from "./getUrlResolver";
+import { deltaConns, getDocumentServiceFactory } from "./getDocumentServiceFactory";
 import { OdspPersistentCache } from "./odspPersistantCache";
 import { OdspUrlResolver } from "./odspUrlResolver";
 

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -20,7 +20,7 @@ import { IOdspTokens, getServer } from "@fluidframework/odsp-doclib-utils";
 import Axios from "axios";
 import { RouteOptions } from "./loader";
 import { createManifestResponse } from "./bohemiaIntercept";
-import { tinyliciousUrls } from "./multiResolver";
+import { tinyliciousUrls } from "./getUrlResolver";
 
 const tokenManager = new OdspTokenManager(odspTokensCache);
 let odspAuthStage = 0;


### PR DESCRIPTION
These aren't required, are not recommendable to our customers, and are abusing URL protocol (one of the items blocking the switch to native URL over url-parse, see #9236).  This change would just select the appropriate url resolver and document service factory directly rather than using the Multi version in webpack-fluid-loader.