### PR TITLE
fix: r11s-driver cache pollutes other docs using same docservicefactory

### DIFF
--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -107,7 +107,7 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
             requestVersion = versions[0];
         }
 
-        const cachedSnapshotTree = await this.snapshotTreeCache?.get(this.getSnapshotCacheKey(requestVersion.treeId));
+        const cachedSnapshotTree = await this.snapshotTreeCache?.get(this.getCacheKey(requestVersion.treeId));
         if (cachedSnapshotTree) {
             return cachedSnapshotTree.snapshotTree as ISnapshotTreeEx;
         }
@@ -129,14 +129,14 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
         );
         const tree = buildHierarchy(rawTree, this.blobsShaCache, true);
         await this.snapshotTreeCache?.put(
-            this.getSnapshotCacheKey(tree.id),
+            this.getCacheKey(tree.id),
             { id: requestVersion.id, snapshotTree: tree },
         );
         return tree;
     }
 
     public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-        const cachedBlob = await this.blobCache?.get(this.getBlobCacheKey(blobId));
+        const cachedBlob = await this.blobCache?.get(this.getCacheKey(blobId));
         if (cachedBlob) {
             return cachedBlob;
         }
@@ -158,7 +158,7 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
         );
         this.blobsShaCache.set(value.sha, "");
         const bufferContent = stringToBuffer(value.content, value.encoding);
-        await this.blobCache?.put(this.getBlobCacheKey(value.sha), bufferContent);
+        await this.blobCache?.put(this.getCacheKey(value.sha), bufferContent);
         return bufferContent;
     }
 
@@ -216,11 +216,7 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
             : undefined;
     }
 
-    private getBlobCacheKey(blobId: string): string {
+    private getCacheKey(blobId: string): string {
         return `${this.id}:${blobId}`;
-    }
-
-    private getSnapshotCacheKey(snapshotId: string): string {
-        return `${this.id}:${snapshotId}`;
     }
 }

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -120,7 +120,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
     }
 
     public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-        const cachedBlob = await this.blobCache.get(this.getBlobCacheKey(blobId));
+        const cachedBlob = await this.blobCache.get(this.getCacheKey(blobId));
         if (cachedBlob !== undefined) {
             return cachedBlob;
         }
@@ -142,7 +142,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
         );
         const bufferValue = stringToBuffer(blob.content, blob.encoding);
 
-        await this.blobCache.put(this.getBlobCacheKey(blob.sha), bufferValue);
+        await this.blobCache.put(this.getCacheKey(blob.sha), bufferValue);
 
         return bufferValue;
     }
@@ -208,7 +208,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
     }
 
     private async fetchAndCacheSnapshotTree(versionId: string, disableCache?: boolean): Promise<ISnapshotTreeVersion> {
-        const cachedSnapshotTreeVersion = await this.snapshotTreeCache.get(this.getSnapshotCacheKey(versionId));
+        const cachedSnapshotTreeVersion = await this.snapshotTreeCache.get(this.getCacheKey(versionId));
         if (cachedSnapshotTreeVersion !== undefined) {
             return { id: cachedSnapshotTreeVersion.id, snapshotTree: cachedSnapshotTreeVersion.snapshotTree };
         }
@@ -236,7 +236,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 
         const cachePs: Promise<any>[] = [
             this.snapshotTreeCache.put(
-                this.getSnapshotCacheKey(snapshotTreeId),
+                this.getCacheKey(snapshotTreeId),
                 snapshotTreeVersion,
             ),
             this.initBlobCache(normalizedWholeSummary.blobs),
@@ -247,7 +247,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
             // However, for something like Redis, this will cache the same value twice. Alternatively, could we simply
             // cache with versionId?
             cachePs.push(this.snapshotTreeCache.put(
-                this.getSnapshotCacheKey(versionId),
+                this.getCacheKey(versionId),
                 snapshotTreeVersion,
             ));
         }
@@ -260,17 +260,13 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
     private async initBlobCache(blobs: Map<string, ArrayBuffer>): Promise<void> {
         const blobCachePutPs: Promise<void>[] = [];
         blobs.forEach((value, id) => {
-            const cacheKey = this.getBlobCacheKey(id);
+            const cacheKey = this.getCacheKey(id);
             blobCachePutPs.push(this.blobCache.put(cacheKey, value));
         });
         await Promise.all(blobCachePutPs);
     }
 
-    private getBlobCacheKey(blobId: string): string {
+    private getCacheKey(blobId: string): string {
         return `${this.id}:${blobId}`;
-    }
-
-    private getSnapshotCacheKey(snapshotId: string): string {
-        return `${this.id}:${snapshotId}`;
     }
 }

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -120,7 +120,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
     }
 
     public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-        const cachedBlob = await this.blobCache.get(blobId);
+        const cachedBlob = await this.blobCache.get(this.getBlobCacheKey(blobId));
         if (cachedBlob !== undefined) {
             return cachedBlob;
         }
@@ -142,7 +142,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
         );
         const bufferValue = stringToBuffer(blob.content, blob.encoding);
 
-        await this.blobCache.put(blob.sha, bufferValue);
+        await this.blobCache.put(this.getBlobCacheKey(blob.sha), bufferValue);
 
         return bufferValue;
     }
@@ -208,7 +208,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
     }
 
     private async fetchAndCacheSnapshotTree(versionId: string, disableCache?: boolean): Promise<ISnapshotTreeVersion> {
-        const cachedSnapshotTreeVersion = await this.snapshotTreeCache.get(versionId);
+        const cachedSnapshotTreeVersion = await this.snapshotTreeCache.get(this.getSnapshotCacheKey(versionId));
         if (cachedSnapshotTreeVersion !== undefined) {
             return { id: cachedSnapshotTreeVersion.id, snapshotTree: cachedSnapshotTreeVersion.snapshotTree };
         }
@@ -236,7 +236,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 
         const cachePs: Promise<any>[] = [
             this.snapshotTreeCache.put(
-                snapshotTreeId,
+                this.getSnapshotCacheKey(snapshotTreeId),
                 snapshotTreeVersion,
             ),
             this.initBlobCache(normalizedWholeSummary.blobs),
@@ -247,7 +247,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
             // However, for something like Redis, this will cache the same value twice. Alternatively, could we simply
             // cache with versionId?
             cachePs.push(this.snapshotTreeCache.put(
-                versionId,
+                this.getSnapshotCacheKey(versionId),
                 snapshotTreeVersion,
             ));
         }
@@ -260,8 +260,17 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
     private async initBlobCache(blobs: Map<string, ArrayBuffer>): Promise<void> {
         const blobCachePutPs: Promise<void>[] = [];
         blobs.forEach((value, id) => {
-            blobCachePutPs.push(this.blobCache.put(id, value));
+            const cacheKey = this.getBlobCacheKey(id);
+            blobCachePutPs.push(this.blobCache.put(cacheKey, value));
         });
         await Promise.all(blobCachePutPs);
+    }
+
+    private getBlobCacheKey(blobId: string): string {
+        return `${this.id}:${blobId}`;
+    }
+
+    private getSnapshotCacheKey(snapshotId: string): string {
+        return `${this.id}:${snapshotId}`;
     }
 }


### PR DESCRIPTION
## Description

If an AzureClient (internally, DocumentServiceFactory) is used to open multiple documents/containers, the internal in-memory cache is not handling that scenario, so the "latest" snapshot will be polluted by the first document loaded.