### PR TITLE
Add IPartitionLambdaPlugin as optional type for Ordering service lambda modules

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/ordering/resourcesFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/ordering/resourcesFactory.ts
@@ -6,14 +6,14 @@
 import { KafkaResources, KafkaResourcesFactory } from "@fluidframework/server-services-ordering-kafkanode";
 import { RdkafkaResourcesFactory } from "@fluidframework/server-services-ordering-rdkafka";
 import { ZookeeperClient } from "@fluidframework/server-services-ordering-zookeeper";
-import { IResourcesFactory } from "@fluidframework/server-services-core";
+import { IPartitionLambdaPlugin, IResourcesFactory } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 
 /**
  * A generic kafka resources factory that picks rdkafka / kafka-node based on the config
  */
 export class OrderingResourcesFactory implements IResourcesFactory<KafkaResources> {
-    constructor(private readonly name: string, private readonly lambdaModule: string) {
+    constructor(private readonly name: string, private readonly lambdaModule: string | IPartitionLambdaPlugin) {
     }
 
     public async create(config: Provider): Promise<KafkaResources> {

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -4,9 +4,14 @@
  */
 
 import { EventEmitter } from "events";
+import { Provider } from "nconf";
 import { safelyParseJSON } from "@fluidframework/common-utils";
 import { BoxcarType, IBoxcarMessage, IMessage } from "./messages";
 import { IQueuedMessage } from "./queue";
+
+export interface IPartitionLambdaPlugin {
+    create(config: Provider): Promise<IPartitionLambdaFactory>;
+}
 
 /**
  * Reasons why a lambda is closing


### PR DESCRIPTION
## Description

Currently, R11s lambdas have to be imported as modules via `require` statements and a filepath. This means that running a service in a docker container looks like
```sh
# server/routerlicious/docker-compose.sh line 26
node packages/routerlicious/dist/kafka-service/index.js deli /usr/src/server/packages/routerlicious/dist/deli/index.js
```
1. Not resilient to Docker container or internal module directory changes
2. A bit difficult to read at a glance
3. **Does not bundle** well with tools like [esbuild](https://github.com/evanw/esbuild)
4. Not strongly typed

The bundling issue is particularly why I am making this change. In AFR, our Docker containers can grow quite large because they end up including all of the dev and prod dependencies in order to build and run each service. There are a lot of way around this, some hackier than others. We have been looking at using `esbuild` to bundle the services into single executable JS files. It has worked great (huge reduction in container size) for HTTP services like Alfred, Riddler, Historian, and Gitrest. However, the Kafka service lambdas' require statements prevent bundling by their need for directory structure to remain unchanged or accessible after building.

After this change, it is _possible_ to make booting Deli look instead like
```sh
node packages/routerlicious/dist/kafka-service/index.js deli
```

Doing so would require a bit of changes in kafka-service/command.ts to allow reading lambdas from imported modules rather than strings, and we will do that in AFR. To **reduce scope** of this change, though, I will not be changing the way R11s imports and runs lambdas (yet).

## Reviewer Guidance

This change is an optional feature and will not alter OSS R11s.
