### PR TITLE
Remove `DeltaScheduler` and `ScheduleManager` from the public API

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -74,6 +74,7 @@ It's not a breaking change, but worth noting: we are now also exposing optional 
 ## 3.0.0 Breaking changes
 - [Remove ISummaryConfigurationHeuristics.idleTime](#Remove-ISummaryConfigurationHeuristicsidleTime)
 - [Remove `IContainerRuntime.flush`](#remove-icontainerruntimeflush)
+- [Remove `ScheduleManager` and `DeltaScheduler`](#remove-schedulemanager-and-deltascheduler)
 
 ### Remove ISummaryConfigurationHeuristics.idleTime
 `ISummaryConfigurationHeuristics.idleTime` has been removed. See [#10008](https://github.com/microsoft/FluidFramework/issues/10008)
@@ -81,6 +82,9 @@ Please move all usage to the new `minIdleTime` and `maxIdleTime` properties in `
 
 ### Remove `IContainerRuntime.flush`
 `IContainerRuntime.flush` has been removed. If a more manual/ensured flushing process is needed, move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
+
+### Remove `ScheduleManager` and `DeltaScheduler`
+`ScheduleManager` and `DeltaScheduler` have been removed from the `@fluidframework/container-runtime` package as they are Fluid internal classes which should not be used.
 
 # 2.0.0
 

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -206,17 +206,6 @@ export interface ContainerRuntimeMessage {
 // @public (undocumented)
 export const DefaultSummaryConfiguration: ISummaryConfiguration;
 
-// @public
-export class DeltaScheduler {
-    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, logger: ITelemetryLogger);
-    // (undocumented)
-    batchBegin(message: ISequencedDocumentMessage): void;
-    // (undocumented)
-    batchEnd(message: ISequencedDocumentMessage): void;
-    // (undocumented)
-    static readonly processingTime = 50;
-}
-
 // @public (undocumented)
 export type EnqueueSummarizeResult = (ISummarizeResults & {
     readonly alreadyEnqueued?: undefined;
@@ -679,15 +668,6 @@ export enum RuntimeMessage {
     Operation = "op",
     // (undocumented)
     Rejoin = "rejoin"
-}
-
-// @public
-export class ScheduleManager {
-    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, emitter: EventEmitter, logger: ITelemetryLogger);
-    // (undocumented)
-    afterOpProcessing(error: any | undefined, message: ISequencedDocumentMessage): void;
-    // (undocumented)
-    beforeOpProcessing(message: ISequencedDocumentMessage): void;
 }
 
 // @public

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -161,6 +161,14 @@
       "TypeAliasDeclaration_SummarizerStopReason": {
         "forwardCompat": false,
         "backCompat": false
+      },
+      "RemovedClassDeclaration_DeltaScheduler": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "RemovedClassDeclaration_ScheduleManager": {
+        "forwardCompat": false,
+        "backCompat": false
       }
     }
   }

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -25,7 +25,6 @@ export {
     DefaultSummaryConfiguration,
     ICompressionRuntimeOptions,
 } from "./containerRuntime";
-export { DeltaScheduler } from "./deltaScheduler";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";
 export {
     gcBlobPrefix,
@@ -39,7 +38,6 @@ export {
     IPendingMessage,
     IPendingState,
 } from "./pendingStateManager";
-export { ScheduleManager } from "./scheduleManager";
 export { Summarizer } from "./summarizer";
 export {
     EnqueueSummarizeResult,

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -139,26 +139,14 @@ use_old_VariableDeclaration_DefaultSummaryConfiguration(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DeltaScheduler": {"forwardCompat": false}
+* "RemovedClassDeclaration_DeltaScheduler": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_DeltaScheduler():
-    TypeOnly<old.DeltaScheduler>;
-declare function use_current_ClassDeclaration_DeltaScheduler(
-    use: TypeOnly<current.DeltaScheduler>);
-use_current_ClassDeclaration_DeltaScheduler(
-    get_old_ClassDeclaration_DeltaScheduler());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_DeltaScheduler": {"backCompat": false}
+* "RemovedClassDeclaration_DeltaScheduler": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_DeltaScheduler():
-    TypeOnly<current.DeltaScheduler>;
-declare function use_old_ClassDeclaration_DeltaScheduler(
-    use: TypeOnly<old.DeltaScheduler>);
-use_old_ClassDeclaration_DeltaScheduler(
-    get_current_ClassDeclaration_DeltaScheduler());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1567,26 +1555,14 @@ use_old_EnumDeclaration_RuntimeMessage(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_ScheduleManager": {"forwardCompat": false}
+* "RemovedClassDeclaration_ScheduleManager": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_ScheduleManager():
-    TypeOnly<old.ScheduleManager>;
-declare function use_current_ClassDeclaration_ScheduleManager(
-    use: TypeOnly<current.ScheduleManager>);
-use_current_ClassDeclaration_ScheduleManager(
-    get_old_ClassDeclaration_ScheduleManager());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_ScheduleManager": {"backCompat": false}
+* "RemovedClassDeclaration_ScheduleManager": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_ScheduleManager():
-    TypeOnly<current.ScheduleManager>;
-declare function use_old_ClassDeclaration_ScheduleManager(
-    use: TypeOnly<old.ScheduleManager>);
-use_old_ClassDeclaration_ScheduleManager(
-    get_current_ClassDeclaration_ScheduleManager());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/test/functional-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/functional-tests/src/test/containerRuntime.spec.ts
@@ -19,7 +19,11 @@ import { IConnectionManagerFactoryArgs } from "@fluidframework/container-loader/
 // eslint-disable-next-line import/no-internal-modules
 import { ConnectionManager } from "@fluidframework/container-loader/dist/connectionManager";
 import { MockDocumentDeltaConnection, MockDocumentService } from "@fluidframework/test-loader-utils";
-import { ScheduleManager, DeltaScheduler } from "@fluidframework/container-runtime";
+// ADO:1981
+// eslint-disable-next-line import/no-internal-modules
+import { ScheduleManager } from "@fluidframework/container-runtime/dist/scheduleManager";
+// eslint-disable-next-line import/no-internal-modules
+import { DeltaScheduler } from "@fluidframework/container-runtime/dist/deltaScheduler";
 
 describe("Container Runtime", () => {
     /**


### PR DESCRIPTION
## Description

These are fluid internal classes which shouldn't be exported.

## Does this introduce a breaking change?

yes
