### PR TITLE
Test/rerun publish steps

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2164,32 +2164,32 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.6.tgz",
-			"integrity": "sha512-X0zholYgV6Tube30OayPMJENPC6TXgSqBD/6cmfdLYiMlhjTN6jZ7jiCAvJfaIRhmdjS9YcdvIgTbgyrjKgYXA==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-1.2.7.tgz",
+			"integrity": "sha512-TWmwCPI4DIkIej5pFruzY+UQBnaYpFGOPhEVnj4QYUlC2TSp+8Qa7JoNkQJwwyg9aJOdWLwg96hRg0k3sCFIhA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.6",
+				"@fluidframework/aqueduct": "^1.2.7",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/local-driver": "^1.2.6",
-				"@fluidframework/odsp-doclib-utils": "^1.2.6",
-				"@fluidframework/odsp-driver": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/local-driver": "^1.2.7",
+				"@fluidframework/odsp-doclib-utils": "^1.2.7",
+				"@fluidframework/odsp-driver": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/test-runtime-utils": "^1.2.6",
-				"@fluidframework/tool-utils": "^1.2.6",
-				"@fluidframework/view-adapters": "^1.2.6",
-				"@fluidframework/view-interfaces": "^1.2.6",
-				"@fluidframework/web-code-loader": "^1.2.6",
+				"@fluidframework/test-runtime-utils": "^1.2.7",
+				"@fluidframework/tool-utils": "^1.2.7",
+				"@fluidframework/view-adapters": "^1.2.7",
+				"@fluidframework/view-interfaces": "^1.2.7",
+				"@fluidframework/web-code-loader": "^1.2.7",
 				"axios": "^0.26.0",
 				"express": "^4.16.3",
 				"nconf": "^0.11.4",
@@ -2385,20 +2385,20 @@
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.2.6.tgz",
-			"integrity": "sha512-X+qAHCAwc3DmcHCtM2WLx1j5mS4pQBHw07qIZmU+laa2+4X86AgKErtDc5QtPc6SMUQI/FgvNAUdCqzNQGYD1w==",
+			"version": "npm:@fluidframework/agent-scheduler@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-1.2.7.tgz",
+			"integrity": "sha512-XMqzFbeJnPVIfvueEqhalKxvigTWa1k997KxpbgbZsVd4AthhKuLz7Dc7+4Qir15zFRQ2oS23sGgHQFY2jl/pw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
-				"@fluidframework/register-collection": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
+				"@fluidframework/register-collection": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2423,25 +2423,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.6.tgz",
-			"integrity": "sha512-HRAwwrk0satMRHweRAGcrtv1w24cXWGOobtjdvBuiXM4XfbngwNtrkUpJ6s4W8pS+8oE1Aww5G5rXwPjJUHi5w==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.7.tgz",
+			"integrity": "sha512-gHM7vc867L8FisszALHnDtF5gPxqe55UAAeUNjKCGNYH1hgSrDbeY1F8GBT4GgR13wmu0Lmd4bSL6WXiZDtisg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
-				"@fluidframework/request-handler": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/synthesize": "^1.2.6",
-				"@fluidframework/view-interfaces": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
+				"@fluidframework/request-handler": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/synthesize": "^1.2.7",
+				"@fluidframework/view-interfaces": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2466,25 +2466,25 @@
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.6.tgz",
-			"integrity": "sha512-HRAwwrk0satMRHweRAGcrtv1w24cXWGOobtjdvBuiXM4XfbngwNtrkUpJ6s4W8pS+8oE1Aww5G5rXwPjJUHi5w==",
+			"version": "npm:@fluidframework/aqueduct@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.7.tgz",
+			"integrity": "sha512-gHM7vc867L8FisszALHnDtF5gPxqe55UAAeUNjKCGNYH1hgSrDbeY1F8GBT4GgR13wmu0Lmd4bSL6WXiZDtisg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
-				"@fluidframework/request-handler": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/synthesize": "^1.2.6",
-				"@fluidframework/view-interfaces": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
+				"@fluidframework/request-handler": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/synthesize": "^1.2.7",
+				"@fluidframework/view-interfaces": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -2623,17 +2623,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.6.tgz",
-			"integrity": "sha512-qPtf4WqydqQny1hQxJYKtjW9h0F8ZyBD6jXZ9Ax/nh02cOfkqptLlqcV2nUa4KgKTc49JS6Y2+QdRkoeTFz1mg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.7.tgz",
+			"integrity": "sha512-ufzmG0CsJaRdWkVwF05Oy8+Z+wwE6KpaV0IW9dAh5F6sjD8vvKsuOm0a/XXpSyflFAnDMthXfTPI8JKlgQ3OCg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2665,17 +2665,17 @@
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.6.tgz",
-			"integrity": "sha512-qPtf4WqydqQny1hQxJYKtjW9h0F8ZyBD6jXZ9Ax/nh02cOfkqptLlqcV2nUa4KgKTc49JS6Y2+QdRkoeTFz1mg==",
+			"version": "npm:@fluidframework/cell@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-1.2.7.tgz",
+			"integrity": "sha512-ufzmG0CsJaRdWkVwF05Oy8+Z+wwE6KpaV0IW9dAh5F6sjD8vvKsuOm0a/XXpSyflFAnDMthXfTPI8JKlgQ3OCg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2733,13 +2733,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.6.tgz",
-			"integrity": "sha512-G+kJJFa1kgDmWZ928vpZGncBWq/DwBbZ6aXF0Yt9RoUxiV4w3z31cSEMCWqKO1uawfrloZXNF2VC9L3vn2sHYg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.7.tgz",
+			"integrity": "sha512-Uca/O1tbMzvpgOz1B2bQFP2iEVuOD1iAt8ffz6rnEomiIoXSmPSFC+DudBBvwGsXbgaM2U/SkLYGu2ZOx6Z3Sw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -2754,13 +2754,13 @@
 			}
 		},
 		"@fluidframework/container-definitions-previous": {
-			"version": "npm:@fluidframework/container-definitions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.6.tgz",
-			"integrity": "sha512-G+kJJFa1kgDmWZ928vpZGncBWq/DwBbZ6aXF0Yt9RoUxiV4w3z31cSEMCWqKO1uawfrloZXNF2VC9L3vn2sHYg==",
+			"version": "npm:@fluidframework/container-definitions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.7.tgz",
+			"integrity": "sha512-Uca/O1tbMzvpgOz1B2bQFP2iEVuOD1iAt8ffz6rnEomiIoXSmPSFC+DudBBvwGsXbgaM2U/SkLYGu2ZOx6Z3Sw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -2775,20 +2775,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.6.tgz",
-			"integrity": "sha512-Rs4qVyvcLx4S8coTp9+BReGfmOsi+UA/HVwC9FzFJPBEPhaQpu5CoxDKFBC2C/0nbSRbAG06hA60EpJG5u9Qvg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.7.tgz",
+			"integrity": "sha512-MDMjZw0x0LxEJZAp+/6x50wo8pR8xMUonye7aRZIsM8KaS9abURNSj3lGvWZwCNrZTpKSFipb9Bxw+E2e08Xuw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2840,20 +2840,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.6.tgz",
-			"integrity": "sha512-Rs4qVyvcLx4S8coTp9+BReGfmOsi+UA/HVwC9FzFJPBEPhaQpu5CoxDKFBC2C/0nbSRbAG06hA60EpJG5u9Qvg==",
+			"version": "npm:@fluidframework/container-loader@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.7.tgz",
+			"integrity": "sha512-MDMjZw0x0LxEJZAp+/6x50wo8pR8xMUonye7aRZIsM8KaS9abURNSj3lGvWZwCNrZTpKSFipb9Bxw+E2e08Xuw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -2905,25 +2905,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.6.tgz",
-			"integrity": "sha512-zQpDil5ttjO+Zi3L8SZKu5depGJ5gtxz/ULXbanx/aBiFE6vnPC0Mk4K/ROkYznLtBi//DtXPZVswIghs0VF4w==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.7.tgz",
+			"integrity": "sha512-ID+09a4mXQ1MRRzEIzns9EWySyp+2lgGpyuojF4a2rSfZTisppJRFTTdgTuMmblTACN38pX7XbBJAESaaVSRaA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/garbage-collector": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/garbage-collector": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -2973,16 +2973,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.6.tgz",
-			"integrity": "sha512-2SuGUXM8rCe08MpzvfpYiXXlRUic80WypsX9NDp/gOboPk47SzyqOYNa610Ydc/rHXM53f/a0t3G/B5fCgA0tQ==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.7.tgz",
+			"integrity": "sha512-LfXsny0KSouyHcTq1Y9XcK9D5krSgWD2E3RwcYokshCxTob6aWWkNR55JB2yvAEapQJbDpS0BNaBsd5mXxgE1A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -2997,16 +2997,16 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.6.tgz",
-			"integrity": "sha512-2SuGUXM8rCe08MpzvfpYiXXlRUic80WypsX9NDp/gOboPk47SzyqOYNa610Ydc/rHXM53f/a0t3G/B5fCgA0tQ==",
+			"version": "npm:@fluidframework/container-runtime-definitions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.7.tgz",
+			"integrity": "sha512-LfXsny0KSouyHcTq1Y9XcK9D5krSgWD2E3RwcYokshCxTob6aWWkNR55JB2yvAEapQJbDpS0BNaBsd5mXxgE1A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3021,25 +3021,25 @@
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.6.tgz",
-			"integrity": "sha512-zQpDil5ttjO+Zi3L8SZKu5depGJ5gtxz/ULXbanx/aBiFE6vnPC0Mk4K/ROkYznLtBi//DtXPZVswIghs0VF4w==",
+			"version": "npm:@fluidframework/container-runtime@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.7.tgz",
+			"integrity": "sha512-ID+09a4mXQ1MRRzEIzns9EWySyp+2lgGpyuojF4a2rSfZTisppJRFTTdgTuMmblTACN38pX7XbBJAESaaVSRaA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/garbage-collector": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/garbage-collector": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
 			},
@@ -3089,15 +3089,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.6.tgz",
-			"integrity": "sha512-hd0eoS7BN2kpeVPuXUoaTgyy15IpBQ51RDQ/5adRxH2GTokG4caqLvhB8LRyLhZJVHldtGvO9eQr6VzURn8o4A==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.7.tgz",
+			"integrity": "sha512-6LYk9PTfl0AwsU3tDR2gD9ArxqhYcBR3tzj90RRi1JCNBeed1Gci69KxASC4O3qvs8ool3WIBBneydhbLvDAUw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3129,15 +3129,15 @@
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.6.tgz",
-			"integrity": "sha512-hd0eoS7BN2kpeVPuXUoaTgyy15IpBQ51RDQ/5adRxH2GTokG4caqLvhB8LRyLhZJVHldtGvO9eQr6VzURn8o4A==",
+			"version": "npm:@fluidframework/container-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.7.tgz",
+			"integrity": "sha512-6LYk9PTfl0AwsU3tDR2gD9ArxqhYcBR3tzj90RRi1JCNBeed1Gci69KxASC4O3qvs8ool3WIBBneydhbLvDAUw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3169,27 +3169,27 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.6.tgz",
-			"integrity": "sha512-/TXSj4ICgVD4/Y2Il3J5c9HZs1Lc+nzIVGLaVbJCx8N0GxfJpn1MEP3BDXAY4+OE2wQVrk3famB6k1wo8VAbGg=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.7.tgz",
+			"integrity": "sha512-fw8wVel2htgRbkCiobmQB1+HpaxMCfqVwTQuXXrKUDr595FHU0j1KdJo39ypo3EANqavC1bZlfeMfES/J6FTaA=="
 		},
 		"@fluidframework/core-interfaces-previous": {
-			"version": "npm:@fluidframework/core-interfaces@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.6.tgz",
-			"integrity": "sha512-/TXSj4ICgVD4/Y2Il3J5c9HZs1Lc+nzIVGLaVbJCx8N0GxfJpn1MEP3BDXAY4+OE2wQVrk3famB6k1wo8VAbGg=="
+			"version": "npm:@fluidframework/core-interfaces@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.7.tgz",
+			"integrity": "sha512-fw8wVel2htgRbkCiobmQB1+HpaxMCfqVwTQuXXrKUDr595FHU0j1KdJo39ypo3EANqavC1bZlfeMfES/J6FTaA=="
 		},
 		"@fluidframework/counter": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.6.tgz",
-			"integrity": "sha512-p9itIFu4hjGbNPkM/Si4GdmMs6XPJqSJVCHlH8IMHJObEqa8qswqoewTUGTRdYlQ2Vqj5tDVwoMFGLWLMiq7YA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.7.tgz",
+			"integrity": "sha512-cyfeXPQ27VeC1dkiDr0Uz00ggUBvL92ElYAFFrl9y10qDgNhzKWm08Xd59AwSYaK2Z6E3Uayaoda2lEevBYdSQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3221,17 +3221,17 @@
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.6.tgz",
-			"integrity": "sha512-p9itIFu4hjGbNPkM/Si4GdmMs6XPJqSJVCHlH8IMHJObEqa8qswqoewTUGTRdYlQ2Vqj5tDVwoMFGLWLMiq7YA==",
+			"version": "npm:@fluidframework/counter@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-1.2.7.tgz",
+			"integrity": "sha512-cyfeXPQ27VeC1dkiDr0Uz00ggUBvL92ElYAFFrl9y10qDgNhzKWm08Xd59AwSYaK2Z6E3Uayaoda2lEevBYdSQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3263,21 +3263,21 @@
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.2.6.tgz",
-			"integrity": "sha512-w/sIj/iCcVSaOqgC8CR8QbkM5LPGJP+hhKqUIoHCAg/F2F/X7FAK4PrlnsyTBe9csNTH5Kuz+34+ldJ7CKTbAg==",
+			"version": "npm:@fluidframework/data-object-base@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-1.2.7.tgz",
+			"integrity": "sha512-FeVr5NDhgJ83MynuBJau4sCqRFJNg+jY+bvQK4+HCHDxQqMOE/3MTaHXDy2T2nf2LalzkB6QCqSK+TAr3zi7Tg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/request-handler": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/request-handler": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3301,24 +3301,24 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.6.tgz",
-			"integrity": "sha512-yT8jrogM8hpkAgkV1n2xya68MY9WEQln4pzg3nE+iSBKI8itAHwoZWYiD0grO2dG68a6mMJkks8SqOyTGknwgA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.7.tgz",
+			"integrity": "sha512-uZdCtMV4QLLLFTOPwHCRcj0EnKZtPIFQTm/DCJSPvuUp3hkjrFPEv6PL4JuD7FzJx/+XWdcKBeoO0MSWYekTRQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/garbage-collector": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/garbage-collector": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3368,16 +3368,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.6.tgz",
-			"integrity": "sha512-edDEC9Zy5yRXF6/zdEYR9y800RdZraK/2WbZjS3ue0Nw500BpI85B47vmU0cEIENvn3sMMlucsgOL/+73LvcGg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.7.tgz",
+			"integrity": "sha512-rBFUDZ6tR0ol6gQsHflXTU2psTDw4fcRyX6r12Y0k3bsdN1PmV4VciiZa2+vNZl3LPD4oKsvqLaZkdR6lVyiSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3410,16 +3410,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.6.tgz",
-			"integrity": "sha512-edDEC9Zy5yRXF6/zdEYR9y800RdZraK/2WbZjS3ue0Nw500BpI85B47vmU0cEIENvn3sMMlucsgOL/+73LvcGg==",
+			"version": "npm:@fluidframework/datastore-definitions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.7.tgz",
+			"integrity": "sha512-rBFUDZ6tR0ol6gQsHflXTU2psTDw4fcRyX6r12Y0k3bsdN1PmV4VciiZa2+vNZl3LPD4oKsvqLaZkdR6lVyiSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
@@ -3452,24 +3452,24 @@
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.6.tgz",
-			"integrity": "sha512-yT8jrogM8hpkAgkV1n2xya68MY9WEQln4pzg3nE+iSBKI8itAHwoZWYiD0grO2dG68a6mMJkks8SqOyTGknwgA==",
+			"version": "npm:@fluidframework/datastore@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.7.tgz",
+			"integrity": "sha512-uZdCtMV4QLLLFTOPwHCRcj0EnKZtPIFQTm/DCJSPvuUp3hkjrFPEv6PL4JuD7FzJx/+XWdcKBeoO0MSWYekTRQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/garbage-collector": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/garbage-collector": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			},
@@ -3519,15 +3519,15 @@
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.6.tgz",
-			"integrity": "sha512-EsUiCkzQ/aS7WFvYEGIrgMUCnGd5bK2DBDklrL12/o/2myxU0DbQUX1w3+Ecfmjs2Si/0SCZPDpESBpAM6QzxQ==",
+			"version": "npm:@fluidframework/dds-interceptions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-1.2.7.tgz",
+			"integrity": "sha512-zJXntvHWwiRJanGdPC22ZCUspBbu1sw7uxLnU5UCHa1ybU5770BsseguRKEKuCGl6lHq3e0HX6xLrJ7OhxAtIg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/map": "^1.2.6",
-				"@fluidframework/merge-tree": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/sequence": "^1.2.6"
+				"@fluidframework/map": "^1.2.7",
+				"@fluidframework/merge-tree": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/sequence": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3551,15 +3551,15 @@
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.2.6.tgz",
-			"integrity": "sha512-I+vMEPLJvvRVPGvr6riWdtiGJXfbXZwRkoPHv49W3liuxubMgZyb/U2U/fzHhdUlAyQXI5N9719Wv58pxqAMCQ==",
+			"version": "npm:@fluidframework/debugger@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-1.2.7.tgz",
+			"integrity": "sha512-UQkWu1qid1kpBXehSJhABgN/m5FOyccYLln5RTL9t2Fm+FZOgrR+Ho46PpcZQezp1isXXCaCEaLO0V/avF52vA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.2.6",
+				"@fluidframework/replay-driver": "^1.2.7",
 				"jsonschema": "^1.2.6"
 			},
 			"dependencies": {
@@ -3592,16 +3592,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.6.tgz",
-			"integrity": "sha512-r/ZiQzqY0zOyvXveZry3e7OZGfFgY+hKqWROH8Xmkx6mHVltySr1U2UnkhA5EGzr+vUOIRMgCpc3RIYHGcpJGA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.7.tgz",
+			"integrity": "sha512-VBYx+YQNsyW/cZJHPdThBHH3xgWzS002Qb1Jtdw4Xn1s31IUYFq0eDDuUL+CBNT28iK4cMaYq3H+H78DzMvONQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3633,16 +3633,16 @@
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.6.tgz",
-			"integrity": "sha512-r/ZiQzqY0zOyvXveZry3e7OZGfFgY+hKqWROH8Xmkx6mHVltySr1U2UnkhA5EGzr+vUOIRMgCpc3RIYHGcpJGA==",
+			"version": "npm:@fluidframework/driver-base@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.7.tgz",
+			"integrity": "sha512-VBYx+YQNsyW/cZJHPdThBHH3xgWzS002Qb1Jtdw4Xn1s31IUYFq0eDDuUL+CBNT28iK4cMaYq3H+H78DzMvONQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3674,12 +3674,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.6.tgz",
-			"integrity": "sha512-NdMhErQiiKngXNDA1bEIx3alLCBBJv7p5wh7C06l9ArAgake0hk9oaS/4OF2IWoicSMaf7jJoZWHNkZvZGpGTA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.7.tgz",
+			"integrity": "sha512-Vk22el2HLNrd7vDMmOM8Dn9hatzhQ11nWSVcUZhbVj74iiKV81javWTHVvPDsp6V6+OKC5DMb71Mw0Tdj/vFmw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -3694,12 +3694,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions-previous": {
-			"version": "npm:@fluidframework/driver-definitions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.6.tgz",
-			"integrity": "sha512-NdMhErQiiKngXNDA1bEIx3alLCBBJv7p5wh7C06l9ArAgake0hk9oaS/4OF2IWoicSMaf7jJoZWHNkZvZGpGTA==",
+			"version": "npm:@fluidframework/driver-definitions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.7.tgz",
+			"integrity": "sha512-Vk22el2HLNrd7vDMmOM8Dn9hatzhQ11nWSVcUZhbVj74iiKV81javWTHVvPDsp6V6+OKC5DMb71Mw0Tdj/vFmw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -3714,18 +3714,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.6.tgz",
-			"integrity": "sha512-oTLAwmAf5rEFeKBezdynS7a8WoVHih8loGxmMqYxmiMJDJQxm4gctB2sVY8kYOm3opUYLN3we1s6dbwzv4Tx5w==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.7.tgz",
+			"integrity": "sha512-OysiT1vMiiuHaeCMVjajrg90z7yWXETmYcqyWg86mjNZW5PfELXINruAWU8adciDKdFg+Q4gygiEKWAlCJU2QQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3775,18 +3775,18 @@
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.6.tgz",
-			"integrity": "sha512-oTLAwmAf5rEFeKBezdynS7a8WoVHih8loGxmMqYxmiMJDJQxm4gctB2sVY8kYOm3opUYLN3we1s6dbwzv4Tx5w==",
+			"version": "npm:@fluidframework/driver-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.7.tgz",
+			"integrity": "sha512-OysiT1vMiiuHaeCMVjajrg90z7yWXETmYcqyWg86mjNZW5PfELXINruAWU8adciDKdFg+Q4gygiEKWAlCJU2QQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			},
@@ -3836,13 +3836,13 @@
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.6.tgz",
-			"integrity": "sha512-CtUl6ROuoBpmTdmaTZyVkW0TlwoKBGI7uoDtXH+cONNO9yem5wjB2vsfflZl18AESIte3Mmk7HHXG74N/p0YJQ==",
+			"version": "npm:@fluidframework/driver-web-cache@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-1.2.7.tgz",
+			"integrity": "sha512-lkKjg9Ax5YDA53xvzJTUcSjzb0aqjQPbLRoUQkfSkhnDqxAXVKo53dQhIXtnBTBoODJza/ZN7U69duRnrpnDtA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3868,16 +3868,16 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.2.6.tgz",
-			"integrity": "sha512-L+ACVBCTmsHD8MZNnpTX41Cu4KoGkCWePiXiIEqEdtbZIrwVqTpvxR0FcX3FKSMrodtquLS8QHhKy/8sPqG6yw==",
+			"version": "npm:@fluidframework/file-driver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-1.2.7.tgz",
+			"integrity": "sha512-wG4rsMVItwnbSyDQ/xGaIgatQ23LbJjadJ/C3qcJD4n0lLYhIJKUfsyhmtTICekZ08ZdbH0yMnHsOTxePAnIBg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/replay-driver": "^1.2.6"
+				"@fluidframework/replay-driver": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3909,22 +3909,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.6.tgz",
-			"integrity": "sha512-G3yBxgXZhXAd0MfErjr23UHKHzTfT76ZCCcUJkxXGV+Buvucl26EwxK3O6GKrr3G6BFI/AoPfW1hAh+LElxWxA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.7.tgz",
+			"integrity": "sha512-IpdlLFDaSIoR1w9vM+bCcipcyoKnkn2YEx3ixVWJlc/+kZvwvCFZgyBZJl2XaJXZ8lEUbLXjiruo2tsE0lsNYA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.6",
+				"@fluidframework/aqueduct": "^1.2.7",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6"
+				"@fluidframework/request-handler": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -3956,22 +3956,22 @@
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.6.tgz",
-			"integrity": "sha512-G3yBxgXZhXAd0MfErjr23UHKHzTfT76ZCCcUJkxXGV+Buvucl26EwxK3O6GKrr3G6BFI/AoPfW1hAh+LElxWxA==",
+			"version": "npm:@fluidframework/fluid-static@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.7.tgz",
+			"integrity": "sha512-IpdlLFDaSIoR1w9vM+bCcipcyoKnkn2YEx3ixVWJlc/+kZvwvCFZgyBZJl2XaJXZ8lEUbLXjiruo2tsE0lsNYA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.6",
+				"@fluidframework/aqueduct": "^1.2.7",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6"
+				"@fluidframework/request-handler": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4003,13 +4003,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.6.tgz",
-			"integrity": "sha512-1wIKikJX0rs4vtZC929IwXSz+4vU4mo/BLktblEcyoX01DheDZEUanytOTvMvGkgDFB7pPqTSEFa0AbQSDTq/A==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.7.tgz",
+			"integrity": "sha512-z+50HcDgL6/tMShBIwkai/HgSVxGfolgfneXDGGAvozDxlUyCw67R+epdmqROI40GuVvifh0YqnQtJSgtHFnow==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4033,13 +4033,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.6.tgz",
-			"integrity": "sha512-1wIKikJX0rs4vtZC929IwXSz+4vU4mo/BLktblEcyoX01DheDZEUanytOTvMvGkgDFB7pPqTSEFa0AbQSDTq/A==",
+			"version": "npm:@fluidframework/garbage-collector@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.7.tgz",
+			"integrity": "sha512-z+50HcDgL6/tMShBIwkai/HgSVxGfolgfneXDGGAvozDxlUyCw67R+epdmqROI40GuVvifh0YqnQtJSgtHFnow==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/runtime-definitions": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4068,17 +4068,17 @@
 			"integrity": "sha512-joY0TA6Be/v7oUieHH0vV2yB3WA1hDjiJAPqYP+sn23M2eQcFCXmdwUb81eZoqyUnmBWsBzIv2JoJzYpvFmW0Q=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.2.6.tgz",
-			"integrity": "sha512-k9y/g1kKLKPuduhPu/ch4rjfdui3cp4fvfDx6Sb7cOkUI4nBQkIby/Tn06WnsDpCBrBTJELtnOPwlzB0uwoqVw==",
+			"version": "npm:@fluidframework/iframe-driver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-1.2.7.tgz",
+			"integrity": "sha512-MKpQoI1jZby8XeGGn+l6rbW5yYVO05AboGGPC9b/+H8/TN22iRJNBokXvGpPN+m8qM36onefqHoKek6dGH0p2A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"comlink": "^4.3.0"
 			},
 			"dependencies": {
@@ -4111,17 +4111,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.6.tgz",
-			"integrity": "sha512-NbAIjBqKPTwYz3tyL9bh01auvyyjbfIXHWvECR13YhaioZb8oUSiApewDpzzyw4ty65aNY2BYl4Vb8A1XZLimg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.7.tgz",
+			"integrity": "sha512-ePbpWx4MiRZ7o5EwL1cPnGW8i4zJ7bFEdC55vG5naCoK8CP0Mgxu1cPCZs/lDIsV6fdZuusMwz5Tbwvbw842wQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4154,17 +4154,17 @@
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.6.tgz",
-			"integrity": "sha512-NbAIjBqKPTwYz3tyL9bh01auvyyjbfIXHWvECR13YhaioZb8oUSiApewDpzzyw4ty65aNY2BYl4Vb8A1XZLimg==",
+			"version": "npm:@fluidframework/ink@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-1.2.7.tgz",
+			"integrity": "sha512-ePbpWx4MiRZ7o5EwL1cPnGW8i4zJ7bFEdC55vG5naCoK8CP0Mgxu1cPCZs/lDIsV6fdZuusMwz5Tbwvbw842wQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -4197,18 +4197,18 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.6.tgz",
-			"integrity": "sha512-7o3PtO1SzJcjCPh9zfoZXLjVviOwFAkqya+xybRl68gnghpheQmbrLUKeWu8qXsY/FyiCh1JRRzmj/gPyYMkkg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.7.tgz",
+			"integrity": "sha512-o/oCYOfB67+0YkJa+oGI4HnKqiOd1y69Bd9avpg6F5LBmno2XOb1X9vkBPDkwDsyDFXr8254ekhbL4yTkD4XPQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-base": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-base": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -4402,18 +4402,18 @@
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.6.tgz",
-			"integrity": "sha512-7o3PtO1SzJcjCPh9zfoZXLjVviOwFAkqya+xybRl68gnghpheQmbrLUKeWu8qXsY/FyiCh1JRRzmj/gPyYMkkg==",
+			"version": "npm:@fluidframework/local-driver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-1.2.7.tgz",
+			"integrity": "sha512-o/oCYOfB67+0YkJa+oGI4HnKqiOd1y69Bd9avpg6F5LBmno2XOb1X9vkBPDkwDsyDFXr8254ekhbL4yTkD4XPQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-base": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-base": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
 				"@fluidframework/server-local-server": "^0.1036.5000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"@fluidframework/server-services-core": "^0.1036.5000",
@@ -4607,20 +4607,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.6.tgz",
-			"integrity": "sha512-2gvNp7tX/74FS4CATGXF09eUpp93Bz2vRzkEjRdQ5tCMZZmrArupOxaudQpYjkGEZtjGP+5PM4OlNUjXzqmnbA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.7.tgz",
+			"integrity": "sha512-v9W7WJ8KGeaGSIUm/lgOkZpuUblhjtiK2mpMGZnoZmQfJjos/YLvSGGFdx54+FUm2aRYc7z/z/yabiO/npsfAQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4653,20 +4653,20 @@
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.6.tgz",
-			"integrity": "sha512-2gvNp7tX/74FS4CATGXF09eUpp93Bz2vRzkEjRdQ5tCMZZmrArupOxaudQpYjkGEZtjGP+5PM4OlNUjXzqmnbA==",
+			"version": "npm:@fluidframework/map@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.7.tgz",
+			"integrity": "sha512-v9W7WJ8KGeaGSIUm/lgOkZpuUblhjtiK2mpMGZnoZmQfJjos/YLvSGGFdx54+FUm2aRYc7z/z/yabiO/npsfAQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
@@ -4699,21 +4699,21 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.6.tgz",
-			"integrity": "sha512-qIFKTT6BQS6MmFFLhko3eLLDjykbyRTb1lVB3TyWESbISvLUBXoW/yJlnBHeHKt/RJduUdHewDIZc78K8iDXtA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.7.tgz",
+			"integrity": "sha512-l1QpmJQZzvYfqMTu1T2F7zt5qxopoGsOm1DhUm6unmYh2Tx16PtafeCQj0zN4meSI4EDpn0J/sJ+QhWfZulTIA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/merge-tree": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/merge-tree": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4763,21 +4763,21 @@
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.6.tgz",
-			"integrity": "sha512-qIFKTT6BQS6MmFFLhko3eLLDjykbyRTb1lVB3TyWESbISvLUBXoW/yJlnBHeHKt/RJduUdHewDIZc78K8iDXtA==",
+			"version": "npm:@fluidframework/matrix@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-1.2.7.tgz",
+			"integrity": "sha512-l1QpmJQZzvYfqMTu1T2F7zt5qxopoGsOm1DhUm6unmYh2Tx16PtafeCQj0zN4meSI4EDpn0J/sJ+QhWfZulTIA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/merge-tree": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/merge-tree": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			},
@@ -4827,21 +4827,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.6.tgz",
-			"integrity": "sha512-5bqjLAnT9LMMVnpIE7Irn4tDXGbcuM6cZTuxFtMW9AmWo/1H5Y1XPP/p6kTn2ze7xJXrKYv+Gcu9zTjpsNSS/g==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.7.tgz",
+			"integrity": "sha512-XrTK+lNIBsv8j0l5WhZe56C6L/vBRgcjbjsTcGnlyCe/bc8lcX0fiGjMAG1/HvhsWiWwqQHeBZtXSkkXEKDolw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4873,21 +4873,21 @@
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.6.tgz",
-			"integrity": "sha512-5bqjLAnT9LMMVnpIE7Irn4tDXGbcuM6cZTuxFtMW9AmWo/1H5Y1XPP/p6kTn2ze7xJXrKYv+Gcu9zTjpsNSS/g==",
+			"version": "npm:@fluidframework/merge-tree@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.7.tgz",
+			"integrity": "sha512-XrTK+lNIBsv8j0l5WhZe56C6L/vBRgcjbjsTcGnlyCe/bc8lcX0fiGjMAG1/HvhsWiWwqQHeBZtXSkkXEKDolw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -4919,36 +4919,36 @@
 			}
 		},
 		"@fluidframework/mocha-test-setup": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.6.tgz",
-			"integrity": "sha512-UACnbRbd7+ciSHThMG0R01bBlmBHT9jECAmpYaybPVyUEaGJ2816GgQI3YK6f0fbpDByhTnh1dvUEdNIFkT7WQ==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.7.tgz",
+			"integrity": "sha512-FBE/Az95sHhpmKgU/WY7NYUaqBoyslQpe0lcfdEzSnxZTwtxusLGpx/GfWwaAQCGMqtfO8XoabQAESsCroLIYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.2.6",
+				"@fluidframework/test-driver-definitions": "^1.2.7",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.6.tgz",
-			"integrity": "sha512-UACnbRbd7+ciSHThMG0R01bBlmBHT9jECAmpYaybPVyUEaGJ2816GgQI3YK6f0fbpDByhTnh1dvUEdNIFkT7WQ==",
+			"version": "npm:@fluidframework/mocha-test-setup@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-1.2.7.tgz",
+			"integrity": "sha512-FBE/Az95sHhpmKgU/WY7NYUaqBoyslQpe0lcfdEzSnxZTwtxusLGpx/GfWwaAQCGMqtfO8XoabQAESsCroLIYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": "^1.2.6",
+				"@fluidframework/test-driver-definitions": "^1.2.7",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.6.tgz",
-			"integrity": "sha512-A63V6LJkVrnfUKYq8m4vvVXKRU+ZE8u32bwRyl5FrmX0X4Yh/eh5OM4kHub5hg6hg7hbRlma6U5rGRHJn5Ul5Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.7.tgz",
+			"integrity": "sha512-gYyKftyTstEtDLmikcJm8f0m53lWeyaIoHFSRyntI4XKetjDbNZRThw61ykvSnVihQXYEFMzJiaEPdCakJiipg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -4973,16 +4973,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.6.tgz",
-			"integrity": "sha512-A63V6LJkVrnfUKYq8m4vvVXKRU+ZE8u32bwRyl5FrmX0X4Yh/eh5OM4kHub5hg6hg7hbRlma6U5rGRHJn5Ul5Q==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-1.2.7.tgz",
+			"integrity": "sha512-gYyKftyTstEtDLmikcJm8f0m53lWeyaIoHFSRyntI4XKetjDbNZRThw61ykvSnVihQXYEFMzJiaEPdCakJiipg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
@@ -5007,22 +5007,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.6.tgz",
-			"integrity": "sha512-CMI3JpsGFTTl2UdZC7A3+P9EPleUwfdwpX1NqqhU3lKkUOHiaoyOg0PIbF8hKHrivJ2j4wgkaZSrL4MgDBY4QA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.7.tgz",
+			"integrity": "sha512-J8uz50i0EW07p3IGg7IQlX6g354Mv7+nhzAzXJaDVU7kUg0VnITLC4mPQOoAy+AwiIb+yOH1+U67aExFFxpTXA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-base": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-base": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
+				"@fluidframework/odsp-doclib-utils": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -5074,38 +5074,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.6.tgz",
-			"integrity": "sha512-Lauwq6/oxh3n0JhWvEAec+fecPN+R9haWcpgsa2LnuiT198vcmKiZ+2e0Y6IF1nHWjNLOPviPqpqtgrCzfLF/w==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.7.tgz",
+			"integrity": "sha512-4pmmEzeNl8hiBu6AOF5rOJ3gIIJRumw4TTr7auiKO3PeZ2bIxmpIVP5pDygyZ1r3GxZDPNMYZmLEYK20lmAZ3w==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.6"
+				"@fluidframework/driver-definitions": "^1.2.7"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.6.tgz",
-			"integrity": "sha512-Lauwq6/oxh3n0JhWvEAec+fecPN+R9haWcpgsa2LnuiT198vcmKiZ+2e0Y6IF1nHWjNLOPviPqpqtgrCzfLF/w==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-1.2.7.tgz",
+			"integrity": "sha512-4pmmEzeNl8hiBu6AOF5rOJ3gIIJRumw4TTr7auiKO3PeZ2bIxmpIVP5pDygyZ1r3GxZDPNMYZmLEYK20lmAZ3w==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^1.2.6"
+				"@fluidframework/driver-definitions": "^1.2.7"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.6.tgz",
-			"integrity": "sha512-CMI3JpsGFTTl2UdZC7A3+P9EPleUwfdwpX1NqqhU3lKkUOHiaoyOg0PIbF8hKHrivJ2j4wgkaZSrL4MgDBY4QA==",
+			"version": "npm:@fluidframework/odsp-driver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-1.2.7.tgz",
+			"integrity": "sha512-J8uz50i0EW07p3IGg7IQlX6g354Mv7+nhzAzXJaDVU7kUg0VnITLC4mPQOoAy+AwiIb+yOH1+U67aExFFxpTXA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-base": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-base": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/gitresources": "^0.1036.5000",
-				"@fluidframework/odsp-doclib-utils": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
+				"@fluidframework/odsp-doclib-utils": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -5157,39 +5157,39 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.6.tgz",
-			"integrity": "sha512-Q+Np2YGudU/gOD4mT3Iyo0GtJbDUlexD2ISBmbZmSwo1anLsNXwnF1aZQAi9i9IVBQSKsbL4WLzaAY4QDEvGmg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.7.tgz",
+			"integrity": "sha512-TIDi1ocEoGrdVKzCtnYJXCOaGhehOz9K/Gf1sFLEKqi1MQmT2ZbYc5Yxb2wX3m7mzSoDIvkkxoa57bOxhFvwgw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/odsp-driver": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6"
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/odsp-driver": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.6.tgz",
-			"integrity": "sha512-Q+Np2YGudU/gOD4mT3Iyo0GtJbDUlexD2ISBmbZmSwo1anLsNXwnF1aZQAi9i9IVBQSKsbL4WLzaAY4QDEvGmg==",
+			"version": "npm:@fluidframework/odsp-urlresolver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-1.2.7.tgz",
+			"integrity": "sha512-TIDi1ocEoGrdVKzCtnYJXCOaGhehOz9K/Gf1sFLEKqi1MQmT2ZbYc5Yxb2wX3m7mzSoDIvkkxoa57bOxhFvwgw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/odsp-driver": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6"
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/odsp-driver": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.6.tgz",
-			"integrity": "sha512-Z1vSJnKLvnXHBUVbHRmUKBOBi2TnBskqf5jFBOf/n2QdF2fDIDboAkC8HaOzw3bHICG7YnNRyBLMMPM0WAvAZg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.7.tgz",
+			"integrity": "sha512-g6+tbbz/3D+dd+pdvfmy+QdWOzG6/xpZqBLlKzvK6G8WYInG/RmFcGJem4nU/iKuTZ63ZWV++sMxzNf8CBNJxg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -5222,17 +5222,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.6.tgz",
-			"integrity": "sha512-Z1vSJnKLvnXHBUVbHRmUKBOBi2TnBskqf5jFBOf/n2QdF2fDIDboAkC8HaOzw3bHICG7YnNRyBLMMPM0WAvAZg==",
+			"version": "npm:@fluidframework/ordered-collection@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-1.2.7.tgz",
+			"integrity": "sha512-g6+tbbz/3D+dd+pdvfmy+QdWOzG6/xpZqBLlKzvK6G8WYInG/RmFcGJem4nU/iKuTZ63ZWV++sMxzNf8CBNJxg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -5284,17 +5284,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.6.tgz",
-			"integrity": "sha512-4UtCjQ5oD82aXRQLWk8MXWAIfrnRx2+Xl99PsIDRS2HSvsXLpXqVVt/wGkNfW1shWQ+UNDWrBYY5d4l1gX2XTw==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.7.tgz",
+			"integrity": "sha512-9IianuZYXlBHVHHnlfjq4tkE4iW4omsg2Bwo4LT6e2gmKaN9LkTMB9Gh3udeCB7pt5TuQCNT0xKwKewpGiA9nQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5342,17 +5342,17 @@
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.6.tgz",
-			"integrity": "sha512-4UtCjQ5oD82aXRQLWk8MXWAIfrnRx2+Xl99PsIDRS2HSvsXLpXqVVt/wGkNfW1shWQ+UNDWrBYY5d4l1gX2XTw==",
+			"version": "npm:@fluidframework/register-collection@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.7.tgz",
+			"integrity": "sha512-9IianuZYXlBHVHHnlfjq4tkE4iW4omsg2Bwo4LT6e2gmKaN9LkTMB9Gh3udeCB7pt5TuQCNT0xKwKewpGiA9nQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5400,16 +5400,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.6.tgz",
-			"integrity": "sha512-/By9AmfUfIeLYMOdB7UmTjW8+a6yEFSsx1cYfksp3F3DqW7mZxnfxZ0RSg5MNTf/tIUItaxoIjnV9gwfWwATgw==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.7.tgz",
+			"integrity": "sha512-zhxqyE2A+iau5lY/hM6+sMSbCAtCkpy51xDgd/kesVi0xOszL8b43xg7Mb4pXK9rT/VHcfS1zM9qZ5GwDGAr0w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5441,16 +5441,16 @@
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.6.tgz",
-			"integrity": "sha512-/By9AmfUfIeLYMOdB7UmTjW8+a6yEFSsx1cYfksp3F3DqW7mZxnfxZ0RSg5MNTf/tIUItaxoIjnV9gwfWwATgw==",
+			"version": "npm:@fluidframework/replay-driver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-1.2.7.tgz",
+			"integrity": "sha512-zhxqyE2A+iau5lY/hM6+sMSbCAtCkpy51xDgd/kesVi0xOszL8b43xg7Mb4pXK9rT/VHcfS1zM9qZ5GwDGAr0w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5482,15 +5482,15 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.6.tgz",
-			"integrity": "sha512-rvRpXYbRjr5xdShZWgELAqvOC4RC4OudFeA/jXOAH5q2iAY/O0PYHIbny20aIErMktjqpu3FPOR2g4fN7zti3A==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.7.tgz",
+			"integrity": "sha512-+Dw00rUPgXSm/CWOKLuAeT/ASrRHgCOrLeGtrWEBkJolUQy/eiPNpVEsf8Kd0vtEl/t35feQ7hoQVmU5NHPjnw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6"
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5514,15 +5514,15 @@
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.6.tgz",
-			"integrity": "sha512-rvRpXYbRjr5xdShZWgELAqvOC4RC4OudFeA/jXOAH5q2iAY/O0PYHIbny20aIErMktjqpu3FPOR2g4fN7zti3A==",
+			"version": "npm:@fluidframework/request-handler@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.7.tgz",
+			"integrity": "sha512-+Dw00rUPgXSm/CWOKLuAeT/ASrRHgCOrLeGtrWEBkJolUQy/eiPNpVEsf8Kd0vtEl/t35feQ7hoQVmU5NHPjnw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6"
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5546,20 +5546,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.6.tgz",
-			"integrity": "sha512-TgsODlYCeFRJBjv2GS3oy79d1nXok+Bfi+VoffJ3w8Q30ADRCs6yQZ3ogMkDzagdtGU3ju0q1FxoCLzk8X33/g==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.7.tgz",
+			"integrity": "sha512-ovjikQ+NcmFdl+c4h4qfE2xRGgOUjBx+/Uli0N9K/bewYwiCBXOh0hV5HvKOA2Rhf000SvFWjtXClxaLZPtYhw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-base": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -5638,20 +5638,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.6.tgz",
-			"integrity": "sha512-TgsODlYCeFRJBjv2GS3oy79d1nXok+Bfi+VoffJ3w8Q30ADRCs6yQZ3ogMkDzagdtGU3ju0q1FxoCLzk8X33/g==",
+			"version": "npm:@fluidframework/routerlicious-driver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.7.tgz",
+			"integrity": "sha512-ovjikQ+NcmFdl+c4h4qfE2xRGgOUjBx+/Uli0N9K/bewYwiCBXOh0hV5HvKOA2Rhf000SvFWjtXClxaLZPtYhw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-base": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-base": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/gitresources": "^0.1036.5000",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5000",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -5730,13 +5730,13 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.6.tgz",
-			"integrity": "sha512-B/nKXk5izLtgoEJRQcmiYPPlAbT2J8ItP8UFqfVe3/1RNO1Rbhea4RJtIDKDBJQZ5v537uUHPaiBaDKqpoj8iw==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-1.2.7.tgz",
+			"integrity": "sha512-FyEUUUBE33RyWhxfiuhawNbYe/H+1NTvgDBIFfG8rSYZoMet1iQtizEGxA5tjPLSIQB0oX3uQPi0vsinxeo19w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"nconf": "^0.11.4"
 			},
@@ -5770,15 +5770,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.6.tgz",
-			"integrity": "sha512-tMl1QkKUPRteyeQdCFUDAlGwqRbNl316yvzptSe22KKpFroQgUfYJbyg7J6NXubw8/TI9LB95e9HOX6ZQSEv3Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.7.tgz",
+			"integrity": "sha512-oPhahKtW/0CXLyU/PP3SJYjudYIzgZPibMEGrZCiNl9n7ZCCWbt1syzUuEo+Hl4ISvGB7kJur7czEf+EpoJ3Yw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -5812,15 +5812,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.6.tgz",
-			"integrity": "sha512-tMl1QkKUPRteyeQdCFUDAlGwqRbNl316yvzptSe22KKpFroQgUfYJbyg7J6NXubw8/TI9LB95e9HOX6ZQSEv3Q==",
+			"version": "npm:@fluidframework/runtime-definitions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.7.tgz",
+			"integrity": "sha512-oPhahKtW/0CXLyU/PP3SJYjudYIzgZPibMEGrZCiNl9n7ZCCWbt1syzUuEo+Hl4ISvGB7kJur7czEf+EpoJ3Yw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@types/node": "^14.18.0"
 			},
@@ -5854,21 +5854,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.6.tgz",
-			"integrity": "sha512-OXmFLu1KWQYo4JmmLbvyhGvyVxsgCtLLj66fn6cCkshS4Bi+s48d/sXqXfPjHjQk49CG5h2Kq0aaJAze6v+isA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.7.tgz",
+			"integrity": "sha512-s+OGN4ui5ZopcTqPSI/wg/fdhvQW09WJsS7Bvln0tSykISSf8Rp6vPDd1FG2JMJj5oTDrUniUqjBcAVvRIbmnQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/garbage-collector": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/garbage-collector": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5916,21 +5916,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.6.tgz",
-			"integrity": "sha512-OXmFLu1KWQYo4JmmLbvyhGvyVxsgCtLLj66fn6cCkshS4Bi+s48d/sXqXfPjHjQk49CG5h2Kq0aaJAze6v+isA==",
+			"version": "npm:@fluidframework/runtime-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.7.tgz",
+			"integrity": "sha512-s+OGN4ui5ZopcTqPSI/wg/fdhvQW09WJsS7Bvln0tSykISSf8Rp6vPDd1FG2JMJj5oTDrUniUqjBcAVvRIbmnQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/garbage-collector": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/garbage-collector": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -5978,21 +5978,21 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.6.tgz",
-			"integrity": "sha512-RY2IgU1VyZrzwYus5+/33xZx2OVJPc3rt/atWzn+kcOmTu69Sz/fvswyj5aVK3xXggNcP36lZSViVOmOS1iPng==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.7.tgz",
+			"integrity": "sha512-43FuttETPMMgvCqA/bG24Xxb4Alk80eI31WivxqJ+Pi2LhSL7iC8yfCmDEkb0M5oWtfJi3Px+PSU1Dx0TCtbhw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/merge-tree": "^1.2.6",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/merge-tree": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -6025,21 +6025,21 @@
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.6.tgz",
-			"integrity": "sha512-RY2IgU1VyZrzwYus5+/33xZx2OVJPc3rt/atWzn+kcOmTu69Sz/fvswyj5aVK3xXggNcP36lZSViVOmOS1iPng==",
+			"version": "npm:@fluidframework/sequence@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.7.tgz",
+			"integrity": "sha512-43FuttETPMMgvCqA/bG24Xxb4Alk80eI31WivxqJ+Pi2LhSL7iC8yfCmDEkb0M5oWtfJi3Px+PSU1Dx0TCtbhw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/merge-tree": "^1.2.6",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/merge-tree": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7373,22 +7373,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.6.tgz",
-			"integrity": "sha512-VDwCTXOqvSkRKCn56IKmaRb9hyryh7UUxfwgIjwOWGEEz4f8VF60LQy2g3uyU4yDCin8Ki6X8bHDlYw4t2kCaA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.7.tgz",
+			"integrity": "sha512-/MqJMzuWourgAfs9sVxOHofesxFnNz6dffzbXwEqPI8tDyOBNxa8GMLAZT/b2oXu/Dcxg6VSPgwyzg8Rx6aktw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7421,22 +7421,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.6.tgz",
-			"integrity": "sha512-VDwCTXOqvSkRKCn56IKmaRb9hyryh7UUxfwgIjwOWGEEz4f8VF60LQy2g3uyU4yDCin8Ki6X8bHDlYw4t2kCaA==",
+			"version": "npm:@fluidframework/shared-object-base@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.7.tgz",
+			"integrity": "sha512-/MqJMzuWourgAfs9sVxOHofesxFnNz6dffzbXwEqPI8tDyOBNxa8GMLAZT/b2oXu/Dcxg6VSPgwyzg8Rx6aktw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/container-utils": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/container-utils": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -7469,17 +7469,17 @@
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.6.tgz",
-			"integrity": "sha512-kNpnDP0tbBTGAC7azMq3GFSbNRuDReNS4ZwBrN7RVMbbTmuQVjFkFFJEY1knOlZR4zm9aZaICqb+P8ztqYMP5w==",
+			"version": "npm:@fluidframework/shared-summary-block@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-1.2.7.tgz",
+			"integrity": "sha512-GHjH7LFRCK8egB7VEMFsRsTfZNM8PYn7U/N3f/GIbKDTkHC+4ruezu84LU59WEnLtf2IAOvgLDAYOAzCCBQeEw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/shared-object-base": "^1.2.6"
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/shared-object-base": "^1.2.7"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -7511,19 +7511,19 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.6.tgz",
-			"integrity": "sha512-Bxu9djL9tVHfEnHOQcHhLJbxfUxkZkoGEkz/+I1q5JkJjTHxaFyJe9kzJ+wfcCjpIbR2lEvl5Oulk10yi/8kbQ=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.7.tgz",
+			"integrity": "sha512-iKBvnU1bLqGzrS/vMCsd3XqqvqDcYDFakjWiYn/A3wtGfwApYwvP89YUF3AHyee29YmpHU7RzS6Ga6bV4F4LWQ=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.6.tgz",
-			"integrity": "sha512-Bxu9djL9tVHfEnHOQcHhLJbxfUxkZkoGEkz/+I1q5JkJjTHxaFyJe9kzJ+wfcCjpIbR2lEvl5Oulk10yi/8kbQ=="
+			"version": "npm:@fluidframework/synthesize@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.7.tgz",
+			"integrity": "sha512-iKBvnU1bLqGzrS/vMCsd3XqqvqDcYDFakjWiYn/A3wtGfwApYwvP89YUF3AHyee29YmpHU7RzS6Ga6bV4F4LWQ=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.6.tgz",
-			"integrity": "sha512-9W3YQ5XBbjteO8uYhvgudOFA68qOC3V5rNXnbmVtnwM+UYecork468O7kwjpbT6nmYVNS/6S8zEvuVBTj94X1w==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.7.tgz",
+			"integrity": "sha512-ehb8dzhXZhzmWzvDgDTF3MCcoMxI8Dsw3kX8OIk5YTlAmiW2KBklKaIg/Q05wt+gf96lfGJHGT7chTGQxYaODw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -7553,9 +7553,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.6.tgz",
-			"integrity": "sha512-9W3YQ5XBbjteO8uYhvgudOFA68qOC3V5rNXnbmVtnwM+UYecork468O7kwjpbT6nmYVNS/6S8zEvuVBTj94X1w==",
+			"version": "npm:@fluidframework/telemetry-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.7.tgz",
+			"integrity": "sha512-ehb8dzhXZhzmWzvDgDTF3MCcoMxI8Dsw3kX8OIk5YTlAmiW2KBklKaIg/Q05wt+gf96lfGJHGT7chTGQxYaODw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -7585,12 +7585,12 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.6.tgz",
-			"integrity": "sha512-tS+jBEEeiooxRjX8OlMxmPOvF+ir1d8w3Kg+OZnpfVgLkGOBMto07uEx0b/w8UttYxzDEgPzd9U1a6Ht5KfSZQ==",
+			"version": "npm:@fluidframework/test-client-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-1.2.7.tgz",
+			"integrity": "sha512-ORCY2bG7IkVVR7Ud73lHfjONmMOO8jdfKIC6YxUwP5AUvCaTyrmzCkJkdfLjEGsLDuVocUBf5lL/G4Ylgz9gHw==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/test-runtime-utils": "^1.2.6",
+				"@fluidframework/test-runtime-utils": "^1.2.7",
 				"sillyname": "^0.1.0"
 			},
 			"dependencies": {
@@ -7605,13 +7605,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.6.tgz",
-			"integrity": "sha512-TWuFLe5KFXOFrEhL+8AgvT9vlHauHE09s78xapP0Z5LT0QLXy0k2JRoS+TA9h/zRuvaO02F0wH65Ea3eX2rznA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.7.tgz",
+			"integrity": "sha512-b3LYeEPKIPBdNyZwzchKmVBBcFMB82kzidnMrRCB5NDAjJH/tkhSuQrOh6CDsg81gJwDeTBE8lmFBQGbG8FRLQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			},
@@ -7627,13 +7627,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions-previous": {
-			"version": "npm:@fluidframework/test-driver-definitions@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.6.tgz",
-			"integrity": "sha512-TWuFLe5KFXOFrEhL+8AgvT9vlHauHE09s78xapP0Z5LT0QLXy0k2JRoS+TA9h/zRuvaO02F0wH65Ea3eX2rznA==",
+			"version": "npm:@fluidframework/test-driver-definitions@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-1.2.7.tgz",
+			"integrity": "sha512-b3LYeEPKIPBdNyZwzchKmVBBcFMB82kzidnMrRCB5NDAjJH/tkhSuQrOh6CDsg81gJwDeTBE8lmFBQGbG8FRLQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"uuid": "^8.3.1"
 			},
@@ -7649,27 +7649,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.6.tgz",
-			"integrity": "sha512-UisROsKCuCENFAqpVKc7/UIuJfUGRzbCe3FKe9ZMb6x7oQvUQdi6pcVmi5Id+DKOseH7DD4u32plHY4nLgDfAQ==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.7.tgz",
+			"integrity": "sha512-Kivw3h8jgK8nNTUcanDF3SmjlJBwV4hh3nVsz0vC4cKsd/XOowyUzc9RLC7w6CxBBE9jcJHIDYMN9bwk+bZILg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/local-driver": "^1.2.6",
-				"@fluidframework/odsp-doclib-utils": "^1.2.6",
-				"@fluidframework/odsp-driver": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
-				"@fluidframework/odsp-urlresolver": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/local-driver": "^1.2.7",
+				"@fluidframework/odsp-doclib-utils": "^1.2.7",
+				"@fluidframework/odsp-driver": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
+				"@fluidframework/odsp-urlresolver": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.6",
-				"@fluidframework/test-pairwise-generator": "^1.2.6",
-				"@fluidframework/test-runtime-utils": "^1.2.6",
-				"@fluidframework/tinylicious-driver": "^1.2.6",
-				"@fluidframework/tool-utils": "^1.2.6",
+				"@fluidframework/test-driver-definitions": "^1.2.7",
+				"@fluidframework/test-pairwise-generator": "^1.2.7",
+				"@fluidframework/test-runtime-utils": "^1.2.7",
+				"@fluidframework/tinylicious-driver": "^1.2.7",
+				"@fluidframework/tool-utils": "^1.2.7",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -7860,27 +7860,27 @@
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.6.tgz",
-			"integrity": "sha512-UisROsKCuCENFAqpVKc7/UIuJfUGRzbCe3FKe9ZMb6x7oQvUQdi6pcVmi5Id+DKOseH7DD4u32plHY4nLgDfAQ==",
+			"version": "npm:@fluidframework/test-drivers@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-1.2.7.tgz",
+			"integrity": "sha512-Kivw3h8jgK8nNTUcanDF3SmjlJBwV4hh3nVsz0vC4cKsd/XOowyUzc9RLC7w6CxBBE9jcJHIDYMN9bwk+bZILg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/local-driver": "^1.2.6",
-				"@fluidframework/odsp-doclib-utils": "^1.2.6",
-				"@fluidframework/odsp-driver": "^1.2.6",
-				"@fluidframework/odsp-driver-definitions": "^1.2.6",
-				"@fluidframework/odsp-urlresolver": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/local-driver": "^1.2.7",
+				"@fluidframework/odsp-doclib-utils": "^1.2.7",
+				"@fluidframework/odsp-driver": "^1.2.7",
+				"@fluidframework/odsp-driver-definitions": "^1.2.7",
+				"@fluidframework/odsp-urlresolver": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
 				"@fluidframework/server-local-server": "^0.1036.5000",
-				"@fluidframework/test-driver-definitions": "^1.2.6",
-				"@fluidframework/test-pairwise-generator": "^1.2.6",
-				"@fluidframework/test-runtime-utils": "^1.2.6",
-				"@fluidframework/tinylicious-driver": "^1.2.6",
-				"@fluidframework/tool-utils": "^1.2.6",
+				"@fluidframework/test-driver-definitions": "^1.2.7",
+				"@fluidframework/test-pairwise-generator": "^1.2.7",
+				"@fluidframework/test-runtime-utils": "^1.2.7",
+				"@fluidframework/tinylicious-driver": "^1.2.7",
+				"@fluidframework/tool-utils": "^1.2.7",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -8071,14 +8071,14 @@
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.6.tgz",
-			"integrity": "sha512-dFGg7UMPdFMmaXmLbgQStpGqY/WKmuWEHgX6DTdCh7WWEdRM7/YC6EZlFmmZU016/JW0SsYelNwt6q30bLnGEA==",
+			"version": "npm:@fluidframework/test-loader-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-1.2.7.tgz",
+			"integrity": "sha512-ZhInfWkC31PmhbOayJEGE5Iuc+MSz4rkWjlsD4oeqp1xVSLOBkLa1R9U/jI/FbP6T4l5gsgnswo7mHZOgPeaqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			},
 			"dependencies": {
@@ -8111,9 +8111,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.6.tgz",
-			"integrity": "sha512-3RrhN1qpY6+hgJtwQmyrizSbZmIT9JDhz/P5lQFKYU19ztLRkfJ5nHxkpPTR+p9e1sH16waP32A/Kh/83vE06A==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.7.tgz",
+			"integrity": "sha512-gG1710c+7yOSFgMSSZpDQ8kJayer0PnxjW6u0tamjbRv8OJJCpqI6h0urOwRkCEAvH0WMv2UNfhxnr9NXzzDDQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
@@ -8140,9 +8140,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.6.tgz",
-			"integrity": "sha512-3RrhN1qpY6+hgJtwQmyrizSbZmIT9JDhz/P5lQFKYU19ztLRkfJ5nHxkpPTR+p9e1sH16waP32A/Kh/83vE06A==",
+			"version": "npm:@fluidframework/test-pairwise-generator@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-1.2.7.tgz",
+			"integrity": "sha512-gG1710c+7yOSFgMSSZpDQ8kJayer0PnxjW6u0tamjbRv8OJJCpqI6h0urOwRkCEAvH0WMv2UNfhxnr9NXzzDDQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
 				"random-js": "^1.0.8"
@@ -8169,22 +8169,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.6.tgz",
-			"integrity": "sha512-7v8BGrRtcOor7OhB5AtpmuO1k3ojkqs/NGsDGLn9hVqTbIKpTTt50fw9JUCrW2PWuCYW/L2WsVCZbCIB41ee9A==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.7.tgz",
+			"integrity": "sha512-SMSERTW+YWpXgfbGaXTBSmic9RV/HYpfB/rNctFBQqpO7RsA8jTF0gtWtd52G1nIes1dPkJc+bQ0prR6AprAxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8219,22 +8219,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.6.tgz",
-			"integrity": "sha512-7v8BGrRtcOor7OhB5AtpmuO1k3ojkqs/NGsDGLn9hVqTbIKpTTt50fw9JUCrW2PWuCYW/L2WsVCZbCIB41ee9A==",
+			"version": "npm:@fluidframework/test-runtime-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-1.2.7.tgz",
+			"integrity": "sha512-SMSERTW+YWpXgfbGaXTBSmic9RV/HYpfB/rNctFBQqpO7RsA8jTF0gtWtd52G1nIes1dPkJc+bQ0prR6AprAxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8275,32 +8275,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.6.tgz",
-			"integrity": "sha512-UMVQzZlp1rgkFLDcmaN0nEW1zWa+t/a4KZWxN+G5sqFqGkh8aN9nw4X6pku/EeFR2Qhrv3IV7PmCsx9iYcT7Dg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.7.tgz",
+			"integrity": "sha512-epPsCTxw2THHo5BZfjlL1wsxOQya41ju1NPGfDU7VxRVmH+mC+KyccZ2f6SmDat7iqEtXW1dOn3emTUUxigt0g==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.6",
+				"@fluidframework/aqueduct": "^1.2.7",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/local-driver": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/local-driver": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.6",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
-				"@fluidframework/test-driver-definitions": "^1.2.6",
-				"@fluidframework/test-runtime-utils": "^1.2.6",
+				"@fluidframework/request-handler": "^1.2.7",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
+				"@fluidframework/test-driver-definitions": "^1.2.7",
+				"@fluidframework/test-runtime-utils": "^1.2.7",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -8334,32 +8334,32 @@
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.6.tgz",
-			"integrity": "sha512-UMVQzZlp1rgkFLDcmaN0nEW1zWa+t/a4KZWxN+G5sqFqGkh8aN9nw4X6pku/EeFR2Qhrv3IV7PmCsx9iYcT7Dg==",
+			"version": "npm:@fluidframework/test-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-1.2.7.tgz",
+			"integrity": "sha512-epPsCTxw2THHo5BZfjlL1wsxOQya41ju1NPGfDU7VxRVmH+mC+KyccZ2f6SmDat7iqEtXW1dOn3emTUUxigt0g==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.6",
+				"@fluidframework/aqueduct": "^1.2.7",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/container-runtime-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/datastore": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/local-driver": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/container-runtime-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/datastore": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/local-driver": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/request-handler": "^1.2.6",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/telemetry-utils": "^1.2.6",
-				"@fluidframework/test-driver-definitions": "^1.2.6",
-				"@fluidframework/test-runtime-utils": "^1.2.6",
+				"@fluidframework/request-handler": "^1.2.7",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/telemetry-utils": "^1.2.7",
+				"@fluidframework/test-driver-definitions": "^1.2.7",
+				"@fluidframework/test-runtime-utils": "^1.2.7",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
@@ -8393,34 +8393,34 @@
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.6.tgz",
-			"integrity": "sha512-NpTZEIL65n96iAIbGlvSFV1AfOSejnCicXcdll5kT5OPL+ULPFyzdCv9ydTY0thLnwupGKPNTCBpFXcy2SEeAg==",
+			"version": "npm:@fluidframework/test-version-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-1.2.7.tgz",
+			"integrity": "sha512-85/7wCeYc97B9bkgBO2cjMfCAlPG72pBAvrG5TvRM2GWf4ODYDtilfn66O3x9UlRct93HUgS1lSjTfSAjsv7wg==",
 			"requires": {
-				"@fluidframework/aqueduct": "^1.2.6",
-				"@fluidframework/cell": "^1.2.6",
+				"@fluidframework/aqueduct": "^1.2.7",
+				"@fluidframework/cell": "^1.2.7",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/container-runtime": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/counter": "^1.2.6",
-				"@fluidframework/datastore-definitions": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/ink": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
-				"@fluidframework/matrix": "^1.2.6",
-				"@fluidframework/mocha-test-setup": "^1.2.6",
-				"@fluidframework/ordered-collection": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/container-runtime": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/counter": "^1.2.7",
+				"@fluidframework/datastore-definitions": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/ink": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
+				"@fluidframework/matrix": "^1.2.7",
+				"@fluidframework/mocha-test-setup": "^1.2.7",
+				"@fluidframework/ordered-collection": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/register-collection": "^1.2.6",
-				"@fluidframework/runtime-definitions": "^1.2.6",
-				"@fluidframework/sequence": "^1.2.6",
-				"@fluidframework/test-driver-definitions": "^1.2.6",
-				"@fluidframework/test-drivers": "^1.2.6",
-				"@fluidframework/test-utils": "^1.2.6",
+				"@fluidframework/register-collection": "^1.2.7",
+				"@fluidframework/runtime-definitions": "^1.2.7",
+				"@fluidframework/sequence": "^1.2.7",
+				"@fluidframework/test-driver-definitions": "^1.2.7",
+				"@fluidframework/test-drivers": "^1.2.7",
+				"@fluidframework/test-utils": "^1.2.7",
 				"nconf": "^0.11.4",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
@@ -8455,22 +8455,22 @@
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.6.tgz",
-			"integrity": "sha512-+xwn9SUtXhAIAUY/GxukYEyAhPnCGRiRIQ5ywtO+qxuwKtUZNW7+k51Jwuxqd92eFz0BJhmtkbrMlkqTZes8gQ==",
+			"version": "npm:@fluidframework/tinylicious-client@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.7.tgz",
+			"integrity": "sha512-wx5RMDktgbPsDtmJeT/u0XCDhc7LcboBp1+PttOkhY2sp2Z7SA3Q+GEmEkH4aezlfdoMivI1jQLilBmOcktGIQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
-				"@fluidframework/fluid-static": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
+				"@fluidframework/fluid-static": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
-				"@fluidframework/runtime-utils": "^1.2.6",
-				"@fluidframework/tinylicious-driver": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
+				"@fluidframework/runtime-utils": "^1.2.7",
+				"@fluidframework/tinylicious-driver": "^1.2.7",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
@@ -8503,15 +8503,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.6.tgz",
-			"integrity": "sha512-hpK4XW60aaOIVt/NTE8nG21P0LXiYmD898KApc49GCePO9Q+lQiTl2jyIzOBiWZvXvi4hRmLNQvMuiiOWKBqbA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.7.tgz",
+			"integrity": "sha512-LuuCUab2Hl54Q6ije3MAFoMZxegHgo0qKGCLdHT7paF2VXXlnGHldOThsL0zKN19fwTbd07fzR9jyVl/a8B3VA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8587,15 +8587,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.6.tgz",
-			"integrity": "sha512-hpK4XW60aaOIVt/NTE8nG21P0LXiYmD898KApc49GCePO9Q+lQiTl2jyIzOBiWZvXvi4hRmLNQvMuiiOWKBqbA==",
+			"version": "npm:@fluidframework/tinylicious-driver@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.7.tgz",
+			"integrity": "sha512-LuuCUab2Hl54Q6ije3MAFoMZxegHgo0qKGCLdHT7paF2VXXlnGHldOThsL0zKN19fwTbd07fzR9jyVl/a8B3VA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/driver-definitions": "^1.2.6",
-				"@fluidframework/driver-utils": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/driver-definitions": "^1.2.7",
+				"@fluidframework/driver-utils": "^1.2.7",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.2.6",
+				"@fluidframework/routerlicious-driver": "^1.2.7",
 				"@fluidframework/server-services-client": "^0.1036.5000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -8671,12 +8671,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.6.tgz",
-			"integrity": "sha512-WErKtYcaSJok56eZrztMGXa49HlD+OJKMO2aquqWpT7g4dh8SjFIXhQIGV6Th0yBfvL4ooKIT4QpI6BdbkqkWQ==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.7.tgz",
+			"integrity": "sha512-by94mdGAS8af5BEF9Z0qMxrbPpT1aMj8hh0+GvX6ChLKgJZPqYMpbO+ceKkavqHkYpRtbRE9fQu2Q0pYiqkdAg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.6",
+				"@fluidframework/odsp-doclib-utils": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -8730,12 +8730,12 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.6.tgz",
-			"integrity": "sha512-WErKtYcaSJok56eZrztMGXa49HlD+OJKMO2aquqWpT7g4dh8SjFIXhQIGV6Th0yBfvL4ooKIT4QpI6BdbkqkWQ==",
+			"version": "npm:@fluidframework/tool-utils@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-1.2.7.tgz",
+			"integrity": "sha512-by94mdGAS8af5BEF9Z0qMxrbPpT1aMj8hh0+GvX6ChLKgJZPqYMpbO+ceKkavqHkYpRtbRE9fQu2Q0pYiqkdAg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/odsp-doclib-utils": "^1.2.6",
+				"@fluidframework/odsp-doclib-utils": "^1.2.7",
 				"@fluidframework/protocol-base": "^0.1036.5000",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"async-mutex": "^0.3.1",
@@ -8789,71 +8789,71 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.6.tgz",
-			"integrity": "sha512-WqKVc6KfFMRa5jjjcAyMjadcLqavrsHqpTOLWhdfChI/i7wKuBNP4YqflpYJTwz9HGd6CAGOXRn+0Rn5sgGO5w==",
+			"version": "npm:@fluidframework/undo-redo@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-1.2.7.tgz",
+			"integrity": "sha512-eDwJeqU4HOYUI1amWG8gbCxhZ4e4U3TH/Wn8f8Rvs5aQtsd2tpQwa3jA05Jdn2FRWVuJW1C+CYgP2ogT/PufjQ==",
 			"requires": {
-				"@fluidframework/map": "^1.2.6",
-				"@fluidframework/matrix": "^1.2.6",
-				"@fluidframework/merge-tree": "^1.2.6",
-				"@fluidframework/sequence": "^1.2.6"
+				"@fluidframework/map": "^1.2.7",
+				"@fluidframework/matrix": "^1.2.7",
+				"@fluidframework/merge-tree": "^1.2.7",
+				"@fluidframework/sequence": "^1.2.7"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.6.tgz",
-			"integrity": "sha512-nczksQ1Bq0ePuioe4xUFSVs26R4c8Axa9D4Vn85VbqMry+FWwM4P8jKy81nZrqkZfMPwxtI40kxKjwqh1YnHEA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.7.tgz",
+			"integrity": "sha512-mDaYzTxHpMxUdos3N9Exd27wUhkh6hYIS1cJOwb69LaOYHkFNA4mXr706UeG5xAli3gNklZpAEoYYfnnJkLtzA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/view-interfaces": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/view-interfaces": "^1.2.7",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.6.tgz",
-			"integrity": "sha512-nczksQ1Bq0ePuioe4xUFSVs26R4c8Axa9D4Vn85VbqMry+FWwM4P8jKy81nZrqkZfMPwxtI40kxKjwqh1YnHEA==",
+			"version": "npm:@fluidframework/view-adapters@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-1.2.7.tgz",
+			"integrity": "sha512-mDaYzTxHpMxUdos3N9Exd27wUhkh6hYIS1cJOwb69LaOYHkFNA4mXr706UeG5xAli3gNklZpAEoYYfnnJkLtzA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6",
-				"@fluidframework/view-interfaces": "^1.2.6",
+				"@fluidframework/core-interfaces": "^1.2.7",
+				"@fluidframework/view-interfaces": "^1.2.7",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.6.tgz",
-			"integrity": "sha512-8UGjlEJqzE40TZz7G5uLjOq+AUnBhFadQMnxi+QBbvclDZA8JmKEcJZV4tbsx2+xRiQScaKo+zsX6PB8F4Pr8Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.7.tgz",
+			"integrity": "sha512-6/+2ekl5S3ioEw4c0da4NC8ZwMQmthlKV6ejqd9rZKcCpk49RuOOhZMc22BOtBJF4P0IxfFcSgfXVwOd3u184A==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6"
+				"@fluidframework/core-interfaces": "^1.2.7"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.6.tgz",
-			"integrity": "sha512-8UGjlEJqzE40TZz7G5uLjOq+AUnBhFadQMnxi+QBbvclDZA8JmKEcJZV4tbsx2+xRiQScaKo+zsX6PB8F4Pr8Q==",
+			"version": "npm:@fluidframework/view-interfaces@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.7.tgz",
+			"integrity": "sha512-6/+2ekl5S3ioEw4c0da4NC8ZwMQmthlKV6ejqd9rZKcCpk49RuOOhZMc22BOtBJF4P0IxfFcSgfXVwOd3u184A==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^1.2.6"
+				"@fluidframework/core-interfaces": "^1.2.7"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.6.tgz",
-			"integrity": "sha512-Vv1KMUwDHlZbDInWqVweddMedh/r95DhhxDiDQS3Dn9xd+sQ2sGLhU+QTGfj+w16tAXElAwM9X2XiDZoPv+qaQ==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.7.tgz",
+			"integrity": "sha512-HeRc29qqb8q8Q8vItQjIQTpaVXM8CcIQKImbIjuttwCzcXydyIhYi5CSzbSS95aPeRzX8hhFDX+Sn3sls963kg==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@1.2.6",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.6.tgz",
-			"integrity": "sha512-Vv1KMUwDHlZbDInWqVweddMedh/r95DhhxDiDQS3Dn9xd+sQ2sGLhU+QTGfj+w16tAXElAwM9X2XiDZoPv+qaQ==",
+			"version": "npm:@fluidframework/web-code-loader@1.2.7",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-1.2.7.tgz",
+			"integrity": "sha512-HeRc29qqb8q8Q8vItQjIQTpaVXM8CcIQKImbIjuttwCzcXydyIhYi5CSzbSS95aPeRzX8hhFDX+Sn3sls963kg==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/core-interfaces": "^1.2.6",
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/core-interfaces": "^1.2.7",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
@@ -36019,7 +36019,7 @@
 				}
 			}
 		},
-        "eslint-config-prettier": {
+		"eslint-config-prettier": {
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q=="
@@ -37456,15 +37456,15 @@
 			"integrity": "sha512-OapHwT5Ug1c3iiv8JNrwh/3XGjP45l/2iwfl25chePrvCgl0786ZvsJK+hxCCaUZjPm1lHdh5LHZhmKRxunziA=="
 		},
 		"fluid-framework-previous": {
-			"version": "npm:fluid-framework@1.2.6",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.6.tgz",
-			"integrity": "sha512-HOBquXb81LaehEmtwzZcZ01hm+9Pc5gZ8h6w4WkuehUF1Qt2TsYyIrOYQiC62vXV8EsX2m2TqRew+rTrHR+08Q==",
+			"version": "npm:fluid-framework@1.2.7",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.7.tgz",
+			"integrity": "sha512-sAvXg4PsPkbXKuPWmr4lM+TWcw/5jkAUzRfqpeJJQKua0pe+NioM2KhanFmdl68FTNESOkFfr1qKcBmEA+xXgA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^1.2.6",
-				"@fluidframework/container-loader": "^1.2.6",
-				"@fluidframework/fluid-static": "^1.2.6",
-				"@fluidframework/map": "^1.2.6",
-				"@fluidframework/sequence": "^1.2.6"
+				"@fluidframework/container-definitions": "^1.2.7",
+				"@fluidframework/container-loader": "^1.2.7",
+				"@fluidframework/fluid-static": "^1.2.7",
+				"@fluidframework/map": "^1.2.7",
+				"@fluidframework/sequence": "^1.2.7"
 			}
 		},
 		"flush-write-stream": {

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -49,7 +49,6 @@ steps:
           echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
-
           echo Deleting @fluid-internal packages
           rm -f fluid-internal-*
           echo Deleting @fluid-example packages
@@ -66,7 +65,6 @@ steps:
     workingFile: $(Pipeline.Workspace)/pack//${{ parameters.artifactPath }}/.npmrc
     customEndPoint: ${{ parameters.customEndPoint }}
 - task: Bash@3
-  retryCountOnTaskFailure: 3
   displayName: Publish Packages for ${{ parameters.artifactPath }}
   inputs:
     targetType: 'inline'
@@ -90,10 +88,6 @@ steps:
         packages=*.tgz
         sorted=false
       fi
-      echo "------------------------------"
-      echo "NPM List : " npm list -g
-      echo "NPM List : " $(npm list -g)
-      echo "------------------------------"
       for packageName in $packages
       do
         if [[ $sorted == true ]]; then
@@ -101,41 +95,32 @@ steps:
         else
           f=$packageName
         fi
+        echo "File Name :" $f
         if [[ $f != "" ]]; then
-          echo "------------------------------"
-          echo "Package Name : " $f
-          echo "------------------------------"
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"
           then
-              if [[ "$(npm list -g $f)" =~ "empty" ]]; then
-                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+              then
+                let t1+=1
+              else
+                echo Package has already been published.
+                local_f="${f}_local"
+                mv "$f" "$local_f"
+                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                npm pack $package_name
+                if cmp -s "$f" "$local_f"
                 then
-                  let t1+=1
+                  echo Continuing as published package matches the current one that was attempting to be released.
                 else
-                  echo Package has already been published.
-                  local_f="${f}_local"
-                  mv "$f" "$local_f"
-                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                  npm pack $package_name
-                  if cmp -s "$f" "$local_f"
-                  then
-                    echo Continuing as published package matches the current one that was attempting to be released.
-                  else
-                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                    let t1+=1
-                  fi
-                  rm "$f"
-                  mv "$local_f" "$f"
+                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                  let t1+=1
                 fi
+                rm "$f"
+                mv "$local_f" "$f"
               fi
           fi
           rm publish_log
-        fi
-        if [[ "$(npm list -g $f)" =~ "empty" ]]; then
-          echo "Not Installed"
-        else
-          echo "Already Installed"
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -88,6 +88,7 @@ steps:
         packages=*.tgz
         sorted=false
       fi
+      echo "Before For"
       for packageName in $packages
       do
         if [[ $sorted == true ]]; then
@@ -95,8 +96,9 @@ steps:
         else
           f=$packageName
         fi
+        echo "After For"
         if [[ $f != "" ]]; then
-          echo "Passed"
+          echo "File Exists : " $f
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"
           then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -66,6 +66,7 @@ steps:
     workingFile: $(Pipeline.Workspace)/pack//${{ parameters.artifactPath }}/.npmrc
     customEndPoint: ${{ parameters.customEndPoint }}
 - task: Bash@3
+  retryCountOnTaskFailure: 3
   displayName: Publish Packages for ${{ parameters.artifactPath }}
   inputs:
     targetType: 'inline'

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -97,7 +97,7 @@ steps:
         fi
         if [[ $f != "" ]]; then
           checkVersion=${f##/*}
-          checkVersion=${checkVersion:0:-4}
+          checkVersion=${checkVersion:2:-4}
 
           echo "CheckVersion 0 :" $checkVersion
 

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -96,8 +96,9 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          checkVersion=$${f##*/}
+          checkVersion=${f##*/}
 
+          echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
           checkVersion=${checkVersion:2:-4}

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -108,8 +108,9 @@ steps:
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
           checkError=$(npm view $checkVersion)
+          echo $checkError
 
-          if [[ grep -q "npm ERR!" ] || [ $checkError == "" ]]; then
+          if [[ grep -q "npm ERR!" ]]; then
             echo "Passed"
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -10,6 +10,9 @@ parameters:
 - name: feedName
   type: string
 
+- name: devFeedName
+  type: string
+
 - name: official
   type: string
 
@@ -36,7 +39,8 @@ steps:
           echo Generating .npmrc for ${{ parameters.feedName }}
           echo "@fluidframework:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "@fluid-example:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-internal:registry=${{ parameters.feedName }}" >> ./.npmrc
+          echo "@fluid-msinternal:registry=${{ parameters.feedName }}" >> ./.npmrc
+          echo "@fluid-internal:registry=${{ parameters.devFeedName }}" >> ./.npmrc
           echo "@fluid-experimental:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
@@ -51,6 +55,8 @@ steps:
           cat .npmrc
           echo Deleting @fluid-internal packages
           rm -f fluid-internal-*
+          echo Deleting @fluid-msinternal packages
+          rm -f fluid-msinternal-*
           echo Deleting @fluid-example packages
           rm -f fluid-example-*
     ${{ if eq(parameters.namespace, false) }}:
@@ -106,37 +112,34 @@ steps:
           fi
 
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
-
           checkError=$(npm view $checkVersion)
-          checkTiny=$(npm view @fluidframework/tinylicious-client@0.0.0-96564-test)
 
-          echo "Error : " $checkError
-          echo "Tinylicious : " $checkTiny
-
-          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-          if grep -q "npm ERR!" "publish_log"
-          then
-              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-              then
-                let t1+=1
-              else
-                echo Package has already been published.
-                local_f="${f}_local"
-                mv "$f" "$local_f"
-                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                npm pack $package_name
-                if cmp -s "$f" "$local_f"
+          if [[ "$checkError" = "" || "$checkError" =~ "npm ERR!" ]]; then
+            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+            if grep -q "npm ERR!" "publish_log"
+            then
+                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
                 then
-                  echo Continuing as published package matches the current one that was attempting to be released.
-                else
-                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
                   let t1+=1
+                else
+                  echo Package has already been published.
+                  local_f="${f}_local"
+                  mv "$f" "$local_f"
+                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                  npm pack $package_name
+                  if cmp -s "$f" "$local_f"
+                  then
+                    echo Continuing as published package matches the current one that was attempting to be released.
+                  else
+                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                    let t1+=1
+                  fi
+                  rm "$f"
+                  mv "$local_f" "$f"
                 fi
-                rm "$f"
-                mv "$local_f" "$f"
-              fi
+            fi
+            rm publish_log
           fi
-          rm publish_log
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -92,12 +92,11 @@ steps:
       do
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
-          checkVersion==${f##*/}
         else
           f=$packageName
-          checkVersion==${f##*/}
         fi
         if [[ $f != "" ]]; then
+          checkVersion=${f##/*}
           checkVersion=${checkVersion:0:-4}
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
@@ -109,8 +108,6 @@ steps:
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
           npm view $checkVersion
-
-          echo "-----------------------"
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -96,47 +96,7 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          checkVersion=${f##*/}
-          echo "Extract File Name I: " $checkVersion
-
-          checkVersion=${checkVersion:0:-4}
-          checkVersion=$(echo ${checkVersion//"***"/fluid})
-
-          echo "Extract File Name II: " $checkVersion
-
-          if [[ $checkVersion == *"fluidframework"* ]]; then
-            echo "FluidFramework Appeared:" $checkVersion
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
-          else
-            echo "FluidFramework Not Appeared:" $checkVersion
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
-          fi
-
-          checkVersion=$(echo $checkVersion | sed -r "s/[*]{3}/fluid/g")
-          echo "Extract File Name III: " $checkVersion
-
-          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
-
-          echo "Extract File Name IV:" $checkVersion
-
-          npm view @fluidframework/tinylicious-client@0.0.0-96564-test
-
-          echo "1----------------------------------"
-
-          npm view @fluidframework/tinylicious-client@1.0.0-96564-test 2>&1 | tee publishError_log
-          if grep -q "npm ERR! code E404" "publishError_log"
-          then
-            echo "Error Raised"
-          fi
-
-          echo "2----------------------------------"
-          npm view $checkVersion
-
-          echo "3----------------------------------"
-          checkVersion=${checkVersion:3}
-          npm view "@fluid"$checkVersion
-
-          echo "4----------------------------------"
+          echo "packageName :" $packageName
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -118,6 +118,7 @@ steps:
           if grep -q "npm ERR!"
             echo $"NPM View Error"
             npm view fluidframework-tinylicious-client-0.0.0-96564-test.tgz
+          fi
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -92,25 +92,27 @@ steps:
       do
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
+          checkVersion=$(find -name "${packageName}-[0-9]*.tgz")
         else
           f=$packageName
+          checkVersion=$packageName
         fi
         if [[ $f != "" ]]; then
-          echo "---------------------------"
-          echo "Check File Name : " $f
-          echo "---------------------------"
+          echo "Check Version : " $checkVersion
 
-          packageVersion=$packageName
-          echo "---------------------------"
-          echo "Before : " $packageVersion
-          echo "---------------------------"
+          checkVersion=${checkVersion:2:-4}
+          checkVersion=${checkVersion//"***"/"fluid"}
 
-          packageVersion=${packageVersion:2:-4}
-          packageVersion=${packageVersion//"***"/"fluid"}
+          if [[ $checkVersion == *"fluidframework"* ]]; then
+            echo "Passed First Case"
+            checkVersion=$(echo $package | sed 's/-/\/''/1')
+          else
+            echo "Passed Second Case"
+            checkVersion=$(echo $package | sed 's/-/\/''/2')
+          fi
 
-          echo "---------------------------"
-          echo "After : " $packageVersion
-          echo "---------------------------"
+          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
+          echo "Final Check : " $checkVersion
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -108,7 +108,7 @@ steps:
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
           checkError=$(npm view $checkVersion)
-          echo $checkError
+          echo "Error : " $checkError
 
           if [[ grep -q "npm ERR!" ]]; then
             echo "Passed"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -100,7 +100,7 @@ steps:
           echo "Extract File Name I: " $checkVersion
 
           checkVersion=${checkVersion:0:-4}
-          checkVersion=$(echo $checkVersion | sed -r "s/[*]{3}/fluid/g")
+          checkVersion=$(echo ${checkVersion//"***"/fluid})
 
           echo "Extract File Name II: " $checkVersion
 
@@ -124,7 +124,7 @@ steps:
           echo "1----------------------------------"
 
           npm view @fluidframework/tinylicious-client@1.0.0-96564-test 2>&1 | tee publishError_log
-          if grep -q "npm ERR!" "publishError_log"
+          if grep -q "npm ERR! code E404" "publishError_log"
           then
             echo "Error Raised"
           fi

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -96,8 +96,13 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
+          echo "Check $f : " $f
+
+          checkFile=$f
           checkFile=${f:2:-4}
           checkFile=${chekFile//"***"/"fluid"}
+
+          echo "Check File : " $checkFile
 
           if [[ $checkFile == *"fluidframework"* ]]; then
             checkFile=$(echo $checkFile | sed 's/-/\/''/1')

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -92,27 +92,26 @@ steps:
       do
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
-          checkVersion=$(find -name "${packageName}-[0-9]*.tgz")
         else
           f=$packageName
-          checkVersion=$packageName
         fi
         if [[ $f != "" ]]; then
-          echo "Check Version : " $checkVersion
+          checkVersion=$${f##*/}
+
+          echo "checkVersion BEFORE : " $checkVersion
 
           checkVersion=${checkVersion:2:-4}
           checkVersion=${checkVersion//"***"/"fluid"}
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
-            echo "Passed First Case"
-            checkVersion=$(echo $package | sed 's/-/\/''/1')
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
           else
-            echo "Passed Second Case"
-            checkVersion=$(echo $package | sed 's/-/\/''/2')
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
           fi
 
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
-          echo "Final Check : " $checkVersion
+
+          echo "checkVersion AFTER : " $checkVersion
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -100,7 +100,7 @@ steps:
           echo "Extract File Name I: " $checkVersion
 
           checkVersion=${checkVersion:0:-4}
-          checkVersion=$(echo $checkVersion | sed -r 's/\*\*\*/fluid/g')
+          checkVersion=$(echo $checkVersion | sed -r "s/[*]{3}/fluid/g")
 
           echo "Extract File Name II: " $checkVersion
 

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -110,33 +110,30 @@ steps:
           checkError=$(npm view $checkVersion)
           echo "Error : " $checkError
 
-          if [[ grep -q "npm ERR!" ]]; then
-            echo "Passed"
-            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-            if grep -q "npm ERR!" "publish_log"
-            then
-                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+          if grep -q "npm ERR!" "publish_log"
+          then
+              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+              then
+                let t1+=1
+              else
+                echo Package has already been published.
+                local_f="${f}_local"
+                mv "$f" "$local_f"
+                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                npm pack $package_name
+                if cmp -s "$f" "$local_f"
                 then
-                  let t1+=1
+                  echo Continuing as published package matches the current one that was attempting to be released.
                 else
-                  echo Package has already been published.
-                  local_f="${f}_local"
-                  mv "$f" "$local_f"
-                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                  npm pack $package_name
-                  if cmp -s "$f" "$local_f"
-                  then
-                    echo Continuing as published package matches the current one that was attempting to be released.
-                  else
-                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                    let t1+=1
-                  fi
-                  rm "$f"
-                  mv "$local_f" "$f"
+                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                  let t1+=1
                 fi
-            fi
-            rm publish_log
+                rm "$f"
+                mv "$local_f" "$f"
+              fi
           fi
+          rm publish_log
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -90,7 +90,8 @@ steps:
         sorted=false
       fi
       echo "------------------------------"
-      echo "NPM List : " npm lit -g
+      echo "NPM List : " npm list -g
+      echo "NPM List : " $(npm list -g)
       echo "------------------------------"
       for packageName in $packages
       do

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -101,7 +101,6 @@ steps:
           echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
-          # checkVersion=${checkVersion:2:-4}
           checkVersion=${checkVersion//"***"/"fluid"}
 
           if [[ $checkVersion == *"fluidframework"* ]]; then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -99,51 +99,43 @@ steps:
           checkVersion=${f##/*}
           checkVersion=${checkVersion:2:-4}
 
-          echo "CheckVersion 0 :" $checkVersion
-
           if [[ $checkVersion == *"fluidframework"* ]]; then
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
           else
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
           fi
 
-          echo "CheckVersion Value I :" $checkVersion
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
-          echo "CheckVersion Value II : " $checkVersion
+          checkError=$(npm view $checkVersion)
 
-          npm view $checkVersion
-
-          echo "-----------------------------------1"
-
-          npm view @fluidframework/tinylicious-client@0.0.0-96564-test
-
-          echo "-----------------------------------2"
-
-          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-          if grep -q "npm ERR!" "publish_log"
-          then
-              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-              then
-                let t1+=1
-              else
-                echo Package has already been published.
-                local_f="${f}_local"
-                mv "$f" "$local_f"
-                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                npm pack $package_name
-                if cmp -s "$f" "$local_f"
+          if [ grep -q "npm ERR!" ] || [ !checkError]; then
+            echo "Passed"
+            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+            if grep -q "npm ERR!" "publish_log"
+            then
+                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
                 then
-                  echo Continuing as published package matches the current one that was attempting to be released.
-                else
-                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
                   let t1+=1
+                else
+                  echo Package has already been published.
+                  local_f="${f}_local"
+                  mv "$f" "$local_f"
+                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                  npm pack $package_name
+                  if cmp -s "$f" "$local_f"
+                  then
+                    echo Continuing as published package matches the current one that was attempting to be released.
+                  else
+                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                    let t1+=1
+                  fi
+                  rm "$f"
+                  mv "$local_f" "$f"
                 fi
-                rm "$f"
-                mv "$local_f" "$f"
-              fi
+            fi
+            rm publish_log
           fi
-          rm publish_log
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -101,12 +101,12 @@ steps:
           echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
-          checkVersion=$(echo $checkVersion | sed -r 's/[*]{3}/fluid/g')
+          checkVersion=$(sed $checkVersion -r 's/[*]{3}/fluid/g')
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
+            checkVersion=$(sed $checkVersion 's/-/\/''/1')
           else
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
+            checkVersion=$(echo $checkVersion 's/-/\/''/2')
           fi
 
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -108,7 +108,10 @@ steps:
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
           checkError=$(npm view $checkVersion)
+          checkTiny=$(npm view @fluidframework/tinylicious-client@0.0.0-96564-test)
+
           echo "Error : " $checkError
+          echo "Tinylicious : " $checkTiny
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -116,6 +116,7 @@ steps:
 
           npm view $checkVersion
           if grep -q "npm ERR!"
+          then
             echo $"NPM View Error"
             npm view @fluidframework/tinylicious-client@0.0.0-96564-test
           fi

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -70,6 +70,7 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     script: |
+      set -x
       tag="--tag canary"
       if [[ "$(release)" == "release" ]]; then
         if [ "$(isLatest)" = "true" ]; then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -131,5 +131,14 @@ steps:
           rm publish_log
         fi
       done
+      k="./***-experimental-property-inspector-0.0.0-95974-test.tgz"
+      echo "***********************************"
+      echo $k
+      echo "***********************************"
+      if [[ "$(npm list -g $f)" =~ "empty" ]]; then
+          echo "Not Installed"
+      else
+          echo "Already Installed"
+      fi
       rm ~/.npmrc
       exit $t1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -109,7 +109,7 @@ steps:
 
           checkError=$(npm view $checkVersion)
 
-          if [ grep -q "npm ERR!" ] || [ !checkError]; then
+          if [[ grep -q "npm ERR!" ] || [ !checkError ]]; then
             echo "Passed"
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -95,8 +95,19 @@ steps:
         else
           f=$packageName
         fi
-        echo "File Name :" $f
         if [[ $f != "" ]]; then
+          checkFile=${f:2:-4}
+          checkFile=${chekFile//"***"/"fluid"}
+
+          if [[ $checkFile == *"fluidframework"* ]]; then
+            checkFile=$(echo $checkFile | sed 's/-/\/''/1')
+          else
+            checkFile=$(echo $checkFile | sed 's/-/\/''/2')
+          fi
+
+          checkFile=@$(echo $checkFile | sed -E 's/-([0-9])/@\1/')
+          echo "Name Format : " $checkFile
+
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"
           then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -101,7 +101,7 @@ steps:
           echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
-          checkVersion=${checkVersion//"***"/"fluid"}
+          checkVersion=$(echo $checkVersion | sed -r 's/[*]{3}/fluid/g')
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,6 +111,13 @@ steps:
           fi
 
           echo "Extract File Name III: " $checkVersion
+          npm view fluidframework/tinylicious-client@0.0.0-96564-test
+
+          npm view fluidframework/tinylicious-client@1.0.0-96564-test
+          if grep -q "npm ERR!"
+          then
+            echo "Error Raised"
+          fi
 
           npm view $checkVersion
 

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,14 +111,19 @@ steps:
           fi
 
           echo "Extract File Name III: " $checkVersion
-          npm view fluidframework/tinylicious-client@0.0.0-96564-test
 
-          npm view fluidframework/tinylicious-client@1.0.0-96564-test
+          npm view @fluidframework/tinylicious-client@0.0.0-96564-test
+
+          echo "1----------------------------------"
+
+          npm view @fluidframework/tinylicious-client@1.0.0-96564-test
           if grep -q "npm ERR!"
           then
             echo "Error Raised"
           fi
 
+          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
+          echo "2----------------------------------"
           npm view $checkVersion
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -109,7 +109,7 @@ steps:
 
           checkError=$(npm view $checkVersion)
 
-          if [[ grep -q "npm ERR!" ] || [ !checkError ]]; then
+          if [[ grep -q "npm ERR!" ] || [ $checkError == "" ]]; then
             echo "Passed"
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -130,15 +130,11 @@ steps:
           fi
           rm publish_log
         fi
-      done
-      k="./***-experimental-property-inspector-0.0.0-95974-test.tgz"
-      echo "***********************************"
-      echo $k
-      echo "***********************************"
-      if [[ "$(npm list -g $f)" =~ "empty" ]]; then
+        if [[ "$(npm list -g $f)" =~ "empty" ]]; then
           echo "Not Installed"
-      else
+        else
           echo "Already Installed"
-      fi
+        fi
+      done
       rm ~/.npmrc
       exit $t1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -114,13 +114,6 @@ steps:
 
           echo "checkVersion AFTER : " $checkVersion
 
-          npm view $checkVersion
-          if grep -q "npm ERR!"
-          then
-            echo $"NPM View Error"
-            npm view @fluidframework/tinylicious-client@0.0.0-96564-test
-          fi
-
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"
           then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -105,9 +105,18 @@ steps:
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
           fi
 
+          echo "CheckVersion Value I :" $checkVersion
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
+          echo "CheckVersion Value II : " $checkVersion
+
           npm view $checkVersion
+
+          echo "-----------------------------------1"
+
+          npm view @fluidframework/tinylicious-client@0.0.0-96564-test
+
+          echo "-----------------------------------2"
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -92,11 +92,25 @@ steps:
       do
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
+          checkVersion==${f##*/}
         else
           f=$packageName
+          checkVersion==${f##*/}
         fi
         if [[ $f != "" ]]; then
-          echo "packageName :" $packageName
+          checkVersion=${checkVersion:0:-4}
+
+          if [[ $checkVersion == *"fluidframework"* ]]; then
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
+          else
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
+          fi
+
+          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
+
+          npm view $checkVersion
+
+          echo "-----------------------"
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -134,7 +134,7 @@ steps:
 
           echo "3----------------------------------"
           checkVersion=${checkVersion:3}
-          npm view "@fluid"$checkVersoin
+          npm view "@fluid"$checkVersion
 
           echo "4----------------------------------"
 

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -101,7 +101,7 @@ steps:
           echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
-          checkVersion=${checkVersion:2:-4}
+          # checkVersion=${checkVersion:2:-4}
           checkVersion=${checkVersion//"***"/"fluid"}
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
@@ -113,6 +113,8 @@ steps:
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
           echo "checkVersion AFTER : " $checkVersion
+
+          npm view $checkVersion
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -102,44 +102,30 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          checkVersion=${f##/*}
-          checkVersion=${checkVersion:2:-4}
-
-          if [[ $checkVersion == *"fluidframework"* ]]; then
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
-          else
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
-          fi
-
-          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
-          checkError=$(npm view $checkVersion)
-
-          if [[ "$checkError" = "" || "$checkError" =~ "npm ERR!" ]]; then
-            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-            if grep -q "npm ERR!" "publish_log"
-            then
-                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+          if grep -q "npm ERR!" "publish_log"
+          then
+              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+              then
+                let t1+=1
+              else
+                echo Package has already been published.
+                local_f="${f}_local"
+                mv "$f" "$local_f"
+                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                npm pack $package_name
+                if cmp -s "$f" "$local_f"
                 then
-                  let t1+=1
+                  echo Continuing as published package matches the current one that was attempting to be released.
                 else
-                  echo Package has already been published.
-                  local_f="${f}_local"
-                  mv "$f" "$local_f"
-                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                  npm pack $package_name
-                  if cmp -s "$f" "$local_f"
-                  then
-                    echo Continuing as published package matches the current one that was attempting to be released.
-                  else
-                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                    let t1+=1
-                  fi
-                  rm "$f"
-                  mv "$local_f" "$f"
+                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                  let t1+=1
                 fi
-            fi
-            rm publish_log
+                rm "$f"
+                mv "$local_f" "$f"
+              fi
           fi
+          rm publish_log
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -105,26 +105,33 @@ steps:
           echo "Extract File Name II: " $checkVersion
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
+            echo "FluidFramework Appeared:" $checkVersion
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
           else
+            echo "FluidFramework Not Appeared:" $checkVersion
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
           fi
 
           echo "Extract File Name III: " $checkVersion
 
+          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
+
+          echo "Extract File Name IV:" $checkVersion
+
           npm view @fluidframework/tinylicious-client@0.0.0-96564-test
 
           echo "1----------------------------------"
 
-          npm view @fluidframework/tinylicious-client@1.0.0-96564-test
-          if grep -q "npm ERR!"
+          npm view @fluidframework/tinylicious-client@1.0.0-96564-test 2>&1 | tee publishError_log
+          if grep -q "npm ERR!" "publishError_log"
           then
             echo "Error Raised"
           fi
 
-          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
           echo "2----------------------------------"
           npm view $checkVersion
+
+          echo "3----------------------------------"
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -96,22 +96,21 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          echo "Check $f : " $f
+          echo "---------------------------"
+          echo "Check File Name : " $f
+          echo "---------------------------"
 
-          checkFile=$f
-          checkFile=${f:2:-4}
-          checkFile=${chekFile//"***"/"fluid"}
+          packageVersion=$packageName
+          echo "---------------------------"
+          echo "Before : " $packageVersion
+          echo "---------------------------"
 
-          echo "Check File : " $checkFile
+          packageVersion=${packageVersion:2:-4}
+          packageVersion=${packageVersion//"***"/"fluid"}
 
-          if [[ $checkFile == *"fluidframework"* ]]; then
-            checkFile=$(echo $checkFile | sed 's/-/\/''/1')
-          else
-            checkFile=$(echo $checkFile | sed 's/-/\/''/2')
-          fi
-
-          checkFile=@$(echo $checkFile | sed -E 's/-([0-9])/@\1/')
-          echo "Name Format : " $checkFile
+          echo "---------------------------"
+          echo "After : " $packageVersion
+          echo "---------------------------"
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -112,6 +112,7 @@ steps:
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
           fi
 
+          checkVersion=$(echo $checkVersion | sed -r "s/[*]{3}/fluid/g")
           echo "Extract File Name III: " $checkVersion
 
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -115,6 +115,9 @@ steps:
           echo "checkVersion AFTER : " $checkVersion
 
           npm view $checkVersion
+          if grep -q "npm ERR!"
+            echo $"NPM View Error"
+            npm view fluidframework-tinylicious-client-0.0.0-96564-test.tgz
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -99,6 +99,8 @@ steps:
           checkVersion=${f##/*}
           checkVersion=${checkVersion:0:-4}
 
+          echo "CheckVersion 0 :" $checkVersion
+
           if [[ $checkVersion == *"fluidframework"* ]]; then
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
           else

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -101,8 +101,8 @@ steps:
           echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
-          checkVersion=$(echo $checkVersion | sed -r 's/[*]{3}/fluid/g')
-          checkVersion=${checkVersion//"***"/"fluid"}
+          checkVersion=$(echo "$checkVersion" | sed -r 's/["*"]{3}/fluid/g')
+          checkVersion=${checkVersion//\*\*\*/fluid}
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -97,26 +97,6 @@ steps:
         fi
         if [[ $f != "" ]]; then
           echo "Passed"
-          # checkVersion=${f##*/}
-
-          # echo "File Name: " $f
-          # echo "checkVersion BEFORE : " $checkVersion
-
-          # checkVersion=${checkVersion:0:-4}
-          # checkVersion=$(echo $checkVersion | sed -r 's/\*\*\*/fluid/g')
-
-          # if [[ $checkVersion == *"fluidframework"* ]]; then
-          #   checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
-          # else
-          #   checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
-          # fi
-
-          # checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
-
-          # echo "checkVersion AFTER : " $checkVersion
-
-          npm view @fluid-tools/fluidapp-odsp-urlresolver@0.0.0-96564-test
-
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"
           then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -88,7 +88,6 @@ steps:
         packages=*.tgz
         sorted=false
       fi
-      echo "Before For"
       for packageName in $packages
       do
         if [[ $sorted == true ]]; then
@@ -96,9 +95,25 @@ steps:
         else
           f=$packageName
         fi
-        echo "After For"
         if [[ $f != "" ]]; then
-          echo "File Exists : " $f
+          checkVersion=${f##*/}
+          echo "Extract File Name I: " $checkVersion
+
+          checkVersion=${checkVersion:0:-4}
+          checkVersion=$(echo $checkVersion | sed -r 's/\*\*\*/fluid/g')
+
+          echo "Extract File Name II: " $checkVersion
+
+          if [[ $checkVersion == *"fluidframework"* ]]; then
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
+          else
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
+          fi
+
+          echo "Extract File Name III: " $checkVersion
+
+          npm view $checkVersion
+
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"
           then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -70,7 +70,6 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     script: |
-      set -x
       tag="--tag canary"
       if [[ "$(release)" == "release" ]]; then
         if [ "$(isLatest)" = "true" ]; then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -89,6 +89,9 @@ steps:
         packages=*.tgz
         sorted=false
       fi
+      echo "------------------------------"
+      echo "NPM List : " npm lit -g
+      echo "------------------------------"
       for packageName in $packages
       do
         if [[ $sorted == true ]]; then
@@ -97,27 +100,32 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
+          echo "------------------------------"
+          echo "Package Name : " $f
+          echo "------------------------------"
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"
           then
-              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-              then
-                let t1+=1
-              else
-                echo Package has already been published.
-                local_f="${f}_local"
-                mv "$f" "$local_f"
-                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                npm pack $package_name
-                if cmp -s "$f" "$local_f"
+              if [[ "$(npm list -g $f)" =~ "empty" ]]; then
+                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
                 then
-                  echo Continuing as published package matches the current one that was attempting to be released.
-                else
-                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
                   let t1+=1
+                else
+                  echo Package has already been published.
+                  local_f="${f}_local"
+                  mv "$f" "$local_f"
+                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                  npm pack $package_name
+                  if cmp -s "$f" "$local_f"
+                  then
+                    echo Continuing as published package matches the current one that was attempting to be released.
+                  else
+                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                    let t1+=1
+                  fi
+                  rm "$f"
+                  mv "$local_f" "$f"
                 fi
-                rm "$f"
-                mv "$local_f" "$f"
               fi
           fi
           rm publish_log

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -96,23 +96,26 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          checkVersion=${f##*/}
+          echo "Passed"
+          # checkVersion=${f##*/}
 
-          echo "File Name: " $f
-          echo "checkVersion BEFORE : " $checkVersion
+          # echo "File Name: " $f
+          # echo "checkVersion BEFORE : " $checkVersion
 
-          checkVersion=${checkVersion:0:-4}
-          checkVersion=$(echo $checkVersion | sed -r 's/\*\*\*/fluid/g')
+          # checkVersion=${checkVersion:0:-4}
+          # checkVersion=$(echo $checkVersion | sed -r 's/\*\*\*/fluid/g')
 
-          if [[ $checkVersion == *"fluidframework"* ]]; then
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
-          else
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
-          fi
+          # if [[ $checkVersion == *"fluidframework"* ]]; then
+          #   checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
+          # else
+          #   checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
+          # fi
 
-          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
+          # checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
 
-          echo "checkVersion AFTER : " $checkVersion
+          # echo "checkVersion AFTER : " $checkVersion
+
+          npm view @fluid-tools/fluidapp-odsp-urlresolver@0.0.0-96564-test
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -133,6 +133,10 @@ steps:
           npm view $checkVersion
 
           echo "3----------------------------------"
+          checkVersion=${checkVersion:3}
+          npm view "@fluid"$checkVersoin
+
+          echo "4----------------------------------"
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
           if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -101,8 +101,8 @@ steps:
           echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
-          checkVersion=$(echo "$checkVersion" | sed -r 's/["*"]{3}/fluid/g')
-          checkVersion=${checkVersion//\*\*\*/fluid}
+          checkVersion=${checkVersion:0:-4}
+          checkVersion=$(echo $checkVersion | sed -r 's/\*\*\*/fluid/g')
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
             checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
@@ -117,7 +117,7 @@ steps:
           npm view $checkVersion
           if grep -q "npm ERR!"
             echo $"NPM View Error"
-            npm view fluidframework-tinylicious-client-0.0.0-96564-test.tgz
+            npm view @fluidframework/tinylicious-client@0.0.0-96564-test
           fi
 
           npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -101,12 +101,13 @@ steps:
           echo "File Name: " $f
           echo "checkVersion BEFORE : " $checkVersion
 
-          checkVersion=$(sed $checkVersion -r 's/[*]{3}/fluid/g')
+          checkVersion=$(echo $checkVersion | sed -r 's/[*]{3}/fluid/g')
+          checkVersion=${checkVersion//"***"/"fluid"}
 
           if [[ $checkVersion == *"fluidframework"* ]]; then
-            checkVersion=$(sed $checkVersion 's/-/\/''/1')
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
           else
-            checkVersion=$(echo $checkVersion 's/-/\/''/2')
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
           fi
 
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')


### PR DESCRIPTION
### Description

665: Ability to Rerun Publish Step If Three Are Any Network Error https://dev.azure.com/fluidframework/internal/_workitems/edit/665/

### Approach

1. `include-publish-npm-package-steps.yml` in `tools/pipelines/templates` directory publishes the package in topological order using the `lerna` library.
2. `packagePublishOrder.txt` is generated inside the `Pipeline.Workspace` and the list of the topologically sorted packages are iterated for publish
3. When iterating through the loop, string variable `checkVersion` extracts the name of the `.tgz` file and goes through conversions listed below  
- `***` are converted to `fluid` 
- if converted to `fluidframework` change the first `-` to `/`, otherwise change the second dash to `/`
- change the last `-` before the first digit to `@`
- add `@` at the beginning and remove the extension `.tgz`
- e.g., `***framework-tinylicious-client-0.0.0-96564-test.tgz` -> `@framework-tinylicious/client@0.0.0-96564-test`
4. Use `npm view $checkVersion` to check whether the package with the specified version number exists in the npm registry
5. If error is detected after the command, package is subject to publish, otherwise does not need to go through the remaining steps