### PR TITLE
Various local-server and local-driver cleanup

### DIFF
--- a/experimental/framework/get-container/src/getSessionStorageContainer.ts
+++ b/experimental/framework/get-container/src/getSessionStorageContainer.ts
@@ -9,11 +9,11 @@ import {
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
-import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { LocalResolver, LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
 
-// The deltaConnection needs to be shared across the Loader instances for collaboration to happen
-const deltaConnectionMap = new Map<string, ILocalDeltaConnectionServer>();
+// The deltaConnectionServer needs to be shared across the Loader instances for collaboration to happen
+const deltaConnectionServer = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
 
 const urlResolver = new LocalResolver();
 
@@ -27,13 +27,7 @@ export async function getSessionStorageContainer(
     containerRuntimeFactory: IRuntimeFactory,
     createNew: boolean,
 ): Promise<IContainer> {
-    let deltaConnection = deltaConnectionMap.get(documentId);
-    if (deltaConnection === undefined) {
-        deltaConnection = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
-        deltaConnectionMap.set(documentId, deltaConnection);
-    }
-
-    const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnection);
+    const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
     const url = `${window.location.origin}/${documentId}`;
 
     // To bypass proposal-based loading, we need a codeLoader that will return our already-in-memory container factory.

--- a/experimental/framework/get-container/src/getSessionStorageContainer.ts
+++ b/experimental/framework/get-container/src/getSessionStorageContainer.ts
@@ -29,7 +29,7 @@ export async function getSessionStorageContainer(
 ): Promise<IContainer> {
     let deltaConnection = deltaConnectionMap.get(documentId);
     if (deltaConnection === undefined) {
-        deltaConnection = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory(documentId));
+        deltaConnection = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
         deltaConnectionMap.set(documentId, deltaConnection);
     }
 

--- a/packages/drivers/local-driver/src/localDeltaStorageService.ts
+++ b/packages/drivers/local-driver/src/localDeltaStorageService.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import * as api from "@fluidframework/driver-definitions";
+import {
+    IDocumentDeltaStorageService,
+    IStream,
+} from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IDatabaseManager } from "@fluidframework/server-services-core";
 import { streamFromMessages } from "@fluidframework/driver-utils";
@@ -11,7 +14,7 @@ import { streamFromMessages } from "@fluidframework/driver-utils";
 /**
  * Provides access to the underlying delta storage on the server for local driver.
  */
-export class LocalDeltaStorageService implements api.IDocumentDeltaStorageService {
+export class LocalDeltaStorageService implements IDocumentDeltaStorageService {
     constructor(
         private readonly tenantId: string,
         private readonly id: string,
@@ -23,7 +26,7 @@ export class LocalDeltaStorageService implements api.IDocumentDeltaStorageServic
         to: number | undefined,
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
-    ): api.IStream<ISequencedDocumentMessage[]> {
+    ): IStream<ISequencedDocumentMessage[]> {
             return streamFromMessages(this.getCore(from, to));
     }
 

--- a/packages/drivers/local-driver/src/localDeltaStorageService.ts
+++ b/packages/drivers/local-driver/src/localDeltaStorageService.ts
@@ -32,9 +32,9 @@ export class LocalDeltaStorageService implements api.IDocumentDeltaStorageServic
         query["operation.sequenceNumber"] = {};
         query["operation.sequenceNumber"].$gt = from - 1; // from is inclusive
 
-        if (to !== undefined) {
-            query["operation.sequenceNumber"].$lt = to;
-        }
+        // This looks like a bug. It used to work without setting $lt key. Now it does not
+        // Need follow up
+        query["operation.sequenceNumber"].$lt = to ?? Number.MAX_SAFE_INTEGER;
 
         const allDeltas = await this.databaseManager.getDeltaCollection(this.tenantId, this.id);
         const dbDeltas = await allDeltas.find(query, { "operation.sequenceNumber": 1 });

--- a/packages/drivers/local-driver/src/localDeltaStorageService.ts
+++ b/packages/drivers/local-driver/src/localDeltaStorageService.ts
@@ -32,9 +32,9 @@ export class LocalDeltaStorageService implements api.IDocumentDeltaStorageServic
         query["operation.sequenceNumber"] = {};
         query["operation.sequenceNumber"].$gt = from - 1; // from is inclusive
 
-        // This looks like a bug. It used to work without setting $lt key. Now it does not
-        // Need follow up
-        query["operation.sequenceNumber"].$lt = to ?? Number.MAX_SAFE_INTEGER;
+        if (to !== undefined) {
+            query["operation.sequenceNumber"].$lt = to;
+        }
 
         const allDeltas = await this.databaseManager.getDeltaCollection(this.tenantId, this.id);
         const dbDeltas = await allDeltas.find(query, { "operation.sequenceNumber": 1 });

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -12,7 +12,7 @@ import {
     NackErrorType,
 } from "@fluidframework/protocol-definitions";
 import { LocalWebSocketServer } from "@fluidframework/server-local-server";
-import * as core from "@fluidframework/server-services-core";
+import { IWebSocketServer } from "@fluidframework/server-services-core";
 import type { Socket } from "socket.io-client";
 
 const testProtocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
@@ -36,7 +36,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
         id: string,
         token: string,
         client: IClient,
-        webSocketServer: core.IWebSocketServer,
+        webSocketServer: IWebSocketServer,
         timeoutMs = 60000,
     ): Promise<LocalDocumentDeltaConnection> {
         const socket = (webSocketServer as LocalWebSocketServer).createConnection();

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -126,11 +126,11 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
      * @param disconnectReason - The reason of the disconnection.
      */
     public disconnectClient(clientId: string, disconnectReason: string) {
-        if (!this.documentDeltaConnectionsMap.has(clientId)) {
+        const documentDeltaConnection = this.documentDeltaConnectionsMap.get(clientId);
+        if (documentDeltaConnection === undefined) {
             throw new Error(`No client with the id: ${clientId}`);
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.documentDeltaConnectionsMap.get(clientId)!.disconnectClient(disconnectReason);
+        documentDeltaConnection.disconnectClient(disconnectReason);
     }
 
     /**
@@ -141,10 +141,10 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
      * @param message - A message about the nack for debugging/logging/telemetry purposes.
      */
     public nackClient(clientId: string, code?: number, type?: NackErrorType, message?: any) {
-        if (!this.documentDeltaConnectionsMap.has(clientId)) {
+        const documentDeltaConnection = this.documentDeltaConnectionsMap.get(clientId);
+        if (documentDeltaConnection === undefined) {
             throw new Error(`No client with the id: ${clientId}`);
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.documentDeltaConnectionsMap.get(clientId)!.nackClient(code, type, message);
+        documentDeltaConnection.nackClient(code, type, message);
     }
 }

--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -85,7 +85,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
      * {@inheritDoc @fluidframework/server-services-core#ICollection.findAll}
      */
     public async findAll(): Promise<any[]> {
-        return Promise.resolve(this.getAllInternal());
+        return this.getAllInternal();
     }
 
     /**
@@ -95,7 +95,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
      * Query is expected to have a member "_id" which is a string used to find value in the database.
      */
     public async findOne(query: any): Promise<any> {
-        return Promise.resolve(this.findOneInternal(query));
+        return this.findOneInternal(query);
     }
 
     /**
@@ -279,9 +279,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
  */
 class LocalSessionStorageDb extends EventEmitter implements IDb {
     private readonly collections = new Map<string, LocalSessionStorageCollection<any>>();
-    public async close(): Promise<void> {
-        return Promise.resolve();
-    }
+    public async close(): Promise<void> { }
     public collection<T>(name: string): ICollection<T> {
         if (!this.collections.has(name)) {
             this.collections.set(name, new LocalSessionStorageCollection<T>(name));

--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -12,10 +12,7 @@ import { v4 as uuid } from "uuid";
  * Functions include database operations such as queries, insertion and update.
  */
 class LocalSessionStorageCollection<T> implements ICollection<T> {
-    private readonly collectionName: string;
-    constructor(namespace, name) {
-        this.collectionName = `${namespace}-${name}`;
-    }
+    constructor(private readonly collectionName: string) { }
 
     public aggregate(pipeline: any, options?: any): any {
         throw new Error("Method Not Implemented");
@@ -282,15 +279,12 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
  */
 class LocalSessionStorageDb extends EventEmitter implements IDb {
     private readonly collections = new Map<string, LocalSessionStorageCollection<any>>();
-    constructor(private readonly namespace) {
-        super();
-    }
     public async close(): Promise<void> {
         return Promise.resolve();
     }
     public collection<T>(name: string): ICollection<T> {
         if (!this.collections.has(name)) {
-            this.collections.set(name, new LocalSessionStorageCollection<T>(`${this.namespace}-db`, name));
+            this.collections.set(name, new LocalSessionStorageCollection<T>(name));
         }
         return this.collections.get(name) as LocalSessionStorageCollection<T>;
     }
@@ -308,10 +302,7 @@ class LocalSessionStorageDb extends EventEmitter implements IDb {
  * A database factory for testing that stores data in the browsers session storage
  */
 export class LocalSessionStorageDbFactory implements ITestDbFactory {
-    public readonly testDatabase: IDb;
-    constructor(namespace: string) {
-        this.testDatabase = new LocalSessionStorageDb(namespace);
-    }
+    public readonly testDatabase: IDb = new LocalSessionStorageDb();
     public async connect(): Promise<IDb> {
         return this.testDatabase;
     }

--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -12,6 +12,9 @@ import { v4 as uuid } from "uuid";
  * Functions include database operations such as queries, insertion and update.
  */
 class LocalSessionStorageCollection<T> implements ICollection<T> {
+    /**
+     * @param collectionName - data type of the collection, e.g. blobs, deltas, trees, etc.
+     */
     constructor(private readonly collectionName: string) { }
 
     public aggregate(pipeline: any, options?: any): any {

--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -85,6 +85,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
      * {@inheritDoc @fluidframework/server-services-core#ICollection.findAll}
      */
     public async findAll(): Promise<any[]> {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this.getAllInternal();
     }
 
@@ -95,6 +96,7 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
      * Query is expected to have a member "_id" which is a string used to find value in the database.
      */
     public async findOne(query: any): Promise<any> {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this.findOneInternal(query);
     }
 

--- a/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
@@ -26,7 +26,7 @@ export function getDocumentServiceFactory(
     odspHostStoragePolicy?: HostStoragePolicy,
 ): IDocumentServiceFactory {
     const deltaConn = deltaConns.get(documentId) ??
-        LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory(documentId));
+        LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
     deltaConns.set(documentId, deltaConn);
 
     const getUser = (): IDevServerUser => ({

--- a/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
@@ -9,7 +9,7 @@ import { LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@flui
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { getRandomName } from "@fluidframework/server-services-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 
@@ -17,18 +17,13 @@ import { v4 as uuid } from "uuid";
 
 import { IDevServerUser, IRouterliciousRouteOptions, RouteOptions } from "./loader";
 
-export const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
+export const deltaConnectionServer = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
 
 export function getDocumentServiceFactory(
-    documentId: string,
     options: RouteOptions,
     odspPersistantCache?: IPersistedCache,
     odspHostStoragePolicy?: HostStoragePolicy,
 ): IDocumentServiceFactory {
-    const deltaConn = deltaConns.get(documentId) ??
-        LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
-    deltaConns.set(documentId, deltaConn);
-
     const getUser = (): IDevServerUser => ({
         id: uuid(),
         name: getRandomName(),
@@ -75,6 +70,6 @@ export function getDocumentServiceFactory(
             );
 
         default: // Local
-            return new LocalDocumentServiceFactory(deltaConn);
+            return new LocalDocumentServiceFactory(deltaConnectionServer);
     }
 }

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -35,7 +35,7 @@ import { RequestParser } from "@fluidframework/runtime-utils";
 import { ensureFluidResolvedUrl, InsecureUrlResolver } from "@fluidframework/driver-utils";
 import { Port } from "webpack-dev-server";
 import { getUrlResolver } from "./getUrlResolver";
-import { deltaConns, getDocumentServiceFactory } from "./getDocumentServiceFactory";
+import { deltaConnectionServer, getDocumentServiceFactory } from "./getDocumentServiceFactory";
 import { OdspPersistentCache } from "./odspPersistantCache";
 import { OdspUrlResolver } from "./odspUrlResolver";
 
@@ -171,7 +171,7 @@ async function createWebLoader(
         odspHostStoragePolicy.fetchBinarySnapshotFormat = true;
     }
     let documentServiceFactory: IDocumentServiceFactory =
-        getDocumentServiceFactory(documentId, options, odspPersistantCache, odspHostStoragePolicy);
+        getDocumentServiceFactory(options, odspPersistantCache, odspHostStoragePolicy);
     // Create the inner document service which will be wrapped inside local driver. The inner document service
     // will be used for ops(like delta connection/delta ops) while for storage, local storage would be used.
     if (testOrderer) {
@@ -183,12 +183,8 @@ async function createWebLoader(
             false, // clientIsSummarizer
         );
 
-        const localDeltaConnectionServer = deltaConns.get(documentId);
-        assert(
-            localDeltaConnectionServer !== undefined,
-            0x319 /* No delta connection server associated with specified document ID */);
         documentServiceFactory = new LocalDocumentServiceFactory(
-            localDeltaConnectionServer,
+            deltaConnectionServer,
             undefined,
             innerDocumentService);
     }

--- a/server/routerlicious/packages/local-server/.eslintrc.js
+++ b/server/routerlicious/packages/local-server/.eslintrc.js
@@ -10,7 +10,4 @@ module.exports = {
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
     },
-    "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
-    }
 }

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -46,6 +46,7 @@ export interface ILocalDeltaConnectionServer {
     databaseManager: IDatabaseManager;
     testDbFactory: ITestDbFactory;
     close(): Promise<void>;
+    hasPendingWork(): Promise<boolean>;
     connectWebSocket(
         tenantId: string,
         documentId: string,
@@ -135,6 +136,13 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
     public async close() {
         await this.webSocketServer.close();
         await this.ordererManager.close();
+    }
+
+    /**
+     * Returns true if there are any received ops that are not yet ordered.
+     */
+    public async hasPendingWork(): Promise<boolean> {
+        return this.ordererManager.hasPendingWork();
     }
 
     public connectWebSocket(

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -82,7 +82,7 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
         const databaseManager = new MongoDatabaseManager(
             false,
             mongoManager,
-            null,
+            mongoManager,
             nodesCollectionName,
             documentsCollectionName,
             deltasCollectionName,

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -35,8 +35,8 @@ import {
     TestHistorian,
     TestTenantManager,
 } from "@fluidframework/server-test-utils";
-import { LocalWebSocketServer } from "./localWebSocketServer";
 import { LocalOrdererManager } from "./localOrdererManager";
+import { LocalWebSocketServer } from "./localWebSocketServer";
 
 /**
  * Items needed for handling deltas.
@@ -46,7 +46,6 @@ export interface ILocalDeltaConnectionServer {
     databaseManager: IDatabaseManager;
     testDbFactory: ITestDbFactory;
     close(): Promise<void>;
-    hasPendingWork(): Promise<boolean>;
     connectWebSocket(
         tenantId: string,
         documentId: string,
@@ -136,13 +135,6 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
     public async close() {
         await this.webSocketServer.close();
         await this.ordererManager.close();
-    }
-
-    /**
-     * Returns true if there are any received ops that are not yet ordered.
-     */
-    public async hasPendingWork(): Promise<boolean> {
-        return this.ordererManager.hasPendingWork();
     }
 
     public connectWebSocket(

--- a/server/routerlicious/packages/local-server/src/localOrdererManager.ts
+++ b/server/routerlicious/packages/local-server/src/localOrdererManager.ts
@@ -45,6 +45,21 @@ export class LocalOrdererManager implements IOrdererManager {
         this.ordererMap.clear();
     }
 
+    /**
+     * Returns true if there are any received ops that are not yet ordered.
+     */
+    public async hasPendingWork(): Promise<boolean> {
+        return Promise.all(this.ordererMap.values()).then((orderers) => {
+            for (const orderer of orderers) {
+                // We know that it ia LocalOrderer, break the abstraction
+                if ((orderer as LocalOrderer).hasPendingWork()) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
     public async getOrderer(tenantId: string, documentId: string): Promise<IOrderer> {
         const key = `${tenantId}/${documentId}`;
 

--- a/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
+++ b/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
@@ -5,10 +5,13 @@
 
 import { EventEmitter } from "events";
 import { IPubSub, ISubscriber, WebSocketSubscriber } from "@fluidframework/server-memory-orderer";
-import * as core from "@fluidframework/server-services-core";
+import {
+    IWebSocket,
+    IWebSocketServer,
+} from "@fluidframework/server-services-core";
 import { v4 as uuid } from "uuid";
 
-export class LocalWebSocket implements core.IWebSocket {
+export class LocalWebSocket implements IWebSocket {
     private readonly events = new EventEmitter();
     private readonly rooms = new Set<string>();
     private readonly subscriber: ISubscriber;
@@ -71,7 +74,7 @@ export class LocalWebSocket implements core.IWebSocket {
     }
 }
 
-export class LocalWebSocketServer implements core.IWebSocketServer {
+export class LocalWebSocketServer implements IWebSocketServer {
     private readonly events = new EventEmitter();
 
     constructor(public readonly pubsub: IPubSub) { }

--- a/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
+++ b/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
@@ -82,7 +82,6 @@ export class LocalWebSocketServer implements core.IWebSocketServer {
 
     public async close(): Promise<void> {
         this.events.removeAllListeners();
-        return Promise.resolve();
     }
 
     public createConnection(): LocalWebSocket {

--- a/server/routerlicious/packages/local-server/src/test/tsconfig.json
+++ b/server/routerlicious/packages/local-server/src/test/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/server/routerlicious/packages/local-server/src/test/webpack.spec.ts
+++ b/server/routerlicious/packages/local-server/src/test/webpack.spec.ts
@@ -49,6 +49,8 @@ describe("Local server", () => {
             webpack(config, (err, stats) => {
                 if (err) {
                     assert.fail(err);
+                } else if (stats === undefined) {
+                    assert.fail(new Error("No stats"));
                 } else if (stats.hasErrors()) {
                     assert.fail(stats.compilation.errors.map((value) => value.stack).join("\n"));
                 } else {

--- a/server/routerlicious/packages/local-server/tsconfig.json
+++ b/server/routerlicious/packages/local-server/tsconfig.json
@@ -4,7 +4,6 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -220,6 +220,14 @@ export class LocalOrderer implements IOrderer {
         this.closeLambdas();
     }
 
+    public hasPendingWork(): boolean {
+        if (this.broadcasterLambda?.lambda) {
+            return (this.broadcasterLambda.lambda as BroadcasterLambda).hasPendingWork();
+        }
+
+        return false;
+    }
+
     private setupKafkas() {
         const deliState: IDeliState = JSON.parse(this.dbObject.deli);
         this.rawDeltasKafka = new LocalKafka(deliState.logOffset + 1);

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -220,14 +220,6 @@ export class LocalOrderer implements IOrderer {
         this.closeLambdas();
     }
 
-    public hasPendingWork(): boolean {
-        if (this.broadcasterLambda?.lambda) {
-            return (this.broadcasterLambda.lambda as BroadcasterLambda).hasPendingWork();
-        }
-
-        return false;
-    }
-
     private setupKafkas() {
         const deliState: IDeliState = JSON.parse(this.dbObject.deli);
         this.rawDeltasKafka = new LocalKafka(deliState.logOffset + 1);

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererSetup.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererSetup.ts
@@ -5,6 +5,7 @@
 
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { IDocumentAttributes } from "@fluidframework/protocol-definitions";
+import { IGitManager } from "@fluidframework/server-services-client";
 import {
     ICollection,
     IDatabaseManager,
@@ -13,8 +14,7 @@ import {
     IDocumentStorage,
     ISequencedOperationMessage,
 } from "@fluidframework/server-services-core";
-// eslint-disable-next-line import/no-internal-modules
-import { IGitManager } from "../../services-client/dist";
+
 import { ILocalOrdererSetup } from "./interfaces";
 
 export class LocalOrdererSetup implements ILocalOrdererSetup {

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -23,9 +23,8 @@ export class TestCollection implements ICollection<any> {
         return this.collection;
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public findOne(query: any): Promise<any> {
-        return Promise.resolve(this.findOneInternal(query));
+    public async findOne(query: any): Promise<any> {
+        return this.findOneInternal(query);
     }
 
     public async update(filter: any, set: any, addToSet: any): Promise<void> {
@@ -100,8 +99,7 @@ export class TestCollection implements ICollection<any> {
         throw new Error("Method not implemented.");
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public createIndex(index: any, unique: boolean): Promise<void> {
+    public async createIndex(index: any, unique: boolean): Promise<void> {
         throw new Error("Method not implemented.");
     }
 
@@ -184,10 +182,7 @@ export class TestDb implements IDb {
     constructor(private collections: { [key: string]: any[]; }) {
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public close(): Promise<void> {
-        return Promise.resolve();
-    }
+    public async close(): Promise<void> { }
 
     public on(event: string, listener: (...args: any[]) => void) {
         this.emitter.on(event, listener);
@@ -223,8 +218,7 @@ export class TestDbFactory implements ITestDbFactory {
         this.testDatabase = new TestDb(collections);
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public connect(): Promise<IDb> {
-        return Promise.resolve(this.testDatabase);
+    public async connect(): Promise<IDb> {
+        return this.testDatabase;
     }
 }

--- a/server/routerlicious/packages/test-utils/src/testContext.ts
+++ b/server/routerlicious/packages/test-utils/src/testContext.ts
@@ -47,10 +47,9 @@ export class TestContext extends EventEmitter implements IContext {
         this.emit("error", error, errorData);
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public waitForOffset(value: number): Promise<void> {
+    public async waitForOffset(value: number): Promise<void> {
         if (value <= this.offset) {
-            return Promise.resolve();
+            return;
         }
 
         const deferred = new Deferred<void>();

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -4,7 +4,26 @@
  */
 
 import { gitHashFile, IsoBuffer } from "@fluidframework/common-utils";
-import * as git from "@fluidframework/gitresources";
+import {
+    IAuthor,
+    IBlob,
+    ICommit,
+    ICommitDetails,
+    ICommitHash,
+    ICommitter,
+    ICreateBlobParams,
+    ICreateBlobResponse,
+    ICreateCommitParams,
+    ICreateRefParams,
+    ICreateTagParams,
+    ICreateTreeEntry,
+    ICreateTreeParams,
+    IPatchRefParams,
+    IRef,
+    ITag,
+    ITree,
+    ITreeEntry,
+} from "@fluidframework/gitresources";
 import {
     IHistorian,
     IWholeFlatSummary,
@@ -20,17 +39,17 @@ export class TestHistorian implements IHistorian {
 
     // back-compat 0.1010 old-collection-format
     private readonly blobs: ICollection<
-        { _id: string; content: string; encoding: string; value?: git.ICreateBlobParams; }>;
+        { _id: string; content: string; encoding: string; value?: ICreateBlobParams; }>;
     private readonly commits: ICollection<{
         _id: string;
         message: string;
         tree: string;
         parents: string[];
-        author: git.IAuthor;
-        value?: git.ICreateCommitParams; }>;
+        author: IAuthor;
+        value?: ICreateCommitParams; }>;
     private readonly trees: ICollection<
-        { _id: string; tree: git.ICreateTreeEntry[]; base_tree?: string; value?: git.ICreateTreeParams; }>;
-    private readonly refs: ICollection<{ _id: string; ref: string; sha: string; value?: git.ICreateRefParams; }>;
+        { _id: string; tree: ICreateTreeEntry[]; base_tree?: string; value?: ICreateTreeParams; }>;
+    private readonly refs: ICollection<{ _id: string; ref: string; sha: string; value?: ICreateRefParams; }>;
 
     constructor(db: IDb = new TestDb({})) {
         this.blobs = db.collection("blobs");
@@ -44,7 +63,7 @@ export class TestHistorian implements IHistorian {
 
         const includeBlobs = [".attributes", ".blobs", ".messages", "header"];
 
-        const blobsP: Promise<git.IBlob>[] = [];
+        const blobsP: Promise<IBlob>[] = [];
         for (const entry of tree.tree) {
             if (entry.type === "blob" && includeBlobs.reduce((pv, cv) => pv || entry.path.endsWith(cv), false)) {
                 const blobP = this.getBlob(entry.sha);
@@ -63,7 +82,7 @@ export class TestHistorian implements IHistorian {
         throw new Error("Not Supported");
     }
 
-    public async getBlob(sha: string): Promise<git.IBlob> {
+    public async getBlob(sha: string): Promise<IBlob> {
         const blob = await this.blobs.findOne({ _id: sha });
         return {
             content: IsoBuffer.from(
@@ -76,7 +95,7 @@ export class TestHistorian implements IHistorian {
         };
     }
 
-    public async createBlob(blob: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> {
+    public async createBlob(blob: ICreateBlobParams): Promise<ICreateBlobResponse> {
         const _id = await gitHashFile(IsoBuffer.from(blob.content, blob.encoding));
         await this.blobs.findOrCreate({ _id }, {
             _id,
@@ -98,7 +117,7 @@ export class TestHistorian implements IHistorian {
         }
     }
 
-    public async getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {
+    public async getCommits(sha: string, count: number): Promise<ICommitDetails[]> {
         const commit = await this.getCommit(sha);
         return commit ? [{
             commit: {
@@ -114,7 +133,7 @@ export class TestHistorian implements IHistorian {
         }] : [];
     }
 
-    public async getCommit(sha: string): Promise<git.ICommit> {
+    public async getCommit(sha: string): Promise<ICommit> {
         let commit = await this.commits.findOne({ _id: sha });
         if (!commit) {
             const ref = await this.getRef(`refs/heads/${sha}`);
@@ -124,12 +143,12 @@ export class TestHistorian implements IHistorian {
         }
         if (commit) {
             return {
-                author: {} as Partial<git.IAuthor> as git.IAuthor,
-                committer: {} as Partial<git.ICommitter> as git.ICommitter,
+                author: {} as Partial<IAuthor> as IAuthor,
+                committer: {} as Partial<ICommitter> as ICommitter,
                 message: commit.message ?? commit.value?.message,
                 parents: commit.parents !== undefined ?
-                    commit.parents.map<git.ICommitHash>((p) => ({ sha: p, url: "" })) :
-                    commit.value?.parents.map<git.ICommitHash>((p) => ({ sha: p, url: "" })),
+                    commit.parents.map<ICommitHash>((p) => ({ sha: p, url: "" })) :
+                    commit.value?.parents.map<ICommitHash>((p) => ({ sha: p, url: "" })),
                 sha: commit._id,
                 tree: {
                     sha: commit.tree ?? commit.value?.tree,
@@ -140,7 +159,7 @@ export class TestHistorian implements IHistorian {
         }
     }
 
-    public async createCommit(commit: git.ICreateCommitParams): Promise<git.ICommit> {
+    public async createCommit(commit: ICreateCommitParams): Promise<ICommit> {
         const _id = commit.tree;
         await this.commits.insertOne({ _id, ...commit, value: commit });
         return this.getCommit(_id);
@@ -158,11 +177,11 @@ export class TestHistorian implements IHistorian {
         throw new Error("Not Supported");
     }
 
-    public async getRefs(): Promise<git.IRef[]> {
+    public async getRefs(): Promise<IRef[]> {
         throw new Error("Not Supported");
     }
 
-    public async getRef(ref: string): Promise<git.IRef> {
+    public async getRef(ref: string): Promise<IRef> {
         const _id = ref.startsWith("refs/") ? ref.substr(5) : ref;
         const val = await this.refs.findOne({ _id });
         if (val) {
@@ -178,13 +197,13 @@ export class TestHistorian implements IHistorian {
         }
     }
 
-    public async createRef(params: git.ICreateRefParams): Promise<git.IRef> {
+    public async createRef(params: ICreateRefParams): Promise<IRef> {
         const _id = params.ref.startsWith("refs/") ? params.ref.substr(5) : params.ref;
         await this.refs.insertOne({ _id, ...params, value: params });
         return this.getRef(params.ref);
     }
 
-    public async updateRef(ref: string, params: git.IPatchRefParams): Promise<git.IRef> {
+    public async updateRef(ref: string, params: IPatchRefParams): Promise<IRef> {
         const _id = ref.startsWith("refs/") ? ref.substr(5) : ref;
         await (params.force
             ? this.refs.upsert({ _id }, { sha: params.sha, ref }, {})
@@ -196,15 +215,15 @@ export class TestHistorian implements IHistorian {
         throw new Error("Not Supported");
     }
 
-    public async createTag(tag: git.ICreateTagParams): Promise<git.ITag> {
+    public async createTag(tag: ICreateTagParams): Promise<ITag> {
         throw new Error("Not Supported");
     }
 
-    public async getTag(tag: string): Promise<git.ITag> {
+    public async getTag(tag: string): Promise<ITag> {
         throw new Error("Not Supported");
     }
 
-    public async createTree(tree: git.ICreateTreeParams): Promise<git.ITree> {
+    public async createTree(tree: ICreateTreeParams): Promise<ITree> {
         const _id = uuid();
         await this.trees.insertOne({
             _id,
@@ -214,21 +233,21 @@ export class TestHistorian implements IHistorian {
         return this.getTree(_id, false);
     }
 
-    public async getTree(sha: string, recursive: boolean): Promise<git.ITree> {
+    public async getTree(sha: string, recursive: boolean): Promise<ITree> {
         return this.getTreeHelper(sha, recursive);
     }
 
-    public async getTreeHelper(sha: string, recursive: boolean, path: string = ""): Promise<git.ITree> {
+    public async getTreeHelper(sha: string, recursive: boolean, path: string = ""): Promise<ITree> {
         const tree = await this.trees.findOne({ _id: sha });
         if (tree) {
-            const finalTree: git.ITree = {
+            const finalTree: ITree = {
                 sha: tree._id,
                 url: "",
                 tree: [],
             };
             for (const entry of tree.tree ?? tree.value?.tree ?? []) {
                 const entryPath: string = path === "" ? entry.path : `${path}/${entry.path}`;
-                const treeEntry: git.ITreeEntry = {
+                const treeEntry: ITreeEntry = {
                     mode: entry.mode,
                     path: entryPath,
                     sha: entry.sha,

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -59,8 +59,7 @@ export class TestHistorian implements IHistorian {
         };
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public getFullTree(sha: string): Promise<any> {
+    public async getFullTree(sha: string): Promise<any> {
         throw new Error("Not Supported");
     }
 
@@ -159,8 +158,7 @@ export class TestHistorian implements IHistorian {
         throw new Error("Not Supported");
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public getRefs(): Promise<git.IRef[]> {
+    public async getRefs(): Promise<git.IRef[]> {
         throw new Error("Not Supported");
     }
 
@@ -198,13 +196,11 @@ export class TestHistorian implements IHistorian {
         throw new Error("Not Supported");
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public createTag(tag: git.ICreateTagParams): Promise<git.ITag> {
+    public async createTag(tag: git.ICreateTagParams): Promise<git.ITag> {
         throw new Error("Not Supported");
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public getTag(tag: string): Promise<git.ITag> {
+    public async getTag(tag: string): Promise<git.ITag> {
         throw new Error("Not Supported");
     }
 

--- a/server/routerlicious/packages/test-utils/src/testKafka.ts
+++ b/server/routerlicious/packages/test-utils/src/testKafka.ts
@@ -5,10 +5,15 @@
 
 import { strict as assert } from "assert";
 import { EventEmitter } from "events";
-import * as core from "@fluidframework/server-services-core";
+import {
+    IConsumer,
+    IProducer,
+    IQueuedMessage,
+    ISequencedOperationMessage,
+} from "@fluidframework/server-services-core";
 import { TestContext } from "./testContext";
 
-export class TestConsumer implements core.IConsumer {
+export class TestConsumer implements IConsumer {
     private readonly emitter = new EventEmitter();
     private pausedQueue: string[] = null;
     private failOnCommit = false;
@@ -34,7 +39,7 @@ export class TestConsumer implements core.IConsumer {
         return undefined;
     }
 
-    public async commitCheckpoint(partitionId: number, queuedMessage: core.IQueuedMessage): Promise<void> {
+    public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
         // For now we assume a single partition for the test consumer
         assert(partitionId === 0);
 
@@ -106,7 +111,7 @@ export class TestConsumer implements core.IConsumer {
     }
 }
 
-export class TestProducer implements core.IProducer {
+export class TestProducer implements IProducer {
     constructor(private readonly kafka: TestKafka) {
     }
 
@@ -136,7 +141,7 @@ export class TestProducer implements core.IProducer {
  * Test Kafka implementation. Allows for the creation of a joined producer/consumer pair.
  */
 export class TestKafka {
-    public static createdQueuedMessage(offset: number, metadata?: any): core.IQueuedMessage {
+    public static createdQueuedMessage(offset: number, metadata?: any): IQueuedMessage {
         return {
             topic: "topic",
             partition: 0,
@@ -145,7 +150,7 @@ export class TestKafka {
         };
     }
 
-    private readonly messages: core.IQueuedMessage[] = [];
+    private readonly messages: IQueuedMessage[] = [];
     private offset = 0;
     private readonly consumers: TestConsumer[] = [];
 
@@ -160,7 +165,7 @@ export class TestKafka {
         return consumer;
     }
 
-    public getRawMessages(): core.IQueuedMessage[] {
+    public getRawMessages(): IQueuedMessage[] {
         return this.messages;
     }
 
@@ -178,11 +183,11 @@ export class TestKafka {
         }
     }
 
-    public getLastMessage(): core.ISequencedOperationMessage {
+    public getLastMessage(): ISequencedOperationMessage {
         return this.getMessage(this.messages.length - 1);
     }
 
-    public getMessage(index: number): core.ISequencedOperationMessage {
-        return this.messages[index].value as core.ISequencedOperationMessage;
+    public getMessage(index: number): ISequencedOperationMessage {
+        return this.messages[index].value as ISequencedOperationMessage;
     }
 }

--- a/server/routerlicious/packages/test-utils/src/testKafka.ts
+++ b/server/routerlicious/packages/test-utils/src/testKafka.ts
@@ -64,10 +64,7 @@ export class TestConsumer implements core.IConsumer {
         return this;
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public close(): Promise<void> {
-        return Promise.resolve();
-    }
+    public async close(): Promise<void> { }
 
     public async pause() {
         if (!this.pausedQueue) {
@@ -117,18 +114,14 @@ export class TestProducer implements core.IProducer {
         return true;
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/promise-function-async
-    public send(messages: object[], key: string): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    public async send(messages: object[], key: string): Promise<any> {
         for (const message of messages) {
             this.kafka.addMessage(message, key);
         }
-        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public close(): Promise<void> {
-        return Promise.resolve();
-    }
+    public async close(): Promise<void> { }
 
     public on(event: string, listener: (...args: any[]) => void): this {
         return this;

--- a/server/routerlicious/packages/test-utils/src/testPublisher.ts
+++ b/server/routerlicious/packages/test-utils/src/testPublisher.ts
@@ -4,14 +4,17 @@
  */
 
 import { EventEmitter } from "events";
-import * as core from "@fluidframework/server-services-core";
+import {
+    IPublisher,
+    ITopic,
+} from "@fluidframework/server-services-core";
 
 export interface IEvent {
     event: string;
     args: any[];
 }
 
-export class TestTopic implements core.ITopic {
+export class TestTopic implements ITopic {
     public events = new Map<string, IEvent[]>();
 
     public emit(event: string, ...args: any[]) {
@@ -27,7 +30,7 @@ export class TestTopic implements core.ITopic {
     }
 }
 
-export class TestPublisher implements core.IPublisher {
+export class TestPublisher implements IPublisher {
     private readonly events = new EventEmitter();
     private topics: { [topic: string]: TestTopic; } = {};
 

--- a/server/routerlicious/packages/test-utils/src/testTenantManager.ts
+++ b/server/routerlicious/packages/test-utils/src/testTenantManager.ts
@@ -55,29 +55,23 @@ export class TestTenantManager implements ITenantManager {
         this.tenant = new TestTenant(url, historian, testDb);
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public createTenant(id?: string): Promise<ITenantConfig & { key: string; }> {
-        return Promise.resolve({
+    public async createTenant(id?: string): Promise<ITenantConfig & { key: string; }> {
+        return {
             id: "test-tenant",
             storage: this.tenant.storage,
             orderer: this.tenant.orderer,
             key: "test-tenant-key",
             customData: {},
-        });
+        };
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public verifyToken(token: string): Promise<void> {
-        return Promise.resolve();
+    public async verifyToken(token: string): Promise<void> { }
+
+    public async getTenant(id: string): Promise<ITenant> {
+        return this.tenant;
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public getTenant(id: string): Promise<ITenant> {
-        return Promise.resolve(this.tenant);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public getKey(tenantId: string): Promise<string> {
-        return Promise.resolve("test");
+    public async getKey(tenantId: string): Promise<string> {
+        return "test";
     }
 }


### PR DESCRIPTION
This change follows up on a few cleanup items I noted while working on the SharedWorker server/driver.  These include:

- Now that the findOneInternal bug is fixed (#12041) we don't need to prefix the keys in SessionStorage.  This aligns it better with e.g. what Tinylicious does (inspect the values themselves to find the associated tenant/document rather than the keys).
    - This additionally allows us to share a single LocalDeltaConnectionServer amongst documents (rather than one per document), since it no longer has to retain a specific documentId to prefix keys with.
- ~~A comment in LocalDeltaStorageService noted a bug when lt was not provided to the query, but this seems to work fine AFAICT so removed the workaround.~~
- ~~Removed hasPendingWork from the server, ordererManager, etc. where it was not called and seems somewhat inappropriate (looks like this is normally retrieved from the DocumentContext or broadcast lambda).~~
- Fixed a cross-package import
- Fixed a couple eslint exceptions
- Turned on strictNullChecks in local-server