### PR TITLE
[GC-Stress] Enable shrinking SweepTimeout for testing

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -30,6 +30,7 @@
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "qt": "npm run tsc && npm run build:test && npm run test",
     "test": "npm run test:mocha",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -567,15 +567,12 @@ export class GarbageCollector implements IGarbageCollector {
              * but make it one day to be safe.
              */
             if (snapshotCacheExpiryMs !== undefined) {
-                const overrideSweepTimeoutMs =
-                    this.mc.config.getNumber("Fluid.GarbageCollection.TestOverride.SweepTimeoutMs");
+                const overrideSweepBufferMs =
+                    this.mc.config.getNumber("Fluid.GarbageCollection.TestOverride.SweepBufferMs");
+                //* Do I need to assert the override is less than 1 day? What about > 0... -_-
+                const buffer = overrideSweepBufferMs ?? oneDayMs;
 
-                this.sweepTimeoutMs =
-                    overrideSweepTimeoutMs
-                    ?? this.sessionExpiryTimeoutMs + snapshotCacheExpiryMs + oneDayMs;
-
-                assert(this.sweepTimeoutMs > this.sessionExpiryTimeoutMs + snapshotCacheExpiryMs,
-                    "SweepTimeout must exceed sessionExpiry + snapshotCacheExpiry even if using TestOverride");
+                this.sweepTimeoutMs = this.sessionExpiryTimeoutMs + snapshotCacheExpiryMs + buffer;
             }
         }
 

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -267,8 +267,7 @@ describe("Garbage Collection Tests", () => {
             });
         });
 
-        //* ONLY
-        describe.only("Session Expiry and Sweep Timeout", () => {
+        describe("Session Expiry and Sweep Timeout", () => {
             const testOverrideInactiveTimeoutMsKey = "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs";
             const testOverrideSessionExpiryMsKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
             const testOverrideSweepTimeoutMsKey = "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs";


### PR DESCRIPTION
This is WIP version of #12044.  I'm pausing that work in terms of merging to main until next week.

This way we can shrink Session Expiry and the Sweep Timeout in the stress test and watch for SweepReady errors.

Here are the settings to set:

* `Fluid.GarbageCollection.TestOverride.SessionExpiryMs`
* `Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache` (disables snapshot caching in driver and uses 0 for the Sweep Timeout calculation)
* `Fluid.GarbageCollection.TestOverride.SweepBufferMs`

Then the total SweepTimeout will be `sessionExpiryMs + sweepBufferMs`