### PR TITLE
[GC-Stress] Force children to revive to see how InactiveObject shows up

### DIFF
--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -48,6 +48,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
         if (this.error && runInfo !== undefined) {
             const logs = this.logs;
             const outputDir = `${__dirname}/output/${crypto.createHash("md5").update(runInfo.url).digest("hex")}`;
+            console.log(`======================= ${outputDir} =======================`);
             if (!fs.existsSync(outputDir)) {
                 fs.mkdirSync(outputDir, { recursive: true });
             }
@@ -81,6 +82,11 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
             this.error = true;
         }
         this.logs.push(event);
+
+        if (event.eventName.includes("InactiveObject_") || event.eventName.includes("SweepReadyObject_")) {
+//            this.flush().catch(() => {}).finally(() => console.log("^^^^^^^^^^^^^^ FLUSHED ^^^^^^^^^^^^"));
+//            throw new Error(`BLOWING UP ${event.eventName}`);
+        }
     }
 }
 

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -1,19 +1,19 @@
 {
     "profiles": {
         "gc": {
-            "opRatePerMin": 120,
+            "opRatePerMin": 60,
             "progressIntervalMs": 5000,
-            "numClients": 10,
-            "totalSendCount": 1000,
+            "numClients": 2,
+            "totalSendCount": 100,
             "optionOverrides":{
                 "tinylicious":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [2000]
                     }
                 },
                 "odsp":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [2000]
                     }
                 }
             }


### PR DESCRIPTION
It looks like if we do nothing, InactiveObject errors will get printed to the console and also to a file.

I tried also throwing but that's not very useful, since it just closes the summarizer.  This is basically the same problem I've been trying to solve for DF.  Before doing more work here we should define the desired outcome.  e.g. maybe we want to run this test as a mocha test like Si did in the CI loop (see `test/mini.spec.ts` file in this package), and then actually have a return code based on what errors we saw.

Also something I'm confused by here - When I run this, I get InactiveObject_Revived errors but no InactiveObject_changed errors. Oh... is this by design to avoid duplicating the signal?