### PR TITLE
Hide the debugging article

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -66,8 +66,6 @@ params:
     message: | # if set, this will override the release notes updates
       [Azure Fluid Relay](/docs/deployment/azure-frs/) is now generally available! [Learn more.](https://devblogs.microsoft.com/microsoft365dev/announcing-general-availability-of-azure-fluid-relay-service/)
 
-ignoreFiles:
-- debugging.md$
 menu:
   main:
   - name: "Getting started"

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -66,6 +66,8 @@ params:
     message: | # if set, this will override the release notes updates
       [Azure Fluid Relay](/docs/deployment/azure-frs/) is now generally available! [Learn more.](https://devblogs.microsoft.com/microsoft365dev/announcing-general-availability-of-azure-fluid-relay-service/)
 
+ignoreFiles:
+- debugging.md$
 menu:
   main:
   - name: "Getting started"

--- a/docs/content/docs/testing/debugging.md
+++ b/docs/content/docs/testing/debugging.md
@@ -2,6 +2,7 @@
 title: Debugging
 menuPosition: 4
 status: unwritten
+draft: true
 ---
 
 ## How to test your application


### PR DESCRIPTION
Fixes https://dev.azure.com/fluidframework/internal/_workitems/edit/1190

It should no longer appear in the Table of Contents (under the Testing folder)

