### PR TITLE
Various fixes to dice roller tutorial

### DIFF
--- a/docs/content/docs/start/tutorial.md
+++ b/docs/content/docs/start/tutorial.md
@@ -32,16 +32,22 @@ Lastly, `root` defines the HTML element that the Dice will render on.
 import { SharedMap } from "fluid-framework";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 
+export const diceValueKey = "dice-value-key";
+
 const client = new TinyliciousClient();
 
 const containerSchema = {
       initialObjects: { diceMap: SharedMap }
   };
 
-const root = document.getElementById("root")
+const root = document.getElementById("content");
 ```
 
-\* To create a Fluid application that can be deployed to Azure, check out the [Azure Fluid Relay]({{< relref "azure-frs.md" >}}).
+{{< callout note >}}
+
+To create a Fluid application that can be deployed to Azure, check out the [Azure Fluid Relay]({{< relref "azure-frs.md" >}}).
+
+{{< /callout >}}
 
 ## Create a Fluid container
 
@@ -51,16 +57,18 @@ Fluid data is stored within containers, and these containers need to be created 
 
 The creation section of the application starts with calling `createContainer` and passing in a schema defining which shared objects will be available on the new `container`. After a new container is created, default data can be set on the shared objects before the container is attached to the Tinylicious service.
 
-The attach call returns the `id` of the container, which the app can later use to load this container. Once attached, any further changes to the shared objects, made by the rendered app, will be communicated to all collaborators.
+The `attach` call publishes the container to the Tinylicious service and returns the `id` of the container, which the app can use to load this container on other clients (or this client in a future session). Once attached, any further changes to the shared objects, made by the rendered app, will be communicated to all collaborators.
+
+The `renderDiceRoller` function is created in a later step. It renders the UI of the app on the local client. 
 
 ```js
 const createNewDice = async () => {
     const { container } = await client.createContainer(containerSchema);
     // Set default data
-    container.initialObjects.diceMap.set("dice-value-key", 1);
+    container.initialObjects.diceMap.set(diceValueKey, 1);
     // Attach container to service and return assigned ID
     const id = container.attach();
-    // load the dice roller
+    // Load the dice roller
     renderDiceRoller(container.initialObjects.diceMap, root);
     return id;
   }
@@ -80,12 +88,14 @@ const loadExistingDice = async (id) => {
 
 ### Switching between loading and creating
 
-The application supports both creating a new container and loading an existing container using its `id`.
-To control which state the app is in, this sample app stores the container ID in the URL hash.
+The app supports both creating a new container and loading an existing container using its `id`.
+But, the app needs to know whether the container already exists. There are many ways of
+determining this. 
+This sample app stores the container ID in the URL hash.
 If the URL has a hash, the app will load that existing container.
 Otherwise, the app creates a new container, attaches it, and sets the returned `id` as the hash.
 
-Because both the `getContainer` and `createContainer` methods are async, the `start` function needs to be created and then called, catching any errors that are returned.
+The decision logic is implemented in a `start` function which is immediately called, catching any errors that are returned.
 
 ```js
 async function start() {
@@ -96,77 +106,89 @@ async function start() {
     location.hash = id;
   }
 }
-start().catch((error) => console.error(error));
 
+start().catch((error) => console.error(error));
 ```
 
 ## Write the dice view
 
-The Fluid Framework is view framework agnostic and works well with React, Vue, Angular and web components. This example uses standard HTML/DOM methods to render a view. You can see examples of the previously mentioned frameworks in the [FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/multi-framework-diceroller).
+The Fluid Framework is agnostic about view frameworks and it works well with React, Vue, Angular and web components. This example uses standard HTML/DOM methods to render a view. You can see examples of the previously mentioned frameworks in the [FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/multi-framework-diceroller).
 
-### Start with a static view
+The `renderDiceRoller` function runs only when the container is created or loaded. It appends the `diceTemplate` to the passed in HTML element, and creates a working dice roller with a random dice value each time the "Roll" button is clicked on a client. 
 
-It is simplest to create the view using local data without Fluid, then add Fluid by changing some key pieces of the app. This tutorial uses this approach.
-
-The `renderDiceRoller` function appends the `diceTemplate` to the passed in HTML element, and creates a working dice roller with a random dice value each time the "Roll" button is clicked. The `diceMap` will be used in the next few steps.
 
 ```js
 const diceTemplate = document.createElement("template");
 
 diceTemplate.innerHTML = `
+  <style>
+    .wrapper { text-align: center }
+    .dice { font-size: 200px }
+    .roll { font-size: 50px;}
+  </style>
   <div class="wrapper">
     <div class="dice"></div>
     <button class="roll"> Roll </button>
   </div>
 `
-function renderDiceRoller(diceMap, elem) {
-    elem.appendChild(diceTemplate.content.cloneNode(true));
+const renderDiceRoller = (diceMap, elem) => {
+    elem.appendChild(template.content.cloneNode(true));
+
     const rollButton = elem.querySelector(".roll");
     const dice = elem.querySelector(".dice");
 
-    rollButton.onclick = () => updateDice(Math.floor(Math.random() * 6)+1);
-
-    const updateDice = (value) => {
-        // Unicode 0x2680-0x2685 are the sides of a die (⚀⚁⚂⚃⚄⚅).
-        dice.textContent = String.fromCodePoint(0x267f + value);
-    };
-    updateDice(1);
+    /* REMAINDER OF THE FUNCTION IS DESCRIBED BELOW */
 }
 ```
 
 ## Connect the view to Fluid data
 
-### Modifying Fluid data
+Let's go through the rest of the `renderDiceRoller` function line-by-line.
 
-To begin using Fluid in the application, the first thing to change is what happens when the user clicks the `rollButton`. Instead of updating the local state directly, the button updates the number stored in the `value` key of the passed in `diceMap`. Because the `diceMap` is a Fluid `SharedMap`, changes will be distributed to all clients. Any changes to the `diceMap` will cause a `valueChanged` event to be emitted, and an event handler can trigger an update of the view.
+### Create the Roll button handler
+
+The next line of the `renderDiceRoller` function assigns a handler to the click event of the "Roll" button. Instead of updating the local state directly, the button updates the number stored in the `value` key of the passed in `diceMap`. Because the `diceMap` is a Fluid `SharedMap`, changes will be distributed to all clients. Any changes to the `diceMap` will cause a `valueChanged` event to be emitted, and an event handler, defined below, can trigger an update of the view.
 
 This pattern is common in Fluid because it enables the view to behave the same way for both local and remote changes.
 
 ```js
-    rollButton.onclick = () => diceMap.set("dice-value-key", Math.floor(Math.random() * 6)+1);
+    rollButton.onclick = () => diceMap.set(diceValueKey, Math.floor(Math.random() * 6) + 1);
 ```
-
 
 ### Relying on Fluid data
 
-The next change that needs to be made is to change the `updateDice` function so it no longer accepts an arbitrary value. This means the app can no longer directly modify the local dice value. Instead, the value will be retrieved from the `SharedMap` each time `updateDice` is called.
+The next line creates the function that will rerender the local view with the lastest dice value. This function will be called:
+
+- When the container is created or loaded.
+- When the dice value changes on any client. 
+
+Note that the current value is retrieved from the `SharedMap` each time `updateDice` is called. It is *not* read from the `textContent` of the local `dice` HTML element.
 
 ```js
-    const updateDice = () => {
-        const diceValue = diceMap.get("dice-value-key");
-        dice.textContent = String.fromCodePoint(0x267f + diceValue);
-    };
+    const updateDice = () => {
+        const diceValue = diceMap.get(diceValueKey);
+        // Unicode 0x2680-0x2685 are the sides of a dice (⚀⚁⚂⚃⚄⚅)
+        dice.textContent = String.fromCodePoint(0x267f + diceValue);
+        dice.style.color = `hsl(${diceValue * 60}, 70%, 30%)`;
+    };
+```
+### Update on creation or load of container
+
+The next line ensures that the dice gets an initial value as soon as `renderDiceRoller` is called, which is when the container is created or loaded.
+
+```js
     updateDice();
 ```
 
 ### Handling remote changes
 
-The values returned from `diceMap` are only a snapshot in time. To keep the data up to date as it changes an event handler must be set on the `diceMap` to call `updateDice` each time that the `valueChanged` event is sent. See the [documentation for SharedMap][SharedMap] to get a list of events fired and the values passed to those events.
+To keep the data up to date as it changes an event handler must be set on the `diceMap` to call `updateDice` each time that the `valueChanged` event is sent. Note that the `valueChanged` event fires whenever the `diceMap` value changes on *any* client; that is, when the "Roll" button is clicked on any client. 
+
+See the [documentation for SharedMap][SharedMap] to get a list of events fired and the values passed to those events.
 
 ```js
     diceMap.on("valueChanged", updateDice);
 ```
-
 
 ## Run the app
 


### PR DESCRIPTION
Fixes https://dev.azure.com/fluidframework/internal/_workitems/edit/1220

The description of that bug is pasted here:

> Consider using "Note" formatting rather than "*" for AFR note
Code snippets in tutorial are not exact match to app.js in repo, e.g.:
const root = document.getElementById("root")
const root = document.getElementById("content");
Consider explaining that the "attach" call is what actually publishes to the server (not just getting an ID)
renderDiceRoller call is not explained in the create/load sections - is there a way to either defer showing this, or else explain it a bit in these sections?
Clarify that using the URL hash to control create/load is just a trick for the demo, and that a real application may have other logic here.
I'm not sure that showing the non-Fluid version of the view first is super helpful?  It's certainly interesting once you know the Fluid version too so you can compare/contrast, but might be confusing why we're showing a non-Fluid implementation.