### PR TITLE
Add GitHub action to comment on PRs with breaking changes

### DIFF
--- a/.github/workflows/breaking-change-warning.yml
+++ b/.github/workflows/breaking-change-warning.yml
@@ -1,0 +1,50 @@
+name: Breaking Change Warning
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches:
+      - main
+      - release/*
+      - next
+
+jobs:
+  check_broken_types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: get-files
+        run: |
+          echo "::set-output name=files::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)"
+
+      - name: Check for changes to broken types
+        id: check
+        run: |
+          declare -a arr=(${{ steps.get-files.outputs.files }})
+          for i in "${arr[@]}"; do
+            if [[ ! "$i" =~ package.json$ ]]; then
+              continue
+            fi
+
+            git checkout ${{ github.head_ref }} --quiet
+            pr=$(jq .typeValidation.broken "$i" | tr -d '\n')
+
+            git checkout ${{ github.base_ref }} --quiet
+            base=$(jq .typeValidation.broken "$i" | tr -d '\n')
+
+            if [ "$pr" != "$base" ]; then
+              echo '::set-output name=isBrokenDetected::true'
+              break
+            fi
+          done
+
+      - name: Comment on PR
+        if: steps.check.outputs.isBrokenDetected == 'true'
+        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@v2
+        with:
+          message: |
+            @${{ github.event.pull_request.user.login }} it looks like this PR might include a breaking change. If so, please ensure you follow the [guidelines](https://github.com/microsoft/FluidFramework/wiki/Communicating-breaking-changes) on how to introduce a breaking change.

--- a/.github/workflows/breaking-change-warning.yml
+++ b/.github/workflows/breaking-change-warning.yml
@@ -16,15 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get changed files
-        id: get-files
-        run: |
-          echo "::set-output name=files::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)"
-
       - name: Check for changes to broken types
         id: check
         run: |
-          declare -a arr=(${{ steps.get-files.outputs.files }})
+          declare -a arr=($(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs))
           for i in "${arr[@]}"; do
             if [[ ! "$i" =~ package.json$ ]]; then
               continue

--- a/.github/workflows/breaking-change-warning.yml
+++ b/.github/workflows/breaking-change-warning.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Description

This PR adds a new GitHub Action that runs on PRs targeting main, next, or releases branches. It will detect when a change is made to the "broken" section of a package.json file and alert the author of the PR to ensure they understand they are making a breaking change. Additionally, it will link the author to our wiki articles for guidance regarding making breaking changes.

See this [example PR](https://github.com/scottn12/FluidFramework/pull/6) for a demonstration!

## Reviewer Guidance

I'd like feedback on:

- The wording of the PR comment, and if any additional information/links should be included.
- Implementation details
- If we think this is a valuable addition to our PR checks

