### PR TITLE
[GC-Stress] Added unreferenced time tracking and enabled reviving data stores.

### DIFF
--- a/packages/test/test-service-load/src/gcDataStore.ts
+++ b/packages/test/test-service-load/src/gcDataStore.ts
@@ -15,7 +15,7 @@ import { IRunConfig } from "./loadTestDataStore";
 /**
  * How much faster than its parent should a data stores at each level send ops.
  */
-const opRateMultiplierPerLevel = 5;
+const opRateMultiplierPerLevel = 1;
 
 /**
  * Activities that data stores perform.
@@ -42,6 +42,10 @@ export interface IGCDataStore {
 interface IChildDetails {
     id: string;
     child: IGCDataStore;
+}
+
+interface IUnreferencedChildDetails extends IChildDetails {
+    unreferencedTimestamp: number;
 }
 
 /**
@@ -140,10 +144,23 @@ export class RootDataObject extends BaseDataObject implements IGCDataStore {
     private readonly uniquechildId = `${this.myId}-child`;
     private child: IGCDataStore | undefined;
 
-    private readonly unreferencedChildrenDetails: IChildDetails[] = [];
+    private _inactiveTimeoutMs: number | undefined;
+    /**
+     * Should not be called before "run" is called which initializes inactiveTimeoutMs.
+     */
+    public get inactiveTimeoutMs(): number {
+        assert(this._inactiveTimeoutMs !== undefined, "inactive timeout is required for GC tests");
+        return this._inactiveTimeoutMs;
+    }
+
+    private readonly unreferencedChildrenDetails: IUnreferencedChildDetails[] = [];
     private readonly referencedChildrenDetails: IChildDetails[] = [];
+    private readonly expiredChildrenDetails: IChildDetails[] = [];
 
     public async run(config: IRunConfig): Promise<boolean> {
+        assert(config.testConfig.inactiveTimeoutMs !== undefined, "inactive timeout is required for GC tests");
+        this._inactiveTimeoutMs = config.testConfig.inactiveTimeoutMs - 500;
+
         this.shouldRun = true;
         const delayBetweenOpsMs = 60 * 1000 / config.testConfig.opRatePerMin;
         const totalSendCount = config.testConfig.totalSendCount;
@@ -250,13 +267,10 @@ export class RootDataObject extends BaseDataObject implements IGCDataStore {
                 }
                 case GCActivityType.Revive: {
                     console.log("########## Reviving child");
-                    /**
-                     * Skip this for now because this may lead to inactive object error.
-                     * Reviving will be added in a follow up PR.
-                     */
-                    // if (this.unreferencedChildrenDetails.length > 0) {
-                    //     return this.reviveChild(config);
-                    // }
+                    const revivableChildDetails = this.getRevivableChild();
+                    if (revivableChildDetails !== undefined) {
+                        return this.reviveChild(config, revivableChildDetails);
+                    }
                     break;
                 }
                 default:
@@ -306,17 +320,16 @@ export class RootDataObject extends BaseDataObject implements IGCDataStore {
         childDetails.child.stop();
 
         this.root.delete(childDetails.id);
-        this.unreferencedChildrenDetails.push(childDetails);
+        this.unreferencedChildrenDetails.push({
+            ...childDetails,
+            unreferencedTimestamp: Date.now(),
+        });
     }
 
     /**
      * Retrieves the oldes unreferenced child, references it and asks it to run.
-     * TODO - Change this to private once it is used. Kept it here for now for PR review.
      */
-    public async reviveChild(config: IRunConfig): Promise<boolean> {
-        const childDetails = this.unreferencedChildrenDetails.shift();
-        assert(childDetails !== undefined, "Cannot find child to revive");
-
+    private async reviveChild(config: IRunConfig, childDetails: IChildDetails): Promise<boolean> {
         this.root.set(childDetails.id, childDetails.child.handle);
         this.referencedChildrenDetails.push(childDetails);
 
@@ -330,6 +343,23 @@ export class RootDataObject extends BaseDataObject implements IGCDataStore {
             },
         };
         return childDetails.child.run(childConfig, childDetails.id);
+    }
+
+    /**
+     * If there is a child that can be revived, returns its details. Otherwise, returns undefined.
+     * It also moves any expired child to the expired child list.
+     */
+    private getRevivableChild(): IUnreferencedChildDetails | undefined {
+        let childDetails = this.unreferencedChildrenDetails.shift();
+        while (childDetails !== undefined) {
+            if (Date.now() - childDetails.unreferencedTimestamp > (this.inactiveTimeoutMs)) {
+                this.expiredChildrenDetails.push(childDetails);
+            } else {
+                break;
+            }
+            childDetails = this.unreferencedChildrenDetails.shift();
+        }
+        return childDetails;
     }
 }
 

--- a/packages/test/test-service-load/src/gcDataStore.ts
+++ b/packages/test/test-service-load/src/gcDataStore.ts
@@ -159,6 +159,7 @@ export class RootDataObject extends BaseDataObject implements IGCDataStore {
 
     public async run(config: IRunConfig): Promise<boolean> {
         assert(config.testConfig.inactiveTimeoutMs !== undefined, "inactive timeout is required for GC tests");
+        // Set the local inactive timeout 500 less than the actual to keep buffer when expiring data stores.
         this._inactiveTimeoutMs = config.testConfig.inactiveTimeoutMs - 500;
 
         this.shouldRun = true;

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -58,7 +58,7 @@ const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
 
 const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
     disableSummaries: [false],
-    initialSummarizerDelayMs: [500],
+    initialSummarizerDelayMs: [undefined],
     summaryConfigOverrides: [undefined],
     maxOpsSinceLastSummary: [undefined],
     summarizerClientElection: booleanCases,
@@ -73,8 +73,8 @@ export function generateRuntimeOptions(
         generatePairwiseOptions(applyOverrides(summaryOptionsMatrix, overrides?.summaryOptions as any), seed);
 
     const runtimeOptionsMatrix: OptionsMatrix<IContainerRuntimeOptions> = {
-        gcOptions: [undefined, ...gcOptions],
-        summaryOptions: [undefined, ...summaryOptions],
+        gcOptions: [...gcOptions],
+        summaryOptions: [...summaryOptions],
         loadSequenceNumberVerification: [undefined],
         enableOfflineLoad: [undefined],
         flushMode: [undefined],

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -21,6 +21,10 @@ export interface ILoadTestConfig {
     numClients: number;
     totalSendCount: number;
     readWriteCycleMs: number;
+    /**
+     * Required for GC tests. The time after which unreferenced objects become inactive.
+     */
+    inactiveTimeoutMs?: number;
     faultInjectionMaxMs?: number;
     faultInjectionMinMs?: number;
     /**

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -5,15 +5,16 @@
             "progressIntervalMs": 5000,
             "numClients": 10,
             "totalSendCount": 1000,
+            "inactiveTimeoutMs": [10000],
             "optionOverrides":{
                 "tinylicious":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
                     }
                 },
                 "odsp":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
                     }
                 }
             }
@@ -23,15 +24,16 @@
             "progressIntervalMs": 5000,
             "numClients": 10,
             "totalSendCount": 72000,
+            "inactiveTimeoutMs": [10000],
             "optionOverrides":{
                 "tinylicious":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
                     }
                 },
                 "odsp":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
                     }
                 }
             }
@@ -43,15 +45,16 @@
             "totalSendCount": 1000,
             "faultInjectionMinMs": 0,
             "faultInjectionMaxMs": 50000,
+            "inactiveTimeoutMs": [10000],
             "optionOverrides":{
                 "tinylicious":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
                     }
                 },
                 "odsp":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [5000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
                     }
                 }
             }


### PR DESCRIPTION
- Updated options matrix to always run summaries and GC.
- Added tracking unreferenced data store timestamps.
- Enabled reviving objects.
- Added config for inactive object timeout so that it data stores can get it. This is a hack and will be fixed later.
- Reduced the frequency of ops sent by child data stores to deal with throttling.