### PR TITLE
Tree: expose EditableTree on SharedTree

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -17,12 +17,18 @@ import { Serializable } from '@fluidframework/datastore-definitions';
 // @public
 export type Anchor = Brand<number, "rebaser.Anchor">;
 
+// @public
+export interface AnchorLocator {
+    locate(anchor: Anchor): UpPath | undefined;
+}
+
 // @public @sealed
 export class AnchorSet {
     applyDelta(delta: Delta.Root): void;
     // (undocumented)
     forget(anchor: Anchor): void;
     isEmpty(): boolean;
+    // (undocumented)
     locate(anchor: Anchor): UpPath | undefined;
     moveChildren(count: number, srcStart: UpPath | undefined, dst: UpPath | undefined): void;
     track(path: UpPath | null): Anchor;
@@ -182,6 +188,7 @@ export interface DetachedField extends Opaque<Brand<string, "tree.DetachedField"
 
 // @public
 export interface EditableTree {
+    readonly [anchorSymbol]: Anchor;
     readonly [getTypeSymbol]: (key?: string, nameOnly?: boolean) => TreeSchema | TreeSchemaIdentifier | undefined;
     readonly [proxyTargetSymbol]: object;
     readonly [valueSymbol]: Value;
@@ -192,6 +199,7 @@ export interface EditableTree {
 export interface EditableTreeContext {
     free(): void;
     prepareForEdit(): void;
+    readonly root: UnwrappedEditableField;
 }
 
 // @public
@@ -379,9 +387,6 @@ export interface GenericTreeNode<TChild> extends GenericFieldsNode<TChild>, Node
 }
 
 // @public
-export function getEditableTree(forest: IEditableForest): [EditableTreeContext, UnwrappedEditableField];
-
-// @public
 export const getTypeSymbol: unique symbol;
 
 // @public
@@ -458,7 +463,9 @@ export interface Invariant<T> extends Contravariant<T>, Covariant<T> {
 export type isAny<T> = boolean extends (T extends {} ? true : false) ? true : false;
 
 // @public
-export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObject {
+export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObject, AnchorLocator {
+    readonly context: EditableTreeContext;
+    readonly root: UnwrappedEditableField;
 }
 
 // @public (undocumented)

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -77,7 +77,7 @@ export interface EditableTree {
     /**
      * Anchor to this node.
      * Valid as long as this EditableTree's context is not freed.
-     * Might not point to any node if this node is deleted from he document.
+     * Might not point to any node if this node is deleted from the document.
      *
      * TODO: When a proper editing API is exposed on EditableTree directly,
      * this should become an implementation detail and rbe removed from this API surface.

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -30,10 +30,15 @@ export const proxyTargetSymbol: unique symbol = Symbol("editable-tree:proxyTarge
  */
 export const getTypeSymbol: unique symbol = Symbol("editable-tree:getType()");
 
- /**
+/**
  * A symbol to get the value of a node in contexts where string keys are already in use for fields.
  */
 export const valueSymbol: unique symbol = Symbol("editable-tree:value");
+
+/**
+ * A symbol to get the anchor of a node in contexts where string keys are already in use for fields.
+ */
+export const anchorSymbol: unique symbol = Symbol("editable-tree:anchor");
 
 /**
  * A tree which can be traversed and edited.
@@ -68,6 +73,16 @@ export interface EditableTree {
      * but the presence of this symbol can be used to separate EditableTrees from other types.
      */
     readonly [proxyTargetSymbol]: object;
+
+    /**
+     * Anchor to this node.
+     * Valid as long as this EditableTree's context is not freed.
+     * Might not point to any node if this node is deleted from he document.
+     *
+     * TODO: When a proper editing API is exposed on EditableTree directly,
+     * this should become an implementation detail and rbe removed from this API surface.
+     */
+    readonly [anchorSymbol]: Anchor;
 
     /**
      * Fields of this node, indexed by their field keys (as strings).
@@ -124,6 +139,21 @@ export type UnwrappedEditableField = UnwrappedEditableTree | undefined | readonl
  */
 export interface EditableTreeContext {
     /**
+     * Gets a Javascript Proxy providing a JavaScript object like API for interacting with the tree.
+     *
+     * Use built-in JS functions to get more information about the data stored e.g.
+     * ```
+     * for (const key of Object.keys(context.root)) { ... }
+     * // OR
+     * if ("foo" in data) { ... }
+     * context.free();
+     * ```
+     *
+     * Not (yet) supported: create properties, set values and delete properties.
+     */
+    readonly root: UnwrappedEditableField;
+
+    /**
      * Call before editing.
      *
      * Note that after performing edits, EditableTrees for nodes that no longer exist are invalid to use.
@@ -142,6 +172,7 @@ export interface EditableTreeContext {
 class ProxyContext implements EditableTreeContext {
     public readonly withCursors: Set<ProxyTarget> = new Set();
     public readonly withAnchors: Set<ProxyTarget> = new Set();
+
     constructor(public readonly forest: IEditableForest) {}
 
     public prepareForEdit(): void {
@@ -150,6 +181,7 @@ class ProxyContext implements EditableTreeContext {
         }
         assert(this.withCursors.size === 0, 0x3c0 /* prepareForEdit should remove all cursors */);
     }
+
     public free(): void {
         for (const target of this.withCursors) {
             target.free();
@@ -159,6 +191,22 @@ class ProxyContext implements EditableTreeContext {
         }
         assert(this.withCursors.size === 0, 0x3c1 /* free should remove all cursors */);
         assert(this.withAnchors.size === 0, 0x3c2 /* free should remove all anchors */);
+    }
+
+    public get root(): UnwrappedEditableField {
+        const cursor = this.forest.allocateCursor();
+        const destination = this.forest.root(this.forest.rootField);
+        const cursorResult = this.forest.tryMoveCursorTo(destination, cursor);
+        const targets: ProxyTarget[] = [];
+        if (cursorResult === TreeNavigationResult.Ok) {
+            do {
+                targets.push(new ProxyTarget(this, cursor));
+            } while (cursor.seek(1) === TreeNavigationResult.Ok);
+        }
+        cursor.free();
+        this.forest.anchors.forget(destination);
+        const rootSchema = this.forest.schema.lookupGlobalFieldSchema(rootFieldKey);
+        return proxifyField(getFieldKind(rootSchema), targets);
     }
 }
 
@@ -184,11 +232,16 @@ class ProxyTarget {
         }
     }
 
-    public prepareForEdit(): void {
+    public getAnchor(): Anchor {
         if (this.anchor === undefined) {
             this.anchor = this.lazyCursor.buildAnchor();
             this.context.withAnchors.add(this);
         }
+        return this.anchor;
+    }
+
+    public prepareForEdit(): void {
+        this.getAnchor();
         this.lazyCursor.clear();
         this.context.withCursors.delete(this);
     }
@@ -303,6 +356,9 @@ const handler: AdaptingProxyHandler<ProxyTarget, EditableTree> = {
             case proxyTargetSymbol: {
                 return target;
             }
+            case anchorSymbol: {
+                return target.getAnchor()
+            }
             default:
                 return undefined;
         }
@@ -412,37 +468,25 @@ function proxifyField(fieldKind: FieldKind, childTargets: ProxyTarget[]): Unwrap
 }
 
 /**
- * A simple API for a Forest to showcase basic interaction scenarios.
+ * A simple API for a Forest to interact with the tree.
  *
- * This function returns an instance of a JS Proxy typed as an EditableTree.
- * Use built-in JS functions to get more information about the data stored e.g.
- * ```
- * const [context, data] = getEditableTree(forest);
- * for (const key of Object.keys(data)) { ... }
- * // OR
- * if ("foo" in data) { ... }
- * context.free();
- * ```
- *
- * Not (yet) supported: create properties, set values and delete properties.
- *
- * @returns {@link EditableTree} for the given {@link IEditableForest}.
- * Also returns an {@link EditableTreeContext} which is used manage the cursors and anchors within the EditableTrees:
+ * @returns {@link EditableTreeContext} which is used manage the cursors and anchors within the EditableTrees:
  * This is necessary for supporting using this tree across edits to the forest, and not leaking memory.
  */
-export function getEditableTree(forest: IEditableForest): [EditableTreeContext, UnwrappedEditableField] {
-    const context = new ProxyContext(forest);
-    const cursor = forest.allocateCursor();
-    const destination = forest.root(forest.rootField);
-    const cursorResult = forest.tryMoveCursorTo(destination, cursor);
-    const targets: ProxyTarget[] = [];
-    if (cursorResult === TreeNavigationResult.Ok) {
-        do {
-            targets.push(new ProxyTarget(context, cursor));
-        } while (cursor.seek(1) === TreeNavigationResult.Ok);
-    }
-    cursor.free();
-    forest.anchors.forget(destination);
-    const rootSchema = forest.schema.lookupGlobalFieldSchema(rootFieldKey);
-    return [context, proxifyField(getFieldKind(rootSchema), targets)];
+export function getEditableTreeContext(forest: IEditableForest): EditableTreeContext {
+    return new ProxyContext(forest);
+}
+
+/**
+ * Checks the type of an UnwrappedEditableField.
+ */
+export function isArrayField(field: UnwrappedEditableField): field is UnwrappedEditableTree[] {
+    return Array.isArray(field);
+}
+
+/**
+ * Checks the type of an UnwrappedEditableField.
+ */
+export function isUnwrappedNode(field: UnwrappedEditableField): field is EditableTree {
+    return typeof field === "object" && !isArrayField(field);
 }

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -4,7 +4,7 @@
  */
 
 export {
-    getEditableTree,
+    getEditableTreeContext,
     EditableTree,
     EditableField,
     EditableTreeOrPrimitive,
@@ -12,8 +12,11 @@ export {
     UnwrappedEditableField,
     getTypeSymbol,
     valueSymbol,
+    anchorSymbol,
     proxyTargetSymbol,
     EditableTreeContext,
+    isArrayField,
+    isUnwrappedNode,
 } from "./editableTree";
 export {
     PrimitiveValue,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -17,6 +17,7 @@ export {
     CursorLocationType,
     ITreeCursorSynchronous,
     GenericFieldsNode,
+    AnchorLocator
 } from "./tree";
 
 export { ITreeCursor, TreeNavigationResult, IEditableForest,
@@ -116,7 +117,6 @@ export {
     UnwrappedEditableTree,
     EditableTreeOrPrimitive,
     EditableTree,
-    getEditableTree,
     isPrimitiveValue,
     isPrimitive,
     getTypeSymbol,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -41,7 +41,7 @@ export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObje
     /**
      * Root field of the tree.
      *
-     * Currently this editable tree fields do not update on edits,
+     * Currently this editable tree's fields do not update on edits,
      * so holding onto this root object across edits will only work if its an unwrapped node.
      * TODO: Fix this issue.
      *

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import {
     IChannel,
     IChannelAttributes,
@@ -14,26 +15,49 @@ import { ISharedObject } from "@fluidframework/shared-object-base";
 import { ICheckout, TransactionResult } from "../checkout";
 import {
     defaultSchemaPolicy,
+    EditableTreeContext,
     ForestIndex, ObjectForest,
     SchemaIndex,
     sequenceChangeFamily,
     SequenceChangeFamily,
     SequenceChangeset,
     SequenceEditBuilder,
+    UnwrappedEditableField,
+    getEditableTreeContext,
 } from "../feature-libraries";
 import { IForestSubscription } from "../forest";
 import { StoredSchemaRepository } from "../schema-stored";
 import { Index, SharedTreeCore } from "../shared-tree-core";
 import { Checkout as TransactionCheckout, runSynchronousTransaction } from "../transaction";
-import { AnchorSet } from "../tree";
+import { Anchor, AnchorLocator, AnchorSet, UpPath } from "../tree";
 
 /**
- * Collaboratively editable tree distributed datastructure,
+ * Collaboratively editable tree distributed data-structure,
  * powered by {@link @fluidframework/shared-object-base#ISharedObject}.
  *
  * See [the README](../../README.md) for details.
  */
-export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObject{}
+export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObject, AnchorLocator {
+    /**
+     * Root field of the tree.
+     *
+     * Currently this editable tree fields do not update on edits,
+     * so holding onto this root object across edits will only work if its an unwrapped node.
+     * TODO: Fix this issue.
+     *
+     * Currently any access to this view of the tree may allocate cursors and thus require
+     * `context.prepareForEdit()` before editing can occur.
+     * TODO: Make this happen automatically.
+     */
+    readonly root: UnwrappedEditableField;
+
+    /**
+     * Context for controlling the EditableTree nodes produced from {@link ISharedTree.root}.
+     *
+     * TODO: Exposing access to this should be unneeded once editing APIs are finished.
+     */
+    readonly context: EditableTreeContext;
+}
 
 /**
  * Shared tree, configured with a good set of indexes and field kinds which will maintain compatibility over time.
@@ -43,6 +67,7 @@ export interface ISharedTree extends ICheckout<SequenceEditBuilder>, ISharedObje
  * TODO: expose or implement Checkout.
  */
 class SharedTree extends SharedTreeCore<SequenceChangeset, SequenceChangeFamily> implements ISharedTree {
+    public readonly context: EditableTreeContext;
     public readonly forest: IForestSubscription;
     /**
      * Rather than implementing TransactionCheckout, have a member that implements it.
@@ -73,6 +98,17 @@ class SharedTree extends SharedTreeCore<SequenceChangeset, SequenceChangeFamily>
                 changeFamily: this.changeFamily,
                 submitEdit: (edit) => this.submitEdit(edit),
             };
+
+            this.context = getEditableTreeContext(forest);
+    }
+
+    public locate(anchor: Anchor): UpPath | undefined {
+        assert(this.editManager.anchors !== undefined, "editManager must have anchors")
+        return this.editManager.anchors?.locate(anchor);
+    }
+
+    public get root(): UnwrappedEditableField {
+        return this.context.root;
     }
 
     public runTransaction(transaction: (

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -16,7 +16,7 @@ import { IEditableForest, initializeForest } from "../../../forest";
 import { JsonableTree, EmptyKey, Value, rootFieldKey } from "../../../tree";
 import { brand, Brand, clone } from "../../../util";
 import {
-    defaultSchemaPolicy, getEditableTree, EditableTree, buildForest, getTypeSymbol, UnwrappedEditableField,
+    defaultSchemaPolicy, getEditableTreeContext, EditableTree, buildForest, getTypeSymbol, UnwrappedEditableField,
     proxyTargetSymbol, emptyField, FieldKinds, valueSymbol, EditableTreeOrPrimitive, isPrimitiveValue, Multiplicity, singleTextCursorNew,
 } from "../../../feature-libraries";
 
@@ -180,8 +180,9 @@ function setupForest(schema: SchemaData, data: JsonableTree[]): IEditableForest 
 
 function buildTestProxy(data: JsonableTree): UnwrappedEditableField {
     const forest = setupForest(fullSchemaData, [data]);
-    const [context, field] = getEditableTree(forest);
-    return field;
+    const context = getEditableTreeContext(forest);
+    const root: UnwrappedEditableField = context.root;
+    return root;
 }
 
 function buildTestPerson(): PersonType {
@@ -301,22 +302,22 @@ describe("editable-tree", () => {
         // Test empty
         {
             const forest = setupForest(schemaData, []);
-            const [context, field] = getEditableTree(forest);
-            assert.deepStrictEqual(field, []);
+            const context = getEditableTreeContext(forest);
+            assert.deepStrictEqual(context.root, []);
             context.free();
         }
         // Test 1 item
         {
             const forest = setupForest(schemaData, [emptyNode]);
-            const [context, field] = getEditableTree(forest);
-            expectTreeSequence(field, [emptyNode]);
+            const context = getEditableTreeContext(forest);
+            expectTreeSequence(context.root, [emptyNode]);
             context.free();
         }
         // Test 2 items
         {
             const forest = setupForest(schemaData, [emptyNode, emptyNode]);
-            const [context, field] = getEditableTree(forest);
-            expectTreeSequence(field, [emptyNode, emptyNode]);
+            const context = getEditableTreeContext(forest);
+            expectTreeSequence(context.root, [emptyNode, emptyNode]);
             context.free();
         }
     });
@@ -328,8 +329,8 @@ describe("editable-tree", () => {
             globalFieldSchema: new Map([[rootFieldKey, rootSchema]]),
         };
         const forest = setupForest(schemaData, [emptyNode]);
-        const [context, field] = getEditableTree(forest);
-        expectTreeEquals(field, emptyNode);
+        const context = getEditableTreeContext(forest);
+        expectTreeEquals(context.root, emptyNode);
         context.free();
     });
 
@@ -342,15 +343,15 @@ describe("editable-tree", () => {
         // Empty
         {
             const forest = setupForest(schemaData, []);
-            const [context, field] = getEditableTree(forest);
-            assert.equal(field, undefined);
+            const context = getEditableTreeContext(forest);
+            assert.equal(context.root, undefined);
             context.free();
         }
         // With value
         {
             const forest = setupForest(schemaData, [emptyNode]);
-            const [context, field] = getEditableTree(forest);
-            expectTreeEquals(field, emptyNode);
+            const context = getEditableTreeContext(forest);
+            expectTreeEquals(context.root, emptyNode);
             context.free();
         }
     });
@@ -362,8 +363,8 @@ describe("editable-tree", () => {
             globalFieldSchema: new Map([[rootFieldKey, rootSchema]]),
         };
         const forest = setupForest(schemaData, [{ type: int32Schema.name, value: 1 }]);
-        const [context, field] = getEditableTree(forest);
-        assert.equal(field, 1);
+        const context = getEditableTreeContext(forest);
+        assert.equal(context.root, 1);
         context.free();
     });
 
@@ -374,8 +375,8 @@ describe("editable-tree", () => {
             globalFieldSchema: new Map([[rootFieldKey, rootSchema]]),
         };
         const forest = setupForest(schemaData, [{ type: optionalChildSchema.name, fields: { child: [{ type: int32Schema.name, value: 1 }] } }]);
-        const [context, field] = getEditableTree(forest);
-        assert.equal((field as EditableTree).child, 1);
+        const context = getEditableTreeContext(forest);
+        assert.equal((context.root as EditableTree).child, 1);
         context.free();
     });
 
@@ -386,8 +387,8 @@ describe("editable-tree", () => {
             globalFieldSchema: new Map([[rootFieldKey, rootSchema]]),
         };
         const forest = setupForest(schemaData, [{ type: optionalChildSchema.name, fields: { child: [{ type: int32Schema.name, value: undefined }] } }]);
-        const [context, field] = getEditableTree(forest);
-        assert.throws(() => ((field as EditableTree).child),
+        const context = getEditableTreeContext(forest);
+        assert.throws(() => ((context.root as EditableTree).child),
             (e) => validateAssertionError(e, "undefined` values not allowed for primitive field"),
             "Expected exception was not thrown");
         context.free();
@@ -404,16 +405,16 @@ describe("editable-tree", () => {
         {
             const data = { type: phonesSchema.name };
             const forest = setupForest(schemaData, [data]);
-            const [context, field] = getEditableTree(forest);
-            assert.deepStrictEqual(field, []);
-            expectTreeEquals(field, data);
+            const context = getEditableTreeContext(forest);
+            assert.deepStrictEqual(context.root, []);
+            expectTreeEquals(context.root, data);
             context.free();
         }
         // Non-empty
         {
             const forest = setupForest(schemaData, [{ type: phonesSchema.name, fields: { [EmptyKey]: [{ type: int32Schema.name, value: 1 }] } }]);
-            const [context, field] = getEditableTree(forest);
-            assert.deepStrictEqual(field, [1]);
+            const context = getEditableTreeContext(forest);
+            assert.deepStrictEqual(context.root, [1]);
             context.free();
         }
     });

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -20,6 +20,21 @@ export type Anchor = Brand<number, "rebaser.Anchor">;
 const NeverAnchor: Anchor = brand(0);
 
 /**
+ * Maps anchors (which must be ones this locator knows about) to paths.
+ */
+export interface AnchorLocator {
+    /**
+     * Get the current location of an Anchor.
+     * The returned value should not be used after an edit has occurred.
+     *
+     * TODO: support extra/custom return types for specific/custom anchor types:
+     * for now caller must rely on data in anchor + returned node location
+     * (not ideal for anchors for places or ranges instead of nodes).
+     */
+    locate(anchor: Anchor): UpPath | undefined;
+}
+
+/**
  * Collection of Anchors at a specific revision.
  *
  * See {@link Rebaser} for how to update across revisions.
@@ -58,14 +73,6 @@ export class AnchorSet {
         return this.root.children.size === 0;
     }
 
-    /**
-     * Get the current location of an Anchor.
-     * The returned value should not be used after an edit has occurred.
-     *
-     * TODO: support extra/custom return types for specific/custom anchor types:
-     * for now caller must rely on data in anchor + returned node location
-     * (not ideal for anchors for places or ranges instead of nodes).
-     */
     public locate(anchor: Anchor): UpPath | undefined {
         if (anchor === NeverAnchor) {
             return undefined;


### PR DESCRIPTION
## Description

This makes it practical to use EditableTree for viewing and editing as part of the SharedTree API