### PR TITLE
Add new error type fluidInvalidSchema 

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -27,6 +27,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 - [Move `TelemetryNullLogger` and `BaseTelemetryNullLogger` to telemetry-utils package](#Move-`TelemetryNullLogger`-and-`BaseTelemetryNullLogger`-to-telemetry-utils-package)
 - [Minor event naming correction on IFluidContainerEvents](#IFluidContainerEvents-event-naming-correction)
 - [Add assertion that prevents sending op while processing another op](#add-assertion-that-prevents-sending-op-while-processing-another-op)
+- [Add fluidInvalidSchema errorType to DriverErrorType enum](#Add-fluidInvalidSchema-errorType-to-DriverErrorType-enum)
 
 ### Remove `type` field from `ShareLinkInfoType`
 This field has been deprecated and will be removed in a future breaking change. You should be able to get the kind of sharing link from `shareLinkInfo.createLink.link` property bag.
@@ -49,6 +50,11 @@ This field has been deprecated and will be removed in a future breaking change. 
 
 ### Add assertion that prevents sending op while processing another op
 `preventConcurrentOpSend` has been added and enabled by default. This will run an assertion that closes the container if attempting to send an op while processing another op. This is meant to prevent non-deterministic outcomes due to concurrent op processing.
+
+### Add fluidInvalidSchema errorType to DriverErrorType enum
+Added fluidInvalidSchema errorType in DriverErrorType enum. This error happens when non-fluid file
+was mistook as a Fluid file, and is unable to be opened. The innerMostErrorCode will also be "fluidInvalidSchema".
+This is not breaking change yet. But if clients do not add handling for this error, their existing version of applications may start receiving this error in the future, and may not handle it correctly.
 
 # 2.0.0
 

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -34,6 +34,7 @@ export enum DriverErrorType {
     fetchFailure = "fetchFailure",
     fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
     fileOverwrittenInStorage = "fileOverwrittenInStorage",
+    fluidInvalidSchema = "fluidInvalidSchema",
     genericError = "genericError",
     genericNetworkError = "genericNetworkError",
     incorrectServerResponse = "incorrectServerResponse",
@@ -182,7 +183,7 @@ export interface IDocumentStorageServicePolicies {
 // @public
 export interface IDriverBasicError extends IDriverErrorBase {
     // (undocumented)
-    readonly errorType: DriverErrorType.genericError | DriverErrorType.fileNotFoundOrAccessDeniedError | DriverErrorType.offlineError | DriverErrorType.unsupportedClientProtocolVersion | DriverErrorType.writeError | DriverErrorType.fetchFailure | DriverErrorType.incorrectServerResponse | DriverErrorType.fileOverwrittenInStorage | DriverErrorType.usageError;
+    readonly errorType: DriverErrorType.genericError | DriverErrorType.fileNotFoundOrAccessDeniedError | DriverErrorType.offlineError | DriverErrorType.unsupportedClientProtocolVersion | DriverErrorType.writeError | DriverErrorType.fetchFailure | DriverErrorType.incorrectServerResponse | DriverErrorType.fileOverwrittenInStorage | DriverErrorType.usageError | DriverErrorType.fluidInvalidSchema;
     // (undocumented)
     readonly statusCode?: number;
 }

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -187,6 +187,15 @@ export const emptyMessageStream: IStream<ISequencedDocumentMessage[]>;
 export function ensureFluidResolvedUrl(resolved: IResolvedUrl | undefined): asserts resolved is IFluidResolvedUrl;
 
 // @public
+export class FluidInvalidSchemaError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {
+    constructor(message: string, props: DriverErrorTelemetryProps);
+    // (undocumented)
+    readonly canRetry = false;
+    // (undocumented)
+    readonly errorType = DriverErrorType.fluidInvalidSchema;
+}
+
+// @public
 export class GenericNetworkError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {
     constructor(message: string, canRetry: boolean, props: DriverErrorTelemetryProps);
     // (undocumented)

--- a/packages/common/driver-definitions/src/driverError.ts
+++ b/packages/common/driver-definitions/src/driverError.ts
@@ -89,6 +89,13 @@ export enum DriverErrorType {
      * ! Should match the value of ContainerErrorType.usageError
      */
     usageError = "usageError",
+
+    /**
+     * When a file is not a Fluid file, but has Fluid extension such as ".note",
+     * server won't be able to open it and will return this error. The innerMostErrorCode will be
+     * "fluidInvalidSchema"
+     */
+     fluidInvalidSchema = "fluidInvalidSchema",
 }
 
 /**
@@ -143,7 +150,8 @@ export interface IDriverBasicError extends IDriverErrorBase {
     | DriverErrorType.fetchFailure
     | DriverErrorType.incorrectServerResponse
     | DriverErrorType.fileOverwrittenInStorage
-    | DriverErrorType.usageError;
+    | DriverErrorType.usageError
+    | DriverErrorType.fluidInvalidSchema;
     readonly statusCode?: number;
 }
 

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -71,6 +71,21 @@ export class DeltaStreamConnectionForbiddenError extends LoggingError implements
     }
 }
 
+/**
+ * FluidInvalidSchema error class.
+ */
+export class FluidInvalidSchemaError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {
+    readonly errorType = DriverErrorType.fluidInvalidSchema;
+    readonly canRetry = false;
+
+    constructor(
+        message: string,
+        props: DriverErrorTelemetryProps,
+    ) {
+        super(message, props);
+    }
+}
+
 export class AuthorizationError extends LoggingError implements IAuthorizationError, IFluidErrorBase {
     readonly errorType = DriverErrorType.authorizationError;
     readonly canRetry = false;


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

For specific guidelines for Pull Requests in this repo, visit [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

Adding a new error type `fluidIvalidSchema` for errors happening when server tries to open non-fluid file with fluid-like extensions, eg. ".note"
Separate PR on handling new error will merge after this 
