### PR TITLE
Use Large pools instead of hosted VMs in build-docs pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -153,7 +153,7 @@ stages:
       displayName: 'Combine api-extractor JSON'
       dependsOn: [] # run in parallel
       environment: 'fluid-docs-env'
-      pool: Small
+      pool: Large
       strategy:
         runOnce:
           deploy:
@@ -217,8 +217,7 @@ stages:
 - stage: guardian
   displayName: Guardian
   dependsOn: [] # run in parallel
-  pool:
-    vmImage: windows-latest
+  pool: Large
   jobs:
     - job: guardian_tasks
       displayName: Guardian tasks


### PR DESCRIPTION
Moves some of the build-docs pipeline jobs to use the large pool so we don't exhaust the shared pool resources.