### PR TITLE
Propagate full protocol to ConnectionStateHadler (make Audience available at that layer)

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -253,7 +253,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 }
                 const details = {
                     protocolInitialized: this.protocol !== undefined,
-                    clientId: this.pendingClientId,
+                    pendingClientId: this.pendingClientId,
                     clientJoined: this.hasMember(this.pendingClientId),
                     waitingForLeaveOp: this.waitingForLeaveOp,
                 };
@@ -336,8 +336,8 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 category: source === "timeout" ? "error" : "generic",
                 details: JSON.stringify({
                     source,
-                    clientId: this.pendingClientId,
-                    oldClientId: this.clientId,
+                    pendingClientId: this.pendingClientId,
+                    clientId: this.clientId,
                     waitingForLeaveOp: this.waitingForLeaveOp,
                     clientJoined: this.hasMember(this.pendingClientId),
                 }),

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -6,19 +6,18 @@
 import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { assert, Timer } from "@fluidframework/common-utils";
 import { IConnectionDetails, IDeltaManager } from "@fluidframework/container-definitions";
-import { ILocalSequencedClient, IProtocolHandler } from "@fluidframework/protocol-base";
-import { ConnectionMode, IQuorumClients } from "@fluidframework/protocol-definitions";
+import { ILocalSequencedClient } from "@fluidframework/protocol-base";
+import { ConnectionMode } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent, loggerToMonitoringContext } from "@fluidframework/telemetry-utils";
 import { ConnectionState } from "./connectionState";
 import { CatchUpMonitor, ICatchUpMonitor } from "./catchUpMonitor";
+import { IProtocolHandler } from "./protocol";
 
 const JoinOpTimeoutMs = 45000;
 
 /** Constructor parameter type for passing in dependencies needed by the ConnectionStateHandler */
 export interface IConnectionStateHandlerInputs {
     logger: ITelemetryLogger;
-    /** Provides access to the clients currently in the quorum */
-    quorumClients: () => IQuorumClients | undefined;
     /** Log to telemetry any change in state, included to Connecting */
     connectionStateChanged:
         (value: ConnectionState, oldState: ConnectionState, reason?: string | undefined) => void;
@@ -107,7 +106,6 @@ class ConnectionStateHandlerPassThrough implements IConnectionStateHandler, ICon
      */
 
     public get logger() { return this.inputs.logger; }
-    public quorumClients() { return this.inputs.quorumClients(); }
     public connectionStateChanged(
         value: ConnectionState,
         oldState: ConnectionState,
@@ -211,6 +209,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
     private _pendingClientId: string | undefined;
     private readonly prevClientLeftTimer: Timer;
     private readonly joinOpTimer: Timer;
+    private protocol?: IProtocolHandler;
 
     private waitEvent: PerformanceEvent | undefined;
 
@@ -252,11 +251,10 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 if (this.connectionState !== ConnectionState.CatchingUp) {
                     return;
                 }
-                const quorumClients = this.handler.quorumClients();
                 const details = {
-                    quorumInitialized: quorumClients !== undefined,
-                    pendingClientId: this.pendingClientId,
-                    inQuorum: quorumClients?.getMember(this.pendingClientId ?? "") !== undefined,
+                    protocolInitialized: this.protocol !== undefined,
+                    clientId: this.pendingClientId,
+                    clientJoined: this.hasMember(this.pendingClientId),
                     waitingForLeaveOp: this.waitingForLeaveOp,
                 };
                 this.handler.logConnectionIssue("NoJoinOp", details);
@@ -317,19 +315,16 @@ class ConnectionStateHandler implements IConnectionStateHandler {
     }
 
     private applyForConnectedState(source: "removeMemberEvent" | "addMemberEvent" | "timeout" | "containerSaved") {
-        const quorumClients = this.handler.quorumClients();
-        assert(quorumClients !== undefined, 0x236 /* "In all cases it should be already installed" */);
+        assert(this.protocol !== undefined, 0x236 /* "In all cases it should be already installed" */);
 
-        assert(this.waitingForLeaveOp === false ||
-            (this.clientId !== undefined && quorumClients.getMember(this.clientId) !== undefined),
+        assert(!this.waitingForLeaveOp || this.hasMember(this.clientId),
             0x2e2 /* "Must only wait for leave message when clientId in quorum" */);
 
         // Move to connected state only if we are in Connecting state, we have seen our join op
         // and there is no timer running which means we are not waiting for previous client to leave
         // or timeout has occurred while doing so.
         if (this.pendingClientId !== this.clientId
-            && this.pendingClientId !== undefined
-            && quorumClients.getMember(this.pendingClientId) !== undefined
+            && this.hasMember(this.pendingClientId)
             && !this.waitingForLeaveOp
         ) {
             this.waitEvent?.end({ source });
@@ -341,10 +336,10 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 category: source === "timeout" ? "error" : "generic",
                 details: JSON.stringify({
                     source,
-                    pendingClientId: this.pendingClientId,
-                    clientId: this.clientId,
+                    clientId: this.pendingClientId,
+                    oldClientId: this.clientId,
                     waitingForLeaveOp: this.waitingForLeaveOp,
-                    inQuorum: quorumClients?.getMember(this.pendingClientId ?? "") !== undefined,
+                    clientJoined: this.hasMember(this.pendingClientId),
                 }),
             });
         }
@@ -379,14 +374,13 @@ class ConnectionStateHandler implements IConnectionStateHandler {
         this._connectionState = ConnectionState.CatchingUp;
 
         const writeConnection = connectionMode === "write";
-        assert(!this.handler.shouldClientJoinWrite() || writeConnection,
-            0x30a /* shouldClientJoinWrite should imply this is a writeConnection */);
-        assert(!this.waitingForLeaveOp || writeConnection,
-            0x2a6 /* "waitingForLeaveOp should imply writeConnection (we need to be ready to flush pending ops)" */);
 
-        // Note that this may be undefined since the connection is established proactively on load
-        // and the quorum may still be under initialization.
-        const quorumClients: IQuorumClients | undefined = this.handler.quorumClients();
+        // The following checks are wrong. They are only valid if user has write access to a file.
+        // If user lost such access mid-session, user will not be able to get "write" connection.
+        // assert(!this.handler.shouldClientJoinWrite() || writeConnection,
+        //    0x30a /* shouldClientJoinWrite should imply this is a writeConnection */);
+        // assert(!this.waitingForLeaveOp || writeConnection,
+        //    0x2a6 /* "waitingForLeaveOp should imply writeConnection (we need to be ready to flush pending ops)" */);
 
         // Stash the clientID to detect when transitioning from connecting (socket.io channel open) to connected
         // (have received the join message for the client ID)
@@ -403,8 +397,8 @@ class ConnectionStateHandler implements IConnectionStateHandler {
         // We are fetching ops from storage in parallel to connecting to Relay Service,
         // and given async processes, it's possible that we have already processed our own join message before
         // connection was fully established.
-        // If quorumClients itself is undefined, we expect it will process the join op after it's initialized.
-        const waitingForJoinOp = writeConnection && quorumClients?.getMember(this._pendingClientId) === undefined;
+        // If protocol is not initialized yet, we expect it will process the join op after it's initialized.
+        const waitingForJoinOp = writeConnection && !this.hasMember(this._pendingClientId);
 
         if (waitingForJoinOp) {
             // Previous client left, and we are waiting for our own join op. When it is processed we'll join the quorum
@@ -430,10 +424,9 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 
         const oldState = this._connectionState;
         this._connectionState = value;
-        const quorumClients = this.handler.quorumClients();
         let client: ILocalSequencedClient | undefined;
         if (this._clientId !== undefined) {
-            client = quorumClients?.getMember(this._clientId);
+            client = this.protocol?.quorum?.getMember(this._clientId);
         }
         if (value === ConnectionState.Connected) {
             assert(oldState === ConnectionState.CatchingUp,
@@ -451,15 +444,13 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 this.stopJoinOpTimer();
             }
 
-            // Only wait for "leave" message if the connected client exists in the quorum because only the write
-            // client will exist in the quorum and only for those clients we will receive "removeMember" event and
-            // the client has some unacked ops.
-            // Also server would not accept ops from read client. Also check if the timer is not already running as
+            // Only wait for "leave" message if the connected client exists in the quorum and had some non-acked ops
+            // Also check if the timer is not already running as
             // we could receive "Disconnected" event multiple times without getting connected and in that case we
             // don't want to reset the timer as we still want to wait on original client which started this timer.
             if (client !== undefined
                 && this.handler.shouldClientJoinWrite()
-                && this.prevClientLeftTimer.hasTimer === false
+                && !this.waitingForLeaveOp // same as !this.prevClientLeftTimer.hasTimer
             ) {
                 this.prevClientLeftTimer.restart();
             } else {
@@ -467,6 +458,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
                 this.handler.logger.sendTelemetryEvent({
                     eventName: "noWaitOnDisconnected",
                     details: JSON.stringify({
+                        clientId: this._clientId,
                         inQuorum: client !== undefined,
                         waitingForLeaveOp: this.waitingForLeaveOp,
                         hadOutstandingOps: this.handler.shouldClientJoinWrite(),
@@ -479,18 +471,38 @@ class ConnectionStateHandler implements IConnectionStateHandler {
         this.handler.connectionStateChanged(this._connectionState, oldState, reason);
     }
 
+    // Helper method to switch between quorum and audience.
+    // Old design was checking only quorum for "write" clients.
+    // Latest change checks audience for all types of connections.
+    protected get membership() {
+        return this.protocol?.quorum;
+    }
+
     public initProtocol(protocol: IProtocolHandler) {
-        protocol.quorum.on("addMember", (clientId, _details) => {
+        this.protocol = protocol;
+
+        this.membership?.on("addMember", (clientId) => {
             this.receivedAddMemberEvent(clientId);
         });
 
-        protocol.quorum.on("removeMember", (clientId) => {
+        this.membership?.on("removeMember", (clientId) => {
             this.receivedRemoveMemberEvent(clientId);
         });
 
+        // Very unlikely race condition, but theoretically can happen - our new connection is already
+        // summarized and we are loading from such summary.
+        if (this.hasMember(this.pendingClientId)) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.receivedAddMemberEvent(this.pendingClientId!);
+        }
+
         // if we have a clientId from a previous container we need to wait for its leave message
-        if (this.clientId !== undefined && protocol.quorum.getMember(this.clientId) !== undefined) {
+        if (this.clientId !== undefined && this.hasMember(this.clientId)) {
             this.prevClientLeftTimer.restart();
         }
+    }
+
+    protected hasMember(clientId?: string) {
+        return this.membership?.getMember(clientId ?? "") !== undefined;
     }
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -633,7 +633,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.connectionStateHandler = createConnectionStateHandler(
             {
                 logger: this.mc.logger,
-                quorumClients: () => this._protocolHandler?.quorum,
                 connectionStateChanged: (value, oldState, reason) => {
                     if (value === ConnectionState.Connected) {
                         this._clientId = this.connectionStateHandler.pendingClientId;

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -7,7 +7,6 @@
 
 import { strict as assert } from "assert";
 import { TelemetryNullLogger, TypedEventEmitter } from "@fluidframework/common-utils";
-import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import { IClient, IClientConfiguration, ITokenClaims, ISequencedClient } from "@fluidframework/protocol-definitions";
 import { IConnectionDetails, IDeltaManager, IDeltaManagerEvents } from "@fluidframework/container-definitions";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
@@ -18,6 +17,8 @@ import {
     IConnectionStateHandler,
     createConnectionStateHandlerCore,
 } from "../connectionStateHandler";
+import { Audience } from "../audience";
+import { ProtocolHandler } from "../protocol";
 
 class MockDeltaManagerForCatchingUp
     extends TypedEventEmitter<IDeltaManagerEvents>
@@ -34,8 +35,7 @@ describe("ConnectionStateHandler Tests", () => {
     let clock: SinonFakeTimers;
     let handlerInputs: IConnectionStateHandlerInputs;
     let connectionStateHandler: IConnectionStateHandler;
-    let connectionStateHandlerWait: IConnectionStateHandler;
-    let protocolHandler: ProtocolOpHandler;
+    let protocolHandler: ProtocolHandler;
     let shouldClientJoinWrite: boolean;
     let connectionDetails: IConnectionDetails;
     let connectionDetails2: IConnectionDetails;
@@ -64,6 +64,16 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Yield the event loop because the outbound op will be processed asynchronously.
         await yieldEventLoop();
+    }
+
+    function createHandler(connectedRaisedWhenCaughtUp: boolean) {
+        const handler = createConnectionStateHandlerCore(
+            connectedRaisedWhenCaughtUp,
+            handlerInputs,
+            deltaManagerForCatchingUp as any,
+            undefined);
+        handler.initProtocol(protocolHandler);
+        return handler;
     }
 
     before(() => {
@@ -118,11 +128,16 @@ describe("ConnectionStateHandler Tests", () => {
             },
             scopes: [],
         };
-        protocolHandler = new ProtocolOpHandler(0, 0, 1, [], [], [], (key, value) => 0);
+        protocolHandler = new ProtocolHandler(
+            { minimumSequenceNumber: 0, sequenceNumber: 0, term: 1 }, // attributes
+            { members: [], proposals: [], values: [] }, // quorumSnapshot
+            (key, value) => 0, // sendProposal
+            [], // initial Clients
+            new Audience(),
+        );
         shouldClientJoinWrite = false;
         handlerInputs = {
             maxClientLeaveWaitTime: expectedTimeout,
-            quorumClients: () => protocolHandler.quorum,
             shouldClientJoinWrite: () => shouldClientJoinWrite,
             logConnectionIssue: (eventName: string, details?: ITelemetryProperties) => { throw new Error(`logConnectionIssue: ${eventName} ${JSON.stringify(details)}`); },
             connectionStateChanged: () => { },
@@ -131,22 +146,11 @@ describe("ConnectionStateHandler Tests", () => {
 
         deltaManagerForCatchingUp = new MockDeltaManagerForCatchingUp();
 
-        connectionStateHandler = createConnectionStateHandlerCore(
-            false,
-            handlerInputs,
-            deltaManagerForCatchingUp as any,
-            undefined);
-        connectionStateHandler.initProtocol(protocolHandler);
-
-        connectionStateHandlerWait = createConnectionStateHandlerCore(
-            true,
-            handlerInputs,
-            deltaManagerForCatchingUp as any,
-            undefined);
-        connectionStateHandlerWait.initProtocol(protocolHandler);
+        connectionStateHandler = createHandler(
+            false); // connectedRaisedWhenCaughtUp
 
         connectionStateHandler_receivedAddMemberEvent =
-            (id: string) => { protocolHandler.quorum.addMember(id, {} as any as ISequencedClient); };
+            (id: string) => { protocolHandler.quorum.addMember(id, { client: {} } as any as ISequencedClient); };
         connectionStateHandler_receivedRemoveMemberEvent =
             (id: string) => { protocolHandler.quorum.removeMember(id); };
     });
@@ -160,10 +164,12 @@ describe("ConnectionStateHandler Tests", () => {
     });
 
     it("Should move to connected after catching up for read client", async () => {
-        connectionStateHandler = connectionStateHandlerWait;
+        connectionStateHandler = createHandler(
+            true); // connectedRaisedWhenCaughtUp
+
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
             "Client should be in Disconnected state");
-            connectionStateHandlerWait.receivedConnectEvent(client.mode, connectionDetails);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
             "Client should be in CatchingUp state");
         deltaManagerForCatchingUp.catchUp();
@@ -188,7 +194,9 @@ describe("ConnectionStateHandler Tests", () => {
 
     it("Should move to connected state after catching up for write client", async () => {
         client.mode = "write";
-        connectionStateHandler = connectionStateHandlerWait;
+        connectionStateHandler = createHandler(
+            true); // connectedRaisedWhenCaughtUp
+
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
             "Client should be in Disconnected state");
         connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
@@ -207,7 +215,12 @@ describe("ConnectionStateHandler Tests", () => {
 
     it("Should move to connected state on normal flow for write client, even if quorum isn't initialized at first", async () => {
         // swap out quorumClients fn for one that returns undefined at first
-        handlerInputs.quorumClients = () => undefined;
+        // ConnectionStateManager without initialized protocol
+        connectionStateHandler = createConnectionStateHandlerCore(
+            false, // connectedRaisedWhenCaughtUp,
+            handlerInputs,
+            deltaManagerForCatchingUp as any,
+            undefined);
 
         client.mode = "write";
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -216,9 +229,11 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.CatchingUp,
             "Client should be in connecting state");
 
-        // Restore quorumClients fn to return the test quorum object
-        handlerInputs.quorumClients = () => protocolHandler.quorum;
         connectionStateHandler_receivedAddMemberEvent(pendingClientId);
+
+        // init protocol
+        connectionStateHandler.initProtocol(protocolHandler);
+
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client should be in connected state");
     });


### PR DESCRIPTION
Prepare catch-up handler to use audience instead of quorum (see #12042 for more details).
This is mostly Noop change with very few exceptions:
- I've changed telemetry output a bit
- I disabled 2 asserts that are not actually correct in general sense (i.e., there can be hit in some rare race conditions, and asserts are wrong)
- Test changes revealed we are not handling well very rare, but possible condition where pending clientId is already in quorum when we initialize protocol (can only happen if new summary was posted and we loaded from it in between of connection to websocket and loading snapshot).