### PR TITLE
v2int/1.1 Port: Fix Race Condition in Initalize Protocol Tree (#12083)

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1192,12 +1192,13 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // ...load in the existing quorum
         // Initialize the protocol handler
-        this._protocolHandler = pendingLocalState === undefined
-            ? await this.initializeProtocolStateFromSnapshot(
+        if (pendingLocalState === undefined) {
+            await this.initializeProtocolStateFromSnapshot(
                 attributes,
                 this.storageService,
-                snapshot,
-            ) : await this.initializeProtocolState(
+                snapshot);
+        } else {
+            this.initializeProtocolState(
                 attributes,
                 {
                     members: pendingLocalState.protocol.members,
@@ -1205,6 +1206,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     values: pendingLocalState.protocol.values,
                 }, // pending IQuorumSnapshot
             );
+        }
 
         const codeDetails = this.getCodeDetailsFromQuorum();
         await this.instantiateContext(
@@ -1279,7 +1281,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Need to just seed the source data in the code quorum. Quorum itself is empty
         const qValues = initQuorumValuesFromCodeDetails(source);
-        this._protocolHandler = await this.initializeProtocolState(
+        this.initializeProtocolState(
             attributes,
             {
                 members: [],
@@ -1316,15 +1318,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             baseTree.blobs.quorumValues,
         );
         const codeDetails = getCodeDetailsFromQuorumValues(qValues);
-        this._protocolHandler =
-            await this.initializeProtocolState(
-                attributes,
-                {
-                    members: [],
-                    proposals: [],
-                    values: codeDetails !== undefined ? initQuorumValuesFromCodeDetails(codeDetails) : [],
-                }, // IQuorumSnapShot
-            );
+        this.initializeProtocolState(
+            attributes,
+            {
+                members: [],
+                proposals: [],
+                values: codeDetails !== undefined ? initQuorumValuesFromCodeDetails(codeDetails) : [],
+            }, // IQuorumSnapShot
+        );
 
         await this.instantiateContextDetached(
             true, // existing
@@ -1387,7 +1388,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         attributes: IDocumentAttributes,
         storage: IDocumentStorageService,
         snapshot: ISnapshotTree | undefined,
-    ): Promise<IProtocolHandler> {
+    ): Promise<void> {
         const quorumSnapshot: IQuorumSnapshot = {
             members: [],
             proposals: [],
@@ -1403,14 +1404,13 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             ]);
         }
 
-        const protocolHandler = await this.initializeProtocolState(attributes, quorumSnapshot);
-        return protocolHandler;
+        this.initializeProtocolState(attributes, quorumSnapshot);
     }
 
-    private async initializeProtocolState(
+    private initializeProtocolState(
         attributes: IDocumentAttributes,
         quorumSnapshot: IQuorumSnapshot,
-    ): Promise<IProtocolHandler> {
+    ): void {
         const protocolHandlerBuilder =
             this.protocolHandlerBuilder ?? ((...args) => new ProtocolHandler(...args, new Audience()));
         const protocol = protocolHandlerBuilder(
@@ -1452,8 +1452,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     });
                 }
             });
-
-        return protocol;
+        // we need to make sure this member get set in a synchronous context,
+        // or other things can happen after the object that will be set is created, but not yet set
+        // this was breaking this._initialClients handling
+        //
+        this._protocolHandler = protocol;
     }
 
     private captureProtocolSummary(): ISummaryTree {


### PR DESCRIPTION
## Description

There is a race condition in the initialization of protocol tree that can lead to initial clients being set after protocol tree is created, but not set due to the async nature of the how we initialize the protocol tree.

Specifically, we kick off initializeProtocolState as an async task. The task runs, so the protocol tree object is created, but this._protocolHandler is not set yet. Before the task returns we connect, so the delta manager connect handler runs, it sees this._protocolHandler is undefined, and puts initial clients in this._initialClients. Then initializeProtocolState completes, and this._protocolHandler is set, without ever looking at this._initialClients which leads to lost member of the audience.

We are seeing this consistently fail in our test runs for intv2/1.1: https://github.com/microsoft/FluidFramework/pull/12071
