### PR TITLE
Make `Container` constructor private

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -119,6 +119,7 @@ bindToContext and related types](#remove-ifluiddatastorechannelbindtocontext-and
 - [Remove deprecated data structures from `@fluidframework/sequence`](#remove-deprecated-data-structures-from-fluidframeworksequence)
 - [Renamed lockTask to volunteerForTask from @fluid-experimental/task-manager](renamed-lockTask-to-volunteerForTask-from-@fluid-experimental/task-manager)
 - [Renamed haveTaskLock to assigned from @fluid-experimental/task-manager](renamed-haveTaskLock-to-assigned-from-@fluid-experimental/task-manager)
+- [`Container` constructor is now private](container-constructor-is-now-private)
 
 ###  Update to React 17
 The following packages use React and thus were impacted:
@@ -248,6 +249,12 @@ The `IContainerRuntime.CreateRootDataStore` method has been removed. Please use 
 
 ### Renamed haveTaskLock to assigned from @fluid-experimental/task-manager
 `TaskManager.haveTaskLock()` has been renamed `assigned()`. Please update all usages accordingly.
+
+### `Container` constructor is now private
+
+The constructor for the `Container` class was not indended to be used outside the class itself so it is now private.
+The correct way to create a Container is through the existing static methods `Container.load()`,
+`Container.createDetached()`, and `Container.rehydrateDetachedFromSnapshot()`.
 
 # 1.2.0
 

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -56,7 +56,6 @@ export enum ConnectionState {
 
 // @public (undocumented)
 export class Container extends EventEmitterWithErrorHandling<IContainerEvents> implements IContainer {
-    constructor(loader: Loader, config: IContainerConfig, protocolHandlerBuilder?: ProtocolHandlerBuilder | undefined);
     // (undocumented)
     attach(request: IRequest): Promise<void>;
     // (undocumented)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -555,7 +555,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     private get scope() { return this.loader.services.scope; }
     private get codeLoader() { return this.loader.services.codeLoader; }
 
-    constructor(
+    private constructor(
         private readonly loader: Loader,
         config: IContainerConfig,
         private readonly protocolHandlerBuilder?: ProtocolHandlerBuilder,

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -70,6 +70,8 @@ describe("Container", () => {
         it("Fluid.Container.CatchUpBeforeDeclaringConnected = true, use CatchUpMonitor", () => {
             injectedSettings["Fluid.Container.CatchUpBeforeDeclaringConnected"] = true;
 
+            // @ts-expect-error Container's constructor is private but it's useful to
+            // to construct the class directly in tests
             const container = new Container({ services: { options: {} } } as Loader, {});
             const deltaManager: any = container.deltaManager;
             deltaManager.connectionManager.connection = {}; // Avoid assert 0x0df
@@ -80,6 +82,8 @@ describe("Container", () => {
         });
 
         it("Fluid.Container.CatchUpBeforeDeclaringConnected undefined, use ImmediateCatchUpMonitor", () => {
+            // @ts-expect-error Container's constructor is private but it's useful to
+            // to construct the class directly in tests
             const container = new Container({ services: { options: {} } } as Loader, {});
             const deltaManager: any = container.deltaManager;
             deltaManager.connectionManager.connection = {}; // Avoid assert 0x0df


### PR DESCRIPTION
## Description

This felt ok based on my current understanding of the framework but I intended this more for gathering feedback from the rest of the team rather than an immediat "I want to get this change in" thing. Have we not done it for a specific reason? Are there actually use cases for the plain constructor (other than unit tests)?

Some unit tests already use the constructor directly and I can see that as an argument against making it private. My personal inclination is to do it anyway to keep the public API surface clean even if means a few more complications in our test code as long as those complications are not huge, which I think is the case here.

Alternatively, document the constructor as `@internal` and clarify that it should not be used in production code? Keeps our unit tests a bit simpler but doesn't prevent accidental misuse of `Container`, so I like the other option better.

## Reviewer Guidance

General question: why should or shouldn't we do this?

## Does this introduce a breaking change?

Yes.
