### PR TITLE
Tree: Add MapTree

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -154,7 +154,7 @@ declare namespace Delta {
         ProtoNode_2 as ProtoNode,
         MoveId,
         Offset,
-        FieldMap_2 as FieldMap,
+        FieldMap,
         FieldMarks,
         MarkType
     }
@@ -319,17 +319,17 @@ export interface FieldLocation {
     readonly parent: ForestLocation;
 }
 
+// @public (undocumented)
+type FieldMap<T> = Map<FieldKey, T>;
+
 // @public
-export interface FieldMap<TChild> {
+export interface FieldMapObject<TChild> {
     // (undocumented)
     [key: string]: TChild[];
 }
 
 // @public (undocumented)
-type FieldMap_2<T> = Map<FieldKey, T>;
-
-// @public (undocumented)
-type FieldMarks = FieldMap_2<MarkList>;
+type FieldMarks = FieldMap<MarkList>;
 
 // @public (undocumented)
 export interface FieldSchema {
@@ -363,9 +363,9 @@ export type GapCount = number;
 // @public
 export interface GenericTreeNode<TChild> extends NodeData {
     // (undocumented)
-    [FieldScope.local]?: FieldMap<TChild>;
+    [FieldScope.local]?: FieldMapObject<TChild>;
     // (undocumented)
-    [FieldScope.global]?: FieldMap<TChild>;
+    [FieldScope.global]?: FieldMapObject<TChild>;
 }
 
 // @public

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -14,6 +14,7 @@ export {
 	TextCursor as TextCursorNew,
 	jsonableTreeFromCursor as jsonableTreeFromCursorNew,
 } from "./treeTextCursor";
+export { singleMapTreeCursor, mapTreeFromCursor } from "./mapTreeCursor";
 export * from "./sequence-change-family";
 export * from "./defaultSchema";
 export {

--- a/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
@@ -11,55 +11,30 @@ import {
 } from "../forest";
 import {
     FieldKey,
-    FieldMapObject,
-    genericTreeKeys,
-    getGenericTreeField,
-    JsonableTree,
     TreeType,
     UpPath,
     Value,
+    MapTree,
+    getMapTreeField,
 } from "../tree";
 import { fail } from "../util";
 
 /**
- * This module provides support for reading and writing a human readable (and editable) tree format.
- *
- * This implementation can handle all trees (so it does not need a fallback for any special cases),
- * and is not optimized.
- *
- * It's suitable for testing and debugging,
- * though it could also reasonably be used as a fallback for edge cases or for small trees.
- *
- * TODO: Use placeholders.
- * build / add operations should be able to include detached ranges instead of children directly.
- * summaries should be able to reference unloaded chunks instead of having children directly.
- * Leverage placeholders in the types below to accomplish this.
- * Determine how this relates to Cursor: should cursor be generic over placeholder values?
- * (Could use them for errors to allow non erroring cursors?)
- *
- * Note:
- * Currently a lot of Tree's codebase is using json for serialization.
- * Because putting json strings inside json works poorly (adds lots of escaping),
- * for now this library actually outputs and inputs the Json compatible type JsonableTree
- * rather than actual strings.
+ * @returns an ITreeCursor for a single MapTree.
  */
-
-/**
- * @returns a TextCursor for a single JsonableTree.
- */
-export function singleTextCursor(root: JsonableTree): TextCursor {
-    return new TextCursor(root);
+export function singleMapTreeCursor(root: MapTree): ITreeCursor {
+    return new MapCursor(root);
 }
 
-type SiblingsOrKey = readonly JsonableTree[] | readonly FieldKey[];
+type SiblingsOrKey = readonly MapTree[] | readonly FieldKey[];
 
 /**
- * An ITreeCursor implementation for JsonableTree.
+ * An ITreeCursor implementation for MapTree.
  *
  * TODO: object-forest's cursor is mostly a superset of this functionality.
  * Maybe do a refactoring to deduplicate this.
  */
-export class TextCursor implements ITreeCursor {
+class MapCursor implements ITreeCursor {
     /**
      * Indices traversed to visit this node: does not include current level (which is stored in `index`).
      * Even indexes are of nodes and odd indexes are for fields.
@@ -81,7 +56,7 @@ export class TextCursor implements ITreeCursor {
     /**
      * Might start at special root where fields are detached sequences.
      */
-    public constructor(root: JsonableTree) {
+    public constructor(root: MapTree) {
         this.siblings = [root];
         this.index = 0;
     }
@@ -101,9 +76,9 @@ export class TextCursor implements ITreeCursor {
         return this.indexStack[height];
     }
 
-    private getStackedNode(height: number): JsonableTree {
+    private getStackedNode(height: number): MapTree {
         const index = this.getStackedNodeIndex(height);
-        return (this.siblingStack[height] as readonly JsonableTree[])[index];
+        return (this.siblingStack[height] as readonly MapTree[])[index];
     }
 
     public getFieldLength(): number {
@@ -192,7 +167,7 @@ export class TextCursor implements ITreeCursor {
     }
 
     public firstField(): boolean {
-        const fields = genericTreeKeys(this.getNode());
+        const fields = [...this.getNode().fields.keys()]; // TODO: don't convert this to array here.
         if (fields.length === 0) {
             return false;
         }
@@ -248,16 +223,16 @@ export class TextCursor implements ITreeCursor {
         this.index = this.indexStack.pop() ?? fail("Unexpected indexStack.length");
     }
 
-    private getNode(): JsonableTree {
+    private getNode(): MapTree {
         // assert(this.mode === CursorLocationType.Nodes, "can only get node when in node");
-        return (this.siblings as JsonableTree[])[this.index];
+        return (this.siblings as MapTree[])[this.index];
     }
 
-    private getField(): readonly JsonableTree[] {
+    private getField(): readonly MapTree[] {
         // assert(this.mode === CursorLocationType.Fields, "can only get field when in fields");
         const parent = this.getStackedNode(this.indexStack.length - 1);
         const key: FieldKey = this.getFieldKey();
-        const field = getGenericTreeField(parent, key, false);
+        const field = getMapTreeField(parent, key, false);
         return field;
     }
 
@@ -284,30 +259,21 @@ export class TextCursor implements ITreeCursor {
 }
 
 /**
- * Extract a JsonableTree from the contents of the given ITreeCursor's current node.
+ * Extract a MapTree from the contents of the given ITreeCursor's current node.
  */
-export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree {
+export function mapTreeFromCursor(cursor: ITreeCursor): MapTree {
     assert(cursor.mode === CursorLocationType.Nodes, "must start at node");
-    let fields: FieldMapObject<JsonableTree> | undefined;
-    let inField = cursor.firstField();
-    while (inField) {
-        fields ??= {};
-        const field: JsonableTree[] = mapCursorField(cursor, jsonableTreeFromCursor);
-        fields[cursor.getFieldKey() as string] = field;
-        inField = cursor.nextNode();
+    const fields: Map<FieldKey, MapTree[]> = new Map();
+    for (let inField = cursor.firstField(); inField; inField = cursor.nextNode()) {
+        const field: MapTree[] = mapCursorField(cursor, mapTreeFromCursor);
+        fields.set(cursor.getFieldKey(), field);
     }
 
-    const node: JsonableTree = {
+    const node: MapTree = {
         type: cursor.type,
         value: cursor.value,
         fields,
     };
-    // Normalize object by only including fields that are required.
-    if (fields === undefined) {
-        delete node.fields;
-    }
-    if (node.value === undefined) {
-        delete node.value;
-    }
+
     return node;
 }

--- a/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
@@ -31,8 +31,9 @@ type SiblingsOrKey = readonly MapTree[] | readonly FieldKey[];
 /**
  * An ITreeCursor implementation for MapTree.
  *
- * TODO: object-forest's cursor is mostly a superset of this functionality.
- * Maybe do a refactoring to deduplicate this.
+ * TODO:
+ * This is based off of TextCursor,
+ * and likely could be further optimized by taking a different approach using map iterators.
  */
 class MapCursor implements ITreeCursor {
     /**

--- a/packages/dds/tree/src/feature-libraries/treeTextCursorLegacy.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursorLegacy.ts
@@ -14,10 +14,9 @@ import {
     DetachedField,
     detachedFieldAsKey,
     FieldKey,
-    FieldMap,
-    FieldScope,
+    FieldMapObject,
+    genericTreeKeys,
     getGenericTreeField,
-    getGenericTreeFieldMap,
     JsonableTree,
     TreeType,
     UpPath,
@@ -100,8 +99,7 @@ export class TextCursor implements ITreeCursor<SynchronousNavigationResult> {
     }
 
     get keys(): Iterable<FieldKey> {
-        return Object.getOwnPropertyNames(
-            getGenericTreeFieldMap(this.getNode(), FieldScope.local, false)) as Iterable<FieldKey>;
+        return genericTreeKeys(this.getNode());
     }
 
     down(key: FieldKey, index: number): SynchronousNavigationResult {
@@ -192,7 +190,7 @@ export class RootedTextCursor extends TextCursor {
  * Extract a JsonableTree from the contents of the given ITreeCursor's current node.
  */
 export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree {
-    let fields: FieldMap<JsonableTree> | undefined;
+    let fields: FieldMapObject<JsonableTree> | undefined;
     for (const key of cursor.keys) {
         fields ??= {};
         const field: JsonableTree[] = mapCursorField(cursor, key, jsonableTreeFromCursor);

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -11,7 +11,7 @@ export {
 export {
     EmptyKey, FieldKey, TreeType, Value, TreeValue, AnchorSet, DetachedField,
     UpPath, Anchor, RootField, ChildCollection,
-    ChildLocation, FieldMap, NodeData, GenericTreeNode, PlaceholderTree, JsonableTree,
+    ChildLocation, FieldMapObject, NodeData, GenericTreeNode, PlaceholderTree, JsonableTree,
     Delta, rootFieldKey, FieldScope, GlobalFieldKeySymbol, symbolFromKey, keyFromSymbol,
 } from "./tree";
 

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -12,7 +12,7 @@ import {
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { JsonCursor } from "../../../domains/json/jsonCursor";
-import { jsonableTreeFromCursorNew } from "../../../feature-libraries";
+import { jsonableTreeFromCursorNew, mapTreeFromCursor, singleMapTreeCursor } from "../../../feature-libraries";
 import { CoordinatesKey, FeatureKey, generateCanada, GeometryKey } from "./json";
 import { averageLocation, sum, sumMap } from "./benchmarks";
 
@@ -75,6 +75,7 @@ function bench(
 
     const cursorFactories: [string, () => ITreeCursorNew][] = [
         ["TextCursor", () => singleTextCursorNew(encodedTree)],
+        ["MapCursor", () => singleMapTreeCursor(mapTreeFromCursor(singleTextCursorNew(encodedTree)))],
     ];
 
     const consumers: [
@@ -86,6 +87,7 @@ function bench(
         // TODO: finish porting other cursor code and enable this.
         // ["cursorToJsonObject", cursorToJsonObjectNew],
         ["jsonableTreeFromCursor", jsonableTreeFromCursorNew],
+        ["mapTreeFromCursor", mapTreeFromCursor],
         ["sum", sum],
         ["sum-map", sumMap],
         ["averageLocation", averageLocation],

--- a/packages/dds/tree/src/test/domains/json/jsonCursorLegacy.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursorLegacy.bench.ts
@@ -173,6 +173,6 @@ function extractCoordinatesFromCanada(cursor: ITreeCursor, calculate: (x: number
     cursor.up();
 }
 
-describe("ITreeCursor", () => {
+describe("ITreeCursor(Legacy)", () => {
     bench([{ name: "canada", getJson: () => canada, dataConsumer: extractCoordinatesFromCanada }]);
 });

--- a/packages/dds/tree/src/test/feature-libraries/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/treeTextCursor.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { mapTreeFromCursor, singleMapTreeCursor } from "../../feature-libraries";
 
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
@@ -61,23 +62,49 @@ const testCases: [string, JsonableTree][] = [
     }],
 ];
 
-function testCursor(suiteName: string, factory: (data: JsonableTree) => ITreeCursor): void {
+// Checks to make sure singleTextCursor and test datasets are working properly,
+// since its used in the below test suite to test other formats.
+describe("JsonableTree extra tests", () => {
+    describe("round trip", () => {
+        for (const [name, data] of testCases) {
+            it(name, () => {
+                const cursor = singleTextCursor(data);
+                const clone = jsonableTreeFromCursor(cursor);
+                assert.deepEqual(clone, data);
+                // Check objects are actually json compatible
+                const text = JSON.stringify(clone);
+                const parsed = JSON.parse(text);
+                assert.deepEqual(parsed, data);
+            });
+        }
+    });
+});
+
+/**
+ * Uses jsonableTree support to check/compare other format support.
+ */
+function testTreeFormat<T>(
+        suiteName: string,
+        toCursor: (data: T) => ITreeCursor,
+        fromCursor: (cursor: ITreeCursor) => T,
+    ): void {
     describe(suiteName, () => {
         describe("round trip", () => {
-            for (const [name, data] of testCases) {
+            for (const [name, jsonableData] of testCases) {
                 it(name, () => {
-                    const cursor = factory(data);
-                    const clone = jsonableTreeFromCursor(cursor);
-                    assert.deepEqual(clone, data);
-                    // Check objects are actually json compatible
-                    const text = JSON.stringify(clone);
-                    const parsed = JSON.parse(text);
-                    assert.deepEqual(parsed, data);
+                    const inputCursor = singleTextCursor(jsonableData);
+                    const convertedData: T = fromCursor(inputCursor);
+                    const cursor = toCursor(convertedData);
+
+                    // Check constructed cursor has the correct content, by reading it into a jsonableTree
+                    const jsonableClone = jsonableTreeFromCursor(cursor);
+                    assert.deepEqual(jsonableClone, jsonableData);
                 });
             }
         });
     });
 }
 
-// Tests for TextCursor and jsonableTreeFromCursor.
-testCursor("textTreeFormat", (data): ITreeCursor => singleTextCursor(data));
+testTreeFormat("textTreeFormat", singleTextCursor, jsonableTreeFromCursor);
+// TODO: this test suite should be refactored to move this into its own file and share the suite implementation.
+testTreeFormat("mapTreeFormat", singleMapTreeCursor, mapTreeFromCursor);

--- a/packages/dds/tree/src/test/feature-libraries/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/treeTextCursor.spec.ts
@@ -96,10 +96,11 @@ function testTreeFormat<T>(
                     const convertedData: T = fromCursor(inputCursor);
                     const cursor = toCursor(convertedData);
 
-                    // Check constructed cursor has the correct content, by reading it into a jsonableTree
+                    // Check constructed cursor has the correct content, by reading it into a jsonableTree.
                     const jsonableClone = jsonableTreeFromCursor(cursor);
                     assert.deepEqual(jsonableClone, jsonableData);
                 });
+                // TODO: test rest of cursor API (getPath, enterNode, enterField etc).
             }
         });
     });

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -16,6 +16,7 @@ export {
     detachedFieldAsKey,
     keyAsDetachedField,
     rootFieldKey,
+    NodeData,
 } from "./types";
 
 export * from "./pathTree";
@@ -23,6 +24,7 @@ export * from "./anchorSet";
 export * from "./treeTextFormat";
 export * from "./visitDelta";
 export * from "./globalFieldKeySymbol";
+export * from "./mapTree";
 
 // Split this up into separate import and export for compatibility with API-Extractor.
 import * as Delta from "./delta";

--- a/packages/dds/tree/src/tree/mapTree.ts
+++ b/packages/dds/tree/src/tree/mapTree.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FieldKey, NodeData } from "./types";
+
+/**
+ * This modules provides a simple in memory tree format.
+ */
+
+/**
+ * Simple in memory tree representation based on Maps.
+ * @public
+ */
+export interface MapTree extends NodeData {
+    fields: Map<FieldKey, MapTree[]>;
+}
+
+/**
+ * Get a field from `node`, optionally modifying the tree to create it if missing.
+ */
+export function getMapTreeField(node: MapTree, key: FieldKey, createIfMissing: boolean): MapTree[] {
+    const field = node.fields.get(key);
+    if (field !== undefined) {
+        return field;
+    }
+    // Handle missing field:
+    if (createIfMissing === false) {
+        return [];
+    }
+    const newField: MapTree[] = [];
+    node.fields.set(key, newField);
+    return newField;
+}

--- a/packages/dds/tree/src/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/tree/treeTextFormat.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TreeSchemaIdentifier } from "../schema-stored";
-import { FieldKey, TreeValue } from "./types";
+import { FieldKey, NodeData } from "./types";
 
 /**
  * This modules provides a simple human readable (and editable) tree format.
@@ -28,30 +27,12 @@ import { FieldKey, TreeValue } from "./types";
 
 /**
  * Json compatible map as object.
- * Keys are TraitLabels,
- * Values are the content of the trait specified by the key.
+ * Keys are FieldKey strings.
+ * Values are the content of the field specified by the key.
  * @public
  */
-export interface FieldMap<TChild> {
+export interface FieldMapObject<TChild> {
     [key: string]: TChild[];
-}
-
-/**
- * The fields required by a node in a tree
- * @public
- */
-export interface NodeData {
-    /**
-     * A payload of arbitrary serializable data
-     */
-    value?: TreeValue;
-
-    /**
-     * The meaning of this node.
-     * Provides contexts/semantics for this node and its content.
-     * Typically use to associate a node with metadata (including a schema) and source code (types, behaviors, etc).
-     */
-    readonly type: TreeSchemaIdentifier;
 }
 
 /**
@@ -60,8 +41,8 @@ export interface NodeData {
  * @public
  */
 export interface GenericTreeNode<TChild> extends NodeData {
-    [FieldScope.local]?: FieldMap<TChild>;
-    [FieldScope.global]?: FieldMap<TChild>;
+    [FieldScope.local]?: FieldMapObject<TChild>;
+    [FieldScope.global]?: FieldMapObject<TChild>;
 }
 
 /**
@@ -114,8 +95,8 @@ export const enum FieldScope {
 /**
  * Get a FieldMap from `node`, optionally modifying the tree to create it if missing.
  */
-export function getGenericTreeFieldMap<T>(
-    node: GenericTreeNode<T>, scope: FieldScope, createIfMissing: boolean): FieldMap<T> {
+function getGenericTreeFieldMap<T>(
+    node: GenericTreeNode<T>, scope: FieldScope, createIfMissing: boolean): FieldMapObject<T> {
     let children = node[scope];
     if (children === undefined) {
         children = {};
@@ -134,4 +115,11 @@ export function getGenericTreeFieldMap<T>(
 export function setGenericTreeField<T>(node: GenericTreeNode<T>, key: FieldKey, content: T[]): void {
     const children = getGenericTreeFieldMap(node, scopeFromKey(key), true);
     children[key as string] = content;
+}
+
+/**
+ * @returns keys for fields of `tree`.
+ */
+export function genericTreeKeys<T>(tree: GenericTreeNode<T>): readonly FieldKey[] {
+    return Object.getOwnPropertyNames(getGenericTreeFieldMap(tree, FieldScope.local, false)) as FieldKey[];
 }

--- a/packages/dds/tree/src/tree/types.ts
+++ b/packages/dds/tree/src/tree/types.ts
@@ -138,3 +138,21 @@ export interface TreeValue extends Serializable {}
   * Value stored on a node.
   */
 export type Value = undefined | TreeValue;
+
+/**
+ * The fields required by a node in a tree
+ * @public
+ */
+ export interface NodeData {
+    /**
+     * A payload of arbitrary serializable data
+     */
+    value?: TreeValue;
+
+    /**
+     * The meaning of this node.
+     * Provides contexts/semantics for this node and its content.
+     * Typically use to associate a node with metadata (including a schema) and source code (types, behaviors, etc).
+     */
+    readonly type: TreeSchemaIdentifier;
+}


### PR DESCRIPTION
## Description

This adds a new in memory tree format, MapTree which uses maps instead of objects. Compare to JsonableTree this allows the keys to include symbols so it can differentiate global and local field keys without having two separate collections. It also has lower risk of special key strings, like `__prototype__`, from causing problems, and has slightly faster iteration.

In a future change most in memory use of JsonableTree will be replaced with this new format as part of fixing global vs local keys.