### PR TITLE
Update `jsdoc/require-description` rule to omit constructors, which are generally pretty self-explanatory

### DIFF
--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -556,7 +556,12 @@
             "error"
         ],
         "jsdoc/require-description": [
-            "error"
+            "error",
+            {
+                "checkConstructors": false,
+                "checkGetters": true,
+                "checkSetters": true
+            }
         ],
         "jsdoc/require-hyphen-before-param-description": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -574,7 +574,12 @@
             "error"
         ],
         "jsdoc/require-description": [
-            "error"
+            "error",
+            {
+                "checkConstructors": false,
+                "checkGetters": true,
+                "checkSetters": true
+            }
         ],
         "jsdoc/require-hyphen-before-param-description": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -94,7 +94,7 @@ module.exports = {
          * Require the description (summary) component in JSDoc/TSDoc comments
          * See <https://github.com/gajus/eslint-plugin-jsdoc#user-content-eslint-plugin-jsdoc-rules-require-description>
          */
-        "jsdoc/require-description": "error",
+        "jsdoc/require-description": ["error", { checkConstructors: false }],
 
         // #endregion
     },


### PR DESCRIPTION
Relaxes restrictions on [jsdoc/require-description](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-description.md#require-description) to not require descriptions for constructors.