### PR TITLE
Cleanup join / leave signal signatures

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -328,10 +328,8 @@ export interface IServerError {
 export interface ISignalClient {
     // (undocumented)
     client: IClient;
-    clientConnectionNumber?: number;
     // (undocumented)
     clientId: string;
-    referenceSequenceNumber?: number;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/src/clients.ts
+++ b/common/lib/protocol-definitions/src/clients.ts
@@ -44,16 +44,6 @@ export interface ISignalClient {
     clientId: string;
 
     client: IClient;
-
-    /**
-     * Counts the number of signals sent by the client
-     */
-    clientConnectionNumber?: number;
-
-    /**
-     * Sequence number that indicates when the signal was created in relation to the delta stream
-     */
-    referenceSequenceNumber?: number;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -285,7 +285,10 @@ export interface ISignalMessage {
     content: any;
 
     /**
-     * Counts the number of signals sent by the client
+     * Counts the number of join & leave signals in a given relay session
+     * This number can be used to
+     * 1. Order clients in a session
+     * 2. Learn about dropped join/leave signals (if there is a gap in numbering)
      */
     clientConnectionNumber?: number;
 

--- a/server/routerlicious/packages/services-core/src/clientManager.ts
+++ b/server/routerlicious/packages/services-core/src/clientManager.ts
@@ -15,9 +15,12 @@ export interface ISequencedSignalClient {
     client: IClient;
 
     /**
-     * Counts the number of signals sent by the client
+     * Counts the number of join & leave signals in a given relay session
+     * This number can be used to
+     * 1. Order clients in a session
+     * 2. Learn about dropped join/leave signals (if there is a gap in numbering)
      */
-    clientConnectionNumber: number;
+     clientConnectionNumber: number;
 
     /**
      * Sequence number that indicates when the signal was created in relation to the delta stream


### PR DESCRIPTION
Splitting from https://github.com/microsoft/FluidFramework/pull/12042

ISignalClient was lying about its shape - extra properties exist only on ISignalMessage, even though they are applicable only for payloads of ISignalClient shape (i.e., join & leave signals).
I believes it would be actually more correct to have that payload on ISignalClient as it would ensure clients would get same info on connection for clients already in audience. But for now, I'm reflecting reality.
