### PR TITLE
[GC-Stress] Added logic for both collab and non-collab data stores to run

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -22,10 +22,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { ILoadTestConfig } from "./testConfigFile";
 import { LeaderElection } from "./leaderElection";
 import {
-    RootDataObject2,
-    rootDataObjectFactory2,
-    DataObjectType1,
-    dataObjectType1Factory,
+    rootDataObjectFactory,
     IGCDataStore,
 } from "./gcDataStore";
 
@@ -424,7 +421,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
     protected async initializingFirstTime() {
         this.root.set(taskManagerKey, TaskManager.create(this.runtime).handle);
 
-        const gcDataStore = await rootDataObjectFactory2.createInstance(this.context.containerRuntime);
+        const gcDataStore = await rootDataObjectFactory.createInstance(this.context.containerRuntime);
         this.root.set(gcDataStore2Key, gcDataStore.handle);
     }
 
@@ -521,11 +518,9 @@ const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntime
 
 export const createFluidExport = (options: IContainerRuntimeOptions) =>
     new ContainerRuntimeFactoryWithDefaultDataStore(
-        LoadTestDataStoreInstantiationFactory,
+        rootDataObjectFactory,
         [
-            [LoadTestDataStore.DataStoreName, Promise.resolve(LoadTestDataStoreInstantiationFactory)],
-            [DataObjectType1.type, Promise.resolve(dataObjectType1Factory)],
-            [RootDataObject2.type, Promise.resolve(rootDataObjectFactory2)],
+            [rootDataObjectFactory.type, Promise.resolve(rootDataObjectFactory)],
         ],
         undefined,
         [innerRequestHandler],


### PR DESCRIPTION
- Replaced the root data store from loadTestDataStore -> gc's rootDataObject.
- Root data object creates one collab data store and one non-collab store. The root data object and these two data objects are common to all clients.
- The collab data object references, unreferences and revives leaf data objects. Two other clients will listen for these and run / stop running these data objects too.
- The non-collab data object references, unreferences and revives leaf data objects. Other clients don't collab on these data stores.