### PR TITLE
Fix bug in LocalSessionStorageCollection findOneInternal method

### DIFF
--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -259,13 +259,18 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
                 }
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const value = JSON.parse(sessionStorage.getItem(ssKey!)!);
+                let foundMismatch = false;
                 for (const qk of queryKeys) {
                     if (value[qk] !== query[qk]) {
-                        continue;
+                        foundMismatch = true;
+                        break;
                     }
                 }
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-                return value;
+
+                if (!foundMismatch) {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                    return value;
+                }
             }
         }
         return null;


### PR DESCRIPTION
findOneInternal has a continue that wants to continue the outer loop but instead just continues the inner loop.  As a result, it thinks every candidate is a match as long as the collectionName matches (even if it's not really a match).