### PR TITLE
[main > release/0.59.4000]: Fix 404 error during HandleSummaryAckError error (#11336) 

### DIFF
--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -69,9 +69,7 @@ export class OdspSummaryUploadManager {
         referenceSequenceNumber: number,
         tree: api.ISummaryTree,
     ): Promise<IWriteSummaryResponse> {
-        const enableContainerTypeSummaryUpload = this.mc.config.getBoolean("Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload");
-        const containsProtocolTree = enableContainerTypeSummaryUpload &&
-            Object.keys(tree.tree).includes(".protocol");
+        const containsProtocolTree = Object.keys(tree.tree).includes(".protocol");
         const { snapshotTree, blobs } = await this.convertSummaryToSnapshotTree(
             parentHandle,
             tree,
@@ -112,7 +110,6 @@ export class OdspSummaryUploadManager {
                     size: postBody.length,
                     referenceSequenceNumber,
                     type: snapshot.type,
-                    enableContainerTypeSummaryUpload,
                 },
                 async () => {
                     const response = await this.epochTracker.fetchAndParseAsJSON<IWriteSummaryResponse>(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2754,25 +2754,29 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         summaryLogger: ITelemetryLogger,
     ) {
         const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-        const { snapshotTree } = await this.fetchSnapshotFromStorage(
-            ackHandle,
-            summaryLogger,
-            {
-                eventName: "RefreshLatestSummaryGetSnapshot",
-                ackHandle,
-                summaryRefSeq,
-                fetchLatest: false,
-            },
-        );
-        const result = await this.summarizerNode.refreshLatestSummary(
-            proposalHandle,
-            summaryRefSeq,
-            async () => snapshotTree,
-            readAndParseBlob,
-            summaryLogger,
-        );
+        // The call to fetch the snapshot is very expensive and not always needed.
+        // It should only be done by the summarizerNode, if required.
+        const snapshotTreeFetcher = async () => {
+            const fetchResult = await this.fetchSnapshotFromStorage(
+             ackHandle,
+             summaryLogger,
+             {
+                 eventName: "RefreshLatestSummaryGetSnapshot",
+                 ackHandle,
+                 summaryRefSeq,
+                 fetchLatest: false,
+             });
+             return fetchResult.snapshotTree;
+         };
+         const result = await this.summarizerNode.refreshLatestSummary(
+             proposalHandle,
+             summaryRefSeq,
+             snapshotTreeFetcher,
+             readAndParseBlob,
+             summaryLogger,
+         );
 
-        // Notify the garbage collector so it can update its latest summary state.
+         // Notify the garbage collector so it can update its latest summary state.
         await this.garbageCollector.latestSummaryStateRefreshed(result, readAndParseBlob);
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -61,6 +61,7 @@ import {
     IQuorumClients,
     ISequencedDocumentMessage,
     ISignalMessage,
+    ISnapshotTree,
     ISummaryConfiguration,
     ISummaryContent,
     ISummaryTree,

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -8,9 +8,15 @@ import { Deferred } from "@fluidframework/common-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ILoader, LoaderHeader } from "@fluidframework/container-definitions";
 import { UsageError } from "@fluidframework/container-utils";
-import { DriverHeader } from "@fluidframework/driver-definitions";
+import { DriverErrorType, DriverHeader } from "@fluidframework/driver-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ChildLogger, IFluidErrorBase, LoggingError, wrapErrorAndLog } from "@fluidframework/telemetry-utils";
+import {
+    ChildLogger,
+    IFluidErrorBase,
+    isFluidError,
+    LoggingError,
+    wrapErrorAndLog,
+} from "@fluidframework/telemetry-utils";
 import {
     FluidObject,
     IFluidHandleContext,
@@ -379,12 +385,36 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             try {
                 const ack = await this.summaryCollection.waitSummaryAck(refSequenceNumber);
                 refSequenceNumber = ack.summaryOp.referenceSequenceNumber;
-
-                await this.internalsProvider.refreshLatestSummaryAck(
-                    ack.summaryOp.contents.handle,
-                    ack.summaryAck.contents.handle,
-                    refSequenceNumber,
-                    summaryLogger,
+                const summaryOpHandle = ack.summaryOp.contents.handle;
+                const summaryAckHandle = ack.summaryAck.contents.handle;
+                // Make sure we block any summarizer from being executed/enqueued while
+                // executing the refreshLatestSummaryAck.
+                // https://dev.azure.com/fluidframework/internal/_workitems/edit/779
+                await this.runningSummarizer.lockedRefreshSummaryAckAction(async () =>
+                    this.internalsProvider.refreshLatestSummaryAck(
+                        summaryOpHandle,
+                        summaryAckHandle,
+                        refSequenceNumber,
+                        summaryLogger,
+                    ).catch(async (error) => {
+                        // If the error is 404, so maybe the fetched version no longer exists on server. We just
+                        // ignore this error in that case, as that means we will have another summaryAck for the
+                        // latest version with which we will refresh the state. However in case of single commit
+                        // summary, we might me missing a summary ack, so in that case we are still fine as the
+                        // code in `submitSummary` function in container runtime, will refresh the latest state
+                        // by calling `refreshLatestSummaryAckFromServer` and we will be fine.
+                        if (isFluidError(error)
+                            && error.errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
+                            summaryLogger.sendTelemetryEvent({
+                                eventName: "HandleSummaryAckErrorIgnored",
+                                referenceSequenceNumber: refSequenceNumber,
+                                proposalHandle: summaryOpHandle,
+                                ackHandle: summaryAckHandle,
+                            }, error);
+                        } else {
+                            throw error;
+                        }
+                    }),
                 );
             } catch (error) {
                 summaryLogger.sendErrorEvent({

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -8,12 +8,11 @@ import { Deferred } from "@fluidframework/common-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ILoader, LoaderHeader } from "@fluidframework/container-definitions";
 import { UsageError } from "@fluidframework/container-utils";
-import { DriverErrorType, DriverHeader } from "@fluidframework/driver-definitions";
+import { DriverHeader } from "@fluidframework/driver-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ChildLogger,
     IFluidErrorBase,
-    isFluidError,
     LoggingError,
     wrapErrorAndLog,
 } from "@fluidframework/telemetry-utils";

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -12,16 +12,14 @@
             "faultInjectionMaxMs": 150000,
             "optionOverrides":{
                 "odsp":{
-                    "loader":{
-                        "summarizeProtocolTree": [false]
+                    "configurations":{
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 },
                 "odsp-odsp-df":{
-                    "loader":{
-                        "summarizeProtocolTree": [false]
-                    },
                     "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1]
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 }
             }
@@ -45,8 +43,8 @@
             "faultInjectionMaxMs": 50000,
             "optionOverrides":{
                 "odsp":{
-                    "loader":{
-                        "summarizeProtocolTree": [false]
+                    "configurations":{
+                        "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 }
             }
@@ -105,23 +103,6 @@
                 "odsp":{
                     "configurations":{
                         "Fluid.Driver.Odsp.snapshotFormatFetchType": [1]
-                    }
-                }
-            }
-        },
-        "odspContainerTypeSummaryUpload": {
-            "opRatePerMin": 60,
-            "progressIntervalMs": 5000,
-            "numClients": 4,
-            "totalSendCount": 150,
-            "readWriteCycleMs": 10000,
-            "optionOverrides":{
-                "odsp":{
-                    "configurations":{
-                        "Fluid.Driver.Odsp.EnableContainerTypeSummaryUpload": [true]
-                    },
-                    "loader":{
-                        "summarizeProtocolTree": [true]
                     }
                 }
             }


### PR DESCRIPTION
## Description

This handle the flow where while summarizer is running into handleAcks flow and waiting for ack promise to get resolved, the summarizer can make a new summary. Now when we try to refresh the state from handles of previous ack, and try to fetch snapshot corresponding to that it might not be present in cache and server(server deletes previous snapshots) and we get 404 from server and run into "HandleSummaryAckError". So before giving up, we try one more time with refreshing the state from latest snapshot handle.