### PR TITLE
Fix Test Timing Issue

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -27,6 +27,7 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
+import { waitContainerToCatchUp } from "@fluidframework/container-loader";
 
 const counterKey = "count";
 
@@ -287,9 +288,11 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
 
                 container1 = await createContainer(documentId, testDataObjectFactory);
                 dataObject1 = await requestFluidObject<TestDataObject>(container1, "default");
+                await waitContainerToCatchUp(container1);
 
                 container2 = await loadContainer(documentId, container1.resolvedUrl, testDataObjectFactory);
                 dataObject2 = await requestFluidObject<TestDataObject>(container2, "default");
+                await waitContainerToCatchUp(container2);
             });
 
             it("Controlled inbounds and outbounds", async function() {


### PR DESCRIPTION
Something on the server has changed timing, and that is leading to a race in the test. Specifically, the loaderContianerTracker doesn't work correctly in this test if the containers are not connected before the test starts
[AB#2005](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2005)