### PR TITLE
Tree: small cursor tidy up

### DIFF
--- a/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
@@ -32,7 +32,7 @@ const adapter: CursorAdapter<MapTree> = {
 export function mapTreeFromCursor(cursor: ITreeCursor): MapTree {
     assert(cursor.mode === CursorLocationType.Nodes, "must start at node");
     const fields: Map<FieldKey, MapTree[]> = new Map();
-    for (let inField = cursor.firstField(); inField; inField = cursor.nextNode()) {
+    for (let inField = cursor.firstField(); inField; inField = cursor.nextField()) {
         const field: MapTree[] = mapCursorField(cursor, mapTreeFromCursor);
         fields.set(cursor.getFieldKey(), field);
     }

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -5,7 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-    FieldMapObject,
     genericTreeKeys,
     getGenericTreeField,
     JsonableTree,
@@ -13,6 +12,7 @@ import {
     CursorLocationType,
     mapCursorFieldNew as mapCursorField,
     ITreeCursorSynchronous,
+    setGenericTreeField,
 } from "../tree";
 import { CursorAdapter, singleStackTreeCursor } from "./treeCursorUtils";
 
@@ -56,26 +56,16 @@ const adapter: CursorAdapter<JsonableTree> = {
  */
 export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree {
     assert(cursor.mode === CursorLocationType.Nodes, "must start at node");
-    let fields: FieldMapObject<JsonableTree> | undefined;
-    let inField = cursor.firstField();
-    while (inField) {
-        fields ??= {};
-        const field: JsonableTree[] = mapCursorField(cursor, jsonableTreeFromCursor);
-        fields[cursor.getFieldKey() as string] = field;
-        inField = cursor.nextNode();
-    }
-
     const node: JsonableTree = {
         type: cursor.type,
-        value: cursor.value,
-        fields,
     };
     // Normalize object by only including fields that are required.
-    if (fields === undefined) {
-        delete node.fields;
+    if (cursor.value !== undefined) {
+        node.value = cursor.value;
     }
-    if (node.value === undefined) {
-        delete node.value;
+    for (let inFields = cursor.firstField(); inFields; inFields = cursor.nextField()) {
+        const field: JsonableTree[] = mapCursorField(cursor, jsonableTreeFromCursor);
+        setGenericTreeField(node, cursor.getFieldKey(), field);
     }
     return node;
 }

--- a/packages/dds/tree/src/tree/cursor.ts
+++ b/packages/dds/tree/src/tree/cursor.ts
@@ -239,9 +239,7 @@ export function mapCursorField<T>(cursor: ITreeCursor, f: (cursor: ITreeCursor) 
 export function forEachNode(
     cursor: ITreeCursor, f: (cursor: ITreeCursor) => void): void {
     assert(cursor.mode === CursorLocationType.Fields, "should be in fields");
-    let inField = cursor.firstNode();
-    while (inField) {
+    for (let inNodes = cursor.firstNode(); inNodes; inNodes = cursor.nextNode()) {
         f(cursor);
-        inField = cursor.nextField();
     }
 }


### PR DESCRIPTION
## Description

This fixes a couple of calls to the wrong "next" function when iterating, uses the for loop syntax, and avoids use of delete, which seems slower that just not adding the fields.

Also uses existing helper to lazily create `fields` which handles scoping (local vs global) properly.
