### PR TITLE
Separate the socket close flow from non socket close

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -32,13 +32,15 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;
-    protected disconnect(socketProtocolError: boolean, reason: IAnyDriverError): void;
+    protected disconnect(reason: IAnyDriverError): void;
     dispose(): void;
     // (undocumented)
-    protected disposeCore(socketProtocolError: boolean, err: IAnyDriverError): void;
+    protected disposeCore(err: IAnyDriverError): void;
     // (undocumented)
     get disposed(): boolean;
     protected _disposed: boolean;
+    // (undocumented)
+    protected disposeSocket(error: IAnyDriverError): void;
     // (undocumented)
     documentId: string;
     // (undocumented)

--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -39,7 +39,6 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     get disposed(): boolean;
     protected _disposed: boolean;
-    // (undocumented)
     protected disposeSocket(error: IAnyDriverError): void;
     // (undocumented)
     documentId: string;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -309,12 +309,17 @@ export class DocumentDeltaConnection
         this.submitCore("submitSignal", [message]);
     }
 
+    /**
+     * Disconnect from the websocket and close the websocket too.
+     */
     protected disposeSocket(error: IAnyDriverError) {
         this.disposeCore(error);
     }
 
     /**
-     * Disconnect from the websocket, and permanently disable this DocumentDeltaConnection.
+     * Disconnect from the websocket, and permanently disable this DocumentDeltaConnection and close the socket.
+     * However the OdspDocumentDeltaConnection differ in dispose as in there we don't close the socket. There is no
+     * multiplexing here, so we need to close the socket here.
      */
     public dispose() {
         this.disposeCore(createGenericNetworkError(

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -370,7 +370,7 @@ export class DocumentDeltaConnection
                 reject(err);
             };
 
-            const fail = (err: IAnyDriverError) => {
+            const failConnection = (err: IAnyDriverError) => {
                 this.disposeCore(err);
                 reject(err);
             };
@@ -435,7 +435,7 @@ export class DocumentDeltaConnection
                     // The only time we expect a mismatch in requested/actual is if we lack write permissions
                     // In this case we will get "read", even if we requested "write"
                     if (actualMode !== requestedMode) {
-                        fail(this.createErrorObject(
+                        failConnection(this.createErrorObject(
                             "connect_document_success",
                             "Connected in a different mode than was requested",
                             false,
@@ -444,7 +444,7 @@ export class DocumentDeltaConnection
                     }
                 } else {
                     if (actualMode === "write") {
-                        fail(this.createErrorObject(
+                        failConnection(this.createErrorObject(
                             "connect_document_success",
                             "Connected in write mode without write permissions",
                             false,
@@ -487,14 +487,14 @@ export class DocumentDeltaConnection
 
                 // This is not an socket.io error - it's Fluid protocol error.
                 // In this case fail connection and indicate that we were unable to create connection
-                fail(this.createErrorObject("connect_document_error", error));
+                failConnection(this.createErrorObject("connect_document_error", error));
             }));
 
             this.socket.emit("connect_document", connectMessage);
 
             // Give extra 2 seconds for handshake on top of socket connection timeout
             this.socketConnectionTimeout = setTimeout(() => {
-                fail(this.createErrorObject("orderingServiceHandshakeTimeout"));
+                failConnection(this.createErrorObject("orderingServiceHandshakeTimeout"));
             }, timeout + 2000);
         });
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -309,18 +309,21 @@ export class DocumentDeltaConnection
         this.submitCore("submitSignal", [message]);
     }
 
+    protected disposeSocket(error: IAnyDriverError) {
+        this.disposeCore(error);
+    }
+
     /**
      * Disconnect from the websocket, and permanently disable this DocumentDeltaConnection.
      */
     public dispose() {
-        this.disposeCore(
-            false, // socketProtocolError
-            createGenericNetworkError(
-                // pre-0.58 error message: clientClosingConnection
-                "Client closing delta connection", { canRetry: true }, { driverVersion }));
+        this.disposeCore(createGenericNetworkError(
+            // pre-0.58 error message: clientClosingConnection
+            "Client closing delta connection", { canRetry: true }, { driverVersion }),
+        );
     }
 
-    protected disposeCore(socketProtocolError: boolean, err: IAnyDriverError) {
+    protected disposeCore(err: IAnyDriverError) {
         // Can't check this.disposed here, as we get here on socket closure,
         // so _disposed & socket.connected might be not in sync while processing
         // "dispose" event.
@@ -336,16 +339,14 @@ export class DocumentDeltaConnection
         this._disposed = true;
 
         this.removeTrackedListeners();
-        this.disconnect(socketProtocolError, err);
+        this.disconnect(err);
     }
 
     /**
      * Disconnect from the websocket.
-     * @param socketProtocolError - true if error happened on socket / socket.io protocol level
-     * (not on Fluid protocol level)
      * @param reason - reason for disconnect
      */
-    protected disconnect(socketProtocolError: boolean, reason: IAnyDriverError) {
+    protected disconnect(reason: IAnyDriverError) {
         this.socket.disconnect();
     }
 
@@ -364,11 +365,15 @@ export class DocumentDeltaConnection
             getMaxInternalSocketReconnectionAttempts() + 1;
 
         this._details = await new Promise<IConnected>((resolve, reject) => {
-            const fail = (socketProtocolError: boolean, err: IAnyDriverError) => {
-                this.disposeCore(socketProtocolError, err);
+            const failAndDisposeSocket = (err: IAnyDriverError) => {
+                this.disposeSocket(err);
                 reject(err);
             };
 
+            const fail = (err: IAnyDriverError) => {
+                this.disposeCore(err);
+                reject(err);
+            };
             // Listen for connection issues
             this.addConnectionListener("connect_error", (error) => {
                 internalSocketConnectionFailureCount++;
@@ -406,12 +411,12 @@ export class DocumentDeltaConnection
                     return;
                 }
 
-                fail(true, this.createErrorObject("connect_error", error));
+                failAndDisposeSocket(this.createErrorObject("connect_error", error));
             });
 
             // Listen for timeouts
             this.addConnectionListener("connect_timeout", () => {
-                fail(true, this.createErrorObject("connect_timeout"));
+                failAndDisposeSocket(this.createErrorObject("connect_timeout"));
             });
 
             this.addConnectionListener("connect_document_success", (response: IConnected) => {
@@ -430,7 +435,7 @@ export class DocumentDeltaConnection
                     // The only time we expect a mismatch in requested/actual is if we lack write permissions
                     // In this case we will get "read", even if we requested "write"
                     if (actualMode !== requestedMode) {
-                        fail(false, this.createErrorObject(
+                        fail(this.createErrorObject(
                             "connect_document_success",
                             "Connected in a different mode than was requested",
                             false,
@@ -439,7 +444,7 @@ export class DocumentDeltaConnection
                     }
                 } else {
                     if (actualMode === "write") {
-                        fail(false, this.createErrorObject(
+                        fail(this.createErrorObject(
                             "connect_document_success",
                             "Connected in write mode without write permissions",
                             false,
@@ -460,7 +465,7 @@ export class DocumentDeltaConnection
             this.addTrackedListener("disconnect", (reason) => {
                 const err = this.createErrorObject("disconnect", reason);
                 this.emit("disconnect", err);
-                fail(true, err);
+                failAndDisposeSocket(err);
             });
 
             this.addTrackedListener("error", ((error) => {
@@ -469,7 +474,7 @@ export class DocumentDeltaConnection
                 const err = this.createErrorObject("error", error, error !== "Invalid namespace");
                 this.emit("error", err);
                 // Disconnect socket - required if happened before initial handshake
-                fail(true, err);
+                failAndDisposeSocket(err);
             }));
 
             this.addConnectionListener("connect_document_error", ((error) => {
@@ -482,14 +487,14 @@ export class DocumentDeltaConnection
 
                 // This is not an socket.io error - it's Fluid protocol error.
                 // In this case fail connection and indicate that we were unable to create connection
-                fail(false, this.createErrorObject("connect_document_error", error));
+                fail(this.createErrorObject("connect_document_error", error));
             }));
 
             this.socket.emit("connect_document", connectMessage);
 
             // Give extra 2 seconds for handshake on top of socket connection timeout
             this.socketConnectionTimeout = setTimeout(() => {
-                fail(false, this.createErrorObject("orderingServiceHandshakeTimeout"));
+                fail(this.createErrorObject("orderingServiceHandshakeTimeout"));
             }, timeout + 2000);
         });
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -77,16 +77,15 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
      * Removes a reference for the given key
      * Once the ref count hits 0, the socket is disconnected and removed
      * @param key - socket reference key
-     * @param isFatalError - true if the socket reference should be removed immediately due to a fatal error
      */
-    public removeSocketIoReference(isFatalError: boolean) {
+    public removeSocketIoReference() {
         assert(this.references > 0, 0x09f /* "No more socketIO refs to remove!" */);
         this.references--;
 
         // see comment in disconnected() getter
         this.isPendingInitialConnection = false;
 
-        if (isFatalError || this.disconnected) {
+        if (this.disconnected) {
             this.closeSocket();
             return;
         }
@@ -140,7 +139,7 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
         }
     }
 
-    private closeSocket() {
+    public closeSocket() {
         if (!this._socket) { return; }
 
         this.clearTimer();
@@ -439,7 +438,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 
     protected serverDisconnectHandler = (error: IFluidErrorBase & OdspError) => {
         this.logger.sendTelemetryEvent({ eventName: "ServerDisconnect", clientId: this.clientId }, error);
-        this.disposeCore(true, error);
+        this.disposeSocket(error);
     };
 
     protected async initialize(connectMessage: IConnect, timeout: number) {
@@ -577,21 +576,31 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     }
 
     /**
+     * Critical path where we need to also close the socket for an error.
+     * @param error - Error causing the socket to close.
+     */
+    protected disposeSocket(error: IAnyDriverError) {
+        const socket = this.socketReference;
+        assert(socket !== undefined, "reentrancy not supported in close socket");
+        socket.closeSocket();
+        this.disposeCore(error);
+    }
+
+    /**
      * Disconnect from the websocket
      */
-    protected disconnect(socketProtocolError: boolean, reason: IAnyDriverError) {
+    protected disconnect(reason: IAnyDriverError) {
         const socket = this.socketReference;
         assert(socket !== undefined, 0x0a2 /* "reentrancy not supported!" */);
 
-        this.socketReference?.off("server_disconnect", this.serverDisconnectHandler);
+        socket.off("server_disconnect", this.serverDisconnectHandler);
         this.socketReference = undefined;
-
-        if (!socketProtocolError && this.hasDetails) {
+        if (this.hasDetails) {
             // tell the server we are disconnecting this client from the document
             this.socket.emit("disconnect_document", this.clientId, this.documentId);
         }
 
-        socket.removeSocketIoReference(socketProtocolError);
+        socket.removeSocketIoReference();
         this.emit("disconnect", reason);
     }
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -155,7 +155,10 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
         // All event raising is synchronous, so clients will have a chance to react before socket is
         // closed without any extra data on why it was closed.
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        Promise.resolve().then(() => { socket.disconnect(); });
+        Promise.resolve().then(() => {
+            assert(this.references === 0, "Nobody should be connected to this socket at this point!");
+            socket.disconnect();
+        });
     }
 
     private get disconnected() {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -76,7 +76,6 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
     /**
      * Removes a reference for the given key
      * Once the ref count hits 0, the socket is disconnected and removed
-     * @param key - socket reference key
      */
     public removeSocketIoReference() {
         assert(this.references > 0, 0x09f /* "No more socketIO refs to remove!" */);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -581,8 +581,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     protected disposeSocket(error: IAnyDriverError) {
         const socket = this.socketReference;
         assert(socket !== undefined, "reentrancy not supported in close socket");
-        socket.closeSocket();
         this.disposeCore(error);
+        socket.closeSocket();
     }
 
     /**


### PR DESCRIPTION
## Description

Simplify the dispose/socketclose flow on socket disconnection either from server or client. This helps simplifying the flow with clear intentions instead of keep passing some variable to let the code down the line to decide what to do with the socket.