### PR TITLE
Add --all argument to release report command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,7 @@
             ],
         },
         {
+            // Runs the `flub release report --all` command with a debugger attached.
             "name": "flub release report",
             "program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev",
             "cwd": "${workspaceFolder}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,22 @@
             ],
         },
         {
+            "name": "flub release report",
+            "program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev",
+            "cwd": "${workspaceFolder}",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node",
+            "args": [
+                "release",
+                "report",
+                "--all",
+                "-v",
+            ],
+        },
+        {
             "name": "flub bump deps",
             "program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev",
             "cwd": "${workspaceFolder}",

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -407,23 +407,20 @@ Generates a report of Fluid Framework releases.
 
 ```
 USAGE
-  $ flub release report [--json] [-d <value>] [-s | -r] [-f -o <value>] [-g client|server|azure|build-tools [--all |
-    ]] [-p <value> ] [--limit <value> ] [-v]
+  $ flub release report [--json] [--days <value>] [-s | -r] [-g client|server|azure|build-tools [--all | -o
+    <value>]] [-p <value> ] [--limit <value> ] [-v]
 
 FLAGS
-  -d, --days=<value>           [default: 10] The number of days to look back for releases to report.
-  -f, --full                   Output a full report. A full report includes additional metadata for each package,
-                               including the time of the release, the type of release (patch, minor, major), and whether
-                               the release is new.
   -g, --releaseGroup=<option>  Name of release group
                                <options: client|server|azure|build-tools>
-  -o, --output=<value>         Output a JSON report file to this location.
+  -o, --output=<value>         Output JSON report files to this location.
   -p, --package=<value>        Name of package.
   -r, --mostRecent             Always pick the most recent version as the latest (ignore semver version sorting).
   -s, --highest                Always pick the greatest semver version as the latest (ignore dates).
   -v, --verbose                Verbose logging.
   --all                        List all releases. Useful when you want to see all the releases done for a release group
                                or package. The number of results can be limited using the --limit argument.
+  --days=<value>               [default: 10] The number of days to look back for releases to report.
   --limit=<value>              Limits the number of displayed releases for each release group.
 
 GLOBAL FLAGS

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -439,6 +439,8 @@ DESCRIPTION
   The command will prompt you to select versions for a package or release group in the event that multiple versions have
   recently been released.
 
+  Using the --all flag, you can list all the releases for a given release group or package.
+
 EXAMPLES
   Generate a minimal release report and display it in the terminal.
 
@@ -455,6 +457,14 @@ EXAMPLES
   Output a full release report to 'report.json'.
 
     $ flub release report -f -o report.json
+
+  List all the releases of the azure release group.
+
+    $ flub release report --all -g azure
+
+  List the 10 most recent client releases.
+
+    $ flub release report --all -g client --limit 10
 ```
 
 ## `flub run bundleStats`

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -111,7 +111,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version)
-@fluid-tools/build-cli/0.4.6000 linux-x64 node-v14.20.0
+@fluid-tools/build-cli/0.4.7000 linux-x64 node-v14.20.0
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND
@@ -313,7 +313,7 @@ USAGE
   $ flub generate packageJson -g client|server|azure|build-tools [-v]
 
 FLAGS
-  -g, --releaseGroup=<option>  (required) release group
+  -g, --releaseGroup=<option>  (required) Name of release group
                                <options: client|server|azure|build-tools>
   -v, --verbose                Verbose logging.
 
@@ -350,7 +350,7 @@ USAGE
   $ flub info [-g client|server|azure|build-tools] [-p] [-v]
 
 FLAGS
-  -g, --releaseGroup=<option>  release group
+  -g, --releaseGroup=<option>  Name of release group
                                <options: client|server|azure|build-tools>
   -p, --[no-]private           Include private packages (default true).
   -v, --verbose                Verbose logging.
@@ -359,7 +359,7 @@ DESCRIPTION
   Get info about the repo, release groups, and packages.
 ```
 
-_See code: [dist/commands/info.ts](https://github.com/microsoft/FluidFramework/blob/v0.4.6000/dist/commands/info.ts)_
+_See code: [dist/commands/info.ts](https://github.com/microsoft/FluidFramework/blob/v0.4.7000/dist/commands/info.ts)_
 
 ## `flub release`
 
@@ -371,7 +371,7 @@ USAGE
     --commit | --branchCheck | --updateCheck | --policyCheck] [-v]
 
 FLAGS
-  -g, --releaseGroup=<option>  release group
+  -g, --releaseGroup=<option>  Name of release group
                                <options: client|server|azure|build-tools>
   -p, --package=<value>        Name of package.
   -t, --bumpType=<option>      Version bump type.
@@ -399,7 +399,7 @@ DESCRIPTION
   released.
 ```
 
-_See code: [dist/commands/release.ts](https://github.com/microsoft/FluidFramework/blob/v0.4.6000/dist/commands/release.ts)_
+_See code: [dist/commands/release.ts](https://github.com/microsoft/FluidFramework/blob/v0.4.7000/dist/commands/release.ts)_
 
 ## `flub release report`
 
@@ -407,16 +407,24 @@ Generates a report of Fluid Framework releases.
 
 ```
 USAGE
-  $ flub release report [--json] [-d <value>] [-s | -r] [-f -o <value>] [-v]
+  $ flub release report [--json] [-d <value>] [-s | -r] [-f -o <value>] [-g client|server|azure|build-tools [--all |
+    ]] [-p <value> ] [--limit <value> ] [-v]
 
 FLAGS
-  -d, --days=<value>    [default: 10] The number of days to look back for releases to report.
-  -f, --full            Output a full report. A full report includes additional metadata for each package, including the
-                        time of the release, the type of release (patch, minor, major), and whether the release is new.
-  -o, --output=<value>  Output a JSON report file to this location.
-  -r, --mostRecent      Always pick the most recent version as the latest (ignore semver version sorting).
-  -s, --highest         Always pick the greatest semver version as the latest (ignore dates).
-  -v, --verbose         Verbose logging.
+  -d, --days=<value>           [default: 10] The number of days to look back for releases to report.
+  -f, --full                   Output a full report. A full report includes additional metadata for each package,
+                               including the time of the release, the type of release (patch, minor, major), and whether
+                               the release is new.
+  -g, --releaseGroup=<option>  Name of release group
+                               <options: client|server|azure|build-tools>
+  -o, --output=<value>         Output a JSON report file to this location.
+  -p, --package=<value>        Name of package.
+  -r, --mostRecent             Always pick the most recent version as the latest (ignore semver version sorting).
+  -s, --highest                Always pick the greatest semver version as the latest (ignore dates).
+  -v, --verbose                Verbose logging.
+  --all                        List all releases. Useful when you want to see all the releases done for a release group
+                               or package. The number of results can be limited using the --limit argument.
+  --limit=<value>              Limits the number of displayed releases for each release group.
 
 GLOBAL FLAGS
   --json  Format output as json.
@@ -510,7 +518,7 @@ EXAMPLES
     $ flub version 2.0.0-internal.1.0.0 --type current
 ```
 
-_See code: [@fluid-tools/version-tools](https://github.com/microsoft/FluidFramework/blob/v0.4.6000/dist/commands/version.ts)_
+_See code: [@fluid-tools/version-tools](https://github.com/microsoft/FluidFramework/blob/v0.4.7000/dist/commands/version.ts)_
 
 ## `flub version latest`
 

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -91,7 +91,7 @@ export abstract class BaseCommand<T extends typeof BaseCommand.flags>
         if (this._logger === undefined) {
             this._logger = {
                 info: (msg: string | Error) => {
-                    this.log(msg.toString());
+                    this.info(msg.toString());
                 },
                 warning: this.warning.bind(this),
                 errorLog: (msg: string | Error) => {

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -44,7 +44,9 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
     static summary = "Generates a report of Fluid Framework releases.";
     static description = `The release report command is used to produce a report of all the packages that were released and their current version. After a release, it is useful to generate this report to provide to customers, so they can update their dependencies to the most recent version.
 
-    The command will prompt you to select versions for a package or release group in the event that multiple versions have recently been released.`;
+    The command will prompt you to select versions for a package or release group in the event that multiple versions have recently been released.
+
+    Using the --all flag, you can list all the releases for a given release group or package.`;
 
     static examples = [
         {
@@ -62,6 +64,14 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
         {
             description: "Output a full release report to 'report.json'.",
             command: "<%= config.bin %> <%= command.id %> -f -o report.json",
+        },
+        {
+            description: "List all the releases of the azure release group.",
+            command: "<%= config.bin %> <%= command.id %> --all -g azure",
+        },
+        {
+            description: "List the 10 most recent client releases.",
+            command: "<%= config.bin %> <%= command.id %> --all -g client --limit 10",
         },
     ];
 
@@ -174,11 +184,6 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
         if (flags.all === true) {
             for (const [pkgOrReleaseGroup, data] of Object.entries(versionData)) {
                 const versions = sortVersions([...data.versions], "version");
-                // const recentReleases = filterVersionsOlderThan(versions, flags.days);
-                // if(recentReleases.length === 0) {
-                //     recentReleases.push(versions[0]);
-                // }
-
                 const t = this.generateAllReleasesTable(pkgOrReleaseGroup, versions);
 
                 this.log(
@@ -514,7 +519,7 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
 
         const limit = this.processedFlags.limit;
         if (limit !== undefined && tableData.length > limit) {
-            this.verbose(
+            this.info(
                 `Reached the release limit (${limit}), ignoring the remaining ${
                     tableData.length - limit
                 } releases.`,

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -95,21 +95,10 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
                 "Always pick the most recent version as the latest (ignore semver version sorting).",
             exclusive: ["highest"],
         }),
-        // outputDir: Flags.directory({
-        //     char: "d",
-        //     description: "Output all report files to this directory.",
-        //     exclusive: ["output"],
-        // }),
         output: Flags.directory({
             char: "o",
             description: "Output JSON report files to this location.",
         }),
-        // full: Flags.boolean({
-        //     char: "f",
-        //     description:
-        //         "Output a full report. A full report includes additional metadata for each package, including the time of the release, the type of release (patch, minor, major), and whether the release is new.",
-        //     dependsOn: ["output"],
-        // }),
         all: Flags.boolean({
             description:
                 "List all releases. Useful when you want to see all the releases done for a release group or package. The number of results can be limited using the --limit argument.",
@@ -606,6 +595,17 @@ interface ReleaseReport {
 
 /**
  * A type representing the different kinds of report formats we output.
+ *
+ * "full" corresponds to the {@link ReleaseReport} interface. It contains a lot of package metadata indexed by package
+ * name.
+ *
+ * "simple" corresponds to the {@link PackageVersionList} interface. It contains a map of package names to versions.
+ *
+ * "caret" corresponds to the {@link PackageCaretRange} interface. It contains a map of package names to
+ * caret-equivalent version range strings.
+ *
+ * "tilde" corresponds to the {@link PackageTildeRange} interface. It contains a map of package names to
+ * tilde-equivalent version range strings.
  */
 type ReportKind = "full" | "caret" | "tilde" | "simple";
 

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -373,12 +373,20 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
 
             const isNewRelease = this.isRecentReleaseByDate(latestDate);
             const scheme = detectVersionScheme(latestVer);
-            const ranges: ReleaseRanges | undefined = scheme === "internal" ? {
-                patch: getVersionRange(latestVer, "patch"),
-                minor: getVersionRange(latestVer, "minor"),
-                tilde: getVersionRange(latestVer, "~"),
-                caret: getVersionRange(latestVer, "^"),
-            } : undefined;
+            const ranges: ReleaseRanges | undefined =
+                scheme === "internal"
+                    ? {
+                          patch: getVersionRange(latestVer, "patch"),
+                          minor: getVersionRange(latestVer, "minor"),
+                          tilde: getVersionRange(latestVer, "~"),
+                          caret: getVersionRange(latestVer, "^"),
+                      }
+                    : {
+                          patch: `~${latestVer}`,
+                          minor: `^${latestVer}`,
+                          tilde: `~${latestVer}`,
+                          caret: `^${latestVer}`,
+                      };
 
             // Expand the release group to its constituent packages.
             if (isReleaseGroup(pkgName)) {
@@ -507,7 +515,8 @@ export default class ReleaseReportCommand extends BaseCommand<typeof ReleaseRepo
         const limit = this.processedFlags.limit;
         if (limit !== undefined && tableData.length > limit) {
             this.verbose(
-                `Reached the release limit (${limit}), ignoring the remaining ${tableData.length - limit
+                `Reached the release limit (${limit}), ignoring the remaining ${
+                    tableData.length - limit
                 } releases.`,
             );
             // The most recent releases are last, so slice from the end.
@@ -546,7 +555,7 @@ interface ReleaseDetails {
     releaseType: VersionBumpType;
     isNewRelease: boolean;
     releaseGroup?: ReleaseGroup;
-    ranges?: ReleaseRanges;
+    ranges: ReleaseRanges;
 }
 
 interface ReleaseRanges {

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -29,7 +29,7 @@ export const rootPathFlag = Flags.build({
  */
 export const releaseGroupFlag = Flags.build({
     char: "g",
-    description: "release group",
+    description: "Name of release group",
     options: [...supportedMonoRepoValues()],
     parse: async (str: string) => {
         const group = str.toLowerCase();

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -29,7 +29,7 @@ export const rootPathFlag = Flags.build({
  */
 export const releaseGroupFlag = Flags.build({
     char: "g",
-    description: "Name of release group",
+    description: "Name of the release group",
     options: [...supportedMonoRepoValues()],
     parse: async (str: string) => {
         const group = str.toLowerCase();

--- a/build-tools/packages/build-cli/src/lib/index.ts
+++ b/build-tools/packages/build-cli/src/lib/index.ts
@@ -19,6 +19,7 @@ export {
     PackageWithRangeSpec,
 } from "./bump";
 export {
+    filterVersionsOlderThan,
     getAllVersions,
     getPreReleaseDependencies,
     generateReleaseGitTagName,

--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -7,7 +7,7 @@ import path from "path";
 import { Context, readJsonAsync, Logger, Package, MonoRepo } from "@fluidframework/build-tools";
 import { isPrereleaseVersion, ReleaseVersion } from "@fluid-tools/version-tools";
 import { PackageName } from "@rushstack/node-core-library";
-import { compareDesc } from "date-fns";
+import { compareDesc, differenceInBusinessDays } from "date-fns";
 import ncu from "npm-check-updates";
 // eslint-disable-next-line import/no-internal-modules
 import { VersionSpec } from "npm-check-updates/build/src/types/VersionSpec";
@@ -466,10 +466,10 @@ export async function getAllVersions(
  *
  * @internal
  */
-export async function sortVersions(
+export function sortVersions(
     versions: VersionDetails[],
     sortKey: "version" | "date",
-): Promise<VersionDetails[]> {
+): VersionDetails[] {
     const sortedVersions: VersionDetails[] = [];
 
     // Clone the array
@@ -486,4 +486,21 @@ export async function sortVersions(
     }
 
     return sortedVersions;
+}
+
+/**
+ * Filters an array of {@link VersionDetails}, removing versions older than a specified number of business days.
+ *
+ * @param versions - The array of versions to filter.
+ * @param numBusinessDays - The number of business days to consider recent.
+ * @returns An array of versions that are more recent than numBusinessDays.
+ */
+export function filterVersionsOlderThan(
+    versions: VersionDetails[],
+    numBusinessDays: number,
+): VersionDetails[] {
+    return versions.filter((v) => {
+        const diff = v.date === undefined ? 0 : differenceInBusinessDays(Date.now(), v.date);
+        return diff <= numBusinessDays;
+    });
 }

--- a/build-tools/packages/version-tools/src/semver.ts
+++ b/build-tools/packages/version-tools/src/semver.ts
@@ -118,12 +118,16 @@ export function detectBumpType(
         throw new Error(`Invalid version: ${v2}`);
     }
 
-    if (isInternalVersionScheme(v1, true)) {
+    const v1IsInternal = isInternalVersionScheme(v1, true);
+    const v2IsInternal = isInternalVersionScheme(v2, true);
+
+    if (v1IsInternal) {
         const [, internalVer] = fromInternalScheme(v1, true);
         v1Parsed = internalVer;
     }
 
-    if (isInternalVersionScheme(v2, true)) {
+    // Only convert if the versions are the same scheme.
+    if (v2IsInternal && v1IsInternal) {
         const [, internalVer] = fromInternalScheme(v2, true);
         v2Parsed = internalVer;
     }

--- a/build-tools/packages/version-tools/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/test/internalVersionScheme.test.ts
@@ -152,9 +152,12 @@ describe("internalScheme", () => {
             assert.isTrue(semver.satisfies(`2.0.0-internal.1.0.2`, range));
             assert.isTrue(semver.satisfies(`2.0.0-internal.1.0.3`, range));
 
-            // Check that minor and major bumps do not saisfy the range
+            // Check that minor and major bumps do not satisfy the range
             assert.isFalse(semver.satisfies(`2.0.0-internal.1.1.0`, range));
             assert.isFalse(semver.satisfies(`2.0.0-internal.2.1.0`, range));
+
+            // Check that prerelease versions do not satisfy the range
+            assert.isFalse(semver.satisfies(`2.0.0-internal.1.0.1.95400`, range));
         });
 
         it("caret ^ dependency equivalent (auto-upgrades minor versions)", () => {
@@ -169,9 +172,12 @@ describe("internalScheme", () => {
             assert.isTrue(semver.satisfies(`2.0.0-internal.1.2.2`, range));
             assert.isTrue(semver.satisfies(`2.0.0-internal.1.3.3`, range));
 
-            // Check that major bumps do not saisfy the range
+            // Check that major bumps do not satisfy the range
             assert.isFalse(semver.satisfies(`2.0.0-internal.2.0.0`, range));
             assert.isFalse(semver.satisfies(`2.0.0-internal.3.1.0`, range));
+
+            // Check that prerelease versions do not satisfy the range
+            assert.isFalse(semver.satisfies(`2.0.0-internal.1.1.1.95400`, range));
         });
     });
 });

--- a/build-tools/packages/version-tools/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/test/internalVersionScheme.test.ts
@@ -155,9 +155,6 @@ describe("internalScheme", () => {
             // Check that minor and major bumps do not satisfy the range
             assert.isFalse(semver.satisfies(`2.0.0-internal.1.1.0`, range));
             assert.isFalse(semver.satisfies(`2.0.0-internal.2.1.0`, range));
-
-            // Check that prerelease versions do not satisfy the range
-            assert.isFalse(semver.satisfies(`2.0.0-internal.1.0.1.95400`, range));
         });
 
         it("caret ^ dependency equivalent (auto-upgrades minor versions)", () => {
@@ -175,9 +172,23 @@ describe("internalScheme", () => {
             // Check that major bumps do not satisfy the range
             assert.isFalse(semver.satisfies(`2.0.0-internal.2.0.0`, range));
             assert.isFalse(semver.satisfies(`2.0.0-internal.3.1.0`, range));
+        });
 
-            // Check that prerelease versions do not satisfy the range
-            assert.isFalse(semver.satisfies(`2.0.0-internal.1.1.1.95400`, range));
+        // Skipped for now because they are known to fail. We'll enable them once we've determined how to number our PR
+        // builds
+        it.skip("Prerelease versions do not satisfy ranges", () => {
+            assert.isFalse(
+                semver.satisfies(
+                    `2.0.0-internal.1.1.1.95400`,
+                    `>=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0`,
+                ),
+            );
+            assert.isFalse(
+                semver.satisfies(
+                    `2.0.0-internal.1.0.1.95400`,
+                    `>=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0`,
+                ),
+            );
         });
     });
 });

--- a/build-tools/packages/version-tools/test/semver.test.ts
+++ b/build-tools/packages/version-tools/test/semver.test.ts
@@ -132,6 +132,26 @@ describe("semver", () => {
         it("invalid semver v2 throws", () => {
             assert.throws(() => detectBumpType("0.0.1", "bad semver"));
         });
+
+        it("v1 is semver, v2 is internal with smaller internal version", () => {
+            assert.equal(detectBumpType("1.2.6", "2.0.0-internal.1.0.0"), "major");
+        });
+
+        it("v1 is virtualPatch, v2 is internal", () => {
+            assert.equal(detectBumpType("0.4.2000", "2.0.0-internal.1.0.0"), "major");
+        });
+
+        it("v1 is semver, v2 is internal with larger internal version", () => {
+            assert.equal(detectBumpType("1.4.1", "2.0.0-internal.3.0.0"), "major");
+        });
+
+        it("v1 is semver, v2 is internal with smaller internal version", () => {
+            assert.equal(detectBumpType("1.4.1", "2.0.0-internal.1.1.0"), "major");
+        });
+
+        it("v1 is semver, v2 is internal but smaller than v1", () => {
+            assert.throws(() => detectBumpType("2.1.0", "2.0.0-internal.3.0.0"));
+        });
     });
 
     describe("internal version scheme ranges", () => {


### PR DESCRIPTION
**Adds a `--all` flag to list all the releases of a particular release group or package.** This is useful when there are a lot of releases over a short period of time, or if you're trying to figure out what the last release of a particular package was.

**Adds the version scheme and dependency ranges to the full JSON output.** This makes it easier for partners to integrate releases without using the version tool separately.

**`--output` argument is now a directory.** When specified, multiple report files will be output to it. There are four report formats: simple, full, caret, and tilde.

- Simple is a map of package to versions. This is what we have traditionally provided to partners.
- Full includes the all metadata about the package.
- Caret and tilde are maps of package names to the semver range that should be used for either `^` or `~` dependencies. These can be consumed by partners that want to use those dependency ranges directly. Note that for packages using semver, the `^` or `~` will be prepended, while Fluid internal versions will use `>= <` ranges. The strings are meant to be used as-is.