### PR TITLE
Added timestamp to GarbageCollection event after GC runs.

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -855,7 +855,7 @@ export class GarbageCollector implements IGarbageCollector {
             const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
 
             const gcStats = await this.runPostGCSteps(gcData, gcResult, logger, currentReferenceTimestampMs);
-            event.end({ ...gcStats });
+            event.end({ ...gcStats, timestamp: currentReferenceTimestampMs });
             this.completedRuns++;
             return gcStats;
         }, { end: true, cancel: "error" });


### PR DESCRIPTION
## Description
Added the current reference timestamp to the GarbageCollection event. This is the timestamp used by GC to mark the time when a data store becomes unreferenced. It will help in debugging inactive object errors where we can correlate in which GC run a data store was marked as unreferenced based on its age (how long it has been unreferenced for).

## Does this introduce a breaking change?
No