### PR TITLE
[GC-Stress] Updated ci config to increase opRatePerMin and inactiveTimeout

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -20,20 +20,20 @@
             }
         },
         "gc_ci": {
-            "opRatePerMin": 120,
+            "opRatePerMin": 240,
             "progressIntervalMs": 5000,
             "numClients": 10,
             "totalSendCount": 72000,
-            "inactiveTimeoutMs": [10000],
+            "inactiveTimeoutMs": [60000],
             "optionOverrides":{
                 "tinylicious":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [60000]
                     }
                 },
                 "odsp":{
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [60000]
                     }
                 }
             }


### PR DESCRIPTION
- Increased opRataPerMin since each client now sends fewer op per min - https://github.com/microsoft/FluidFramework/pull/12110.
- Increased inactiveTimeout since each client is now sending fewer ops and hence does fewer activities. So giving it more time to revive data stores.