### PR TITLE
Simplify catch up monitor

### DIFF
--- a/packages/loader/container-loader/src/catchUpMonitor.ts
+++ b/packages/loader/container-loader/src/catchUpMonitor.ts
@@ -3,34 +3,29 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, IEvent } from "@fluidframework/common-definitions";
-import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
+import { IDisposable } from "@fluidframework/common-definitions";
+import { assert } from "@fluidframework/common-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 
-/** @see ICatchUpMonitor for usage */
+/** @see CatchUpMonitor for usage */
 type CaughtUpListener = () => void;
 
-/** @see ICatchUpMonitor for usage */
-export interface ICatchUpMonitorEvents extends IEvent {
-    (event: "caughtUp", listener: CaughtUpListener): void;
-}
-
 /** Monitor that emits an event when a Container has caught up to a given point in the op stream */
-export interface ICatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents>, IDisposable { }
+export type ICatchUpMonitor = IDisposable;
 
 /**
  * Monitors a Container's DeltaManager, notifying listeners when all ops have been processed
  * that were known at the time the monitor was created.
  */
-export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> implements ICatchUpMonitor {
+export class CatchUpMonitor implements ICatchUpMonitor {
     private readonly targetSeqNumber: number;
     private caughtUp: boolean = false;
 
     private readonly opHandler = (message: Pick<ISequencedDocumentMessage, "sequenceNumber">) => {
         if (!this.caughtUp && message.sequenceNumber >= this.targetSeqNumber) {
             this.caughtUp = true;
-            this.emit("caughtUp");
+            this.listener();
         }
     };
 
@@ -39,9 +34,8 @@ export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> imp
      */
     constructor(
         private readonly deltaManager: IDeltaManager<any, any>,
+        private readonly listener: CaughtUpListener,
     ) {
-        super();
-
         this.targetSeqNumber = this.deltaManager.lastKnownSeqNumber;
 
         assert(this.targetSeqNumber >= this.deltaManager.lastSequenceNumber,
@@ -51,16 +45,6 @@ export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> imp
 
         // Simulate the last processed op to set caughtUp in case we already are
         this.opHandler({ sequenceNumber: this.deltaManager.lastSequenceNumber });
-
-        // If a listener is added after we are already caught up, notify that new listener immediately
-        this.on("newListener", (event: string, listener) => {
-            if (event === "caughtUp") {
-                const caughtUpListener = listener as CaughtUpListener;
-                if (this.caughtUp) {
-                    caughtUpListener();
-                }
-            }
-        });
     }
 
     public disposed: boolean = false;
@@ -70,7 +54,6 @@ export class CatchUpMonitor extends TypedEventEmitter<ICatchUpMonitorEvents> imp
         }
         this.disposed = true;
 
-        this.removeAllListeners();
         this.deltaManager.off("op", this.opHandler);
     }
 }

--- a/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
+++ b/packages/loader/container-loader/src/test/catchUpMonitor.spec.ts
@@ -56,7 +56,7 @@ describe("CatchUpMonitor", () => {
             lastKnownSeqNumber: 15, // Should be impossible in real world
         });
 
-        assert.throws(() => new CatchUpMonitor(mockDeltaManager), "Expect assert when DeltaManager in invalid state");
+        assert.throws(() => new CatchUpMonitor(mockDeltaManager, () => {}), "Expect assert when DeltaManager in invalid state");
     });
 
     it("Emits caughtUp event when caught up to the point it was created", () => {
@@ -67,28 +67,13 @@ describe("CatchUpMonitor", () => {
         let caughtUp = false;
 
         mockDeltaManager.lastKnownSeqNumber = 20;
-        monitor = new CatchUpMonitor(mockDeltaManager);
+        monitor = new CatchUpMonitor(mockDeltaManager, () => { caughtUp = true; });
         mockDeltaManager.lastKnownSeqNumber = 25;  // Shouldn't change anything about the monitor
-        monitor.on("caughtUp", () => { caughtUp = true; });
 
         mockDeltaManager.emitOpWithSequenceNumber(19); // Less than 20
         assert(!caughtUp, "Shouldn't be considered caught up yet");
         mockDeltaManager.emitOpWithSequenceNumber(21); // Greater than 20
         assert(caughtUp, "Should be considered caught up now");
-    });
-
-    it("Adding a listener after already caught up invokes the listener immediately", () => {
-        const mockDeltaManager = MockDeltaManagerForCatchingUp.create({
-            lastSequenceNumber: 10,
-            lastKnownSeqNumber: 15,
-        });
-        let caughtUp = false;
-
-        monitor = new CatchUpMonitor(mockDeltaManager);
-        mockDeltaManager.emitOpToCatchUp();
-
-        monitor.on("caughtUp", () => { caughtUp = true; });
-        assert(caughtUp, "caughtUp should have fired immediately");
     });
 
     it("Emits caught up immediately if last known/processed sequence numbers match", () => {
@@ -98,9 +83,8 @@ describe("CatchUpMonitor", () => {
         });
         let caughtUp = false;
 
-        monitor = new CatchUpMonitor(mockDeltaManager);
+        monitor = new CatchUpMonitor(mockDeltaManager, () => { caughtUp = true; });
 
-        monitor.on("caughtUp", () => { caughtUp = true; });
         assert(caughtUp, "caughtUp should have fired immediately");
     });
 
@@ -111,32 +95,21 @@ describe("CatchUpMonitor", () => {
         });
         let caughtUpCount = 0;
 
-        monitor = new CatchUpMonitor(mockDeltaManager);
-        monitor.on("caughtUp", () => { ++caughtUpCount; });
+        monitor = new CatchUpMonitor(mockDeltaManager, () => { ++caughtUpCount; });
 
         mockDeltaManager.emitOpWithSequenceNumber(15);
         assert.equal(caughtUpCount, 1, "caughtUp should have fired once");
         mockDeltaManager.emitOpWithSequenceNumber(16);
         assert.equal(caughtUpCount, 1, "caughtUp should have fired only once");
-
-        let secondCaughtUpCount = 0;
-        monitor.on("caughtUp", () => { secondCaughtUpCount = 1; });
-        assert.equal(secondCaughtUpCount, 1, "New listener should still get invoked once caught up");
-        mockDeltaManager.emitOpWithSequenceNumber(17);
-        assert.equal(secondCaughtUpCount, 1, "Subsequent ops will not cause caughtUp again on second listener");
     });
 
     it("Dispose removes all listeners", () => {
         const mockDeltaManager = MockDeltaManagerForCatchingUp.create();
-        monitor = new CatchUpMonitor(mockDeltaManager);
+        monitor = new CatchUpMonitor(mockDeltaManager, () => {});
 
-        monitor.on("caughtUp", () => {});
-        monitor.on("caughtUp", () => {});
-        monitor.on("caughtUp", () => {});
         monitor.dispose();
 
         assert(monitor.disposed, "dispose() should set disposed");
-        assert.equal(monitor.listenerCount("caughtUp"), 0, "dispose() should clear all listeners");
         assert.equal(mockDeltaManager.listenerCount("op"), 0, "CatchUpMonitor.dispose should remove listener on DeltaManager");
     });
 });

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -7,16 +7,12 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
 import assert from "assert";
-import { EventEmitter } from "events";
 import { AttachState, IAudience, IContainer, IContainerEvents, IDeltaManager, IDeltaManagerEvents, ReadOnlyInfo } from "@fluidframework/container-definitions";
-import { sessionStorageConfigProvider } from "@fluidframework/telemetry-utils";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import { IFluidRouter } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, IDocumentMessage } from "@fluidframework/protocol-definitions";
-import { Container, waitContainerToCatchUp } from "../container";
-import { Loader } from "../loader";
-import { CatchUpMonitor } from "../catchUpMonitor";
+import { waitContainerToCatchUp } from "../container";
 import { ConnectionState } from "../connectionState";
 
 class MockDeltaManager
@@ -50,36 +46,6 @@ class MockContainer extends TypedEventEmitter<IContainerEvents> implements Parti
 }
 
 describe("Container", () => {
-    describe("constructor", () => {
-        const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
-        let injectedSettings = {};
-
-        before(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
-        });
-
-        afterEach(() => {
-            injectedSettings = {};
-        });
-
-        after(() => {
-            sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
-        });
-
-        it("Fluid.Container.CatchUpBeforeDeclaringConnected = true, use CatchUpMonitor", () => {
-            injectedSettings["Fluid.Container.CatchUpBeforeDeclaringConnected"] = true;
-
-            const container = new Container({ services: { options: {} } } as Loader, {});
-            const deltaManager: any = container.deltaManager;
-            deltaManager.connectionManager.connection = {}; // Avoid assert 0x0df
-            (deltaManager as EventEmitter).emit("connect", { clientId: "someClientId" });
-
-            const catchUpMonitor = (container as any).connectionStateHandler.catchUpMonitor;
-            assert(catchUpMonitor instanceof CatchUpMonitor);
-        });
-    });
-
     describe("waitContainerToCatchUp", () => {
         it("Closed Container fails", async () => {
             const mockContainer = new MockContainer();


### PR DESCRIPTION
Also prepare it for the future changes where we use latest sequence number from join signal for catch-up activity (i.e. this info becomes available only when base layer transitions to "connected" event)
