### PR TITLE
Use globalThis instead of window in performanceBrowser

### DIFF
--- a/common/lib/common-utils/src/performanceBrowser.ts
+++ b/common/lib/common-utils/src/performanceBrowser.ts
@@ -5,4 +5,4 @@
 
 import { IsomorphicPerformance } from "./performanceIsomorphic";
 
-export const performance: IsomorphicPerformance = window.performance;
+export const performance: IsomorphicPerformance = globalThis.performance;


### PR DESCRIPTION
The window object is not available in all browser contexts, in particular Workers.  globalThis is an appropriate replacement here.