### PR TITLE
[GC-Stress] Added config to run the test twice - After all containers are done and closed, wait for some time, reload them and run the test again.

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -20,10 +20,10 @@
             }
         },
         "gc_ci": {
-            "opRatePerMin": 240,
+            "opRatePerMin": 120,
             "progressIntervalMs": 5000,
             "numClients": 10,
-            "totalSendCount": 72000,
+            "totalSendCount": 10800,
             "inactiveTimeoutMs": [60000],
             "optionOverrides":{
                 "tinylicious":{


### PR DESCRIPTION
## Reviewer guidance
Please note that this is an experiment / prototype in a test branch not in main.

## Description
- Added a new config `rerunDelayMs`. When this is set, the test will load all container and once the containers run to completion, wait for `rerunDelayMs` and do it all over again.
- This is to test scenario where a document is at rest for a while and then re-opened. During the time the document did not have clients, some objects can become inactive or sweep ready, it can have trailing ops that can change the reference state of the system, etc.
- Currently, I set the `rerunDelayMs` to be slightly greater than `inactiveTimeoutMs` so that objects become inactive while the document is at rest.
- Updated the root data stores to run based on localSendCount and not the global counter value. The reason is when the test runs second time, the global counter value is already at totalSendCount so nothing happens.