### PR TITLE
Update scope for npm dependencies and pin aria-logger version (#11615)

### DIFF
--- a/tools/pipelines/dependency-injection/.npmrc
+++ b/tools/pipelines/dependency-injection/.npmrc
@@ -4,5 +4,5 @@ always-auth=false
 @fluidframework:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
 @fluid-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
 @ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
-@ms:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
+@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
 always-auth=true

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -146,7 +146,7 @@ jobs:
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-internal:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-            echo "@ms:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+            echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
             echo "always-auth=true" >> ./.npmrc
             cat .npmrc
 
@@ -176,7 +176,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
-          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger'
+          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger@0.0.11'
           customRegistry: 'useNpmrc'
 
       # Download Test Files & Install Extra Dependencies


### PR DESCRIPTION
Port this https://github.com/microsoft/FluidFramework/pull/11615 into 0.59.400x to fix the e2e tests