### PR TITLE
Signals fix in test-service-load: send signals only when the client is not disconnected or disposed

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -513,7 +513,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
         const signalsGapMs = cycleMs / signalsPerCycle;
         let submittedSignals = 0;
         try {
-            while (submittedSignals < clientSignalsSendCount) {
+            while (submittedSignals < clientSignalsSendCount && this.runtime.connected && !this.runtime.disposed) {
                 // all the clients are sending signals;
                 // with signals, there is no particular need to have staggered writers and readers
                 this.runtime.submitSignal("generic-signal", true);

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -513,11 +513,13 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
         const signalsGapMs = cycleMs / signalsPerCycle;
         let submittedSignals = 0;
         try {
-            while (submittedSignals < clientSignalsSendCount && this.runtime.connected && !this.runtime.disposed) {
+            while (submittedSignals < clientSignalsSendCount && !this.runtime.disposed) {
                 // all the clients are sending signals;
                 // with signals, there is no particular need to have staggered writers and readers
-                this.runtime.submitSignal("generic-signal", true);
-                submittedSignals++;
+                if (this.runtime.connected) {
+                    this.runtime.submitSignal("generic-signal", true);
+                    submittedSignals++;
+                }
                 // Random jitter of +- 50% of signalGapMs
                 await delay(signalsGapMs + signalsGapMs * random.real(0, .5, true)(config.randEng));
             }


### PR DESCRIPTION
- in loadTestDataStore.ts, send signals only when runtime is not disconnected or disposed
- this should hopefully reduce the recent uptick in `submitSignalDisconnected` errors we have been seeing