### PR TITLE
Auto start root datastore for gc sweep test

### DIFF
--- a/packages/test/test-gc-sweep-tests/package.json
+++ b/packages/test/test-gc-sweep-tests/package.json
@@ -24,11 +24,11 @@
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
-    "test": "npm run test:mocha-not-in-ci",
+    "test": "npm run test:mocha-not-in-ci:verbose",
     "test:build": "npm run build && npm run test:mocha-not-in-ci",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "test:mocha-not-in-ci": "mocha --ignore 'dist/test/types/*' --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
-    "test:mocha-not-in-ci:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
+    "test:mocha-not-in-ci:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha-not-in-ci",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"
   },

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithChildDataObject.ts
@@ -10,7 +10,7 @@ import { DataObjectWithCounter, dataObjectWithCounterFactory } from "./dataObjec
 
 export class RootDataObjectWithChildDataObject extends DataObjectWithCounter {
     private child?: DataObjectWithCounter;
-    private readonly count = 100;
+    private readonly opsToWait = 1000;
     private get childKey(): string {
         assert(this.context.clientId !== undefined, `client id needs to be defined to retrieve the child key!`);
         return `childKey:${this.context.clientId}`;
@@ -42,8 +42,7 @@ export class RootDataObjectWithChildDataObject extends DataObjectWithCounter {
         assert(this.isRunning === true, "Should be running to send ops");
         while (this.isRunning && !this.disposed) {
             let opsPerformed = 0;
-            while (opsPerformed < this.count && this.isRunning && !this.disposed) {
-                // This count is shared across dataObjects so this should reach clients * datastores * count
+            while (opsPerformed < this.opsToWait && this.isRunning && !this.disposed) {
                 super.sendOp();
                 // This data is local and allows us to understand the number of changes a local client has created
                 opsPerformed++;

--- a/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
+++ b/packages/test/test-gc-sweep-tests/src/dataObjectWithCounter.ts
@@ -16,13 +16,13 @@ import { SharedCounter } from "@fluidframework/counter";
 const counterKey = "counter";
 export class DataObjectWithCounter extends DataObject {
     private _counter?: SharedCounter;
-    public isRunning: boolean = false;
+    protected isRunning: boolean = false;
     protected readonly delayPerOpMs = 100;
     public static get type(): string {
         return "DataObjectWithCounter";
     }
 
-    public get counter(): SharedCounter {
+    protected get counter(): SharedCounter {
         assert(this._counter !== undefined, "Need counter to be defined before retreiving!");
         return this._counter;
     }
@@ -35,11 +35,6 @@ export class DataObjectWithCounter extends DataObject {
         const handle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
         assert(handle !== undefined, `The counter handle should exist on initialization!`);
         this._counter = await handle.get();
-    }
-
-    protected sendOp() {
-        assert(this.counter !== undefined, "Can't send ops when the counter isn't initialized!");
-        assert(this.isRunning === true, `The DataObject should be running in order to generate ops!`);
     }
 
     public stop() {

--- a/packages/test/test-gc-sweep-tests/src/test/autoRunTest.spec.ts
+++ b/packages/test/test-gc-sweep-tests/src/test/autoRunTest.spec.ts
@@ -1,0 +1,105 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable max-len */
+import { assert } from "console";
+import {
+    ContainerRuntimeFactoryWithDefaultDataStore,
+} from "@fluidframework/aqueduct";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
+import {
+    DefaultSummaryConfiguration,
+    IContainerRuntimeOptions,
+    ISummaryConfigurationHeuristics,
+} from "@fluidframework/container-runtime";
+import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { makeRandom } from "@fluid-internal/stochastic-test-utils";
+import { delay } from "@fluidframework/common-utils";
+import { mockConfigProvider } from "../mockConfigProvider";
+import { IgnoreErrorLogger } from "../ignoreErrorLogger";
+import { ContainerManager } from "../containerManager";
+import { rootDataObjectWithChildDataObjectFactory } from "../dataObjectWithChildDataObject";
+import { dataObjectWithCounterFactory } from "../dataObjectWithCounter";
+
+describeNoCompat("GC InactiveObjectX tests", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+
+    const summaryOptions = DefaultSummaryConfiguration as ISummaryConfigurationHeuristics;
+    summaryOptions.summarizerClientElection = true;
+    // Summaries should run automatically
+    const runtimeOptions: IContainerRuntimeOptions = {
+        summaryOptions,
+        gcOptions: {
+            gcAllowed: true,
+        },
+    };
+    const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+        runtime.IFluidHandleContext.resolveHandle(request);
+    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+        rootDataObjectWithChildDataObjectFactory,
+        [
+            [rootDataObjectWithChildDataObjectFactory.type, Promise.resolve(rootDataObjectWithChildDataObjectFactory)],
+            [dataObjectWithCounterFactory.type, Promise.resolve(dataObjectWithCounterFactory)],
+        ],
+        undefined,
+        [innerRequestHandler],
+        runtimeOptions,
+    );
+
+    // const sessionExpiryDurationMs = 3000; // 3 seconds
+    const inactiveTimeoutMs = 10 * 1000; // 10 seconds
+
+    // Set settings here, may be useful to put everything in the mockConfigProvider
+    const settings = {
+        // "Fluid.GarbageCollection.RunSessionExpiry": "true",
+        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": inactiveTimeoutMs,
+        // "Fluid.GarbageCollection.TestOverride.SessionExpiryMs": sessionExpiryDurationMs,
+    };
+    const configProvider = mockConfigProvider(settings);
+
+    let overrideLogger: IgnoreErrorLogger;
+
+    // Test timeout
+    const testTimeout = 5 * 60 * 1000; // 5 minutes
+
+    // Currently for GC Sweep testing only, run with npm run test. Should not be running in CI
+    // Note: can run with npm run test:build to build and run the test
+    // TODO: have this configurable via mocha cmd arguments
+    // TODO: setup test to run in CI
+    const numberOfTests = 1;
+    for (let i = 0; i < numberOfTests; i++) {
+        const seed = Math.random();
+        const liveContainers = 10;
+        const random = makeRandom();
+        it(`GC Ops Test with Seed: ${seed}, Containers: ${liveContainers}`, async () => {
+            provider = getTestObjectProvider({
+                syncSummarizer: true,
+            });
+
+            // Wrap the logger
+            overrideLogger = new IgnoreErrorLogger(provider.logger);
+            provider.logger = overrideLogger;
+
+            // Create the containerManager responsible for retrieving, creating, loading, and tracking the lifetime of containers.
+            const containerManager = new ContainerManager(runtimeFactory, configProvider, provider);
+            await containerManager.createContainer();
+            const testStart = Date.now();
+            while (Date.now() - testStart < testTimeout) {
+                if (containerManager.connectedContainerCount < liveContainers) {
+                    await containerManager.loadContainer();
+                } else {
+                    containerManager.closeRandomContainer(random);
+                }
+                await delay(inactiveTimeoutMs);
+            }
+
+            overrideLogger.logEvents(seed);
+            assert(overrideLogger.inactiveObjectEvents.length === 0, `InactiveObject events occurred - look at nyc/testData-${seed}/inactiveObjectEvents.json`);
+            assert(overrideLogger.errorEvents.length === 0, `Error events occurred - look at nyc/testData-${seed}/errorEvents.json`);
+        }).timeout(testTimeout + 40 * 1000);
+    }
+});

--- a/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
+++ b/packages/test/test-gc-sweep-tests/src/test/gcSweepTest.spec.ts
@@ -36,7 +36,7 @@ interface ITestAction {
     [key: string]: any;
 }
 
-describeNoCompat("GC Sweep tests", (getTestObjectProvider) => {
+describeNoCompat.skip("GC Sweep tests", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
 
     // Summaries should run automatically


### PR DESCRIPTION
Part of [AB#1847](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1847) and [AB#1837](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1837)

As a part of https://github.com/microsoft/FluidFramework/pull/11928/files#

The `RootDataObjectWithChildDataObject` should be generating ops and then referencing and unreferencing its child datastore as soon as it is initialized. This should repeat until the container closes, or the test ends.