### PR TITLE
Add TestOverride setting for SweepTimeout

### DIFF
--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -267,8 +267,7 @@ describe("Garbage Collection Tests", () => {
             });
         });
 
-        //* ONLY
-        describe.only("Session Expiry and Sweep Timeout", () => {
+        describe("Session Expiry and Sweep Timeout", () => {
             const testOverrideInactiveTimeoutMsKey = "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs";
             const testOverrideSessionExpiryMsKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
             const testOverrideSweepTimeoutMsKey = "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs";


### PR DESCRIPTION
We need a way to shrink the SweepTimeout value for manual testing of sweep flows.

_Reviewing tip: Start with the tests! See if you agree with that "spec", then see how I implemented it_

**WARNING** if you mix and match this value with the default computed value in different sessions for a single document, you can wrongly trigger sweep earlier than is valid.  This is mostly protected against by the fact that SweepTimeout can't be smaller than the persisted value of SessionExpiry, so it's not very useful on existing documents.