### PR TITLE
fix batch flushing test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -296,6 +296,7 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
 
                 // Yield a turn so that the ops are flushed.
                 await yieldJSTurn();
+                await provider.ensureSynchronized();
 
                 // Send the second set of ops that are to be batched together.
                 dataObject1map1.set("key3", "value3");
@@ -303,6 +304,7 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
 
                 // Yield a turn so that the ops are flushed.
                 await yieldJSTurn();
+                await provider.ensureSynchronized();
 
                 // Send a third set of ops that are to be batched together.
                 dataObject1map1.set("key5", "value5");

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -293,16 +293,14 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
                 dataObject1map1.set("key1", "value1");
                 dataObject1map2.set("key2", "value2");
 
-                // Yield a turn so that the ops are flushed.
-                await yieldJSTurn();
+                // wait for ops to be flushed.
                 await provider.ensureSynchronized();
 
                 // Send the second set of ops that are to be batched together.
                 dataObject1map1.set("key3", "value3");
                 dataObject1map2.set("key4", "value4");
 
-                // Yield a turn so that the ops are flushed.
-                await yieldJSTurn();
+                // wait for ops to be flushed.
                 await provider.ensureSynchronized();
 
                 // Send a third set of ops that are to be batched together.

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -284,7 +284,7 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
             });
 
             // Disabled due to issue #9546
-            it.skip("can send and receive consecutive batches that are flushed on JS turn", async () => {
+            it("can send and receive consecutive batches that are flushed on JS turn", async () => {
                 /**
                  * This test verifies that among other things, the PendingStateManager's algorithm of handling
                  * consecutive batches is correct.

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -283,7 +283,6 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
                 verifyBatchMetadata(dataObject2BatchMessages);
             });
 
-            // Disabled due to issue #9546
             it("can send and receive consecutive batches that are flushed on JS turn", async () => {
                 /**
                  * This test verifies that among other things, the PendingStateManager's algorithm of handling


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

For specific guidelines for Pull Requests in this repo, visit [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


## Description
Adding `await ensureSynchronized()`  to replace yieldJSTurn to make sure ops are flushed completely, therefore fixing the test.
The original awaiting JS turn was not sufficient to flush the ops, causing the batch metadata not loaded correctly, and the test failed
# [AB#492](https://dev.azure.com/fluidframework/internal/_workitems/edit/492)
