### PR TITLE
Simplified model for Audience; Leverage join signal's referenceSequenceNumber for catch up logic

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -25,7 +25,6 @@ import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISequencedProposal } from '@fluidframework/protocol-definitions';
-import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
 import { ISummaryContent } from '@fluidframework/protocol-definitions';
@@ -78,7 +77,7 @@ export interface IAudience extends EventEmitter {
 
 // @public
 export interface IAudienceOwner extends IAudience {
-    addMember(clientId: string, details: IClient): any;
+    addMember(clientId: string, details: IClient): void;
     clear(): any;
     removeMember(clientId: string): boolean;
 }
@@ -110,15 +109,9 @@ export interface IConnectionDetails {
     // (undocumented)
     clientId: string;
     // (undocumented)
-    existing: boolean;
-    // (undocumented)
-    initialClients: ISignalClient[];
-    // (undocumented)
     mode: ConnectionMode;
     // (undocumented)
     serviceConfiguration: IClientConfiguration;
-    // (undocumented)
-    version: string;
 }
 
 // @public

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -25,6 +25,7 @@ import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISequencedProposal } from '@fluidframework/protocol-definitions';
+import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
 import { ISummaryContent } from '@fluidframework/protocol-definitions';
@@ -109,9 +110,15 @@ export interface IConnectionDetails {
     // (undocumented)
     clientId: string;
     // (undocumented)
+    existing: boolean;
+    // (undocumented)
+    initialClients: ISignalClient[];
+    // (undocumented)
     mode: ConnectionMode;
     // (undocumented)
     serviceConfiguration: IClientConfiguration;
+    // (undocumented)
+    version: string;
 }
 
 // @public

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -79,7 +79,6 @@ export interface IAudience extends EventEmitter {
 // @public
 export interface IAudienceOwner extends IAudience {
     addMember(clientId: string, details: IClient): void;
-    clear(): any;
     removeMember(clientId: string): boolean;
 }
 

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -37,7 +37,6 @@ import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
-import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
@@ -226,7 +225,7 @@ export class Loader implements IHostLoader {
 }
 
 // @public
-export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number, initialClients: ISignalClient[]) => IProtocolHandler;
+export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;
 
 // @public (undocumented)
 export class RelativeLoader implements ILoader {

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -555,6 +555,12 @@ export enum ScopeType {
     SummaryWrite = "summary:write"
 }
 
+// @public (undocumented)
+export enum SignalType {
+    ClientJoin = "join",
+    ClientLeave = "leave"
+}
+
 // @public
 export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
 

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -328,10 +328,8 @@ export interface IServerError {
 export interface ISignalClient {
     // (undocumented)
     client: IClient;
-    clientConnectionNumber?: number;
     // (undocumented)
     clientId: string;
-    referenceSequenceNumber?: number;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/src/clients.ts
+++ b/common/lib/protocol-definitions/src/clients.ts
@@ -44,16 +44,6 @@ export interface ISignalClient {
     clientId: string;
 
     client: IClient;
-
-    /**
-     * Counts the number of signals sent by the client
-     */
-    clientConnectionNumber?: number;
-
-    /**
-     * Sequence number that indicates when the signal was created in relation to the delta stream
-     */
-    referenceSequenceNumber?: number;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -285,9 +285,12 @@ export interface ISignalMessage {
     content: any;
 
     /**
-     * Counts the number of signals sent by the client
+     * Counts the number of join & leave signals in a given relay session
+     * This number can be used to
+     * 1. Order clients in a session
+     * 2. Learn about dropped join/leave signals (if there is a gap in numbering)
      */
-    clientConnectionNumber?: number;
+     clientConnectionNumber?: number;
 
     /**
      * Sequence number that indicates when the signal was created in relation to the delta stream

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -77,13 +77,13 @@ export enum SignalType {
     /**
      * System signal sent to indicate a new client has joined the collaboration.
      */
-     ClientJoin = "join",
+    ClientJoin = "join",
 
-     /**
-      * System signal sent to indicate a client has left the collaboration.
-      */
-     ClientLeave = "leave",
- }
+    /**
+     * System signal sent to indicate a client has left the collaboration.
+     */
+    ClientLeave = "leave",
+}
 
 /**
  * Messages to track latency trace
@@ -302,7 +302,7 @@ export interface ISignalMessage {
      * 1. Order clients in a session
      * 2. Learn about dropped join/leave signals (if there is a gap in numbering)
      */
-     clientConnectionNumber?: number;
+    clientConnectionNumber?: number;
 
     /**
      * Sequence number that indicates when the signal was created in relation to the delta stream

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -73,6 +73,18 @@ export enum MessageType {
     Control = "control",
 }
 
+export enum SignalType {
+    /**
+     * System signal sent to indicate a new client has joined the collaboration.
+     */
+     ClientJoin = "join",
+
+     /**
+      * System signal sent to indicate a client has left the collaboration.
+      */
+     ClientLeave = "leave",
+ }
+
 /**
  * Messages to track latency trace
  */

--- a/packages/common/container-definitions/src/audience.ts
+++ b/packages/common/container-definitions/src/audience.ts
@@ -20,11 +20,6 @@ export interface IAudienceOwner extends IAudience {
      * @returns if a client was removed from the audience
      */
      removeMember(clientId: string): boolean;
-
-     /**
-      * Clears the audience
-      */
-     clear();
 }
 
 /**

--- a/packages/common/container-definitions/src/audience.ts
+++ b/packages/common/container-definitions/src/audience.ts
@@ -13,7 +13,7 @@ export interface IAudienceOwner extends IAudience {
     /**
      * Adds a new client to the audience
      */
-     addMember(clientId: string, details: IClient);
+     addMember(clientId: string, details: IClient): void;
 
      /**
      * Removes a client from the audience. Only emits an event if a client is actually removed

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -10,6 +10,7 @@ import {
     IClientDetails,
     IDocumentMessage,
     ISequencedDocumentMessage,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@fluidframework/protocol-definitions";
@@ -20,7 +21,10 @@ import {
 export interface IConnectionDetails {
     clientId: string;
     claims: ITokenClaims;
+    existing: boolean;
     mode: ConnectionMode;
+    version: string;
+    initialClients: ISignalClient[];
     serviceConfiguration: IClientConfiguration;
     /**
      * Last known sequence number to ordering service at the time of connection

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -10,7 +10,6 @@ import {
     IClientDetails,
     IDocumentMessage,
     ISequencedDocumentMessage,
-    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@fluidframework/protocol-definitions";
@@ -21,10 +20,7 @@ import {
 export interface IConnectionDetails {
     clientId: string;
     claims: ITokenClaims;
-    existing: boolean;
     mode: ConnectionMode;
-    version: string;
-    initialClients: ISignalClient[];
     serviceConfiguration: IClientConfiguration;
     /**
      * Last known sequence number to ordering service at the time of connection

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -21,8 +21,12 @@ export class Audience extends EventEmitter implements IAudienceOwner {
      * Adds a new client to the audience
      */
     public addMember(clientId: string, details: IClient) {
-        this.members.set(clientId, details);
-        this.emit("addMember", clientId, details);
+        // Given that signal delivery is unreliable process, we might observe same client being added twice
+        // In such case we should see exactly same payload (IClient), and should not raise event twice!
+        if (!this.members.has(clientId)) {
+            this.members.set(clientId, details);
+            this.emit("addMember", clientId, details);
+        }
     }
 
     /**

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -57,14 +57,4 @@ export class Audience extends EventEmitter implements IAudienceOwner {
     public getMember(clientId: string): IClient | undefined {
         return this.members.get(clientId);
     }
-
-    /**
-     * Clears the audience
-     */
-    public clear(): void {
-        const clientIds = this.members.keys();
-        for (const clientId of clientIds) {
-            this.removeMember(clientId);
-        }
-    }
 }

--- a/packages/loader/container-loader/src/catchUpMonitor.ts
+++ b/packages/loader/container-loader/src/catchUpMonitor.ts
@@ -3,34 +3,29 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, IEvent } from "@fluidframework/common-definitions";
-import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
+import { IDisposable } from "@fluidframework/common-definitions";
+import { assert } from "@fluidframework/common-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 
-/** @see ICatchUpMonitor for usage */
+/** @see CatchUpMonitor for usage */
 type CaughtUpListener = () => void;
 
-/** @see ICatchUpMonitor for usage */
-export interface ICatchUpMonitorEvents extends IEvent {
-    (event: "caughtUp", listener: CaughtUpListener): void;
-}
-
 /** Monitor that emits an event when a Container has caught up to a given point in the op stream */
-export interface ICatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents>, IDisposable { }
+export type ICatchUpMonitor = IDisposable;
 
 /**
  * Monitors a Container's DeltaManager, notifying listeners when all ops have been processed
  * that were known at the time the monitor was created.
  */
-export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> implements ICatchUpMonitor {
+export class CatchUpMonitor implements ICatchUpMonitor {
     private readonly targetSeqNumber: number;
     private caughtUp: boolean = false;
 
     private readonly opHandler = (message: Pick<ISequencedDocumentMessage, "sequenceNumber">) => {
         if (!this.caughtUp && message.sequenceNumber >= this.targetSeqNumber) {
             this.caughtUp = true;
-            this.emit("caughtUp");
+            this.listener();
         }
     };
 
@@ -39,9 +34,8 @@ export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> imp
      */
     constructor(
         private readonly deltaManager: IDeltaManager<any, any>,
+        private readonly listener: CaughtUpListener,
     ) {
-        super();
-
         this.targetSeqNumber = this.deltaManager.lastKnownSeqNumber;
 
         assert(this.targetSeqNumber >= this.deltaManager.lastSequenceNumber,
@@ -51,16 +45,6 @@ export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> imp
 
         // Simulate the last processed op to set caughtUp in case we already are
         this.opHandler({ sequenceNumber: this.deltaManager.lastSequenceNumber });
-
-        // If a listener is added after we are already caught up, notify that new listener immediately
-        this.on("newListener", (event: string, listener) => {
-            if (event === "caughtUp") {
-                const caughtUpListener = listener as CaughtUpListener;
-                if (this.caughtUp) {
-                    caughtUpListener();
-                }
-            }
-        });
     }
 
     public disposed: boolean = false;
@@ -70,7 +54,6 @@ export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> imp
         }
         this.disposed = true;
 
-        this.removeAllListeners();
         this.deltaManager.off("op", this.opHandler);
     }
 }

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -59,6 +59,7 @@ import {
     IConnectionManagerFactoryArgs,
 } from "./contracts";
 import { DeltaQueue } from "./deltaQueue";
+import { SignalType } from "./protocol";
 
 const MaxReconnectDelayInMs = 8000;
 const InitialReconnectDelayInMs = 1000;
@@ -282,9 +283,12 @@ export class ConnectionManager implements IConnectionManager {
         return {
             claims: connection.claims,
             clientId: connection.clientId,
+            existing: connection.existing,
             checkpointSequenceNumber: connection.checkpointSequenceNumber,
+            get initialClients() { return connection.initialClients; },
             mode: connection.mode,
             serviceConfiguration: connection.serviceConfiguration,
+            version: connection.version,
         };
     }
 
@@ -725,7 +729,7 @@ export class ConnectionManager implements IConnectionManager {
         const clearSignal: ISignalMessage = {
             clientId: null, // system message
             content: JSON.stringify({
-                type: "clear",
+                type: SignalType.Clear,
             }),
         };
         this.props.signalHandler(clearSignal);
@@ -734,7 +738,7 @@ export class ConnectionManager implements IConnectionManager {
             const joinSignal: ISignalMessage = {
                 clientId: null, // system signal
                 content: JSON.stringify({
-                    type: MessageType.ClientJoin,
+                    type: SignalType.ClientJoin,
                     content: priorClient, // ISignalClient
                 }),
                 // clientConnectionNumber?: number;

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -720,12 +720,6 @@ export class ConnectionManager implements IConnectionManager {
 
         this.connectFirstConnection = false;
 
-        if (connection.initialSignals !== undefined) {
-            for (const signal of connection.initialSignals) {
-                this.props.signalHandler(signal);
-            }
-        }
-
         const clearSignal: ISignalMessage = {
             clientId: null, // system message
             content: JSON.stringify({
@@ -745,6 +739,16 @@ export class ConnectionManager implements IConnectionManager {
                 // referenceSequenceNumber?: number;
             };
             this.props.signalHandler(joinSignal);
+        }
+
+        // Unfortunately, there is no defined order between initialSignals (including join & leave signals)
+        // and connection.initialClients. In practice, connection.initialSignals quite often contains join signal
+        // for "self" and connection.initialClients does not contain "self", so we have to process them after
+        // "clear" signal above.
+        if (connection.initialSignals !== undefined) {
+            for (const signal of connection.initialSignals) {
+                this.props.signalHandler(signal);
+            }
         }
     }
 

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -6,19 +6,24 @@
 import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { assert, Timer } from "@fluidframework/common-utils";
 import { IConnectionDetails, IDeltaManager } from "@fluidframework/container-definitions";
-import { ILocalSequencedClient, IProtocolHandler } from "@fluidframework/protocol-base";
-import { ConnectionMode, IQuorumClients } from "@fluidframework/protocol-definitions";
+import { ILocalSequencedClient } from "@fluidframework/protocol-base";
+import { ConnectionMode } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent, loggerToMonitoringContext } from "@fluidframework/telemetry-utils";
 import { ConnectionState } from "./connectionState";
 import { CatchUpMonitor, ICatchUpMonitor } from "./catchUpMonitor";
+import { IProtocolHandler } from "./protocol";
 
+// Based on recent data, it looks like majority of cases where we get stuck are due to really slow or
+// timing out ops fetches. So attempt recovery infrequently. Also fetch uses 30 second timeout, so
+// if retrying fixes the problem, we should not see these events.
 const JoinOpTimeoutMs = 45000;
+
+// Timeout waiting for "self" join signal, before giving up
+const JoinSignalTimeoutMs = 5000;
 
 /** Constructor parameter type for passing in dependencies needed by the ConnectionStateHandler */
 export interface IConnectionStateHandlerInputs {
     logger: ITelemetryLogger;
-    /** Provides access to the clients currently in the quorum */
-    quorumClients: () => IQuorumClients | undefined;
     /** Log to telemetry any change in state, included to Connecting */
     connectionStateChanged:
         (value: ConnectionState, oldState: ConnectionState, reason?: string | undefined) => void;
@@ -51,7 +56,8 @@ export function createConnectionStateHandler(
 ) {
     const mc = loggerToMonitoringContext(inputs.logger);
     return createConnectionStateHandlerCore(
-        mc.config.getBoolean("Fluid.Container.CatchUpBeforeDeclaringConnected") === true,
+        mc.config.getBoolean("Fluid.Container.CatchUpBeforeDeclaringConnected") === true, // connectedRaisedWhenCaughtUp
+        mc.config.getBoolean("Fluid.Container.DisableJoinSignalWait") !== true, // readClientsWaitForJoinSignal
         inputs,
         deltaManager,
         clientId,
@@ -59,17 +65,21 @@ export function createConnectionStateHandler(
 }
 
 export function createConnectionStateHandlerCore(
-    wait: boolean,
+    connectedRaisedWhenCaughtUp: boolean,
+    readClientsWaitForJoinSignal: boolean,
     inputs: IConnectionStateHandlerInputs,
     deltaManager: IDeltaManager<any, any>,
     clientId?: string,
 ) {
-    if (!wait) {
-        return new ConnectionStateHandler(inputs, clientId);
+    if (!connectedRaisedWhenCaughtUp) {
+        return new ConnectionStateHandler(inputs, readClientsWaitForJoinSignal, clientId);
     }
     return new ConnectionStateCatchup(
         inputs,
-        (handler: IConnectionStateHandlerInputs) => new ConnectionStateHandler(handler, clientId),
+        (handler: IConnectionStateHandlerInputs) => new ConnectionStateHandler(
+            handler,
+            readClientsWaitForJoinSignal,
+            clientId),
         deltaManager);
 }
 
@@ -107,7 +117,6 @@ class ConnectionStateHandlerPassThrough implements IConnectionStateHandler, ICon
      */
 
     public get logger() { return this.inputs.logger; }
-    public quorumClients() { return this.inputs.quorumClients(); }
     public connectionStateChanged(
         value: ConnectionState,
         oldState: ConnectionState,
@@ -147,9 +156,11 @@ class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
         switch (value) {
             case ConnectionState.Connected:
                 assert(this._connectionState === ConnectionState.CatchingUp, "connectivity transitions");
-                assert(this.catchUpMonitor !== undefined,
-                    "catchUpMonitor should always be set if pendingClientId is set");
-                this.catchUpMonitor.on("caughtUp", this.transitionToConnectedState);
+                // Create catch-up monitor here (not earlier), as we might get more exact info by now about how far
+                // client is behind through join signal. This is only true if base layer uses signals (i.e. audience,
+                // not quorum, including for "rea" connections) to make decisions about moving to "connected" state.
+                assert(this.catchUpMonitor === undefined, "catchUpMonitor should be gone");
+                this.catchUpMonitor = new CatchUpMonitor(this.deltaManager, this.transitionToConnectedState);
                 return;
             case ConnectionState.Disconnected:
                 this.catchUpMonitor?.dispose();
@@ -157,9 +168,6 @@ class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
                 break;
             case ConnectionState.CatchingUp:
                 assert(this._connectionState === ConnectionState.Disconnected, "connectivity transitions");
-                // We may want to catch up to known ops as of now before transitioning to Connected state
-                assert(this.catchUpMonitor === undefined, "catchUpMonitor should be gone");
-                this.catchUpMonitor = new CatchUpMonitor(this.deltaManager);
                 break;
             default:
         }
@@ -201,8 +209,8 @@ class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
  *
  * For (a) we give up waiting after some time (same timeout as server uses), and go ahead and transition to Connected.
  *
- * For (b) we log telemetry if it takes too long, but still only transition to Connected when the Join op is processed
- * and we are added to the Quorum.
+ * For (b) we log telemetry if it takes too long, but still only transition to Connected when the Join op/signal is
+ * processed.
  *
  * For (c) this is optional behavior, controlled by the parameters of receivedConnectEvent
  */
@@ -211,6 +219,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
     private _pendingClientId: string | undefined;
     private readonly prevClientLeftTimer: Timer;
     private readonly joinOpTimer: Timer;
+    private protocol?: IProtocolHandler;
 
     private waitEvent: PerformanceEvent | undefined;
 
@@ -228,6 +237,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 
     constructor(
         private readonly handler: IConnectionStateHandlerInputs,
+        private readonly readClientsWaitForJoinSignal: boolean,
         private _clientId?: string,
     ) {
         this.prevClientLeftTimer = new Timer(
@@ -241,22 +251,18 @@ class ConnectionStateHandler implements IConnectionStateHandler {
             },
         );
 
-        // Based on recent data, it looks like majority of cases where we get stuck are due to really slow or
-        // timing out ops fetches. So attempt recovery infrequently. Also fetch uses 30 second timeout, so
-        // if retrying fixes the problem, we should not see these events.
         this.joinOpTimer = new Timer(
-            JoinOpTimeoutMs,
+            JoinOpTimeoutMs, // default value is not used - startJoinOpTimer() explicitly provides timeout
             () => {
                 // I've observed timer firing within couple ms from disconnect event, looks like
                 // queued timer callback is not cancelled if timer is cancelled while callback sits in the queue.
                 if (this.connectionState !== ConnectionState.CatchingUp) {
                     return;
                 }
-                const quorumClients = this.handler.quorumClients();
                 const details = {
-                    quorumInitialized: quorumClients !== undefined,
-                    pendingClientId: this.pendingClientId,
-                    inQuorum: quorumClients?.getMember(this.pendingClientId ?? "") !== undefined,
+                    protocolInitialized: this.protocol !== undefined,
+                    clientId: this.pendingClientId,
+                    clientJoined: this.hasMember(this.pendingClientId),
                     waitingForLeaveOp: this.waitingForLeaveOp,
                 };
                 this.handler.logConnectionIssue("NoJoinOp", details);
@@ -264,9 +270,11 @@ class ConnectionStateHandler implements IConnectionStateHandler {
         );
     }
 
-    private startJoinOpTimer() {
+    private startJoinOpTimer(writeConnection: boolean) {
         assert(!this.joinOpTimer.hasTimer, 0x234 /* "has joinOpTimer" */);
-        this.joinOpTimer.start();
+        this.joinOpTimer.start(
+            writeConnection ? JoinOpTimeoutMs : JoinSignalTimeoutMs,
+        );
     }
 
     private stopJoinOpTimer() {
@@ -317,34 +325,33 @@ class ConnectionStateHandler implements IConnectionStateHandler {
     }
 
     private applyForConnectedState(source: "removeMemberEvent" | "addMemberEvent" | "timeout" | "containerSaved") {
-        const quorumClients = this.handler.quorumClients();
-        assert(quorumClients !== undefined, 0x236 /* "In all cases it should be already installed" */);
+        assert(this.protocol !== undefined, 0x236 /* "In all cases it should be already installed" */);
 
-        assert(this.waitingForLeaveOp === false ||
-            (this.clientId !== undefined && quorumClients.getMember(this.clientId) !== undefined),
+        assert(!this.waitingForLeaveOp || this.hasMember(this.clientId),
             0x2e2 /* "Must only wait for leave message when clientId in quorum" */);
 
         // Move to connected state only if we are in Connecting state, we have seen our join op
         // and there is no timer running which means we are not waiting for previous client to leave
         // or timeout has occurred while doing so.
         if (this.pendingClientId !== this.clientId
-            && this.pendingClientId !== undefined
-            && quorumClients.getMember(this.pendingClientId) !== undefined
+            && this.hasMember(this.pendingClientId)
             && !this.waitingForLeaveOp
         ) {
             this.waitEvent?.end({ source });
             this.setConnectionState(ConnectionState.Connected);
         } else {
             // Adding this event temporarily so that we can get help debugging if something goes wrong.
+            // We may not see any ops due to being disconnected all that time - that's not an error!
+            const error = source === "timeout" && this.connectionState !== ConnectionState.Disconnected;
             this.handler.logger.sendTelemetryEvent({
                 eventName: "connectedStateRejected",
-                category: source === "timeout" ? "error" : "generic",
+                category: error ? "error" : "generic",
                 details: JSON.stringify({
                     source,
-                    pendingClientId: this.pendingClientId,
-                    clientId: this.clientId,
+                    clientId: this.pendingClientId,
+                    oldClientId: this.clientId,
                     waitingForLeaveOp: this.waitingForLeaveOp,
-                    inQuorum: quorumClients?.getMember(this.pendingClientId ?? "") !== undefined,
+                    clientJoined: this.hasMember(this.pendingClientId),
                 }),
             });
         }
@@ -379,14 +386,13 @@ class ConnectionStateHandler implements IConnectionStateHandler {
         this._connectionState = ConnectionState.CatchingUp;
 
         const writeConnection = connectionMode === "write";
-        assert(!this.handler.shouldClientJoinWrite() || writeConnection,
-            0x30a /* shouldClientJoinWrite should imply this is a writeConnection */);
-        assert(!this.waitingForLeaveOp || writeConnection,
-            0x2a6 /* "waitingForLeaveOp should imply writeConnection (we need to be ready to flush pending ops)" */);
 
-        // Note that this may be undefined since the connection is established proactively on load
-        // and the quorum may still be under initialization.
-        const quorumClients: IQuorumClients | undefined = this.handler.quorumClients();
+        // The following checks are wrong. They are only valid if user has write access to a file.
+        // If user lost such access mid-session, user will not be able to get "write" connection.
+        // assert(!this.handler.shouldClientJoinWrite() || writeConnection,
+        //    0x30a /* shouldClientJoinWrite should imply this is a writeConnection */);
+        // assert(!this.waitingForLeaveOp || writeConnection,
+        //    0x2a6 /* "waitingForLeaveOp should imply writeConnection (we need to be ready to flush pending ops)" */);
 
         // Stash the clientID to detect when transitioning from connecting (socket.io channel open) to connected
         // (have received the join message for the client ID)
@@ -399,17 +405,19 @@ class ConnectionStateHandler implements IConnectionStateHandler {
         // IMPORTANT: Report telemetry after we set _pendingClientId, but before transitioning to Connected state
         this.handler.connectionStateChanged(ConnectionState.CatchingUp, oldState);
 
-        // For write connections, this pending clientId could be in the quorum already (i.e. join op already processed).
+        // Pending clientId could have joined already (i.e. join op/signal already processed).
         // We are fetching ops from storage in parallel to connecting to Relay Service,
         // and given async processes, it's possible that we have already processed our own join message before
         // connection was fully established.
-        // If quorumClients itself is undefined, we expect it will process the join op after it's initialized.
-        const waitingForJoinOp = writeConnection && quorumClients?.getMember(this._pendingClientId) === undefined;
+        // If protocol is not initialized yet, receivedAddMemberEvent() will be called by initProtocol()
+        // later in boot sequence if needed.
+        const waitingForJoinOp = (writeConnection || this.readClientsWaitForJoinSignal) &&
+            !this.hasMember(this._pendingClientId);
 
         if (waitingForJoinOp) {
-            // Previous client left, and we are waiting for our own join op. When it is processed we'll join the quorum
-            // and attempt to transition to Connected state via receivedAddMemberEvent.
-            this.startJoinOpTimer();
+            // Previous client left, and we are waiting for our own join op / signal. When it is processed
+            // we'll attempt to transition to Connected state via receivedAddMemberEvent() flow.
+            this.startJoinOpTimer(writeConnection);
         } else if (!this.waitingForLeaveOp) {
             // We're not waiting for Join or Leave op (if read-only connection those don't even apply),
             // go ahead and declare the state to be Connected!
@@ -430,10 +438,13 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 
         const oldState = this._connectionState;
         this._connectionState = value;
-        const quorumClients = this.handler.quorumClients();
+
+        // This is the only place in code that deals with quorum. The rest works with audience
+        // The code below ensures that we do not send ops until we know that old "write" client's disconnect
+        // produced (and sequenced) leave op
         let client: ILocalSequencedClient | undefined;
         if (this._clientId !== undefined) {
-            client = quorumClients?.getMember(this._clientId);
+            client = this.protocol?.quorum?.getMember(this._clientId);
         }
         if (value === ConnectionState.Connected) {
             assert(oldState === ConnectionState.CatchingUp,
@@ -451,15 +462,13 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 this.stopJoinOpTimer();
             }
 
-            // Only wait for "leave" message if the connected client exists in the quorum because only the write
-            // client will exist in the quorum and only for those clients we will receive "removeMember" event and
-            // the client has some unacked ops.
-            // Also server would not accept ops from read client. Also check if the timer is not already running as
+            // Only wait for "leave" message if the connected client exists in the quorum and had some non-acked ops
+            // Also check if the timer is not already running as
             // we could receive "Disconnected" event multiple times without getting connected and in that case we
             // don't want to reset the timer as we still want to wait on original client which started this timer.
             if (client !== undefined
                 && this.handler.shouldClientJoinWrite()
-                && this.prevClientLeftTimer.hasTimer === false
+                && !this.waitingForLeaveOp // same as !this.prevClientLeftTimer.hasTimer
             ) {
                 this.prevClientLeftTimer.restart();
             } else {
@@ -467,6 +476,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 this.handler.logger.sendTelemetryEvent({
                     eventName: "noWaitOnDisconnected",
                     details: JSON.stringify({
+                        clientId: this._clientId,
                         inQuorum: client !== undefined,
                         waitingForLeaveOp: this.waitingForLeaveOp,
                         hadOutstandingOps: this.handler.shouldClientJoinWrite(),
@@ -479,18 +489,38 @@ class ConnectionStateHandler implements IConnectionStateHandler {
         this.handler.connectionStateChanged(this._connectionState, oldState, reason);
     }
 
+    // Helper method to switch between quorum and audience.
+    // Old design was checking only quorum for "write" clients.
+    // Latest change checks audience for all types of connections.
+    protected get membership() {
+        return this.protocol?.audience;
+    }
+
     public initProtocol(protocol: IProtocolHandler) {
-        protocol.quorum.on("addMember", (clientId, _details) => {
+        this.protocol = protocol;
+
+        this.membership?.on("addMember", (clientId) => {
             this.receivedAddMemberEvent(clientId);
         });
 
-        protocol.quorum.on("removeMember", (clientId) => {
+        this.membership?.on("removeMember", (clientId) => {
             this.receivedRemoveMemberEvent(clientId);
         });
 
+        // Very unlikely race condition, but theoretically can happen - our new connection is already
+        // summarized and we are loading from such summary.
+        if (this.hasMember(this.pendingClientId)) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.receivedAddMemberEvent(this.pendingClientId!);
+        }
+
         // if we have a clientId from a previous container we need to wait for its leave message
-        if (this.clientId !== undefined && protocol.quorum.getMember(this.clientId) !== undefined) {
+        if (this.clientId !== undefined && this.hasMember(this.clientId)) {
             this.prevClientLeftTimer.restart();
         }
+    }
+
+    protected hasMember(clientId?: string) {
+        return this.membership?.getMember(clientId ?? "") !== undefined;
     }
 }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -310,7 +310,12 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                     this.close(normalizeError(error));
                 }
             },
-            signalHandler: (message: ISignalMessage) => this._inboundSignal.push(message),
+            signalHandler: (message: ISignalMessage) => {
+                if (message.referenceSequenceNumber !== undefined) {
+                    this.updateLatestKnownOpSeqNumber(message.referenceSequenceNumber);
+                }
+                this._inboundSignal.push(message);
+            },
             reconnectionDelayHandler: (delayMs: number, error: unknown) =>
                 this.emitDelayInfo(this.deltaStreamDelayId, delayMs, error),
             closeHandler: (error: any) => this.close(error),

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -61,6 +61,9 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
         // Join/leave signals are ignored for "write" clients in favor of join / leave ops
         this.quorum.on("addMember", (clientId, details) => audience.addMember(clientId, details.client));
         this.quorum.on("removeMember", (clientId) => audience.removeMember(clientId));
+        for (const [clientId, details] of this.quorum.getMembers()) {
+            this.audience.addMember(clientId, details.client);
+        }
     }
 
     public processMessage(message: ISequencedDocumentMessage, local: boolean): IProcessMessageResult {

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -87,7 +87,12 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
         const innerContent = message.content as { content: any; type: string; };
         switch (innerContent.type) {
             case SignalType.Clear: {
-                this.audience.clear();
+                const members = this.audience.getMembers();
+                for (const [clientId, client] of members) {
+                    if (client.mode === "read") {
+                        this.audience.removeMember(clientId);
+                    }
+                }
                 break;
             }
             case SignalType.ClientJoin: {

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -20,6 +20,13 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { canBeCoalescedByService } from "@fluidframework/driver-utils";
 
+// ADO: #1986: Start using enum from protocol-base.
+export enum SignalType {
+    ClientJoin = "join", // same value as MessageType.ClientJoin,
+    ClientLeave = "leave", // same value as MessageType.ClientLeave,
+    Clear = "clear", // used only by client for synthetic signals
+}
+
 /**
  * Function to be used for creating a protocol handler.
  */
@@ -79,11 +86,11 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
     public processSignal(message: ISignalMessage) {
         const innerContent = message.content as { content: any; type: string; };
         switch (innerContent.type) {
-            case "clear": {
+            case SignalType.Clear: {
                 this.audience.clear();
                 break;
             }
-            case MessageType.ClientJoin: {
+            case SignalType.ClientJoin: {
                 const newClient = innerContent.content as ISignalClient;
                 // Ignore write clients - quorum will control such clients.
                 if (newClient.client.mode === "read") {
@@ -91,7 +98,7 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
                 }
                 break;
             }
-            case MessageType.ClientLeave: {
+            case SignalType.ClientLeave: {
                 const leftClientId = innerContent.content as string;
                 // Ignore write clients - quorum will control such clients.
                 if (this.audience.getMember(leftClientId)?.mode === "read") {

--- a/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
+++ b/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
@@ -56,7 +56,7 @@ describe("CatchUpMonitor", () => {
             lastKnownSeqNumber: 15, // Should be impossible in real world
         });
 
-        assert.throws(() => new CatchUpMonitor(mockDeltaManager), "Expect assert when DeltaManager in invalid state");
+        assert.throws(() => new CatchUpMonitor(mockDeltaManager, () => {}), "Expect assert when DeltaManager in invalid state");
     });
 
     it("Emits caughtUp event when caught up to the point it was created", () => {
@@ -67,28 +67,13 @@ describe("CatchUpMonitor", () => {
         let caughtUp = false;
 
         mockDeltaManager.lastKnownSeqNumber = 20;
-        monitor = new CatchUpMonitor(mockDeltaManager);
+        monitor = new CatchUpMonitor(mockDeltaManager, () => { caughtUp = true; });
         mockDeltaManager.lastKnownSeqNumber = 25;  // Shouldn't change anything about the monitor
-        monitor.on("caughtUp", () => { caughtUp = true; });
 
         mockDeltaManager.emitOpWithSequenceNumber(19); // Less than 20
         assert(!caughtUp, "Shouldn't be considered caught up yet");
         mockDeltaManager.emitOpWithSequenceNumber(21); // Greater than 20
         assert(caughtUp, "Should be considered caught up now");
-    });
-
-    it("Adding a listener after already caught up invokes the listener immediately", () => {
-        const mockDeltaManager = MockDeltaManagerForCatchingUp.create({
-            lastSequenceNumber: 10,
-            lastKnownSeqNumber: 15,
-        });
-        let caughtUp = false;
-
-        monitor = new CatchUpMonitor(mockDeltaManager);
-        mockDeltaManager.emitOpToCatchUp();
-
-        monitor.on("caughtUp", () => { caughtUp = true; });
-        assert(caughtUp, "caughtUp should have fired immediately");
     });
 
     it("Emits caught up immediately if last known/processed sequence numbers match", () => {
@@ -98,9 +83,8 @@ describe("CatchUpMonitor", () => {
         });
         let caughtUp = false;
 
-        monitor = new CatchUpMonitor(mockDeltaManager);
+        monitor = new CatchUpMonitor(mockDeltaManager, () => { caughtUp = true; });
 
-        monitor.on("caughtUp", () => { caughtUp = true; });
         assert(caughtUp, "caughtUp should have fired immediately");
     });
 
@@ -111,32 +95,21 @@ describe("CatchUpMonitor", () => {
         });
         let caughtUpCount = 0;
 
-        monitor = new CatchUpMonitor(mockDeltaManager);
-        monitor.on("caughtUp", () => { ++caughtUpCount; });
+        monitor = new CatchUpMonitor(mockDeltaManager, () => { ++caughtUpCount; });
 
         mockDeltaManager.emitOpWithSequenceNumber(15);
         assert.equal(caughtUpCount, 1, "caughtUp should have fired once");
         mockDeltaManager.emitOpWithSequenceNumber(16);
         assert.equal(caughtUpCount, 1, "caughtUp should have fired only once");
-
-        let secondCaughtUpCount = 0;
-        monitor.on("caughtUp", () => { secondCaughtUpCount = 1; });
-        assert.equal(secondCaughtUpCount, 1, "New listener should still get invoked once caught up");
-        mockDeltaManager.emitOpWithSequenceNumber(17);
-        assert.equal(secondCaughtUpCount, 1, "Subsequent ops will not cause caughtUp again on second listener");
     });
 
     it("Dispose removes all listeners", () => {
         const mockDeltaManager = MockDeltaManagerForCatchingUp.create();
-        monitor = new CatchUpMonitor(mockDeltaManager);
+        monitor = new CatchUpMonitor(mockDeltaManager, () => {});
 
-        monitor.on("caughtUp", () => {});
-        monitor.on("caughtUp", () => {});
-        monitor.on("caughtUp", () => {});
         monitor.dispose();
 
         assert(monitor.disposed, "dispose() should set disposed");
-        assert.equal(monitor.listenerCount("caughtUp"), 0, "dispose() should clear all listeners");
         assert.equal(mockDeltaManager.listenerCount("op"), 0, "CatchUpMonitor.dispose should remove listener on DeltaManager");
     });
 });

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -89,7 +89,10 @@ describe("ConnectionStateHandler Tests", () => {
             clientId: pendingClientId,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             claims: {} as ITokenClaims,
+            existing: true,
             mode: "read",
+            version: "0.1",
+            initialClients: [],
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             serviceConfiguration: {} as IClientConfiguration,
             checkpointSequenceNumber: undefined,
@@ -98,7 +101,10 @@ describe("ConnectionStateHandler Tests", () => {
             clientId: pendingClientId2,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             claims: {} as ITokenClaims,
+            existing: true,
             mode: "read",
+            version: "0.1",
+            initialClients: [],
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             serviceConfiguration: {} as IClientConfiguration,
             checkpointSequenceNumber: undefined,
@@ -107,7 +113,10 @@ describe("ConnectionStateHandler Tests", () => {
             clientId: pendingClientId3,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             claims: {} as ITokenClaims,
+            existing: true,
             mode: "read",
+            version: "0.1",
+            initialClients: [],
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             serviceConfiguration: {} as IClientConfiguration,
             checkpointSequenceNumber: undefined,

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -7,16 +7,12 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
 import assert from "assert";
-import { EventEmitter } from "events";
 import { AttachState, IAudience, IContainer, IContainerEvents, IDeltaManager, IDeltaManagerEvents, ReadOnlyInfo } from "@fluidframework/container-definitions";
-import { sessionStorageConfigProvider } from "@fluidframework/telemetry-utils";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import { IFluidRouter } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, IDocumentMessage } from "@fluidframework/protocol-definitions";
-import { Container, waitContainerToCatchUp } from "../container";
-import { Loader } from "../loader";
-import { CatchUpMonitor } from "../catchUpMonitor";
+import { waitContainerToCatchUp } from "../container";
 import { ConnectionState } from "../connectionState";
 
 class MockDeltaManager
@@ -50,36 +46,6 @@ class MockContainer extends TypedEventEmitter<IContainerEvents> implements Parti
 }
 
 describe("Container", () => {
-    describe("constructor", () => {
-        const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
-        let injectedSettings = {};
-
-        before(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
-        });
-
-        afterEach(() => {
-            injectedSettings = {};
-        });
-
-        after(() => {
-            sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
-        });
-
-        it("Fluid.Container.CatchUpBeforeDeclaringConnected = true, use CatchUpMonitor", () => {
-            injectedSettings["Fluid.Container.CatchUpBeforeDeclaringConnected"] = true;
-
-            const container = new Container({ services: { options: {} } } as Loader, {});
-            const deltaManager: any = container.deltaManager;
-            deltaManager.connectionManager.connection = {}; // Avoid assert 0x0df
-            (deltaManager as EventEmitter).emit("connect", { clientId: "someClientId" });
-
-            const catchUpMonitor = (container as any).connectionStateHandler.catchUpMonitor;
-            assert(catchUpMonitor instanceof CatchUpMonitor);
-        });
-    });
-
     describe("waitContainerToCatchUp", () => {
         it("Closed Container fails", async () => {
             const mockContainer = new MockContainer();

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -61,7 +61,7 @@ import {
     SessionState,
 } from "@fluidframework/server-services-telemetry";
 import { DocumentContext } from "@fluidframework/server-lambdas-driver";
-import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import { IEvent } from "@fluidframework/common-definitions";
 import {
     logCommonSessionEndMetrics,
@@ -1798,10 +1798,15 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
      * @param signalMessage - Ticketed join signal message
      */
     private addSequencedSignalClient(clientJoinMessage: IClientJoin, signalMessage: ISignalMessageOutput) {
+        const op = signalMessage.message.operation;
+        assert(op.referenceSequenceNumber !== undefined,
+            "ISignalMessage.referenceSequenceNumber is undefined for sequenced signal");
+        assert(op.clientConnectionNumber !== undefined,
+            "ISignalMessage.clientConnectionNumber is undefined for sequenced signal");
         const sequencedSignalClient: ISequencedSignalClient = {
             client: clientJoinMessage.detail,
-            referenceSequenceNumber: signalMessage.message.operation.referenceSequenceNumber,
-            clientConnectionNumber: signalMessage.message.operation.clientConnectionNumber,
+            referenceSequenceNumber: op.referenceSequenceNumber,
+            clientConnectionNumber: op.clientConnectionNumber,
             exp: Date.now() + this.serviceConfiguration.deli.clientTimeout,
         };
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1401,8 +1401,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                 throw new Error(`Cannot create signal message for type ${message.operation.type}`);
         }
 
-        (signalMessage as any).referenceSequenceNumber = sequenceNumber;
-        (signalMessage as any).clientConnectionNumber = ++this.signalClientConnectionNumber;
+        signalMessage.referenceSequenceNumber = sequenceNumber;
+        signalMessage.clientConnectionNumber = ++this.signalClientConnectionNumber;
 
         return {
             ticketType: TicketType.Signal,
@@ -1800,8 +1800,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
     private addSequencedSignalClient(clientJoinMessage: IClientJoin, signalMessage: ISignalMessageOutput) {
         const sequencedSignalClient: ISequencedSignalClient = {
             client: clientJoinMessage.detail,
-            referenceSequenceNumber: (signalMessage.message.operation as any).referenceSequenceNumber,
-            clientConnectionNumber: (signalMessage.message.operation as any).clientConnectionNumber,
+            referenceSequenceNumber: signalMessage.message.operation.referenceSequenceNumber,
+            clientConnectionNumber: signalMessage.message.operation.clientConnectionNumber,
             exp: Date.now() + this.serviceConfiguration.deli.clientTimeout,
         };
 

--- a/server/routerlicious/packages/services-core/src/clientManager.ts
+++ b/server/routerlicious/packages/services-core/src/clientManager.ts
@@ -15,9 +15,12 @@ export interface ISequencedSignalClient {
     client: IClient;
 
     /**
-     * Counts the number of signals sent by the client
+     * Counts the number of join & leave signals in a given relay session
+     * This number can be used to
+     * 1. Order clients in a session
+     * 2. Learn about dropped join/leave signals (if there is a gap in numbering)
      */
-    clientConnectionNumber: number;
+     clientConnectionNumber: number;
 
     /**
      * Sequence number that indicates when the signal was created in relation to the delta stream


### PR DESCRIPTION
Note: I've started to break this PR into smaller pieces (will update list as they come available):
- https://github.com/microsoft/FluidFramework/pull/12094
- https://github.com/microsoft/FluidFramework/pull/12095
- https://github.com/microsoft/FluidFramework/pull/12096
- https://github.com/microsoft/FluidFramework/pull/12098
- https://github.com/microsoft/FluidFramework/pull/12164 (sort of final change)
- some small lingering changes - TBD

**Most important changes:**
1. **"self" will show up at the same time in Quorum and Audience** for "write" connection. This is done by ignoring signals for such connections and duplicating Quorum changes into Audience. This gives clients simpler picture to work with.
   - I'd think it makes sense to merge these two data structures in the future, and instead of having 2 of them, provide various adapters / filters that keep usage simple for scenarios where someone needs only "write" clients (as an example).
2. **"connected" transition will happen after "self" shows up in Audience**. This significantly simplifies programming model for users
   - In case of failure (currently defined as 5 seconds of not receiving join signal), we force reconnect. It's hard to say how often it happens and if such recovery is too expensive / has good success rates. If tracking performance of join op any indicator, likely such recovery will not be very successful, but tracking it in telemetry will help us find real bugs in relay service.
   - This is the part that I'm least sure about. Planning to test it in ODSP scalability runs. Kill-bit feature gate has been added.
3. **referenceSequenceNumber from join signal** (if provided) is used to determine if client needs to fetch ops from storage to catch up, as well as a data point to know when to raise "connected" event. Later requires enabling existing Fluid.Container.CatchUpBeforeDeclaringConnected gate.

**Less important:**
- Simplified Protocol creation and initializing / resetting audience on connection by leveraging signal queue for this sequence.
- ISignalClient was lying about its shape - extra properties exist only on ISignalMessage, even though they are applicable only for payloads of ISignalClient shape (i.e., join & leave signals).
   - I believes it would be actually more correct to have that payload on ISignalClient as it would ensure clients would get same info on connection for clients already in audience. But for now, I'm reflecting reality.
- Added SignalType to separate it from MessageType. Opened ADO#1986 to track moving existing code to using it.
- Simplified CatchUpMonitor a bit
- Removed some number of unneeded type casts.

**Back-compat considerations:**
- There should be no back-compat concerns here, as behavior (where changed) was never defined. I.e., order in which clients show up in Audience and Quorum are undefined.
- Similar, order of "connected" transition and presence of "self" in Audience is undefined.