### PR TITLE
Tree: Use Cursor in Delta

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -506,7 +506,7 @@ export interface ITreeCursorNew {
     readonly value: Value;
 }
 
-// @public (undocumented)
+// @public
 export interface ITreeCursorSynchronous extends ITreeCursorNew {
     // (undocumented)
     readonly pending: false;

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -29,7 +29,7 @@ export class AnchorSet {
 }
 
 // @public
-function applyModifyToInsert(node: ProtoNode_2, modify: Modify): Map<FieldKey, MarkList>;
+function applyModifyToInsert(node: JsonableTree, modify: Modify): Map<FieldKey, MarkList>;
 
 // @public
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
@@ -506,6 +506,12 @@ export interface ITreeCursorNew {
     readonly value: Value;
 }
 
+// @public (undocumented)
+export interface ITreeCursorSynchronous extends ITreeCursorNew {
+    // (undocumented)
+    readonly pending: false;
+}
+
 // @public
 export interface ITreeSubscriptionCursor extends ITreeCursor {
     buildAnchor(): Anchor;
@@ -819,7 +825,7 @@ export abstract class ProgressiveEditBuilder<TChange> {
 export type ProtoNode = JsonableTree;
 
 // @public
-type ProtoNode_2 = JsonableTree;
+type ProtoNode_2 = ITreeCursorSynchronous;
 
 // @public
 export const proxyTargetSymbol: unique symbol;
@@ -941,7 +947,7 @@ export class SimpleDependee implements Dependee {
 export function singleTextCursor(root: JsonableTree): TextCursor;
 
 // @public (undocumented)
-export function singleTextCursorNew(root: JsonableTree): TextCursorNew;
+export function singleTextCursorNew(root: JsonableTree): ITreeCursorSynchronous;
 
 // @public (undocumented)
 export type Skip = number;
@@ -1010,51 +1016,6 @@ export class TextCursor implements ITreeCursor<SynchronousNavigationResult> {
     get type(): TreeType;
     // (undocumented)
     up(): SynchronousNavigationResult;
-    // (undocumented)
-    get value(): Value;
-}
-
-// @public
-export class TextCursorNew implements ITreeCursorNew {
-    constructor(root: JsonableTree);
-    // (undocumented)
-    get chunkLength(): number;
-    // (undocumented)
-    get chunkStart(): number;
-    // (undocumented)
-    enterField(key: FieldKey): void;
-    // (undocumented)
-    enterNode(index: number): void;
-    // (undocumented)
-    exitField(): void;
-    // (undocumented)
-    exitNode(): void;
-    // (undocumented)
-    get fieldIndex(): number;
-    // (undocumented)
-    firstField(): boolean;
-    // (undocumented)
-    firstNode(): boolean;
-    // (undocumented)
-    getFieldKey(): FieldKey;
-    // (undocumented)
-    getFieldLength(): number;
-    // (undocumented)
-    getPath(): UpPath | undefined;
-    // (undocumented)
-    get mode(): CursorLocationType;
-    // (undocumented)
-    nextField(): boolean;
-    // (undocumented)
-    nextNode(): boolean;
-    // (undocumented)
-    get pending(): boolean;
-    // (undocumented)
-    seekNodes(offset: number): boolean;
-    // (undocumented)
-    skipPendingFields(): boolean;
-    // (undocumented)
-    get type(): TreeType;
     // (undocumented)
     get value(): Value;
 }

--- a/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
@@ -9,6 +9,7 @@ import { ITreeCursor } from "../forest";
 import { FieldKindIdentifier } from "../schema-stored";
 import { AnchorSet, Delta, JsonableTree } from "../tree";
 import { brand, clone, fail, JsonCompatible, JsonCompatibleReadOnly } from "../util";
+import { singleTextCursor } from "./treeTextCursor";
 import {
     FieldKind,
     Multiplicity,
@@ -310,14 +311,14 @@ const valueChangeHandler: FieldChangeHandler<ValueChangeset> = {
         if (change.value !== undefined) {
             let mark: Delta.Mark;
             if (change.changes === undefined) {
-                mark = { type: Delta.MarkType.Insert, content: [change.value] };
+                mark = { type: Delta.MarkType.Insert, content: [singleTextCursor(change.value)] };
             } else {
                 const modify = deltaFromChild(change.changes);
                 const content = clone(change.value);
                 const fields = Delta.applyModifyToInsert(content, modify);
                 mark = fields.size === 0
-                    ? { type: Delta.MarkType.Insert, content: [content] }
-                    : { type: Delta.MarkType.InsertAndModify, content, fields };
+                    ? { type: Delta.MarkType.Insert, content: [singleTextCursor(content)] }
+                    : { type: Delta.MarkType.InsertAndModify, content: singleTextCursor(content), fields };
             }
 
             return [

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -19,6 +19,7 @@ import { Index, SummaryElement, SummaryElementParser, SummaryElementStringifier 
 import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
 import { JsonableTree, Delta } from "../tree";
 import { jsonableTreeFromCursor } from "./treeTextCursorLegacy";
+import { singleTextCursorNew } from ".";
 
 /**
  * The storage key for the blob in the summary containing tree data
@@ -129,7 +130,7 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
             const treeBufferString = bufferToString(treeBuffer, "utf8");
             const tree = parse(treeBufferString) as string;
             const placeholderTree = JSON.parse(tree) as JsonableTree[];
-            initializeForest(this.forest, placeholderTree);
+            initializeForest(this.forest, placeholderTree.map(singleTextCursorNew));
         }
     }
 }

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -19,7 +19,7 @@ import { Index, SummaryElement, SummaryElementParser, SummaryElementStringifier 
 import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
 import { JsonableTree, Delta } from "../tree";
 import { jsonableTreeFromCursor } from "./treeTextCursorLegacy";
-import { singleTextCursorNew } from ".";
+import { singleTextCursor } from "./treeTextCursor";
 
 /**
  * The storage key for the blob in the summary containing tree data
@@ -130,7 +130,7 @@ export class ForestIndex implements Index<unknown>, SummaryElement {
             const treeBufferString = bufferToString(treeBuffer, "utf8");
             const tree = parse(treeBufferString) as string;
             const placeholderTree = JSON.parse(tree) as JsonableTree[];
-            initializeForest(this.forest, placeholderTree.map(singleTextCursorNew));
+            initializeForest(this.forest, placeholderTree.map(singleTextCursor));
         }
     }
 }

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -11,7 +11,6 @@ export * from "./schemaIndex";
 export * from "./treeTextCursorLegacy";
 export {
 	singleTextCursor as singleTextCursorNew,
-	TextCursor as TextCursorNew,
 	jsonableTreeFromCursor as jsonableTreeFromCursorNew,
 } from "./treeTextCursor";
 export { singleMapTreeCursor, mapTreeFromCursor } from "./mapTreeCursor";

--- a/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
@@ -5,24 +5,23 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-    ITreeCursorNew as ITreeCursor,
-    CursorLocationType,
-    mapCursorFieldNew as mapCursorField,
-} from "../forest";
-import {
     FieldKey,
     TreeType,
     UpPath,
     Value,
     MapTree,
     getMapTreeField,
+    ITreeCursorNew as ITreeCursor,
+    CursorLocationType,
+    mapCursorFieldNew as mapCursorField,
+    ITreeCursorSynchronous,
 } from "../tree";
 import { fail } from "../util";
 
 /**
  * @returns an ITreeCursor for a single MapTree.
  */
-export function singleMapTreeCursor(root: MapTree): ITreeCursor {
+export function singleMapTreeCursor(root: MapTree): ITreeCursorSynchronous {
     return new MapCursor(root);
 }
 
@@ -35,7 +34,7 @@ type SiblingsOrKey = readonly MapTree[] | readonly FieldKey[];
  * This is based off of TextCursor,
  * and likely could be further optimized by taking a different approach using map iterators.
  */
-class MapCursor implements ITreeCursor {
+class MapCursor implements ITreeCursorSynchronous {
     /**
      * Indices traversed to visit this node: does not include current level (which is stored in `index`).
      * Even indexes are of nodes and odd indexes are for fields.
@@ -150,7 +149,7 @@ class MapCursor implements ITreeCursor {
         return this.siblingStack.length % 2 === 0 ? CursorLocationType.Nodes : CursorLocationType.Fields;
     }
 
-    public get pending(): boolean {
+    public get pending(): false {
         return false;
     }
 

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -4,12 +4,12 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { jsonableTreeFromCursor, RootedTextCursor, singleTextCursor } from "../treeTextCursorLegacy";
+import { RootedTextCursor } from "../treeTextCursorLegacy";
 import {
     DisposingDependee, ObservingDependent, recordDependency, SimpleDependee, SimpleObservingDependent,
 } from "../../dependency-tracking";
 import {
-    ITreeCursor, ITreeSubscriptionCursor, IEditableForest,
+    ITreeSubscriptionCursor, IEditableForest,
     ITreeSubscriptionCursorState,
     TreeNavigationResult,
 } from "../../forest";
@@ -17,8 +17,10 @@ import { StoredSchemaRepository } from "../../schema-stored";
 import {
     FieldKey, DetachedField, AnchorSet, detachedFieldAsKey, keyAsDetachedField,
     Value, Delta, JsonableTree, getGenericTreeField, UpPath, Anchor, visitDelta,
+    ITreeCursorNew,
 } from "../../tree";
 import { brand, fail } from "../../util";
+import { jsonableTreeFromCursor } from "../treeTextCursor";
 
 export class ObjectForest extends SimpleDependee implements IEditableForest {
     private readonly dependent = new SimpleObservingDependent(() => this.invalidateDependents());
@@ -101,7 +103,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
             },
             onInsert: (index: number, content: Delta.ProtoNode[]): void => {
                 assert(currentField !== undefined, 0x366 /* must be in field to onInsert */);
-                const range = this.add(content.map((data) => singleTextCursor(data)));
+                const range = this.add(content);
                 moveIn(index, range);
             },
             onMoveOut: (index: number, count: number, id?: Delta.MoveId): void => {
@@ -194,7 +196,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         return range;
     }
 
-    private add(nodes: Iterable<ITreeCursor>): DetachedField {
+    private add(nodes: Iterable<ITreeCursorNew>): DetachedField {
         const range = this.newDetachedField();
         assert(!this.roots.has(range), 0x370 /* new range must not already exist */);
         const field: ObjectField = Array.from(nodes, jsonableTreeFromCursor);

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -4,6 +4,7 @@
  */
 
 import { unreachableCase } from "@fluidframework/common-utils";
+import { singleTextCursorNew } from "../..";
 import { TreeSchemaIdentifier } from "../../../schema-stored";
 import { FieldKey, Value, Delta } from "../../../tree";
 import { brand, brandOpaque, clone, fail, makeArray, OffsetListFactory } from "../../../util";
@@ -34,7 +35,8 @@ function convertMarkList(marks: T.MarkList): Delta.MarkList {
                 case "Insert": {
                     const insertMark: Delta.Insert = {
                         type: Delta.MarkType.Insert,
-                        content: cloneTreeContent(mark.content),
+                        // TODO: can we skip this clone?
+                        content: clone(mark.content).map(singleTextCursorNew),
                     };
                     out.pushContent(insertMark);
                     break;
@@ -117,7 +119,7 @@ function convertMarkList(marks: T.MarkList): Delta.MarkList {
                     const insertMark: Delta.Insert = {
                         type: Delta.MarkType.Insert,
                         // TODO: Restore the actual node
-                        content: makeArray(mark.count, () => ({ type: DUMMY_REVIVED_NODE_TYPE })),
+                        content: makeArray(mark.count, () => singleTextCursorNew({ type: DUMMY_REVIVED_NODE_TYPE })),
                     };
                     out.pushContent(insertMark);
                     break;
@@ -126,7 +128,7 @@ function convertMarkList(marks: T.MarkList): Delta.MarkList {
                     const insertMark: Delta.Insert = {
                         type: Delta.MarkType.Insert,
                         // TODO: Restore the actual node
-                        content: [{ type: DUMMY_REVIVED_NODE_TYPE }],
+                        content: [singleTextCursorNew({ type: DUMMY_REVIVED_NODE_TYPE })],
                     };
                     out.pushContent(insertMark);
                     break;
@@ -151,15 +153,6 @@ function convertMarkList(marks: T.MarkList): Delta.MarkList {
 const DUMMY_REVIVED_NODE_TYPE: TreeSchemaIdentifier = brand("RevivedNode");
 
 /**
- * Clones the content described by a Changeset into tree content expected by Delta.
- */
-function cloneTreeContent(content: ProtoNode[]): Delta.ProtoNode[] {
-    // The changeset and Delta format currently use the same interface to represent inserted content.
-    // This is an implementation detail that may not remain true.
-    return clone(content);
-}
-
-/**
  * Converts inserted content into the format expected in Delta instances.
  * This involves applying all except MoveIn changes.
  *
@@ -167,9 +160,9 @@ function cloneTreeContent(content: ProtoNode[]): Delta.ProtoNode[] {
  */
 function cloneAndModify(insert: T.ModifyInsert): DeltaInsertModification {
     // TODO: consider processing modifications at the same time as cloning to avoid unnecessary cloning
-    const outNode = cloneTreeContent([insert.content])[0];
+    const outNode = clone(insert.content);
     const outModifications = applyOrCollectModifications(outNode, insert);
-    return { content: outNode, fields: outModifications };
+    return { content: singleTextCursorNew(outNode), fields: outModifications };
 }
 
 /**
@@ -202,7 +195,7 @@ interface DeltaInsertModification {
  *   all modifications are applied by the function.
  */
 function applyOrCollectModifications(
-    node: Delta.ProtoNode,
+    node: ProtoNode,
     modify: ChangesetMods,
 ): Delta.FieldMarks {
     const outFieldsMarks: Delta.FieldMarks = new Map();
@@ -226,7 +219,8 @@ function applyOrCollectModifications(
                     const type = mark.type;
                     switch (type) {
                         case "Insert": {
-                            const content = cloneTreeContent(mark.content);
+                            // TODO: can we skip this clone?
+                            const content = clone(mark.content).map(singleTextCursorNew);
                             outNodes.splice(index, 0, ...content);
                             index += content.length;
                             outMarks.pushOffset(content.length);

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -44,7 +44,7 @@ import { fail } from "../util";
  */
 
 /**
- * @returns a ITreeCursorSynchronous for a single JsonableTree.
+ * @returns an ITreeCursorSynchronous for a single JsonableTree.
  */
 export function singleTextCursor(root: JsonableTree): ITreeCursorSynchronous {
     return new TextCursor(root);

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -5,11 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-    ITreeCursorNew as ITreeCursor,
-    CursorLocationType,
-    mapCursorFieldNew as mapCursorField,
-} from "../forest";
-import {
     FieldKey,
     FieldMapObject,
     genericTreeKeys,
@@ -18,6 +13,10 @@ import {
     TreeType,
     UpPath,
     Value,
+    ITreeCursorNew as ITreeCursor,
+    CursorLocationType,
+    mapCursorFieldNew as mapCursorField,
+    ITreeCursorSynchronous,
 } from "../tree";
 import { fail } from "../util";
 
@@ -45,9 +44,9 @@ import { fail } from "../util";
  */
 
 /**
- * @returns a TextCursor for a single JsonableTree.
+ * @returns a ITreeCursorSynchronous for a single JsonableTree.
  */
-export function singleTextCursor(root: JsonableTree): TextCursor {
+export function singleTextCursor(root: JsonableTree): ITreeCursorSynchronous {
     return new TextCursor(root);
 }
 
@@ -59,7 +58,7 @@ type SiblingsOrKey = readonly JsonableTree[] | readonly FieldKey[];
  * TODO: object-forest's cursor is mostly a superset of this functionality.
  * Maybe do a refactoring to deduplicate this.
  */
-export class TextCursor implements ITreeCursor {
+class TextCursor implements ITreeCursorSynchronous {
     /**
      * Indices traversed to visit this node: does not include current level (which is stored in `index`).
      * Even indexes are of nodes and odd indexes are for fields.
@@ -174,7 +173,7 @@ export class TextCursor implements ITreeCursor {
         return this.siblingStack.length % 2 === 0 ? CursorLocationType.Nodes : CursorLocationType.Fields;
     }
 
-    public get pending(): boolean {
+    public get pending(): false {
         return false;
     }
 

--- a/packages/dds/tree/src/forest/editableForest.ts
+++ b/packages/dds/tree/src/forest/editableForest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AnchorSet, FieldKey, DetachedField, Delta, JsonableTree, detachedFieldAsKey, Anchor } from "../tree";
+import { AnchorSet, FieldKey, DetachedField, Delta, detachedFieldAsKey, Anchor, ITreeCursorSynchronous } from "../tree";
 import { IForestSubscription, ITreeSubscriptionCursor } from "./forest";
 
 /**
@@ -27,7 +27,7 @@ export interface IEditableForest extends IForestSubscription {
     applyDelta(delta: Delta.Root): void;
 }
 
-export function initializeForest(forest: IEditableForest, content: JsonableTree[]): void {
+export function initializeForest(forest: IEditableForest, content: ITreeCursorSynchronous[]): void {
     // TODO: maybe assert forest is empty?
     const insert: Delta.Insert = { type: Delta.MarkType.Insert, content };
     const rootField = detachedFieldAsKey(forest.rootField);

--- a/packages/dds/tree/src/forest/index.ts
+++ b/packages/dds/tree/src/forest/index.ts
@@ -10,12 +10,6 @@ export {
     SynchronousNavigationResult,
     reduceField,
 } from "./cursorLegacy";
-export {
-    ITreeCursor as ITreeCursorNew,
-    CursorLocationType,
-    mapCursorField as mapCursorFieldNew,
-    forEachNode,
-} from "./cursor";
 export * from "./forest";
 export {
     IEditableForest, FieldLocation, TreeLocation, isFieldLocation, ForestLocation, initializeForest,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -13,6 +13,9 @@ export {
     UpPath, Anchor, RootField, ChildCollection,
     ChildLocation, FieldMapObject, NodeData, GenericTreeNode, PlaceholderTree, JsonableTree,
     Delta, rootFieldKey, FieldScope, GlobalFieldKeySymbol, symbolFromKey, keyFromSymbol,
+    ITreeCursorNew,
+    CursorLocationType,
+    ITreeCursorSynchronous,
 } from "./tree";
 
 export { ITreeCursor, TreeNavigationResult, IEditableForest,
@@ -23,8 +26,6 @@ export { ITreeCursor, TreeNavigationResult, IEditableForest,
     ITreeSubscriptionCursor,
     ITreeSubscriptionCursorState,
     SynchronousNavigationResult,
-    ITreeCursorNew,
-    CursorLocationType,
 } from "./forest";
 
 export {
@@ -121,7 +122,6 @@ export {
     proxyTargetSymbol,
     defaultSchemaPolicy,
     singleTextCursorNew,
-    TextCursorNew,
     jsonableTreeFromCursorNew,
     PrimitiveValue,
     SequenceEditBuilder,

--- a/packages/dds/tree/src/test/changeset/toDelta.spec.ts
+++ b/packages/dds/tree/src/test/changeset/toDelta.spec.ts
@@ -3,16 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { fail, strict as assert } from "assert";
 import {
+    jsonableTreeFromCursorNew,
     ProtoNode,
+    singleTextCursorNew,
     toDelta as toDeltaImpl,
     Transposed as T,
 } from "../../feature-libraries";
 import { TreeSchemaIdentifier } from "../../schema-stored";
-import { FieldKey, Delta } from "../../tree";
-import { brand, brandOpaque } from "../../util";
-import { deepFreeze } from "../utils";
+import { FieldKey, Delta, ITreeCursorSynchronous } from "../../tree";
+import { brand, brandOpaque, JsonCompatibleReadOnly } from "../../util";
+import { deepFreeze, assertMarkListEqual } from "../utils";
 
 function toDelta(changeset: T.LocalChangeset): Delta.Root {
     deepFreeze(changeset);
@@ -35,6 +37,11 @@ const content: ProtoNode[] = [{
     value: 42,
     fields: { foo: [{ type, value: 43 }] },
 }];
+const contentCursor: ITreeCursorSynchronous[] = [singleTextCursorNew({
+    type,
+    value: 42,
+    fields: { foo: [{ type, value: 43 }] },
+})];
 
 const opId = 42;
 const moveId = brandOpaque<Delta.MoveId>(opId);
@@ -91,7 +98,7 @@ describe("toDelta", () => {
         ];
         const mark: Delta.Insert = {
             type: Delta.MarkType.Insert,
-            content,
+            content: contentCursor,
         };
         const expected: Delta.MarkList = [mark];
         const actual = toTreeDelta(changeset);
@@ -110,7 +117,7 @@ describe("toDelta", () => {
         }];
         const mark: Delta.Insert = {
             type: Delta.MarkType.Insert,
-            content,
+            content: contentCursor,
         };
         const expected: Delta.MarkList = [{
             type: Delta.MarkType.Modify,
@@ -324,7 +331,7 @@ describe("toDelta", () => {
         };
         const ins: Delta.Insert = {
             type: Delta.MarkType.Insert,
-            content,
+            content: contentCursor,
         };
         const set: Delta.Modify = {
             type: Delta.MarkType.Modify,
@@ -359,13 +366,13 @@ describe("toDelta", () => {
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,
-                content: [{
+                content: [singleTextCursorNew({
                     type,
                     value: 4242,
                     fields: {
                         foo: [{ type, value: 4343 }],
                     },
-                }],
+                })],
             };
             const expected: Delta.MarkList = [mark];
             const actual = toTreeDelta(changeset);
@@ -397,7 +404,7 @@ describe("toDelta", () => {
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,
-                content: [{
+                content: [singleTextCursorNew({
                     type,
                     value: 42,
                     fields: {
@@ -407,11 +414,11 @@ describe("toDelta", () => {
                             { type, value: 45 },
                         ],
                     },
-                }],
+                })],
             };
             const expected: Delta.MarkList = [mark];
             const actual = toTreeDelta(changeset);
-            assert.deepStrictEqual(actual, expected);
+            assertMarkListEqual(actual, expected);
         });
 
         it("modified inserts", () => {
@@ -435,17 +442,17 @@ describe("toDelta", () => {
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,
-                content: [{
+                content: [singleTextCursorNew({
                     type,
                     value: 42,
                     fields: {
                         foo: [{ type, value: 43 }, { type, value: 4545 }],
                     },
-                }],
+                })],
             };
             const expected: Delta.MarkList = [mark];
             const actual = toTreeDelta(changeset);
-            assert.deepStrictEqual(actual, expected);
+            assertMarkListEqual(actual, expected);
         });
 
         it("delete", () => {
@@ -467,10 +474,10 @@ describe("toDelta", () => {
             ];
             const mark: Delta.Insert = {
                 type: Delta.MarkType.Insert,
-                content: [{
+                content: [singleTextCursorNew({
                     type,
                     value: 42,
-                }],
+                })],
             };
             const expected: Delta.MarkList = [mark];
             const actual = toTreeDelta(changeset);

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { forEachNode, ITreeCursorNew } from "../../../forest";
+import { forEachNode, ITreeCursorNew } from "../../../tree";
 
 export function sum(cursor: ITreeCursorNew): number {
     let total = 0;

--- a/packages/dds/tree/src/test/domains/json/jsonCursorLegacy.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursorLegacy.bench.ts
@@ -18,7 +18,7 @@ import { initializeForest, TreeNavigationResult } from "../../../forest";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { cursorToJsonObject, JsonCursor } from "../../../domains/json/jsonCursor";
-import { defaultSchemaPolicy } from "../../../feature-libraries";
+import { defaultSchemaPolicy, singleTextCursorNew } from "../../../feature-libraries";
 import { SchemaData, StoredSchemaRepository } from "../../../schema-stored";
 import { CoordinatesKey, FeatureKey, generateCanada, GeometryKey } from "./json";
 import { averageLocation, sum } from "./benchmarksLegacy";
@@ -90,7 +90,7 @@ function bench(
             ["TextCursor", () => singleTextCursor(encodedTree)],
             ["object-forest Cursor", () => {
                 const forest = buildForest(schema);
-                initializeForest(forest, [encodedTree]);
+                initializeForest(forest, [singleTextCursorNew(encodedTree)]);
                 const cursor = forest.allocateCursor();
                 assert.equal(forest.tryMoveCursorTo(forest.root(forest.rootField), cursor), TreeNavigationResult.Ok);
                 return cursor;

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -16,7 +16,7 @@ import { JsonableTree, EmptyKey, Value, rootFieldKey } from "../../../tree";
 import { brand, Brand, clone } from "../../../util";
 import {
     defaultSchemaPolicy, getEditableTree, EditableTree, buildForest, getTypeSymbol, UnwrappedEditableField,
-    proxyTargetSymbol, emptyField, FieldKinds, valueSymbol, EditableTreeOrPrimitive, isPrimitiveValue, Multiplicity,
+    proxyTargetSymbol, emptyField, FieldKinds, valueSymbol, EditableTreeOrPrimitive, isPrimitiveValue, Multiplicity, singleTextCursorNew,
 } from "../../../feature-libraries";
 
 // eslint-disable-next-line import/no-internal-modules
@@ -173,7 +173,7 @@ const person: JsonableTree = {
 function setupForest(schema: SchemaData, data: JsonableTree[]): IEditableForest {
     const schemaRepo = new StoredSchemaRepository(defaultSchemaPolicy, schema);
     const forest = buildForest(schemaRepo);
-    initializeForest(forest, data);
+    initializeForest(forest, data.map(singleTextCursorNew));
     return forest;
 }
 

--- a/packages/dds/tree/src/test/feature-libraries/treeTextCursor.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/treeTextCursor.spec.ts
@@ -9,9 +9,8 @@ import { mapTreeFromCursor, singleMapTreeCursor } from "../../feature-libraries"
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { jsonableTreeFromCursor, singleTextCursor } from "../../feature-libraries/treeTextCursor";
-import { ITreeCursorNew as ITreeCursor } from "../../forest";
 
-import { JsonableTree } from "../../tree";
+import { JsonableTree, ITreeCursorNew as ITreeCursor } from "../../tree";
 import { brand } from "../../util";
 
 const testCases: [string, JsonableTree][] = [

--- a/packages/dds/tree/src/test/feature-libraries/treeTextCursorLegacy.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/treeTextCursorLegacy.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { jsonTypeSchema } from "../../domains";
-import { defaultSchemaPolicy, ObjectForest } from "../../feature-libraries";
+import { defaultSchemaPolicy, ObjectForest, singleTextCursorNew } from "../../feature-libraries";
 
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
@@ -97,7 +97,7 @@ testCursor("object-forest cursor", (data): ITreeCursor => {
         treeSchema: jsonTypeSchema,
     };
     const forest = new ObjectForest(new StoredSchemaRepository(defaultSchemaPolicy, schemaData));
-    initializeForest(forest, [data]);
+    initializeForest(forest, [singleTextCursorNew(data)]);
     const cursor = forest.allocateCursor();
     assert.equal(forest.tryMoveCursorTo(forest.root(forest.rootField), cursor), TreeNavigationResult.Ok);
     return cursor;

--- a/packages/dds/tree/src/test/feature-libraries/valueFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/valueFieldKind.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { FieldKinds, NodeChangeset, singleTextCursor } from "../../feature-libraries";
+import { FieldKinds, NodeChangeset, singleTextCursor, singleTextCursorNew } from "../../feature-libraries";
 import { TreeSchemaIdentifier } from "../../schema-stored";
 import { Delta } from "../../tree";
 import { brand, JsonCompatibleReadOnly } from "../../util";
@@ -121,9 +121,9 @@ describe("Value field changesets", () => {
     });
 
     it("can be represented as a delta", () => {
-        const expected = [
+        const expected: Delta.MarkList = [
             { type: Delta.MarkType.Delete, count: 1 },
-            { type: Delta.MarkType.Insert, content: [{ type: nodeType, value: "value3" }] },
+            { type: Delta.MarkType.Insert, content: [singleTextCursorNew({ type: nodeType, value: "value3" })] },
         ];
 
         const deltaFromChild = (child: NodeChangeset): Delta.Modify => {

--- a/packages/dds/tree/src/test/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/objectForest.spec.ts
@@ -20,7 +20,7 @@ import { recordDependency } from "../dependency-tracking";
 import { clonePath, Delta, detachedFieldAsKey, JsonableTree, UpPath, rootFieldKey } from "../tree";
 import { jsonableTreeFromCursor } from "..";
 import { brand } from "../util";
-import { defaultSchemaPolicy, FieldKinds, isNeverField } from "../feature-libraries";
+import { defaultSchemaPolicy, FieldKinds, isNeverField, singleTextCursorNew } from "../feature-libraries";
 import { MockDependent } from "./utils";
 
 /**
@@ -52,9 +52,10 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
                     // Check schema is actually valid. If we forgot to add some required types this would fail.
                     assert(!isNeverField(defaultSchemaPolicy, schema, rootFieldSchema));
 
+                    // TODO: use new JsonCursor directly when ready instead of converting.
                     const insertCursor = new JsonCursor(data);
-                    const content: JsonableTree[] = [jsonableTreeFromCursor(insertCursor)];
-                    initializeForest(forest, content);
+                    const content: JsonableTree = jsonableTreeFromCursor(insertCursor);
+                    initializeForest(forest, [singleTextCursorNew(content)]);
 
                     const reader = forest.allocateCursor();
                     assert.equal(
@@ -70,8 +71,8 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
 
         it("setValue", () => {
             const forest = factory(new StoredSchemaRepository(defaultSchemaPolicy));
-            const content: JsonableTree[] = [{ type: jsonNumber.name, value: 1 }];
-            initializeForest(forest, content);
+            const content: JsonableTree = { type: jsonNumber.name, value: 1 };
+            initializeForest(forest, [singleTextCursorNew(content)]);
             const anchor = forest.root(forest.rootField);
 
             const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: 2 };
@@ -88,8 +89,8 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
 
         it("clear value", () => {
             const forest = factory(new StoredSchemaRepository(defaultSchemaPolicy));
-            const content: JsonableTree[] = [{ type: jsonNumber.name, value: 1 }];
-            initializeForest(forest, content);
+            const content: JsonableTree = { type: jsonNumber.name, value: 1 };
+            initializeForest(forest, [singleTextCursorNew(content)]);
             const anchor = forest.root(forest.rootField);
 
             const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: undefined };
@@ -107,7 +108,7 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
         it("delete", () => {
             const forest = factory(new StoredSchemaRepository(defaultSchemaPolicy));
             const content: JsonableTree[] = [{ type: jsonNumber.name, value: 1 }, { type: jsonNumber.name, value: 2 }];
-            initializeForest(forest, content);
+            initializeForest(forest, content.map(singleTextCursorNew));
             const anchor = forest.root(forest.rootField);
 
             // TODO: does does this select what to delete?
@@ -134,7 +135,7 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
                     { type: jsonNumber.name, value: 1 }, { type: jsonNumber.name, value: 2 }],
                 } },
             ];
-            initializeForest(forest, content);
+            initializeForest(forest, content.map(singleTextCursorNew));
 
             const rootAnchor = forest.root(forest.rootField);
 
@@ -206,7 +207,7 @@ function testForest(suiteName: string, factory: (schema: StoredSchemaRepository)
                 recordDependency(dependent, forest);
 
                 const content: JsonableTree[] = [{ type: jsonNumber.name, value: 1 }];
-                const insert: Delta.Insert = { type: Delta.MarkType.Insert, content };
+                const insert: Delta.Insert = { type: Delta.MarkType.Insert, content: content.map(singleTextCursorNew) };
                 // TODO: make type-safe
                 const rootField = detachedFieldAsKey(forest.rootField);
                 const delta: Delta.Root = new Map([[rootField, [insert]]]);

--- a/packages/dds/tree/src/test/sequence-change-family/sequenceEditBuilder.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/sequenceEditBuilder.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "assert";
 import { jsonString } from "../../domains";
-import { AnchorSet, Delta, FieldKey, UpPath } from "../../tree";
-import { SequenceEditBuilder, singleTextCursor } from "../../feature-libraries";
+import { AnchorSet, Delta, FieldKey, ITreeCursorSynchronous, UpPath } from "../../tree";
+import { SequenceEditBuilder, singleTextCursor, singleTextCursorNew } from "../../feature-libraries";
 import { brand, brandOpaque } from "../../util";
 
 const rootKey = brand<FieldKey>("root");
@@ -75,6 +75,7 @@ const root_bar2_bar5_bar7: UpPath = {
 };
 
 const nodeX = { type: jsonString.name, value: "X" };
+const nodeXCursor: ITreeCursorSynchronous = singleTextCursorNew(nodeX);
 const content = [nodeX];
 const moveId = brandOpaque<Delta.MoveId>(0);
 const moveId2 = brandOpaque<Delta.MoveId>(1);
@@ -139,10 +140,11 @@ describe("SequenceEditBuilder", () => {
             rootKey,
             [{
                 type: Delta.MarkType.Insert,
-                content,
+                content: [nodeXCursor],
             }],
         ]]);
         builder.insert(root, singleTextCursor(nodeX));
+        assert.deepEqual(deltas, [expected]);
     });
 
     it("Can insert a child node", () => {
@@ -164,7 +166,7 @@ describe("SequenceEditBuilder", () => {
                                     5,
                                     {
                                         type: Delta.MarkType.Insert,
-                                        content,
+                                        content: [nodeXCursor],
                                     },
                                 ],
                             ]]),

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { singleMapTreeCursor, singleTextCursorNew } from "../../feature-libraries";
 import { Anchor, AnchorSet, clonePath, Delta, FieldKey, JsonableTree, UpPath } from "../../tree";
 import { brand } from "../../util";
 
@@ -29,7 +30,7 @@ describe("AnchorSet", () => {
 
         const insert = {
             type: Delta.MarkType.Insert,
-            content: [node, node],
+            content: [node, node].map(singleTextCursorNew),
         };
 
         anchors.applyDelta(makeDelta(insert, makePath([fieldFoo, 4])));

--- a/packages/dds/tree/src/test/tree/visit.spec.ts
+++ b/packages/dds/tree/src/test/tree/visit.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 import { jsonString } from "../../domains";
+import { singleTextCursorNew } from "../../feature-libraries";
 import { FieldKey, Delta, DeltaVisitor, visitDelta } from "../../tree";
 import { brand } from "../../util";
 import { deepFreeze } from "../utils";
@@ -56,7 +57,7 @@ function testTreeVisit(marks: Delta.MarkList, expected: Readonly<VisitScript>): 
 const rootKey: FieldKey = brand("root");
 const fooKey: FieldKey = brand("foo");
 const nodeX = { type: jsonString.name, value: "X" };
-const content = [nodeX];
+const content = [singleTextCursorNew(nodeX)];
 
 describe("visit", () => {
     it("empty delta", () => {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/common-utils";
+import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
@@ -20,6 +20,9 @@ import {
 } from "@fluidframework/test-utils";
 import { InvalidationToken, SimpleObservingDependent } from "../dependency-tracking";
 import { ISharedTree, SharedTreeFactory } from "../shared-tree";
+import { Delta, ITreeCursorSynchronous } from "../tree";
+import { jsonableTreeFromCursorNew } from "../feature-libraries";
+import { fail } from "../util";
 
 // Testing utilities
 
@@ -173,4 +176,47 @@ export function spyOnMethod(methodClass: Function, methodName: string, spy: () =
     return () => {
         prototype[methodName] = method;
     };
+}
+
+/**
+ * Assert two MarkList are equal, handling cursors.
+ */
+export function assertMarkListEqual(a: Delta.MarkList, b: Delta.MarkList): void {
+    assert.deepStrictEqual(uncursorContent(a), uncursorContent(b));
+}
+
+/**
+ * This clones objects, assuming "content" fields are cursors and replaces those with JsonableTrees.
+ * Works for the types in Delta.MarkList, but is not general.
+ */
+function uncursorContent(a: unknown): unknown {
+    if (typeof a !== "object") {
+        return a;
+    }
+    if (Array.isArray(a)) {
+        return a.map(uncursorContent);
+    }
+    if (a instanceof Map) {
+        return new Map([...a].map((k, v) => [k, uncursorContent(v)]));
+    }
+    const copy: Record<string, unknown> = {};
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key in a) {
+        if (Object.prototype.hasOwnProperty.call(a, key)) {
+            const element = (a as Record<string, unknown>)[key];
+            if (key === "content") {
+                const cursor = element as ITreeCursorSynchronous | ITreeCursorSynchronous[];
+                if (Array.isArray(cursor)) {
+                    copy[key] = cursor.map(jsonableTreeFromCursorNew);
+                } else {
+                    copy[key] = jsonableTreeFromCursorNew(cursor);
+                }
+            } else {
+                copy[key] = uncursorContent(element);
+            }
+        } else {
+            fail("unexpected property from prototype");
+        }
+    }
+    return copy;
 }

--- a/packages/dds/tree/src/tree/cursor.ts
+++ b/packages/dds/tree/src/tree/cursor.ts
@@ -4,7 +4,8 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { FieldKey, TreeType, UpPath, Value } from "../tree";
+import { UpPath } from "./pathTree";
+import { FieldKey, TreeType, Value } from "./types";
 
 /**
  * A stateful low-level interface for reading tree data.
@@ -210,7 +211,7 @@ export const enum CursorLocationType {
     Fields,
 }
 
-export interface ITreeCursorSynchronous extends ITreeCursor{
+export interface ITreeCursorSynchronous extends ITreeCursor {
     readonly pending: false;
 }
 

--- a/packages/dds/tree/src/tree/cursor.ts
+++ b/packages/dds/tree/src/tree/cursor.ts
@@ -211,6 +211,9 @@ export const enum CursorLocationType {
     Fields,
 }
 
+/**
+ * {@link ITreeCursor} that is never pending.
+ */
 export interface ITreeCursorSynchronous extends ITreeCursor {
     readonly pending: false;
 }

--- a/packages/dds/tree/src/tree/delta.ts
+++ b/packages/dds/tree/src/tree/delta.ts
@@ -5,8 +5,9 @@
 
 import { unreachableCase } from "@fluidframework/common-utils";
 import { Brand, fail, OffsetListFactory, Opaque } from "../util";
-import { FieldKey, Value } from "./types";
+import { ITreeCursorSynchronous } from "./cursor";
 import { JsonableTree } from "./treeTextFormat";
+import { FieldKey, Value } from "./types";
 
 /**
  * This format describes changes that must be applied to a document tree in order to update it.
@@ -241,6 +242,7 @@ export interface MoveInAndModify {
  */
 export interface Insert {
     type: typeof MarkType.Insert;
+    // TODO: use a single cursor with multiple nodes instead of array of cursors.
     content: ProtoNode[];
 }
 
@@ -255,12 +257,11 @@ export interface InsertAndModify {
 }
 
 /**
- * The contents of a subtree to be created
- * @remarks
- * Delta does not rely on the fact that JsonableTree is serializable.
- * We may use a non-serializable format in the future, but this is the most convenient for now.
+ * The contents of a subtree to be created.
+ *
+ * TODO: eventually we should support "pending" data here via using just `ITreeCursor`.
  */
-export type ProtoNode = JsonableTree;
+export type ProtoNode = ITreeCursorSynchronous;
 
 /**
  * Uniquely identifies a MoveOut/MoveIn pair within a delta.
@@ -325,7 +326,7 @@ export function inputLength(mark: Mark): number {
  *   all modifications are applied by the function.
  */
  export function applyModifyToInsert(
-    node: ProtoNode,
+    node: JsonableTree,
     modify: Modify,
 ): Map<FieldKey, MarkList> {
     const outFieldsMarks: Map<FieldKey, MarkList> = new Map();

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -26,6 +26,14 @@ export * from "./visitDelta";
 export * from "./globalFieldKeySymbol";
 export * from "./mapTree";
 
+export {
+    ITreeCursor as ITreeCursorNew,
+    CursorLocationType,
+    mapCursorField as mapCursorFieldNew,
+    forEachNode,
+    ITreeCursorSynchronous,
+} from "./cursor";
+
 // Split this up into separate import and export for compatibility with API-Extractor.
 import * as Delta from "./delta";
 export { Delta };


### PR DESCRIPTION
## Description

Use the new Cursor API in Delta instead of JsonableTree.

Move the new Cursor API from forest to tree so it can be used in Delta.

Remove exports new TextCursor type.

Use synchronous cursor type where appropriate.
