### PR TITLE
Update default policy for table links to signature item kinds to display more useful information

### DIFF
--- a/tools/api-markdown-documenter/src/Policies.ts
+++ b/tools/api-markdown-documenter/src/Policies.ts
@@ -3,7 +3,13 @@
  * Licensed under the MIT License.
  */
 import { Utilities } from "@microsoft/api-documenter/lib/utils/Utilities";
-import { ApiDeclaredItem, ApiItem, ApiItemKind, ApiPackage } from "@microsoft/api-extractor-model";
+import {
+    ApiDeclaredItem,
+    ApiItem,
+    ApiItemKind,
+    ApiPackage,
+    Excerpt,
+} from "@microsoft/api-extractor-model";
 
 import { ApiMemberKind, getQualifiedApiItemName, getUnscopedPackageName } from "./utilities";
 
@@ -216,7 +222,6 @@ export namespace DefaultPolicies {
      * - Interface
      *
      * - Namespace
-     *
      */
     export const defaultDocumentBoundaries: ApiMemberKind[] = [
         ApiItemKind.Class,
@@ -279,14 +284,7 @@ export namespace DefaultPolicies {
                 // For signature items, the display-name is not particularly useful information
                 // ("(constructor)", "(call)", etc.).
                 // Instead, we will use a cleaned up variation on the type signature.
-                // Regex replaces line breaks with spaces to ensure everything ends up on a single line.
-                let signatureExcerpt = (apiItem as ApiDeclaredItem).excerpt.text
-                    .trim()
-                    .replace(/[\r\n\s]+/g, " ");
-                if (signatureExcerpt.endsWith(";")) {
-                    signatureExcerpt = signatureExcerpt.slice(0, signatureExcerpt.length - 1);
-                }
-                return signatureExcerpt;
+                return getSingleLineExcerptText((apiItem as ApiDeclaredItem).excerpt);
             default:
                 return apiItem.displayName;
         }
@@ -301,6 +299,13 @@ export namespace DefaultPolicies {
         switch (apiItem.kind) {
             case ApiItemKind.Model:
                 return "Packages";
+            case ApiItemKind.CallSignature:
+            case ApiItemKind.ConstructSignature:
+            case ApiItemKind.IndexSignature:
+                // For signature items, the display-name is not particularly useful information
+                // ("(constructor)", "(call)", etc.).
+                // Instead, we will use a cleaned up variation on the type signature.
+                return getSingleLineExcerptText((apiItem as ApiDeclaredItem).excerpt);
             default:
                 return Utilities.getConciseSignature(apiItem);
         }
@@ -331,3 +336,14 @@ export const defaultPolicyOptions: Required<PolicyOptions> = {
     packageFilterPolicy: DefaultPolicies.defaultPackageFilterPolicy,
     emptyTableCellText: "",
 };
+
+function getSingleLineExcerptText(excerpt: Excerpt): string {
+    // Regex replaces line breaks with spaces to ensure everything ends up on a single line.
+    let signatureExcerpt = excerpt.text.trim().replace(/[\r\n\s]+/g, " ");
+
+    if (signatureExcerpt.endsWith(";")) {
+        signatureExcerpt = signatureExcerpt.slice(0, signatureExcerpt.length - 1);
+    }
+
+    return signatureExcerpt;
+}

--- a/tools/api-markdown-documenter/src/Policies.ts
+++ b/tools/api-markdown-documenter/src/Policies.ts
@@ -337,6 +337,12 @@ export const defaultPolicyOptions: Required<PolicyOptions> = {
     emptyTableCellText: "",
 };
 
+/**
+ * Extracts the text from the provided excerpt and adjusts it to be on a single line, and to omit any trailing `;`.
+ *
+ * @privateRemarks If we find that this is useful in more places, we might consider moving this to a
+ * public utilities module and make it part of the public helper suite.
+ */
 function getSingleLineExcerptText(excerpt: Excerpt): string {
     // Regex replaces line breaks with spaces to ensure everything ends up on a single line.
     let signatureExcerpt = excerpt.text.trim().replace(/[\r\n\s]+/g, " ");

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
@@ -18,7 +18,7 @@ Here are some remarks about the interface
 
 |  ConstructSignature | Return Type | Description |
 |  --- | --- | --- |
-|  [(new)()](./simple-suite-test/testinterface-interface#_new_-constructsignature) | [TestInterface](./simple-suite-test/testinterface-interface) | Test construct signature. |
+|  [new (): TestInterface](./simple-suite-test/testinterface-interface#_new_-constructsignature) | [TestInterface](./simple-suite-test/testinterface-interface) | Test construct signature. |
 
 ## Events
 
@@ -43,8 +43,8 @@ Here are some remarks about the interface
 
 |  CallSignature | Description |
 |  --- | --- |
-|  [(call)(event, listener)](./simple-suite-test/testinterface-interface#_call_-callsignature) | Test interface event call signature |
-|  [(call)(event, listener)](./simple-suite-test/testinterface-interface#_call__1-callsignature) | Another example call signature |
+|  [(event: 'testCallSignature', listener: (input: unknown) => void): any](./simple-suite-test/testinterface-interface#_call_-callsignature) | Test interface event call signature |
+|  [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](./simple-suite-test/testinterface-interface#_call__1-callsignature) | Another example call signature |
 
 ## Construct Signature Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/default-config/simple-suite-test/testinterfacewithindexsignature-interface.md
@@ -14,7 +14,7 @@ export interface TestInterfaceWithIndexSignature
 
 |  IndexSignature | Description |
 |  --- | --- |
-|  [(indexer)(foo)](./simple-suite-test/testinterfacewithindexsignature-interface#_indexer_-indexsignature) | Test index signature. |
+|  [[foo: number]: { bar: string; }](./simple-suite-test/testinterfacewithindexsignature-interface#_indexer_-indexsignature) | Test index signature. |
 
 ## Index Signature Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/flat-config/simple-suite-test.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/flat-config/simple-suite-test.md
@@ -121,7 +121,7 @@ Here are some remarks about the interface
 
 |  ConstructSignature | Return Type | Description |
 |  --- | --- | --- |
-|  [(new)()](docs/simple-suite-test#testinterface-_new_-constructsignature) | [TestInterface](docs/simple-suite-test#testinterface-interface) | Test construct signature. |
+|  [new (): TestInterface](docs/simple-suite-test#testinterface-_new_-constructsignature) | [TestInterface](docs/simple-suite-test#testinterface-interface) | Test construct signature. |
 
 #### Events
 
@@ -146,8 +146,8 @@ Here are some remarks about the interface
 
 |  CallSignature | Description |
 |  --- | --- |
-|  [(call)(event, listener)](docs/simple-suite-test#testinterface-_call_-callsignature) | Test interface event call signature |
-|  [(call)(event, listener)](docs/simple-suite-test#testinterface-_call__1-callsignature) | Another example call signature |
+|  [(event: 'testCallSignature', listener: (input: unknown) => void): any](docs/simple-suite-test#testinterface-_call_-callsignature) | Test interface event call signature |
+|  [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](docs/simple-suite-test#testinterface-_call__1-callsignature) | Another example call signature |
 
 #### Construct Signature Details
 
@@ -334,7 +334,7 @@ export interface TestInterfaceWithIndexSignature
 
 |  IndexSignature | Description |
 |  --- | --- |
-|  [(indexer)(foo)](docs/simple-suite-test#testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |
+|  [[foo: number]: { bar: string; }](docs/simple-suite-test#testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |
 
 #### Index Signature Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/sparse-config/simple-suite-test/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/sparse-config/simple-suite-test/testinterface-interface.md
@@ -16,7 +16,7 @@ Here are some remarks about the interface
 
 |  ConstructSignature | Return Type | Description |
 |  --- | --- | --- |
-|  [(new)()](docs/simple-suite-test/testinterface-_new_-constructsignature) | [TestInterface](docs/simple-suite-test/testinterface-interface) | Test construct signature. |
+|  [new (): TestInterface](docs/simple-suite-test/testinterface-_new_-constructsignature) | [TestInterface](docs/simple-suite-test/testinterface-interface) | Test construct signature. |
 
 ## Events
 
@@ -41,8 +41,8 @@ Here are some remarks about the interface
 
 |  CallSignature | Description |
 |  --- | --- |
-|  [(call)(event, listener)](docs/simple-suite-test/testinterface-_call_-callsignature) | Test interface event call signature |
-|  [(call)(event, listener)](docs/simple-suite-test/testinterface-_call__1-callsignature) | Another example call signature |
+|  [(event: 'testCallSignature', listener: (input: unknown) => void): any](docs/simple-suite-test/testinterface-_call_-callsignature) | Test interface event call signature |
+|  [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](docs/simple-suite-test/testinterface-_call__1-callsignature) | Another example call signature |
 
 ## See also {#testinterface-see-also}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/sparse-config/simple-suite-test/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/simple-suite-test/sparse-config/simple-suite-test/testinterfacewithindexsignature-interface.md
@@ -12,4 +12,4 @@ export interface TestInterfaceWithIndexSignature
 
 |  IndexSignature | Description |
 |  --- | --- |
-|  [(indexer)(foo)](docs/simple-suite-test/testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |
+|  [[foo: number]: { bar: string; }](docs/simple-suite-test/testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |


### PR DESCRIPTION
Updates default policy link text rendering to display the actual signature of the items, rather than the current display text, which is not particularly useful. 

See the updated test assets for examples.

Also see [here](https://fluidframework.com/docs/apis/fluid-static/ifluidcontainerevents-interface/#call-signatures) for an example on fluidframework.com of the current rendering.