### PR TITLE
Remove webpack-fluid-loader from collaborative-textarea

### DIFF
--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -51,7 +51,6 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.1.2.0 <2.0.0-internal.2.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@fluidframework/test-tools": "^0.2.3074",

--- a/examples/apps/collaborative-textarea/src/app.ts
+++ b/examples/apps/collaborative-textarea/src/app.ts
@@ -39,10 +39,6 @@ async function start() {
     if (contentDiv !== null) {
         ReactDOM.render(React.createElement(CollaborativeTextView, { text: defaultObject.text }), contentDiv);
     }
-
-    // Setting "fluidStarted" is just for our test automation
-    // eslint-disable-next-line @typescript-eslint/dot-notation
-    window["fluidStarted"] = true;
 }
 
 start().catch((e) => {

--- a/examples/apps/collaborative-textarea/src/index.html
+++ b/examples/apps/collaborative-textarea/src/index.html
@@ -1,0 +1,14 @@
+<!-- Copyright (c) Microsoft Corporation and contributors. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+<!doctype html>
+<html lang="en" style="height: 100%;">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test application</title>
+</head>
+<body style="margin: 0; height: 100%;">
+    <div id="content" style="min-height: 100%;"></div>
+</body>
+</html>

--- a/examples/apps/collaborative-textarea/webpack.config.js
+++ b/examples/apps/collaborative-textarea/webpack.config.js
@@ -3,17 +3,17 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const { merge } = require("webpack-merge");
 const webpack = require("webpack");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = env => {
     const isProduction = env && env.production;
 
     return merge({
         entry: {
-            main: "./src/app.ts"
+            app: "./src/app.ts"
         },
         resolve: {
             extensions: [".ts", ".tsx", ".js"],
@@ -31,30 +31,17 @@ module.exports = env => {
             // https://github.com/webpack/webpack/issues/5767
             // https://github.com/webpack/webpack/issues/7939
             devtoolNamespace: "fluid-example/collaborative-textarea",
-            // This is required to run webpacked code in webworker/node
-            // https://github.com/webpack/webpack/issues/6522
-            globalObject: "(typeof self !== 'undefined' ? self : this)",
             libraryTarget: "umd"
-        },
-        devServer: {
-            headers: {
-                'Access-Control-Allow-Origin': '*'
-            },
         },
         plugins: [
             new webpack.ProvidePlugin({
                 process: 'process/browser'
             }),
+            new HtmlWebpackPlugin({
+                template: "./src/index.html",
+            }),
         ],
-        // This impacts which files are watched by the dev server (and likely by webpack if watch is true).
-        // This should be configurable under devServer.static.watch
-        // (see https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) but that does not seem to work.
-        // The CLI options for disabling watching don't seem to work either, so this may be a symptom of using webpack4 with the newer webpack-cli and webpack-dev-server.
-        watchOptions: {
-            ignored: "**/node_modules/**",
-        }
     }, isProduction
         ? require("./webpack.prod")
-        : require("./webpack.dev"),
-    fluidRoute.devServerConfig(__dirname, env));
+        : require("./webpack.dev"));
 };

--- a/examples/apps/contact-collection/webpack.config.js
+++ b/examples/apps/contact-collection/webpack.config.js
@@ -43,9 +43,6 @@ module.exports = env => {
             }),
             // new CleanWebpackPlugin(),
         ],
-        resolve: {
-            extensions: [".ts", ".tsx", ".js"],
-        },
     }, isProduction
         ? require("./webpack.prod")
         : require("./webpack.dev"));


### PR DESCRIPTION
This demo was probably never supposed to use webpack-fluid-loader, as it included an app.ts using getTinyliciousContainer.