### PR TITLE
Azure client telemetry

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -57,6 +57,7 @@
     "@fluidframework/routerlicious-driver": "^1.0.1",
     "@fluidframework/runtime-utils": "^1.0.1",
     "@fluidframework/server-services-client": "^0.1037.1000-0",
+    "@fluidframework/telemetry-utils": "^1.0.1",
     "axios": "^0.26.0",
     "uuid": "^8.3.1"
   },

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -187,6 +187,7 @@ export class AzureClient {
             azClientLogger,
             { eventName: "GetContainer", docId: id },
             async () => {
+                // Create doc url
                 const url = new URL(this.props.connection.endpoint);
                 url.searchParams.append(
                     "storage",
@@ -197,12 +198,15 @@ export class AzureClient {
                     encodeURIComponent(getTenantId(this.props.connection)),
                 );
                 url.searchParams.append("containerId", encodeURIComponent(id));
+
+                // Resolve fluid container
                 const container = await loader.resolve({ url: url.href });
                 const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
                 const fluidContainer = new FluidContainer(container, rootDataObject);
-                const services = this.getContainerServices(container);
-                throw new Error("Unable to resolved URL1");
-                return { container: fluidContainer, services };
+                return {
+                    container: fluidContainer,
+                    services: this.getContainerServices(container),
+                };
             },
         );
     }

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -121,20 +121,16 @@ export class AzureClient {
         const loader = this.createLoader(containerSchema);
         const azClientLogger = this.createLogger(loader);
 
+        // Create doc url
+        const url = new URL(this.props.connection.endpoint);
+        url.searchParams.append("storage", encodeURIComponent(this.props.connection.endpoint));
+        url.searchParams.append("tenantId", encodeURIComponent(getTenantId(this.props.connection)));
+        url.searchParams.append("containerId", encodeURIComponent(id));
+
         return PerformanceEvent.timedExecAsync(
             azClientLogger,
             { eventName: "ContainerCopy" },
             async () => {
-                const url = new URL(this.props.connection.endpoint);
-                url.searchParams.append(
-                    "storage",
-                    encodeURIComponent(this.props.connection.endpoint),
-                );
-                url.searchParams.append(
-                    "tenantId",
-                    encodeURIComponent(getTenantId(this.props.connection)),
-                );
-                url.searchParams.append("containerId", encodeURIComponent(id));
                 const sourceContainer = await loader.resolve({ url: url.href });
 
                 if (sourceContainer.resolvedUrl === undefined) {
@@ -183,23 +179,17 @@ export class AzureClient {
         const loader = this.createLoader(containerSchema);
         const azClientLogger = this.createLogger(loader);
 
+        // Create doc url
+        const url = new URL(this.props.connection.endpoint);
+        url.searchParams.append("storage", encodeURIComponent(this.props.connection.endpoint));
+        url.searchParams.append("tenantId", encodeURIComponent(getTenantId(this.props.connection)));
+        url.searchParams.append("containerId", encodeURIComponent(id));
+
         return PerformanceEvent.timedExecAsync(
             azClientLogger,
             { eventName: "GetContainer", docId: id },
             async () => {
-                // Create doc url
-                const url = new URL(this.props.connection.endpoint);
-                url.searchParams.append(
-                    "storage",
-                    encodeURIComponent(this.props.connection.endpoint),
-                );
-                url.searchParams.append(
-                    "tenantId",
-                    encodeURIComponent(getTenantId(this.props.connection)),
-                );
-                url.searchParams.append("containerId", encodeURIComponent(id));
-
-                // Resolve fluid container
+                // Resolve Fluid container
                 const container = await loader.resolve({ url: url.href });
                 const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
                 const fluidContainer = new FluidContainer(container, rootDataObject);


### PR DESCRIPTION
Adding some basic azure-client perf telemetry. When azure-client users look at FF telemetry (https://fluidframework.com/docs/testing/telemetry/) they should be able to quickly understand/filter telemetry around concepts & API surface they are familiar with: azure-client, fluid container, audience etc. With this PR we are adding azure-client telemetry under “AzureClient” namespace. No explicit opt-in is required.
 
Follow up items:
-       Documenting useful telemetry (error types etc) and linking that to specific actions.
-       FluidContainer telemetry (we need to surface errors on IFluidContainer, at the same time)
 
We still need to explore how we can make telemetry more effective or useful for partners, service developers etc. For example, service partners may want to run stress/perf scenario and look at our telemetry for service level indicators. Those “usefulness” explorations we can run through custom loggers (for now) that know how to make sense of existing telemetry and deliver relevant/friendly data points. After that round of research, will have more clarity what feature work is needed for further telemetry improvements.