### PR TITLE
[GC-Stress] Added functionality where multiple clients collaborate on the same data store

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -102,8 +102,7 @@
     "ps-node": "^0.1.6",
     "random-js": "^1.0.8",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251",
-    "uuid": "^8.3.1"
+    "tinylicious": "^0.4.89251"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -22,8 +22,8 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { ILoadTestConfig } from "./testConfigFile";
 import { LeaderElection } from "./leaderElection";
 import {
-    RootDataObject,
-    rootDataObjectFactory,
+    RootDataObject2,
+    rootDataObjectFactory2,
     DataObjectType1,
     dataObjectType1Factory,
     IGCDataStore,
@@ -424,7 +424,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
     protected async initializingFirstTime() {
         this.root.set(taskManagerKey, TaskManager.create(this.runtime).handle);
 
-        const gcDataStore = await rootDataObjectFactory.createInstance(this.context.containerRuntime);
+        const gcDataStore = await rootDataObjectFactory2.createInstance(this.context.containerRuntime);
         this.root.set(gcDataStore2Key, gcDataStore.handle);
     }
 
@@ -525,7 +525,7 @@ export const createFluidExport = (options: IContainerRuntimeOptions) =>
         [
             [LoadTestDataStore.DataStoreName, Promise.resolve(LoadTestDataStoreInstantiationFactory)],
             [DataObjectType1.type, Promise.resolve(dataObjectType1Factory)],
-            [RootDataObject.type, Promise.resolve(rootDataObjectFactory)],
+            [RootDataObject2.type, Promise.resolve(rootDataObjectFactory2)],
         ],
         undefined,
         [innerRequestHandler],


### PR DESCRIPTION
Extended the root data store to add collaborating with other clients. Basically, each client will also run child data stores from two other clients. I did not add running all other clients data stores because that will create too many ops. We could add this later if needed.