### PR TITLE
Odsp binary snapshot parsing: Rework string manipulation code

### DIFF
--- a/packages/drivers/odsp-driver/src/ReadBufferUtils.ts
+++ b/packages/drivers/odsp-driver/src/ReadBufferUtils.ts
@@ -52,5 +52,6 @@ export class ReadBuffer {
     public skip(length: number) {
         assert(length >= 0, 0x224 /* "Skip length should be positive" */);
         this.index += length;
+        assert(this.index <= this.data.length, "skipping past size of buffer");
     }
 }

--- a/packages/drivers/odsp-driver/src/WriteBufferUtils.ts
+++ b/packages/drivers/odsp-driver/src/WriteBufferUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/common-utils";
+import { assert, IsoBuffer } from "@fluidframework/common-utils";
 import { ReadBuffer } from "./ReadBufferUtils";
 import {
     BlobCore,
@@ -143,53 +143,66 @@ const boolToCodeMap = [
 /**
  * Implementation of serialization of blobs in buffer with Marker Codes etc.
  * @param buffer - Buffer to serialize to.
+ * @param content - string to be serialized.
+ * @param dictionary - Const strings dictionary to be used while serializing.
+ */
+ function serializeDictionaryString(buffer: WriteBuffer, content: string, dictionary: Map<string, number>) {
+    let id = dictionary.get(content);
+    let idLength: number;
+    if (id === undefined) {
+        const data = IsoBuffer.from(content, "utf8");
+        const lengthOfDataLen = calcLength(data.length);
+
+        id = dictionary.size + 1;
+        idLength = calcLength(id);
+        dictionary.set(content, id);
+        const code = lengthOfDataLen > 1 || idLength > 1
+            ? MarkerCodes.ConstStringDeclareBig
+            : MarkerCodes.ConstStringDeclare;
+        // Write marker code for const string.
+        buffer.write(code);
+        const bytes = getValueSafely(codeToBytesMap, code);
+        assert(bytes >= lengthOfDataLen, 0x283 /* "Length of data len should fit in the bytes from the map" */);
+        assert(bytes >= idLength, 0x284 /* "Length of id should fit in the bytes from the map" */);
+        // Assign and write id for const string.
+        buffer.write(id, bytes);
+        // Write length of const string.
+        buffer.write(data.length, bytes);
+        // Write const string data.
+        for (const element of data) {
+            buffer.write(element);
+        }
+    } else {
+        idLength = calcLength(id);
+    }
+    // Write Marker Code
+    buffer.write(getValueSafely(constStringBytesToCodeMap, idLength));
+    // Write id of const string
+    buffer.write(id, idLength);
+}
+
+function serializeString(buffer: WriteBuffer, content: string, codeMap = binaryBytesToCodeMap) {
+    serializeBlob(
+        buffer,
+        IsoBuffer.from(content, "utf8"),
+        utf8StringBytesToCodeMap);
+}
+
+/**
+ * Implementation of serialization of blobs in buffer with Marker Codes etc.
+ * @param buffer - Buffer to serialize to.
  * @param blob - blob to be serialized.
  * @param dictionary - Const strings dictionary to be used while serializing.
  */
-function serializeBlob(buffer: WriteBuffer, blob: BlobCore, dictionary: Map<string, number>) {
-    const data = blob.buffer;
+function serializeBlob(buffer: WriteBuffer, data: Uint8Array, codeMap: Record<number, number> = binaryBytesToCodeMap) {
     const lengthOfDataLen = calcLength(data.length);
-    if (blob.constString) {
-        const content = blob.toString();
-        let id = dictionary.get(content);
-        let idLength: number;
-        if (id === undefined) {
-            id = dictionary.size + 1;
-            idLength = calcLength(id);
-            dictionary.set(content, id);
-            const code = lengthOfDataLen > 1 || idLength > 1
-                ? MarkerCodes.ConstStringDeclareBig
-                : MarkerCodes.ConstStringDeclare;
-            // Write marker code for const string.
-            buffer.write(code);
-            const bytes = getValueSafely(codeToBytesMap, code);
-            assert(bytes >= lengthOfDataLen, 0x283 /* "Length of data len should fit in the bytes from the map" */);
-            assert(bytes >= idLength, 0x284 /* "Length of id should fit in the bytes from the map" */);
-            // Assign and write id for const string.
-            buffer.write(id, bytes);
-            // Write length of const string.
-            buffer.write(data.length, bytes);
-            // Write const string data.
-            for (const element of data) {
-                buffer.write(element);
-            }
-        } else {
-            idLength = calcLength(id);
-        }
-        // Write Marker Code
-        buffer.write(getValueSafely(constStringBytesToCodeMap, idLength));
-        // Write id of const string
-        buffer.write(id, idLength);
-    } else {
-        // Write Marker code.
-        buffer.write(blob.useUtf8Code ? getValueSafely(utf8StringBytesToCodeMap, lengthOfDataLen)
-            : getValueSafely(binaryBytesToCodeMap, lengthOfDataLen));
-        // Write actual data if length greater than 0, otherwise Marker Code is enough.
-        if (lengthOfDataLen > 0) {
-            buffer.write(data.length, lengthOfDataLen);
-            for (const element of data) {
-                buffer.write(element);
-            }
+    // Write Marker code.
+    buffer.write(getValueSafely(codeMap, lengthOfDataLen));
+    // Write actual data if length greater than 0, otherwise Marker Code is enough.
+    if (lengthOfDataLen > 0) {
+        buffer.write(data.length, lengthOfDataLen);
+        for (const element of data) {
+            buffer.write(element);
         }
     }
 }
@@ -212,7 +225,7 @@ function serializeNodeCore(buffer: WriteBuffer, nodeCore: NodeCore, dictionary: 
             serializeNodeCore(buffer, child, dictionary);
             buffer.write(endCode);
         } else if (child instanceof BlobCore) {
-            serializeBlob(buffer, child, dictionary);
+            serializeBlob(buffer, child.buffer);
         } else if (typeof child === "number") {
             // Calculate length in which integer will be stored
             const len = calcLength(child);
@@ -225,7 +238,12 @@ function serializeNodeCore(buffer: WriteBuffer, nodeCore: NodeCore, dictionary: 
         } else if (typeof child === "boolean") {
             buffer.write(boolToCodeMap[child ? 1 : 0]);
         } else {
-            unreachableCase(child, "Unsupported node type");
+            assert(child._stringElement, "Unsupported node type");
+            if (child.dictionary) {
+                serializeDictionaryString(buffer, child.content, dictionary);
+            } else {
+                serializeString(buffer, child.content);
+            }
         }
     }
 }

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -39,7 +39,7 @@ function readBlobSection(node: NodeTypes) {
         const blob = node.getNode(count);
         const records = getNodeProps(blob);
         assertBlobCoreInstance(records.data, "data should be of BlobCore type");
-        const id = getStringInstance(records.id, "blob id should be of BlobCore type");
+        const id = getStringInstance(records.id, "blob id should be string");
         blobs.set(id, records.data.arrayBuffer);
     }
     return blobs;
@@ -73,12 +73,12 @@ function readTreeSection(node: NodeCore) {
         commits: {},
         trees: {},
     };
-    for (let count = 0; count < node.length; count++) {
-        const treeNode = node.getNode(count);
+    for (const treeNode of node) {
+        assertNodeCoreInstance(treeNode, "getNode should return a node");
         const records = getNodeProps(treeNode);
-        const path = getStringInstance(records.name, "Path should be of BlobCore");
+        const path = getStringInstance(records.name, "Path name should be string");
         if (records.value !== undefined) {
-            const value = getStringInstance(records.value, "Blob value should be BlobCore");
+            const value = getStringInstance(records.value, "Blob value should be string");
             snapshotTree.blobs[path] = value;
         } else if (records.children !== undefined) {
             assertNodeCoreInstance(records.children, "Trees should be of type NodeCore");
@@ -88,7 +88,7 @@ function readTreeSection(node: NodeCore) {
         }
         if (records.unreferenced !== undefined) {
             assertBoolInstance(records.unreferenced, "Unreferenced flag should be bool");
-            const unreferenced = records.unreferenced.valueOf();
+            const unreferenced = records.unreferenced;
             assert(unreferenced, 0x281 /* "Unreferenced if present should be true" */);
             snapshotTree.unreferenced = unreferenced;
         }
@@ -107,7 +107,7 @@ function readSnapshotSection(node: NodeTypes): ISnapshotSection {
     assertNodeCoreInstance(records.treeNodes, "TreeNodes should be of type NodeCore");
     assertNumberInstance(records.sequenceNumber, "sequenceNumber should be of type number");
     const snapshotTree: ISnapshotTree = readTreeSection(records.treeNodes);
-    snapshotTree.id = getStringInstance(records.id, "snapshotId should be BlobCore");
+    snapshotTree.id = getStringInstance(records.id, "snapshotId should be string");
     const sequenceNumber = records.sequenceNumber.valueOf();
     return {
         sequenceNumber,
@@ -127,8 +127,8 @@ export function parseCompactSnapshotResponse(buffer: ReadBuffer): ISnapshotConte
 
     const records = getNodeProps(root);
 
-    const mrv = getStringInstance(records.mrv, "minReadVersion should be of BlobCore type");
-    const cv = getStringInstance(records.cv, "createVersion should be of BlobCore type");
+    const mrv = getStringInstance(records.mrv, "minReadVersion should be string");
+    const cv = getStringInstance(records.cv, "createVersion should be string");
     if (records.lsn !== undefined) {
         assertNumberInstance(records.lsn, "lsn should be a number");
     }

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -7,7 +7,6 @@ import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { ISnapshotContents } from "./odspPublicUtils";
 import { ReadBuffer } from "./ReadBufferUtils";
-import { ISnapshotTreeEx } from "./contracts";
 import {
     assertBlobCoreInstance,
     getStringInstance,
@@ -68,10 +67,10 @@ function readOpsSection(node: NodeTypes) {
  * @param node - tree node to de-serialize from
  */
 function readTreeSection(node: NodeCore) {
-    const snapshotTree: ISnapshotTreeEx = {
+    const trees = {};
+    const snapshotTree: ISnapshotTree = {
         blobs: {},
-        commits: {},
-        trees: {},
+        trees,
     };
     for (const treeNode of node) {
         assertNodeCoreInstance(treeNode, "tree nodes should be nodes");
@@ -88,9 +87,9 @@ function readTreeSection(node: NodeCore) {
             snapshotTree.blobs[path] = getStringInstance(records.value, "Blob value should be string");
         } else if (records.children !== undefined) {
             assertNodeCoreInstance(records.children, "Trees should be of type NodeCore");
-            snapshotTree.trees[path] = readTreeSection(records.children);
+            trees[path] = readTreeSection(records.children);
         } else {
-            snapshotTree.trees[path] = { blobs: {}, commits: {}, trees: {} };
+            trees[path] = { blobs: {}, trees: {} };
         }
     }
     return snapshotTree;

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -9,7 +9,13 @@ import { snapshotMinReadVersion } from "./compactSnapshotParser";
 import { ISnapshotContents } from "./odspPublicUtils";
 import { ReadBuffer } from "./ReadBufferUtils";
 import { TreeBuilderSerializer } from "./WriteBufferUtils";
-import { addBoolProperty, addNumberProperty, addStringProperty, NodeCore } from "./zipItDataRepresentationUtils";
+import {
+    addBoolProperty,
+    addNumberProperty,
+    addStringProperty,
+    addDictionaryStringProperty,
+    NodeCore,
+} from "./zipItDataRepresentationUtils";
 
 /**
  * Writes header section of the snapshot.
@@ -28,16 +34,16 @@ function writeSnapshotProps(node: NodeCore, latestSequenceNumber: number) {
  * @param blobs - blobs that is being serialized
 */
 function writeBlobsSection(snapshotNode: NodeCore, blobs: Map<string, IBlob | ArrayBuffer>) {
-    snapshotNode.addString("blobs", true);
+    snapshotNode.addDictionaryString("blobs");
     const blobsNode = snapshotNode.addNode("list");
     for (const [storageBlobId, blob] of blobs) {
         const blobNode = blobsNode.addNode();
-        addStringProperty(blobNode, "id", storageBlobId, true);
-        blobNode.addString("data", true);
+        addDictionaryStringProperty(blobNode, "id", storageBlobId);
+        blobNode.addString("data");
         if (blob instanceof ArrayBuffer) {
-            blobNode.addBlob(new Uint8Array(blob), false);
+            blobNode.addBlob(new Uint8Array(blob));
         } else {
-            blobNode.addBlob(new Uint8Array(stringToBuffer(blob.contents, blob.encoding ?? "utf-8")), false);
+            blobNode.addBlob(new Uint8Array(stringToBuffer(blob.contents, blob.encoding ?? "utf-8")));
         }
     }
 }
@@ -48,7 +54,7 @@ function writeBlobsSection(snapshotNode: NodeCore, blobs: Map<string, IBlob | Ar
  * @param snapshotTree - snapshot tree that is being serialized
 */
 function writeTreeSection(snapshotNode: NodeCore, snapshotTree: ISnapshotTree) {
-    snapshotNode.addString("treeNodes", true);
+    snapshotNode.addDictionaryString("treeNodes");
     const treesNode = snapshotNode.addNode("list");
     writeTreeSectionCore(treesNode, snapshotTree);
 }
@@ -56,13 +62,16 @@ function writeTreeSection(snapshotNode: NodeCore, snapshotTree: ISnapshotTree) {
 function writeTreeSectionCore(treesNode: NodeCore, snapshotTree: ISnapshotTree) {
     for (const [path, value] of Object.entries(snapshotTree.trees)) {
         const treeNode = treesNode.addNode();
-        addStringProperty(treeNode, "name", path);
+        // Many leaf nodes in the tree have same names like "content", "body", "header"
+        // We could be smarter here and not use dictionary where we are sure reuse is unlikely, but
+        // it does not feel like it's worth it.
+        addDictionaryStringProperty(treeNode, "name", path);
         if (snapshotTree.unreferenced) {
             addBoolProperty(treeNode, "unreferenced", snapshotTree.unreferenced);
         }
         // Only write children prop if either blobs or trees are present.
         if (Object.keys(value.blobs).length > 0 || Object.keys(value.trees).length > 0) {
-            treeNode.addString("children", true);
+            treeNode.addDictionaryString("children");
             const childNode = treeNode.addNode("list");
             writeTreeSectionCore(childNode, value);
         }
@@ -71,8 +80,8 @@ function writeTreeSectionCore(treesNode: NodeCore, snapshotTree: ISnapshotTree) 
     if (snapshotTree.blobs) {
         for (const [path, id] of Object.entries(snapshotTree.blobs)) {
             const blobNode = treesNode.addNode();
-            addStringProperty(blobNode, "name", path);
-            addStringProperty(blobNode, "value", id, true);
+            addDictionaryStringProperty(blobNode, "name", path);
+            addDictionaryStringProperty(blobNode, "value", id);
         }
     }
 }
@@ -89,7 +98,7 @@ function writeSnapshotSection(
     snapshotTree: ISnapshotTree,
     snapshotSequenceNumber: number,
 ) {
-    rootNode.addString("snapshot", true);
+    rootNode.addDictionaryString("snapshot");
     const snapshotNode = rootNode.addNode();
 
     const snapshotId = snapshotTree.id;
@@ -113,13 +122,13 @@ function writeOpsSection(rootNode: NodeCore, ops: ISequencedDocumentMessage[]) {
         firstSequenceNumber = ops[0].sequenceNumber;
     }
     if (firstSequenceNumber !== undefined) {
-        rootNode.addString("deltas", true);
+        rootNode.addDictionaryString("deltas");
         const opsNode = rootNode.addNode();
         addNumberProperty(opsNode, "firstSequenceNumber", firstSequenceNumber);
-        opsNode.addString("deltas", true);
+        opsNode.addDictionaryString("deltas");
         const deltaNode = opsNode.addNode("list");
         ops.forEach((op) => {
-            deltaNode.addString(JSON.stringify(op), false);
+            deltaNode.addString(JSON.stringify(op));
         });
     }
 }

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -7,20 +7,6 @@ import * as api from "@fluidframework/protocol-definitions";
 import { HostStoragePolicy } from "@fluidframework/odsp-driver-definitions";
 import { ISnapshotContents } from "./odspPublicUtils";
 
-/** https://portal.microsofticm.com/imp/v3/incidents/details/308931013/home
- * The commits property was removed from protocol-definitions but in order to support back compat, we will
- * temporarily add back in this local structure in order to upload the snapshot to support rolling back to 0.58.
- * Notice this entire interface will be removed once the backward compatibility is not required anymore.
-*/
-export interface ISnapshotTreeEx {
-    id?: string;
-    blobs: { [path: string]: string; };
-    commits: { [path: string]: string; };
-    trees: { [path: string]: ISnapshotTreeEx; };
-    // Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
-    unreferenced?: true;
-}
-
 /**
  * Socket storage discovery api response
  */

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -4,11 +4,10 @@
  */
 
 import { v4 as uuid } from "uuid";
-import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { ISummaryTree, SummaryType, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { getDocAttributesFromProtocolSummary } from "@fluidframework/driver-utils";
 import { stringToBuffer, unreachableCase } from "@fluidframework/common-utils";
 import { ISnapshotContents } from "./odspPublicUtils";
-import { ISnapshotTreeEx } from "./contracts";
 
 /**
  * Converts a summary(ISummaryTree) taken in detached container to snapshot tree and blobs
@@ -35,10 +34,9 @@ function convertCreateNewSummaryTreeToTreeAndBlobsCore(
     summary: ISummaryTree,
     blobs: Map<string, ArrayBuffer>,
 ) {
-    const treeNode: ISnapshotTreeEx = {
+    const treeNode: ISnapshotTree = {
         blobs: {},
         trees: {},
-        commits: {},
         unreferenced: summary.unreferenced,
     };
     const keys = Object.keys(summary.tree);

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -5,7 +5,7 @@
 
 import { assert, stringToBuffer } from "@fluidframework/common-utils";
 import * as api from "@fluidframework/protocol-definitions";
-import { IOdspSnapshot, IOdspSnapshotCommit, ISnapshotTreeEx } from "./contracts";
+import { IOdspSnapshot, IOdspSnapshotCommit } from "./contracts";
 import { ISnapshotContents } from "./odspPublicUtils";
 
 /**
@@ -18,7 +18,7 @@ import { ISnapshotContents } from "./odspPublicUtils";
 function buildHierarchy(flatTree: IOdspSnapshotCommit): api.ISnapshotTree {
     const lookup: { [path: string]: api.ISnapshotTree; } = {};
     // id is required for root tree as it will be used to determine the version we loaded from.
-    const root: ISnapshotTreeEx = { id: flatTree.id, blobs: {}, commits: {}, trees: {} };
+    const root: api.ISnapshotTree = { id: flatTree.id, blobs: {}, trees: {} };
     lookup[""] = root;
 
     for (const entry of flatTree.entries) {
@@ -31,10 +31,9 @@ function buildHierarchy(flatTree: IOdspSnapshotCommit): api.ISnapshotTree {
 
         // Add in either the blob or tree
         if (entry.type === "tree") {
-            const newTree: ISnapshotTreeEx = {
+            const newTree: api.ISnapshotTree = {
                 blobs: {},
                 trees: {},
-                commits: {},
                 unreferenced: entry.unreferenced,
             };
             node.trees[decodeURIComponent(entryPathBase)] = newTree;

--- a/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
@@ -108,7 +108,7 @@ describe("JSON Snapshot Format Conversion Tests", () => {
         assert(Object.keys(result.snapshotTree.trees).length === 2, "2 trees should be there");
         const shouldBeEmptyTree = result.snapshotTree.trees[".app"]?.trees[".channels"]
             ?.trees["23c54bd8-ef53-42fa-a898-413de4c6f0f2"]?.trees["d65a4af3-0bf8-4052-8442-a898651ad9b8"];
-        const emptyTree = { blobs: {}, trees: {}, commits: {}, unreferenced: undefined };
+        const emptyTree = { blobs: {}, trees: {}, unreferenced: undefined };
         assert.deepStrictEqual(shouldBeEmptyTree, emptyTree, "Tree should have no blobs and trees");
     });
 });

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -6,17 +6,15 @@
 /* eslint-disable max-len */
 
 import { strict as assert } from "assert";
-import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { stringToBuffer } from "@fluidframework/common-utils";
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser";
 import { convertToCompactSnapshot } from "../compactSnapshotWriter";
 import { ISnapshotContents } from "../odspPublicUtils";
-import { ISnapshotTreeEx } from "../contracts";
 
-const snapshotTree: ISnapshotTreeEx = {
+const snapshotTree: ISnapshotTree = {
     id: "SnapshotId",
     blobs: {},
-    commits: {},
     trees: {
         ".protocol": {
             blobs: {
@@ -24,29 +22,24 @@ const snapshotTree: ISnapshotTreeEx = {
                 quorumMembers: "bARBkx1nses1pHL1vKnmFUfIC",
                 quorumProposals: "bARBkx1nses1pHL1vKnmFUfIC",
             },
-            commits: {},
             trees: {},
         },
         ".app": {
             blobs: { ".metadata": "bARD4RKvW4LL1KmaUKp6hUMSp" },
-            commits: {},
             trees: {
                 ".channels": {
                     blobs: {},
-                    commits: {},
                     trees: {
                         default: {
                             blobs: {
                                 ".component": "bARC6dCXlcrPxQHw3PeROtmKc",
                                 "gc": "bARDNMoBed+nKrsf04id52iUA",
                             },
-                            commits: {},
                             trees: {
                                 ".channels": {
                                     blobs: {},
-                                    commits: {},
                                     trees: {
-                                        root: { blobs: {}, commits: {}, trees: {} },
+                                        root: { blobs: {}, trees: {} },
                                     },
                                 },
                             },
@@ -54,7 +47,7 @@ const snapshotTree: ISnapshotTreeEx = {
                     },
                     unreferenced: true,
                 },
-                ".blobs": { blobs: {}, commits: {}, trees: {} },
+                ".blobs": { blobs: {}, trees: {} },
             },
             unreferenced: true,
         },

--- a/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
@@ -16,6 +16,7 @@ import {
     assertNodeCoreInstance,
     assertNumberInstance,
     assertBoolInstance,
+    IStringElement,
 } from "../zipItDataRepresentationUtils";
 
 function compareNodes(node1: NodeTypes, node2: NodeTypes) {
@@ -36,7 +37,10 @@ function compareNodes(node1: NodeTypes, node2: NodeTypes) {
         assert(typeof node2 === "boolean", "Content2 should be boolean");
         assert.strictEqual(node1, node2, "Bool value should be equal");
     } else {
-        assert.fail("Unknown entity type!!");
+        assert(node1._stringElement, "Unknown entity type!!");
+        const maybeString2 = node2 as IStringElement;
+        assert(maybeString2._stringElement, "Content2 is not a string");
+        assert(node1.content === maybeString2.content, "Blob contents not same");
     }
 }
 
@@ -93,44 +97,44 @@ describe("Tree Representation tests", () => {
     });
 
     it("empty string", async () => {
-        builder.addString("", false);
+        builder.addString("");
         // 1 for Marker Code is enough for empty string.
         validate(1);
     });
 
     it("small string", async () => {
-        builder.addString("first", false);
+        builder.addString("first");
         validate(2 + 5);
     });
 
     it("small const string", async () => {
-        builder.addString("first", true);
+        builder.addDictionaryString("first");
         validate(8 + 2);
     });
 
     it("empty buffer", async () => {
-        builder.addBlob(createLongBuffer(0), false);
+        builder.addBlob(createLongBuffer(0));
         validate(1);
     });
 
     it("single long buffer (255)", async () => {
-        builder.addBlob(createLongBuffer(255), false);
+        builder.addBlob(createLongBuffer(255));
         validate(2 + 255);
     });
 
     it("single long buffer (256)", async () => {
-        builder.addBlob(createLongBuffer(256), false);
+        builder.addBlob(createLongBuffer(256));
         // 1 for Marker Code, 2 for representing length of buffer and 256 for data
         validate(1 + 2 + 256);
     });
 
     it("single long buffer (257)", async () => {
-        builder.addBlob(createLongBuffer(257), false);
+        builder.addBlob(createLongBuffer(257));
         validate(1 + 2 + 257);
     });
 
     it("single long buffer", async () => {
-        builder.addBlob(createLongBuffer(65538), false);
+        builder.addBlob(createLongBuffer(65538));
         validate(1 + 4 + 65538);
     });
 
@@ -141,18 +145,18 @@ describe("Tree Representation tests", () => {
     });
 
     it("two buffer", async () => {
-        builder.addString("first", false);
-        builder.addString("Seventeen", false);
+        builder.addString("first");
+        builder.addString("Seventeen");
         validate(2 + 5 + 2 + 9);
     });
 
     it("single node + buffer", async () => {
-        builder.addNode().addString("first", false);
+        builder.addNode().addString("first");
         validate(2 + 2 + 5);
     });
 
     it("single node + const string", async () => {
-        builder.addNode().addString("first", true);
+        builder.addNode().addDictionaryString("first");
         validate(2 + 8 + 2);
     });
 
@@ -161,22 +165,22 @@ describe("Tree Representation tests", () => {
         for (let i = 0; i <= 256; ++i) {
             str += "a";
         }
-        builder.addNode().addString(str, true);
+        builder.addNode().addDictionaryString(str);
         validate(2 + 9 + 257 + 2);
     });
 
     it("complex tree structure", async () => {
-        builder.addString("first", false);
+        builder.addString("first");
         const node = builder.addNode();
-        node.addString("second", false);
-        node.addString("third", false);
+        node.addString("second");
+        node.addString("third");
         const node2 = node.addNode();
-        node2.addString("fourth", false);
+        node2.addString("fourth");
         validate(2 + 5 + 2 + 2 + 6 + 2 + 5 + 2 + 2 + 6);
     });
 
     it("blob instance test", async () => {
-        const blobNode = new BlobShallowCopy(new ReadBuffer(new Uint8Array()), 0, 0, false);
+        const blobNode = new BlobShallowCopy(new ReadBuffer(new Uint8Array()), 0, 0);
         assertBlobCoreInstance(blobNode, "should be a blob");
 
         let success = true;
@@ -194,7 +198,7 @@ describe("Tree Representation tests", () => {
         assertNodeCoreInstance(node, "should be a node");
 
         let success = true;
-        const nonNode: NodeTypes = new BlobShallowCopy(new ReadBuffer(new Uint8Array()), 0, 0, false);
+        const nonNode: NodeTypes = new BlobShallowCopy(new ReadBuffer(new Uint8Array()), 0, 0);
         try {
             assertNodeCoreInstance(nonNode, "should be a node");
         } catch (err) {
@@ -208,7 +212,7 @@ describe("Tree Representation tests", () => {
         assertNumberInstance(numNode, "should be a number");
 
         let success = true;
-        const nonNumberNode: NodeTypes = new BlobShallowCopy(new ReadBuffer(new Uint8Array()), 0, 0, false);
+        const nonNumberNode: NodeTypes = new BlobShallowCopy(new ReadBuffer(new Uint8Array()), 0, 0);
         try {
             assertNumberInstance(nonNumberNode, "should be a number");
         } catch (err) {

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -430,7 +430,10 @@ export class NodeCore {
                     this.children.push(false);
                     continue;
                 case MarkerCodesEnd.list:
+                    assert(this.type === "list", "Mismatch in end of list");
+                    return;
                 case MarkerCodesEnd.set:
+                    assert(this.type === "set", "Mismatch in end of set");
                     return;
                 default:
                     throw new Error(`Invalid code: ${code}`);

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -114,7 +114,7 @@ export function getValueSafely(map: { [index: number]: number; }, key: number) {
 export function getNodeProps(node: NodeCore) {
     const res: Record<string, NodeTypes> = {};
     for (const [keyNode, valueNode] of node.iteratePairs()) {
-        const id = getStringInstance(keyNode, "keynode should be a blob");
+        const id = getStringInstance(keyNode, "keynode should be a string");
         res[id] = valueNode;
     }
     return res;
@@ -283,7 +283,7 @@ export class NodeCore {
 
     public getString(index: number): string {
         const node = this.children[index];
-        return getStringInstance(node, "getString should return stringblob");
+        return getStringInstance(node, "getString should return string");
     }
 
     public getBlob(index: number): BlobCore {


### PR DESCRIPTION
More clearly separate blobs, dictionary strings and strings.
Reduce amount of time we parse blobs when dealing with dictionary strings (by keeping a dictionary of strings, not blobs), and overall attempt to reduce number of objects we create on a string parsing path.
Removed a bunch of validation in getAndValidateNodeProps() and pushed it to callers, as they already validate presence and type of properties. Returning extra properties is Ok here.