### PR TITLE
Remove generic event uploadSummaryWithContext.

### DIFF
--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -164,6 +164,9 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
             this.logger,
             {
                 eventName: "uploadSummaryWithContext",
+                proposalHandle: context.proposalHandle,
+                ackHandle: context.ackHandle,
+                referenceSequenceNumber: context.referenceSequenceNumber,
             },
             async () => {
                 const summaryUploadManager = await this.getSummaryUploadManager();

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -152,6 +152,9 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
             this.logger,
             {
                 eventName: "uploadSummaryWithContext",
+                proposalHandle: context.proposalHandle,
+                ackHandle: context.ackHandle,
+                referenceSequenceNumber: context.referenceSequenceNumber,
             },
             async () => {
                 const summaryUploadManager = await this.getSummaryUploadManager();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2486,11 +2486,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             let handle: string;
             try {
-                // Logging removal tracked by task 1884.
-                this.logger.sendTelemetryEvent({ eventName: "uploadSummaryWithContext",
-                    proposalHandle: summaryContext.proposalHandle,
-                    ackHandle: summaryContext.ackHandle,
-                    referenceSequenceNumber: summaryContext.referenceSequenceNumber });
                 handle = await this.storage.uploadSummaryWithContext(summarizeResult.summary, summaryContext);
             } catch (error) {
                 return { stage: "generate", ...generateSummaryData, error };


### PR DESCRIPTION
After addressing the fetch that was happening whenever we refreshed the summary, there is no more need to address [task 1871](https://fluidframework.visualstudio.com/internal/_workitems/edit/1871)  and we do not need the additional logging we added on [task 1884](https://fluidframework.visualstudio.com/internal/_workitems/edit/1884).  Taking the chance to also add the proposal handle to the existing telemetry for uploadSummaryWithContext on the AFR driver. 