### PR TITLE
Release v2Int/1.0 Processing Summary Acks: Fetch snapshot from storage only if required…

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3032,25 +3032,29 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         summaryLogger: ITelemetryLogger,
     ) {
         const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-        const { snapshotTree } = await this.fetchSnapshotFromStorage(
-            ackHandle,
-            summaryLogger,
-            {
-                eventName: "RefreshLatestSummaryGetSnapshot",
-                ackHandle,
-                summaryRefSeq,
-                fetchLatest: false,
-            },
-        );
-        const result = await this.summarizerNode.refreshLatestSummary(
-            proposalHandle,
-            summaryRefSeq,
-            async () => snapshotTree,
-            readAndParseBlob,
-            summaryLogger,
-        );
+        // The call to fetch the snapshot is very expensive and not always needed.
+        // It should only be done by the summarizerNode, if required.
+        const snapshotTreeFetcher = async () => {
+            const fetchResult = await this.fetchSnapshotFromStorage(
+             ackHandle,
+             summaryLogger,
+             {
+                 eventName: "RefreshLatestSummaryGetSnapshot",
+                 ackHandle,
+                 summaryRefSeq,
+                 fetchLatest: false,
+             });
+             return fetchResult.snapshotTree;
+         };
+         const result = await this.summarizerNode.refreshLatestSummary(
+             proposalHandle,
+             summaryRefSeq,
+             snapshotTreeFetcher,
+             readAndParseBlob,
+             summaryLogger,
+         );
 
-        // Notify the garbage collector so it can update its latest summary state.
+         // Notify the garbage collector so it can update its latest summary state.
         await this.garbageCollector.latestSummaryStateRefreshed(result, readAndParseBlob);
     }
 


### PR DESCRIPTION
… (#11897)

Addressing [Bug
1870](https://dev.azure.com/fluidframework/internal/_workitems/edit/1870)
- On receiving a summary ack, fetch the corresponding snapshot only if required

## Description

PR [11336](https://github.com/microsoft/FluidFramework/pull/11336) regressed the previous behavior in which we would only download the snapshot corresponding to an ack if there were no pending state or the current's node referenceSeqNumber was less than the Ack's refSeqNumber.

This change simply reverts the logic back to the previous behavior. 

## Does this introduce a breaking change?

No
