### PR TITLE
Odsp binary snapshot: unrolling most sensitive code to get 40% parsing perf gain

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -36,6 +36,25 @@ function readBlobSection(node: NodeTypes) {
     const blobs: Map<string, ArrayBuffer> = new Map();
     for (const blob of node) {
         assertNodeCoreInstance(blob, "blob should be node");
+
+        const length = blob.length;
+        assert((length % 2) === 0, "reading pairs");
+
+        /**
+         * Perf optimization - the most common cases!
+         * This is essentially unrolling code below for faster processing
+         * It speeds up tree parsing by 2-3x times!
+         */
+        if (blob.length === 4 && blob.getMaybeString(0) === "id" && blob.getMaybeString(2) === "data") {
+            // "id": <node name>
+            // "data": <blob>
+            blobs.set(blob.getString(1), blob.getBlob(3).arrayBuffer);
+            continue;
+        }
+
+        /**
+         * More generalized workflow
+         */
         const records = getNodeProps(blob);
         assertBlobCoreInstance(records.data, "data should be of BlobCore type");
         const id = getStringInstance(records.id, "blob id should be string");
@@ -74,6 +93,58 @@ function readTreeSection(node: NodeCore) {
     };
     for (const treeNode of node) {
         assertNodeCoreInstance(treeNode, "tree nodes should be nodes");
+
+        const length = treeNode.length;
+        assert((length % 2) === 0, "reading pairs");
+
+        /**
+         * Perf optimization - the most common cases!
+         * This is essentially unrolling code below for faster processing
+         * It speeds up tree parsing by 2-3x times!
+         */
+        if (treeNode.getMaybeString(0) === "name") {
+            if (treeNode.length === 4) {
+                const content = treeNode.getMaybeString(2);
+                // "name": <node name>
+                // "children": <blob id>
+                if (content === "children") {
+                    trees[treeNode.getString(1)] = readTreeSection(treeNode.getNode(3));
+                    continue;
+                }
+                // "name": <node name>
+                // "value": <blob id>
+                if (content === "value") {
+                    snapshotTree.blobs[treeNode.getString(1)] = treeNode.getString(3);
+                    continue;
+                }
+            }
+
+            // "name": <node name>
+            // "nodeType": 3
+            // "value": <blob id>
+            if (treeNode.length === 6 &&
+                    treeNode.getMaybeString(2) === "nodeType" &&
+                    treeNode.getMaybeString(4) === "value") {
+                snapshotTree.blobs[treeNode.getString(1)] = treeNode.getString(5);
+                continue;
+            }
+
+            // "name": <node name>
+            // "unreferenced": true
+            // "children": <blob id>
+            if (treeNode.length === 6 &&
+                    treeNode.getMaybeString(2) === "unreferenced" &&
+                    treeNode.getMaybeString(4) === "children") {
+                trees[treeNode.getString(1)] = readTreeSection(treeNode.getNode(5));
+                assert(treeNode.getBool(3), "Unreferenced if present should be true");
+                snapshotTree.unreferenced = true;
+                continue;
+            }
+        }
+
+        /**
+         * More generalized workflow
+         */
         const records = getNodeProps(treeNode);
 
         if (records.unreferenced !== undefined) {

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -37,9 +37,6 @@ function readBlobSection(node: NodeTypes) {
     for (const blob of node) {
         assertNodeCoreInstance(blob, "blob should be node");
 
-        const length = blob.length;
-        assert((length % 2) === 0, "reading pairs");
-
         /**
          * Perf optimization - the most common cases!
          * This is essentially unrolling code below for faster processing
@@ -94,16 +91,14 @@ function readTreeSection(node: NodeCore) {
     for (const treeNode of node) {
         assertNodeCoreInstance(treeNode, "tree nodes should be nodes");
 
-        const length = treeNode.length;
-        assert((length % 2) === 0, "reading pairs");
-
         /**
          * Perf optimization - the most common cases!
          * This is essentially unrolling code below for faster processing
          * It speeds up tree parsing by 2-3x times!
          */
         if (treeNode.getMaybeString(0) === "name") {
-            if (treeNode.length === 4) {
+            const length = treeNode.length;
+            if (length === 4) {
                 const content = treeNode.getMaybeString(2);
                 // "name": <node name>
                 // "children": <blob id>
@@ -122,7 +117,7 @@ function readTreeSection(node: NodeCore) {
             // "name": <node name>
             // "nodeType": 3
             // "value": <blob id>
-            if (treeNode.length === 6 &&
+            if (length === 6 &&
                     treeNode.getMaybeString(2) === "nodeType" &&
                     treeNode.getMaybeString(4) === "value") {
                 snapshotTree.blobs[treeNode.getString(1)] = treeNode.getString(5);

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -96,8 +96,8 @@ function readTreeSection(node: NodeCore) {
          * This is essentially unrolling code below for faster processing
          * It speeds up tree parsing by 2-3x times!
          */
-        if (treeNode.getMaybeString(0) === "name") {
-            const length = treeNode.length;
+         const length = treeNode.length;
+         if (length > 0 && treeNode.getMaybeString(0) === "name") {
             if (length === 4) {
                 const content = treeNode.getMaybeString(2);
                 // "name": <node name>
@@ -127,7 +127,7 @@ function readTreeSection(node: NodeCore) {
             // "name": <node name>
             // "unreferenced": true
             // "children": <blob id>
-            if (treeNode.length === 6 &&
+            if (length === 6 &&
                     treeNode.getMaybeString(2) === "unreferenced" &&
                     treeNode.getMaybeString(4) === "children") {
                 trees[treeNode.getString(1)] = readTreeSection(treeNode.getNode(5));

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -286,6 +286,11 @@ export class NodeCore {
         return getStringInstance(node, "getString should return string");
     }
 
+    public getMaybeString(index: number) {
+        const node = this.children[index];
+        return getMaybeStringInstance(node);
+    }
+
     public getBlob(index: number): BlobCore {
         const node = this.children[index];
         assertBlobCoreInstance(node, "getBlob should return a blob");
@@ -453,6 +458,13 @@ export class TreeBuilder extends NodeCore {
         builder.load(buffer, dictionary);
         assert(buffer.eof, 0x233 /* "Unexpected data at the end of buffer" */);
         return builder;
+    }
+}
+
+export function getMaybeStringInstance(node: NodeTypes): string | undefined {
+    const maybeString = node as IStringElement;
+    if (maybeString._stringElement) {
+        return maybeString.content;
     }
 }
 


### PR DESCRIPTION
These changes make
- readSnapshotSection() 2.5x faster
- readBlobSection() 1.5x faster

Overall, it looks like it makes binary snapshot parsing code about 40% faster.