### PR TITLE
Handle cluster expansion case in IdCompressor

### DIFF
--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -632,7 +632,7 @@ export class IdCompressor {
 						// than fit in the expanded cluster, this will be the last final in the cluster
 						const newLastFinal = (newLastFinalizedFinal +
 							Math.min(newLastFinalizedLocal - lastLocal, this.newClusterCapacity)) as FinalCompressedId;
-						assert(newLastFinal >= newLastFinalizedFinal);
+						assert(newLastFinal >= newLastFinalizedFinal, 'The number of unfinalized locals should only be positive');
 						const finalPivot = (newLastFinalizedFinal - overflow + 1) as FinalCompressedId;
 						// Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
 						// that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -612,16 +612,28 @@ export class IdCompressor {
 						// Example with cluster size of 3:
 						// Ids generated so far:   -1  1  2 -4 -5  <-- note positive numbers are eager finals
 						//         Cluster:      [  0  1  2 ]
-						// ~ finalizing happens, causing expansion ~
-						//        Cluster:       [  0  1  2  3  4  5 ]
-						// corresponding locals:   -1       -4
-						//      lastFinalizedLocalId^              ^newLastFinalizedLocalId = -6
+						// ~ finalizing happens, causing expansion of 2 (overflow) + 3 (cluster capacity) ~
+						//        Cluster:       [  0  1  2  3  4  _  _  _ ]
+						// corresponding locals:   -1       -4 -5
+						//      lastFinalizedLocalId^           ^newLastFinalizedLocalId = -5
 						//                  overflow = 2:    ----
 						//                       localIdPivot^
 						//                    lastFinalizedFinal^
-						const lastFinalizedFinal = (currentBaseFinalId + currentCluster.count - 1) as FinalCompressedId;
-						const finalPivot = (lastFinalizedFinal - overflow + 1) as FinalCompressedId;
-						this.sessionIdNormalizer.addFinalIds(finalPivot, lastFinalizedFinal, currentCluster);
+						const newLastFinalizedFinal = (currentBaseFinalId + currentCluster.count - 1) as FinalCompressedId;
+                        assert(session.lastFinalizedLocalId !== undefined, 'Cluster already exists for session but there is no finalized local ID');
+                        const newLastFinalizedLocal = (session.lastFinalizedLocalId - finalizeCount);
+                        const lastLocal = -this.localIdCount;
+                        // Calculate the last final in the cluster that aligns with an existing local. If there are more unfinalized locals
+                        // than fit in the expanded cluster, this will be the last final in the cluster
+                        const newLastFinal = newLastFinalizedFinal + Math.min(newLastFinalizedLocal - lastLocal, this.newClusterCapacity) as FinalCompressedId;
+                        assert(newLastFinal >= newLastFinalizedFinal);
+						const finalPivot = (newLastFinalizedFinal - overflow + 1) as FinalCompressedId;
+                        // Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
+                        // that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.
+                        // It is safe to associate the unfinalized locals with their future final IDs even before the ranges for those locals are
+                        // actually finalized, because total order broadcast guarantees that any usage of those final IDs will be observed after
+                        // the finalization of the ranges.
+						this.sessionIdNormalizer.addFinalIds(finalPivot, newLastFinal, currentCluster);
 						this.logger?.sendTelemetryEvent({
 							eventName: 'IdCompressor:ClusterExpansion',
 							sessionId: this.localSessionId,

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -619,20 +619,26 @@ export class IdCompressor {
 						//                  overflow = 2:    ----
 						//                       localIdPivot^
 						//                    lastFinalizedFinal^
-						const newLastFinalizedFinal = (currentBaseFinalId + currentCluster.count - 1) as FinalCompressedId;
-                        assert(session.lastFinalizedLocalId !== undefined, 'Cluster already exists for session but there is no finalized local ID');
-                        const newLastFinalizedLocal = (session.lastFinalizedLocalId - finalizeCount);
-                        const lastLocal = -this.localIdCount;
-                        // Calculate the last final in the cluster that aligns with an existing local. If there are more unfinalized locals
-                        // than fit in the expanded cluster, this will be the last final in the cluster
-                        const newLastFinal = newLastFinalizedFinal + Math.min(newLastFinalizedLocal - lastLocal, this.newClusterCapacity) as FinalCompressedId;
-                        assert(newLastFinal >= newLastFinalizedFinal);
+						const newLastFinalizedFinal = (currentBaseFinalId +
+							currentCluster.count -
+							1) as FinalCompressedId;
+						assert(
+							session.lastFinalizedLocalId !== undefined,
+							'Cluster already exists for session but there is no finalized local ID'
+						);
+						const newLastFinalizedLocal = session.lastFinalizedLocalId - finalizeCount;
+						const lastLocal = -this.localIdCount;
+						// Calculate the last final in the cluster that aligns with an existing local. If there are more unfinalized locals
+						// than fit in the expanded cluster, this will be the last final in the cluster
+						const newLastFinal = (newLastFinalizedFinal +
+							Math.min(newLastFinalizedLocal - lastLocal, this.newClusterCapacity)) as FinalCompressedId;
+						assert(newLastFinal >= newLastFinalizedFinal);
 						const finalPivot = (newLastFinalizedFinal - overflow + 1) as FinalCompressedId;
-                        // Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
-                        // that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.
-                        // It is safe to associate the unfinalized locals with their future final IDs even before the ranges for those locals are
-                        // actually finalized, because total order broadcast guarantees that any usage of those final IDs will be observed after
-                        // the finalization of the ranges.
+						// Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
+						// that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.
+						// It is safe to associate the unfinalized locals with their future final IDs even before the ranges for those locals are
+						// actually finalized, because total order broadcast guarantees that any usage of those final IDs will be observed after
+						// the finalization of the ranges.
 						this.sessionIdNormalizer.addFinalIds(finalPivot, newLastFinal, currentCluster);
 						this.logger?.sendTelemetryEvent({
 							eventName: 'IdCompressor:ClusterExpansion',

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -632,7 +632,10 @@ export class IdCompressor {
 						// than fit in the expanded cluster, this will be the last final in the cluster
 						const newLastFinal = (newLastFinalizedFinal +
 							Math.min(newLastFinalizedLocal - lastLocal, this.newClusterCapacity)) as FinalCompressedId;
-						assert(newLastFinal >= newLastFinalizedFinal, 'The number of unfinalized locals should only be positive');
+						assert(
+							newLastFinal >= newLastFinalizedFinal,
+							'The number of unfinalized locals should only be positive'
+						);
 						const finalPivot = (newLastFinalizedFinal - overflow + 1) as FinalCompressedId;
 						// Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
 						// that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.

--- a/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
+++ b/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
@@ -113,8 +113,8 @@ export class SessionIdNormalizer<TRangeObject> {
 	}
 
 	/**
-	 * Returns the index of the supplied session-space ID in the total range of IDs created by the session, if the ID was created
-	 * by the session for this `SessionIdNormalizer`.
+	 * Returns the index of the local ID corresponding to the supplied final ID in the total range of IDs created by the session,
+     * if the ID was created by the session for this `SessionIdNormalizer`.
 	 */
 	public getCreationIndex(finalId: FinalCompressedId): number | undefined {
 		const localRange = this.idRanges.getPairOrNextLowerByValue(finalId);

--- a/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
+++ b/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
@@ -114,7 +114,7 @@ export class SessionIdNormalizer<TRangeObject> {
 
 	/**
 	 * Returns the index of the local ID corresponding to the supplied final ID in the total range of IDs created by the session,
-     * if the ID was created by the session for this `SessionIdNormalizer`.
+	 * if the ID was created by the session for this `SessionIdNormalizer`.
 	 */
 	public getCreationIndex(finalId: FinalCompressedId): number | undefined {
 		const localRange = this.idRanges.getPairOrNextLowerByValue(finalId);

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -1256,6 +1256,37 @@ describe('IdCompressor', () => {
 				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
 				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
 			});
+
+            it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
+				const compressor = createCompressor(Client.Client1, 2);
+
+                // Before cluster expansion
+                expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+                const rangeA = compressor.takeNextCreationRange();
+                compressor.finalizeCreationRange(rangeA);
+                expect(isFinalId(compressor.generateCompressedId())).to.be.true;
+
+                // After cluster expansion
+                expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+                const rangeB = compressor.takeNextCreationRange();
+                const localId = compressor.generateCompressedId();
+                expect(isLocalId(localId)).to.be.true;
+
+                // Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
+                const rangeC = compressor.takeNextCreationRange();
+
+                compressor.finalizeCreationRange(rangeB);
+                const eagerId = compressor.generateCompressedId();
+                expect(isFinalId(eagerId)).to.be.true;
+
+                expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+                expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+
+                compressor.finalizeCreationRange(rangeC);
+
+                expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+                expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+            });
 		});
 
 		describe('Finalizing', () => {

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -1257,36 +1257,36 @@ describe('IdCompressor', () => {
 				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
 			});
 
-            it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
+			it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
 				const compressor = createCompressor(Client.Client1, 2);
 
-                // Before cluster expansion
-                expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-                const rangeA = compressor.takeNextCreationRange();
-                compressor.finalizeCreationRange(rangeA);
-                expect(isFinalId(compressor.generateCompressedId())).to.be.true;
+				// Before cluster expansion
+				expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+				const rangeA = compressor.takeNextCreationRange();
+				compressor.finalizeCreationRange(rangeA);
+				expect(isFinalId(compressor.generateCompressedId())).to.be.true;
 
-                // After cluster expansion
-                expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-                const rangeB = compressor.takeNextCreationRange();
-                const localId = compressor.generateCompressedId();
-                expect(isLocalId(localId)).to.be.true;
+				// After cluster expansion
+				expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+				const rangeB = compressor.takeNextCreationRange();
+				const localId = compressor.generateCompressedId();
+				expect(isLocalId(localId)).to.be.true;
 
-                // Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
-                const rangeC = compressor.takeNextCreationRange();
+				// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
+				const rangeC = compressor.takeNextCreationRange();
 
-                compressor.finalizeCreationRange(rangeB);
-                const eagerId = compressor.generateCompressedId();
-                expect(isFinalId(eagerId)).to.be.true;
+				compressor.finalizeCreationRange(rangeB);
+				const eagerId = compressor.generateCompressedId();
+				expect(isFinalId(eagerId)).to.be.true;
 
-                expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-                expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+				expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+				expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
 
-                compressor.finalizeCreationRange(rangeC);
+				compressor.finalizeCreationRange(rangeC);
 
-                expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-                expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
-            });
+				expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+				expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+			});
 		});
 
 		describe('Finalizing', () => {


### PR DESCRIPTION
This fixes a bug in which a client of the IdCompressor would receive incorrect (specifically, duplicate) IDs after decompression. The compressor did not properly update the session normalizer to account for outstanding local IDs (i.e. local IDs that had not yet been finalized) when performing the cluster expansion operation.