### PR TITLE
Fix Race Condition in Initalize Protocol Tree

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1181,19 +1181,21 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // ...load in the existing quorum
         // Initialize the protocol handler
-        this._protocolHandler = pendingLocalState === undefined
-            ? await this.initializeProtocolStateFromSnapshot(
+        if (pendingLocalState === undefined) {
+            await this.initializeProtocolStateFromSnapshot(
                 attributes,
                 this.storageService,
-                snapshot,
-            ) : this.initializeProtocolState(
-                attributes,
-                {
-                    members: pendingLocalState.protocol.members,
-                    proposals: pendingLocalState.protocol.proposals,
-                    values: pendingLocalState.protocol.values,
-                }, // pending IQuorumSnapshot
-            );
+                snapshot);
+        } else {
+                this.initializeProtocolState(
+                    attributes,
+                    {
+                        members: pendingLocalState.protocol.members,
+                        proposals: pendingLocalState.protocol.proposals,
+                        values: pendingLocalState.protocol.values,
+                    }, // pending IQuorumSnapshot
+                );
+        }
 
         const codeDetails = this.getCodeDetailsFromQuorum();
         await this.instantiateContext(
@@ -1268,7 +1270,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Need to just seed the source data in the code quorum. Quorum itself is empty
         const qValues = initQuorumValuesFromCodeDetails(source);
-        this._protocolHandler = await this.initializeProtocolState(
+        this._protocolHandler = this.initializeProtocolState(
             attributes,
             {
                 members: [],
@@ -1305,15 +1307,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             baseTree.blobs.quorumValues,
         );
         const codeDetails = getCodeDetailsFromQuorumValues(qValues);
-        this._protocolHandler =
-            await this.initializeProtocolState(
-                attributes,
-                {
-                    members: [],
-                    proposals: [],
-                    values: codeDetails !== undefined ? initQuorumValuesFromCodeDetails(codeDetails) : [],
-                }, // IQuorumSnapShot
-            );
+        this.initializeProtocolState(
+            attributes,
+            {
+                members: [],
+                proposals: [],
+                values: codeDetails !== undefined ? initQuorumValuesFromCodeDetails(codeDetails) : [],
+            }, // IQuorumSnapShot
+        );
 
         await this.instantiateContextDetached(
             true, // existing
@@ -1354,7 +1355,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         attributes: IDocumentAttributes,
         storage: IDocumentStorageService,
         snapshot: ISnapshotTree | undefined,
-    ): Promise<IProtocolHandler> {
+    ): Promise<void> {
         const quorumSnapshot: IQuorumSnapshot = {
             members: [],
             proposals: [],
@@ -1370,14 +1371,13 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             ]);
         }
 
-        const protocolHandler = await this.initializeProtocolState(attributes, quorumSnapshot);
-        return protocolHandler;
+        this.initializeProtocolState(attributes, quorumSnapshot);
     }
 
     private initializeProtocolState(
         attributes: IDocumentAttributes,
         quorumSnapshot: IQuorumSnapshot,
-    ): IProtocolHandler {
+    ): void {
         const protocolHandlerBuilder =
             this.protocolHandlerBuilder ?? ((...args) => new ProtocolHandler(...args, new Audience()));
         const protocol = protocolHandlerBuilder(
@@ -1420,7 +1420,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 }
             });
 
-        return protocol;
+        this._protocolHandler = protocol;
     }
 
     private captureProtocolSummary(): ISummaryTree {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1186,7 +1186,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 attributes,
                 this.storageService,
                 snapshot,
-            ) : await this.initializeProtocolState(
+            ) : this.initializeProtocolState(
                 attributes,
                 {
                     members: pendingLocalState.protocol.members,
@@ -1374,10 +1374,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return protocolHandler;
     }
 
-    private async initializeProtocolState(
+    private initializeProtocolState(
         attributes: IDocumentAttributes,
         quorumSnapshot: IQuorumSnapshot,
-    ): Promise<IProtocolHandler> {
+    ): IProtocolHandler {
         const protocolHandlerBuilder =
             this.protocolHandlerBuilder ?? ((...args) => new ProtocolHandler(...args, new Audience()));
         const protocol = protocolHandlerBuilder(

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1270,7 +1270,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Need to just seed the source data in the code quorum. Quorum itself is empty
         const qValues = initQuorumValuesFromCodeDetails(source);
-        this._protocolHandler = this.initializeProtocolState(
+        this.initializeProtocolState(
             attributes,
             {
                 members: [],

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1187,14 +1187,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 this.storageService,
                 snapshot);
         } else {
-                this.initializeProtocolState(
-                    attributes,
-                    {
-                        members: pendingLocalState.protocol.members,
-                        proposals: pendingLocalState.protocol.proposals,
-                        values: pendingLocalState.protocol.values,
-                    }, // pending IQuorumSnapshot
-                );
+            this.initializeProtocolState(
+                attributes,
+                {
+                    members: pendingLocalState.protocol.members,
+                    proposals: pendingLocalState.protocol.proposals,
+                    values: pendingLocalState.protocol.values,
+                }, // pending IQuorumSnapshot
+            );
         }
 
         const codeDetails = this.getCodeDetailsFromQuorum();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1419,7 +1419,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     });
                 }
             });
-
+        // we need to make sure this member get set in a synchronous context,
+        // or other things can happen after the object that will be set is created, but not yet set
+        // this was breaking this._initialClients handling
+        //
         this._protocolHandler = protocol;
     }
 


### PR DESCRIPTION

## Description

There is a race condition in the initialization of protocol tree that can lead to initial clients being set after protocol tree is created, but not set due to the async nature of the how we initialize the protocol tree.

Specifically, we kick off initializeProtocolState as an async task. The task runs, so the protocol tree object is created, but this._protocolHandler is not set yet. Before the task returns we connect, so the delta manager connect handler runs, it sees this._protocolHandler is undefined, and puts initial clients in this._initialClients. Then initializeProtocolState completes, and this._protocolHandler is set, without ever looking at  this._initialClients which leads to lost member of the audience.

We are seeing this consistently fail in our test runs for intv2/1.1: https://github.com/microsoft/FluidFramework/pull/12071