### PR TITLE
Mark containerRuntime as dirty while uploading blob

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -83,7 +83,8 @@ export interface IBlobManagerLoadInfo {
 // Restrict the IContainerRuntime interface to the subset required by BlobManager.  This helps to make
 // the contract explicit and reduces the amount of mocking required for tests.
 export type IBlobManagerRuntime =
-    Pick<IContainerRuntime, "attachState" | "connected" | "logger"> & TypedEventEmitter<IContainerRuntimeEvents>;
+    Pick<IContainerRuntime, "attachState" | "connected" | "logger" | "isDirty">
+    & TypedEventEmitter<IContainerRuntimeEvents>;
 
 // Note that while offline we "submit" an op before uploading the blob, but we always
 // expect blobs to be uploaded before we actually see the op round-trip
@@ -287,6 +288,7 @@ export class BlobManager {
     }
 
     public async createBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
+        assert(this.runtime.isDirty, "runtime should be dirty while creting blob");
         if (this.runtime.attachState === AttachState.Detached) {
             return this.createBlobDetached(blob);
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2633,6 +2633,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         this.verifyNotClosed();
         const previousDirtyState = this.isDirty;
+        this.emitDirtyDocumentEvent = true;
         this.updateDocumentDirtyState(true, true);
         const handle = await this.blobManager.createBlob(blob);
         this.updateDocumentDirtyState(previousDirtyState, true);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2632,7 +2632,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
     public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         this.verifyNotClosed();
-        return this.blobManager.createBlob(blob);
+        const previousDirtyState = this.isDirty;
+        this.updateDocumentDirtyState(true);
+        const handle = await this.blobManager.createBlob(blob);
+        this.updateDocumentDirtyState(previousDirtyState);
+        return handle;
     }
 
     private submit(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2590,12 +2590,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this.pendingStateManager.hasPendingMessages() || !this.emptyBatch;
     }
 
-    private updateDocumentDirtyState(dirty: boolean) {
+    private updateDocumentDirtyState(dirty: boolean, uploadingBlob: boolean = false) {
         if (this.attachState !== AttachState.Attached) {
             assert(dirty, 0x3d2 /* Non-attached container is dirty */);
         } else {
             // Other way is not true = see this.isContainerMessageDirtyable()
-            assert(!dirty || this.hasPendingMessages(),
+            assert(!dirty || this.hasPendingMessages() || uploadingBlob,
                 0x3d3 /* if doc is dirty, there has to be pending ops */);
         }
 
@@ -2633,9 +2633,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         this.verifyNotClosed();
         const previousDirtyState = this.isDirty;
-        this.updateDocumentDirtyState(true);
+        this.updateDocumentDirtyState(true, true);
         const handle = await this.blobManager.createBlob(blob);
-        this.updateDocumentDirtyState(previousDirtyState);
+        this.updateDocumentDirtyState(previousDirtyState, true);
         return handle;
     }
 

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -52,6 +52,9 @@ class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements 
             this,
         );
     }
+    public get isDirty(): boolean {
+        return true;
+    }
 
     public get storage() {
         return (this.attachState === AttachState.Detached ?


### PR DESCRIPTION
## Description

It seems like a pretty common concern for hosts to want to know if a fluid document has blobs pending upload, so that they can present some UI informing the user on attempted close.

After discussions with @Abe27342 and @anthony-murphy we believe marking the containerRuntima while uploading blobs is the best solution for hosts to determine whether or not there will be data loss if error or disconnections happens.

## Reviewer Guidance

> The change is mainly making sure container is dirty while blob uploading plus some caveats to avoid asserts to be triggered and adding a unit tets for dirty flag checks while blobs uploading process.



