### PR TITLE
Update scope for npm dependencies and pin aria-logger version (#11615)

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -176,7 +176,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
-          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger'
+          customCommand: 'install $(Initialize.testPackageTgz) @ff-internal/aria-logger@0.0.11'
           customRegistry: 'useNpmrc'
 
       # Download Test Files & Install Extra Dependencies


### PR DESCRIPTION
Port this https://github.com/microsoft/FluidFramework/pull/11615 into 1.2.x to fix the e2e tests