### PR TITLE
Use named arguments for functions in merge-tree test code

### DIFF
--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -304,8 +304,16 @@ function checkInsertMergeTree(
     let checkText = new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
     checkText = editFlat(checkText, pos, 0, textSegment.text);
     const clockStart = clock();
-    insertText(mergeTree, pos, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber,
-        textSegment.text, undefined, undefined);
+    insertText({
+        mergeTree,
+        pos,
+        refSeq: UniversalSequenceNumber,
+        clientId: LocalClientId,
+        seq: UniversalSequenceNumber,
+        text: textSegment.text,
+        props: undefined,
+        opArgs: undefined,
+    });
     accumTime += elapsedMicroseconds(clockStart);
     const updatedText = new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
     const result = (checkText === updatedText);
@@ -379,8 +387,16 @@ export function mergeTreeLargeTest() {
         const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
         const pos = random.integer(0, preLen)(mt);
         const clockStart = clock();
-        insertText(mergeTree, pos, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber,
-            s, undefined, undefined);
+        insertText({
+            mergeTree,
+            pos,
+            refSeq: UniversalSequenceNumber,
+            clientId: LocalClientId,
+            seq: UniversalSequenceNumber,
+            text: s,
+            props: undefined,
+            opArgs: undefined,
+        });
         accumTime += elapsedMicroseconds(clockStart);
         if ((i > 0) && (0 === (i % 50000))) {
             const perIter = (accumTime / (i + 1)).toFixed(3);
@@ -1728,15 +1744,16 @@ function findReplacePerf(filename: string) {
                     1,
                     false,
                     undefined as any);
-                insertText(
-                    client.mergeTree,
-                    pos + i,
-                    UniversalSequenceNumber,
-                    client.getClientId(),
-                    1,
-                    "teh",
-                    undefined,
-                    undefined);
+                insertText({
+                    mergeTree: client.mergeTree,
+                    pos: pos + i,
+                    refSeq: UniversalSequenceNumber,
+                    clientId: client.getClientId(),
+                    seq: 1,
+                    text: "teh",
+                    props: undefined,
+                    opArgs: undefined,
+                });
                 pos = pos + i + 3;
                 cReplaces++;
             } else {

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -10,6 +10,7 @@ import { Marker, reservedMarkerIdKey, SegmentGroup } from "../mergeTreeNodes";
 import { MergeTreeDeltaType, ReferenceType } from "../ops";
 import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
+import { insertSegments } from "./testUtils";
 
 describe("client.rollback", () => {
     const localUserLongId = "localUser";
@@ -17,13 +18,15 @@ describe("client.rollback", () => {
 
     beforeEach(() => {
         client = new TestClient();
-        client.mergeTree.insertSegments(
-            0,
-            [TextSegment.make("")],
-            UniversalSequenceNumber,
-            client.getClientId(),
-            UniversalSequenceNumber,
-            undefined);
+        insertSegments({
+            mergeTree: client.mergeTree,
+            pos: 0,
+            segments: [TextSegment.make("")],
+            refSeq: UniversalSequenceNumber,
+            clientId: client.getClientId(),
+            seq: UniversalSequenceNumber,
+            opArgs: undefined,
+        });
         client.startOrUpdateCollaboration(localUserLongId);
     });
 

--- a/packages/dds/merge-tree/src/test/client.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.spec.ts
@@ -13,6 +13,7 @@ import { ReferenceType } from "../ops";
 import { reservedTileLabelsKey } from "../referencePositions";
 import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
+import { insertSegments } from "./testUtils";
 
 describe("TestClient", () => {
     const localUserLongId = "localUser";
@@ -20,13 +21,15 @@ describe("TestClient", () => {
 
     beforeEach(() => {
         client = new TestClient();
-        client.mergeTree.insertSegments(
-            0,
-            [TextSegment.make("")],
-            UniversalSequenceNumber,
-            client.getClientId(),
-            UniversalSequenceNumber,
-            undefined);
+        insertSegments({
+            mergeTree: client.mergeTree,
+            pos: 0,
+            segments: [TextSegment.make("")],
+            refSeq: UniversalSequenceNumber,
+            clientId: client.getClientId(),
+            seq: UniversalSequenceNumber,
+            opArgs: undefined,
+        });
         client.startOrUpdateCollaboration(localUserLongId);
     });
 

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
@@ -74,15 +74,16 @@ describe("MergeTree", () => {
         });
 
         it("Annotate over local insertion", () => {
-            insertText(
+            insertText({
                 mergeTree,
-                4,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                "a",
-                undefined,
-                undefined);
+                pos: 4,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                text: "a",
+                props: undefined,
+                opArgs: undefined,
+            });
 
             const count = countOperations(mergeTree);
 
@@ -108,15 +109,16 @@ describe("MergeTree", () => {
             const remoteClientId: number = 35;
             let remoteSequenceNumber = currentSequenceNumber;
 
-            insertText(
+            insertText({
                 mergeTree,
-                4,
-                remoteSequenceNumber,
-                remoteClientId,
-                ++remoteSequenceNumber,
-                "a",
-                undefined,
-                undefined);
+                pos: 4,
+                refSeq: remoteSequenceNumber,
+                clientId: remoteClientId,
+                seq: ++remoteSequenceNumber,
+                text: "a",
+                props: undefined,
+                opArgs: undefined,
+            });
 
             const count = countOperations(mergeTree);
 

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
@@ -9,7 +9,7 @@ import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
 import { TextSegment } from "../textSegment";
 import { MergeTree } from "../mergeTree";
-import { countOperations, insertSegments, insertText } from "./testUtils";
+import { countOperations, insertSegments, insertText, markRangeRemoved } from "./testUtils";
 
 describe("MergeTree", () => {
     let mergeTree: MergeTree;
@@ -146,14 +146,16 @@ describe("MergeTree", () => {
             const remoteClientId: number = 35;
             let remoteSequenceNumber = currentSequenceNumber;
 
-            mergeTree.markRangeRemoved(
-                4,
-                6,
-                remoteSequenceNumber,
-                remoteClientId,
-                ++remoteSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 4,
+                end: 6,
+                refSeq: remoteSequenceNumber,
+                clientId: remoteClientId,
+                seq: ++remoteSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             const count = countOperations(mergeTree);
 
@@ -179,14 +181,16 @@ describe("MergeTree", () => {
             const remoteClientId: number = 35;
             let remoteSequenceNumber = currentSequenceNumber;
 
-            mergeTree.markRangeRemoved(
-                3,
-                8,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 3,
+                end: 8,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             const count = countOperations(mergeTree);
 

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
@@ -9,7 +9,7 @@ import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
 import { TextSegment } from "../textSegment";
 import { MergeTree } from "../mergeTree";
-import { countOperations, insertText } from "./testUtils";
+import { countOperations, insertSegments, insertText } from "./testUtils";
 
 describe("MergeTree", () => {
     let mergeTree: MergeTree;
@@ -17,13 +17,15 @@ describe("MergeTree", () => {
     let currentSequenceNumber: number;
     beforeEach(() => {
         mergeTree = new MergeTree();
-        mergeTree.insertSegments(
-            0,
-            [TextSegment.make("hello world")],
-            UniversalSequenceNumber,
-            LocalClientId,
-            UniversalSequenceNumber,
-            undefined);
+        insertSegments({
+            mergeTree,
+            pos: 0,
+            segments: [TextSegment.make("hello world")],
+            refSeq: UniversalSequenceNumber,
+            clientId: LocalClientId,
+            seq: UniversalSequenceNumber,
+            opArgs: undefined,
+        });
 
         currentSequenceNumber = 0;
         mergeTree.startCollaboration(

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -12,6 +12,7 @@ import { BaseSegment, Marker } from "../mergeTreeNodes";
 import { ICombiningOp, MergeTreeDeltaType, ReferenceType } from "../ops";
 import { TextSegment } from "../textSegment";
 import { MergeTree } from "../mergeTree";
+import { insertSegments } from "./testUtils";
 
 describe("MergeTree", () => {
     let mergeTree: MergeTree;
@@ -26,22 +27,26 @@ describe("MergeTree", () => {
 
     beforeEach(() => {
         mergeTree = new MergeTree();
-        mergeTree.insertSegments(
-            0,
-            [TextSegment.make("hello world!")],
-            UniversalSequenceNumber,
-            LocalClientId,
-            UniversalSequenceNumber,
-            undefined as any);
+        insertSegments({
+            mergeTree,
+            pos: 0,
+            segments: [TextSegment.make("hello world!")],
+            refSeq: UniversalSequenceNumber,
+            clientId: LocalClientId,
+            seq: UniversalSequenceNumber,
+            opArgs: undefined as any,
+        });
 
         currentSequenceNumber = 0;
-        mergeTree.insertSegments(
-            markerPosition,
-            [Marker.make(ReferenceType.Tile)],
-            currentSequenceNumber,
-            remoteClientId,
-            ++currentSequenceNumber,
-            undefined as any);
+        insertSegments({
+            mergeTree,
+            pos: markerPosition,
+            segments: [Marker.make(ReferenceType.Tile)],
+            refSeq: currentSequenceNumber,
+            clientId: remoteClientId,
+            seq: ++currentSequenceNumber,
+            opArgs: undefined as any,
+        });
     });
 
     describe("annotateRange", () => {

--- a/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
@@ -44,15 +44,16 @@ describe("MergeTree", () => {
                     eventCalled++;
                 };
 
-            insertText(
+            insertText({
                 mergeTree,
-                0,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } });
+                pos: 0,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             assert.equal(eventCalled, 1);
         });
@@ -66,15 +67,16 @@ describe("MergeTree", () => {
                     eventCalled++;
                 };
 
-            insertText(
+            insertText({
                 mergeTree,
-                textLength,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } });
+                pos: textLength,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             assert.equal(eventCalled, 1);
         });
@@ -82,15 +84,16 @@ describe("MergeTree", () => {
         it("Insert middle text", () => {
             const count = countOperations(mergeTree);
 
-            insertText(
+            insertText({
                 mergeTree,
-                4,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } });
+                pos: 4,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.INSERT]: 1,
@@ -104,15 +107,16 @@ describe("MergeTree", () => {
 
             const count = countOperations(mergeTree);
 
-            insertText(
+            insertText({
                 mergeTree,
-                0,
-                currentSequenceNumber,
-                remoteClientId,
-                ++remoteSequenceNumber,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } });
+                pos: 0,
+                refSeq: currentSequenceNumber,
+                clientId: remoteClientId,
+                seq: ++remoteSequenceNumber,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.INSERT]: 1,

--- a/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
@@ -127,15 +127,16 @@ describe("MergeTree", () => {
         it("Insert marker", () => {
             const count = countOperations(mergeTree);
 
-            insertMarker(
+            insertMarker({
                 mergeTree,
-                4,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                ReferenceType.Simple,
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } });
+                pos: 4,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                behaviors: ReferenceType.Simple,
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.INSERT]: 1,

--- a/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
@@ -12,7 +12,7 @@ import {
     ReferenceType,
 } from "../ops";
 import { TextSegment } from "../textSegment";
-import { countOperations, insertMarker, insertText } from "./testUtils";
+import { countOperations, insertMarker, insertSegments, insertText } from "./testUtils";
 
 describe("MergeTree", () => {
     let mergeTree: MergeTree;
@@ -20,13 +20,15 @@ describe("MergeTree", () => {
     let currentSequenceNumber: number;
     beforeEach(() => {
         mergeTree = new MergeTree();
-        mergeTree.insertSegments(
-            0,
-            [TextSegment.make("hello world!")],
-            UniversalSequenceNumber,
-            LocalClientId,
-            UniversalSequenceNumber,
-            undefined);
+        insertSegments({
+            mergeTree,
+            pos: 0,
+            segments: [TextSegment.make("hello world!")],
+            refSeq: UniversalSequenceNumber,
+            clientId: LocalClientId,
+            seq: UniversalSequenceNumber,
+            opArgs: undefined,
+        });
 
         currentSequenceNumber = 0;
         mergeTree.startCollaboration(

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -71,15 +71,16 @@ const treeFactories: ITestTreeFactory[] = [
                 undefined);
             for (let i = 1; i < MaxNodesInBlock - 1; i++) {
                 const text = i.toString();
-                insertText(
+                insertText({
                     mergeTree,
-                    mergeTree.getLength(UniversalSequenceNumber, localClientId),
-                    UniversalSequenceNumber,
-                    localClientId,
-                    UniversalSequenceNumber,
+                    pos: mergeTree.getLength(UniversalSequenceNumber, localClientId),
+                    refSeq: UniversalSequenceNumber,
+                    clientId: localClientId,
+                    seq: UniversalSequenceNumber,
                     text,
-                    undefined,
-                    undefined);
+                    props: undefined,
+                    opArgs: undefined,
+                });
                 initialText += text;
             }
 
@@ -126,15 +127,16 @@ const treeFactories: ITestTreeFactory[] = [
                 undefined);
             for (let i = 1; i < MaxNodesInBlock * 4; i++) {
                 const text = i.toString();
-                insertText(
+                insertText({
                     mergeTree,
-                    mergeTree.getLength(UniversalSequenceNumber, localClientId),
-                    UniversalSequenceNumber,
-                    localClientId,
-                    UniversalSequenceNumber,
+                    pos: mergeTree.getLength(UniversalSequenceNumber, localClientId),
+                    refSeq: UniversalSequenceNumber,
+                    clientId: localClientId,
+                    seq: UniversalSequenceNumber,
                     text,
-                    undefined,
-                    undefined);
+                    props: undefined,
+                    opArgs: undefined,
+                });
                 initialText += text;
             }
 
@@ -192,15 +194,16 @@ describe("MergeTree.insertingWalk", () => {
             });
             describe("insertText", () => {
                 it("at beginning", () => {
-                    insertText(
-                        testData.mergeTree,
-                        0,
-                        testData.refSeq,
-                        localClientId,
-                        UnassignedSequenceNumber,
-                        "a",
-                        undefined,
-                        undefined);
+                    insertText({
+                        mergeTree: testData.mergeTree,
+                        pos: 0,
+                        refSeq: testData.refSeq,
+                        clientId: localClientId,
+                        seq: UnassignedSequenceNumber,
+                        text: "a",
+                        props: undefined,
+                        opArgs: undefined,
+                    });
 
                     assert.equal(
                         testData.mergeTree.getLength(testData.refSeq, localClientId),
@@ -213,15 +216,16 @@ describe("MergeTree.insertingWalk", () => {
                 });
 
                 it("at end", () => {
-                    insertText(
-                        testData.mergeTree,
-                        testData.initialText.length,
-                        testData.refSeq,
-                        localClientId,
-                        UnassignedSequenceNumber,
-                        "a",
-                        undefined,
-                        undefined);
+                    insertText({
+                        mergeTree: testData.mergeTree,
+                        pos: testData.initialText.length,
+                        refSeq: testData.refSeq,
+                        clientId: localClientId,
+                        seq: UnassignedSequenceNumber,
+                        text: "a",
+                        props: undefined,
+                        opArgs: undefined,
+                    });
 
                     assert.equal(
                         testData.mergeTree.getLength(testData.refSeq, localClientId),
@@ -234,15 +238,16 @@ describe("MergeTree.insertingWalk", () => {
                 });
 
                 it("in middle", () => {
-                    insertText(
-                        testData.mergeTree,
-                        testData.middle,
-                        testData.refSeq,
-                        localClientId,
-                        UnassignedSequenceNumber,
-                        "a",
-                        undefined,
-                        undefined);
+                    insertText({
+                        mergeTree: testData.mergeTree,
+                        pos: testData.middle,
+                        refSeq: testData.refSeq,
+                        clientId: localClientId,
+                        seq: UnassignedSequenceNumber,
+                        text: "a",
+                        props: undefined,
+                        opArgs: undefined,
+                    });
 
                     assert.equal(
                         testData.mergeTree.getLength(testData.refSeq, localClientId),
@@ -275,15 +280,16 @@ describe("MergeTree.insertingWalk", () => {
             undefined);
         for (let i = 1; i < MaxNodesInBlock; i++) {
             const text = String.fromCharCode(i + 64);
-            insertText(
+            insertText({
                 mergeTree,
-                0,
-                UniversalSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
+                pos: 0,
+                refSeq: UniversalSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
                 text,
-                undefined,
-                undefined);
+                props: undefined,
+                opArgs: undefined,
+            });
             initialText += text;
         }
 
@@ -306,14 +312,14 @@ describe("MergeTree.insertingWalk", () => {
         // all segments but the 0 are unacked, this insert should place the segment directly
         // before the 0. Prior to this regression test, an issue with `rightExcursion` in the
         // merge conflict logic instead caused the segment to be placed before the removed segments.
-        insertText(
+        insertText({
             mergeTree,
-            0,
-            UniversalSequenceNumber,
-            localClientId + 1,
-            ++seq,
-            "x",
-        );
+            pos: 0,
+            refSeq: UniversalSequenceNumber,
+            clientId: localClientId + 1,
+            seq: ++seq,
+            text: "x",
+        });
 
         const segments: string[] = [];
         mergeTree.walkAllSegments(mergeTree.root, (seg) => {

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -16,7 +16,7 @@ import {
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
 import { MergeTree } from "../mergeTree";
 import { MergeTreeTextHelper } from "../MergeTreeTextHelper";
-import { insertText, nodeOrdinalsHaveIntegrity } from "./testUtils";
+import { insertSegments, insertText, nodeOrdinalsHaveIntegrity } from "./testUtils";
 
 interface ITestTreeFactory {
     readonly create: () => ITestData;
@@ -37,13 +37,15 @@ const treeFactories: ITestTreeFactory[] = [
         create: () => {
             const initialText = "hello world";
             const mergeTree = new MergeTree();
-            mergeTree.insertSegments(
-                0,
-                [TextSegment.make(initialText)],
-                UniversalSequenceNumber,
-                LocalClientId,
-                UniversalSequenceNumber,
-                undefined);
+            insertSegments({
+                mergeTree,
+                pos: 0,
+                segments: [TextSegment.make(initialText)],
+                refSeq: UniversalSequenceNumber,
+                clientId: LocalClientId,
+                seq: UniversalSequenceNumber,
+                opArgs: undefined,
+            });
             mergeTree.startCollaboration(
                 localClientId,
                 /* minSeq: */ UniversalSequenceNumber,
@@ -62,13 +64,15 @@ const treeFactories: ITestTreeFactory[] = [
         create: () => {
             let initialText = "0";
             const mergeTree = new MergeTree();
-            mergeTree.insertSegments(
-                0,
-                [TextSegment.make(initialText)],
-                UniversalSequenceNumber,
-                LocalClientId,
-                UniversalSequenceNumber,
-                undefined);
+            insertSegments({
+                mergeTree,
+                pos: 0,
+                segments: [TextSegment.make(initialText)],
+                refSeq: UniversalSequenceNumber,
+                clientId: LocalClientId,
+                seq: UniversalSequenceNumber,
+                opArgs: undefined,
+            });
             for (let i = 1; i < MaxNodesInBlock - 1; i++) {
                 const text = i.toString();
                 insertText({
@@ -118,13 +122,15 @@ const treeFactories: ITestTreeFactory[] = [
         create: () => {
             let initialText = "0";
             const mergeTree = new MergeTree();
-            mergeTree.insertSegments(
-                0,
-                [TextSegment.make(initialText)],
-                UniversalSequenceNumber,
-                LocalClientId,
-                UniversalSequenceNumber,
-                undefined);
+            insertSegments({
+                mergeTree,
+                pos: 0,
+                segments: [TextSegment.make(initialText)],
+                refSeq: UniversalSequenceNumber,
+                clientId: LocalClientId,
+                seq: UniversalSequenceNumber,
+                opArgs: undefined,
+            });
             for (let i = 1; i < MaxNodesInBlock * 4; i++) {
                 const text = i.toString();
                 insertText({
@@ -271,13 +277,15 @@ describe("MergeTree.insertingWalk", () => {
         let seq = 0;
         const mergeTree = new MergeTree();
         mergeTree.startCollaboration(localClientId, 0, seq);
-        mergeTree.insertSegments(
-            0,
-            [TextSegment.make(initialText)],
-            UniversalSequenceNumber,
-            localClientId,
-            UniversalSequenceNumber,
-            undefined);
+        insertSegments({
+            mergeTree,
+            pos: 0,
+            segments: [TextSegment.make(initialText)],
+            refSeq: UniversalSequenceNumber,
+            clientId: localClientId,
+            seq: UniversalSequenceNumber,
+            opArgs: undefined,
+        });
         for (let i = 1; i < MaxNodesInBlock; i++) {
             const text = String.fromCharCode(i + 64);
             insertText({

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
@@ -10,7 +10,7 @@ import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback";
 import { MergeTreeDeltaType } from "../ops";
 import { TextSegment } from "../textSegment";
 import { MergeTree } from "../mergeTree";
-import { countOperations, insertSegments } from "./testUtils";
+import { countOperations, insertSegments, markRangeRemoved } from "./testUtils";
 
 describe("MergeTree", () => {
     let mergeTree: MergeTree;
@@ -38,14 +38,16 @@ describe("MergeTree", () => {
         it("Event on Removal", () => {
             const count = countOperations(mergeTree);
 
-            mergeTree.markRangeRemoved(
-                4,
-                6,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 4,
+                end: 6,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.REMOVE]: 1,
@@ -60,14 +62,16 @@ describe("MergeTree", () => {
             const start = 4;
             const end = 6;
 
-            mergeTree.markRangeRemoved(
+            markRangeRemoved({
+                mergeTree,
                 start,
                 end,
-                /* refSeq: */ currentSequenceNumber,
-                /* clientId: */ localClientId,
-                /* seq: */ UnassignedSequenceNumber,
-                /* overwrite: */ false,
-                /* opArgs */ undefined as any);
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             // In order for the removed segment to unlinked by zamboni, we need to ACK the segment
             // and advance the collaboration window's minSeq past the removedSeq.
@@ -99,25 +103,29 @@ describe("MergeTree", () => {
             const remoteClientId: number = 35;
             let remoteSequenceNumber = currentSequenceNumber;
 
-            mergeTree.markRangeRemoved(
-                4,
-                6,
-                remoteSequenceNumber,
-                remoteClientId,
-                ++remoteSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 4,
+                end: 6,
+                refSeq: remoteSequenceNumber,
+                clientId: remoteClientId,
+                seq: ++remoteSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             const count = countOperations(mergeTree);
 
-            mergeTree.markRangeRemoved(
-                3,
-                5,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 3,
+                end: 5,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.REMOVE]: 1,
@@ -129,25 +137,29 @@ describe("MergeTree", () => {
             const remoteClientId: number = 35;
             let remoteSequenceNumber = currentSequenceNumber;
 
-            mergeTree.markRangeRemoved(
-                4,
-                6,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 4,
+                end: 6,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             const count = countOperations(mergeTree);
 
-            mergeTree.markRangeRemoved(
-                3,
-                5,
-                remoteSequenceNumber,
-                remoteClientId,
-                ++remoteSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 3,
+                end: 5,
+                refSeq: remoteSequenceNumber,
+                clientId: remoteClientId,
+                seq: ++remoteSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.REMOVE]: 1,
@@ -159,25 +171,29 @@ describe("MergeTree", () => {
             const remoteClientId: number = 35;
             let remoteSequenceNumber = currentSequenceNumber;
 
-            mergeTree.markRangeRemoved(
-                3,
-                6,
-                currentSequenceNumber,
-                localClientId,
-                UnassignedSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 3,
+                end: 6,
+                refSeq: currentSequenceNumber,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             const count = countOperations(mergeTree);
 
-            mergeTree.markRangeRemoved(
-                4,
-                5,
-                remoteSequenceNumber,
-                remoteClientId,
-                ++remoteSequenceNumber,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 4,
+                end: 5,
+                refSeq: remoteSequenceNumber,
+                clientId: remoteClientId,
+                seq: ++remoteSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             assert.deepStrictEqual(count, {
                 /* MergeTreeDeltaType.REMOVE is absent as it should not be fired. */

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
@@ -10,7 +10,7 @@ import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback";
 import { MergeTreeDeltaType } from "../ops";
 import { TextSegment } from "../textSegment";
 import { MergeTree } from "../mergeTree";
-import { countOperations } from "./testUtils";
+import { countOperations, insertSegments } from "./testUtils";
 
 describe("MergeTree", () => {
     let mergeTree: MergeTree;
@@ -18,13 +18,15 @@ describe("MergeTree", () => {
     let currentSequenceNumber: number;
     beforeEach(() => {
         mergeTree = new MergeTree();
-        mergeTree.insertSegments(
-            0,
-            [TextSegment.make("hello world!")],
-            UniversalSequenceNumber,
-            LocalClientId,
-            UniversalSequenceNumber,
-            undefined);
+        insertSegments({
+            mergeTree,
+            pos: 0,
+            segments: [TextSegment.make("hello world!")],
+            refSeq: UniversalSequenceNumber,
+            clientId: LocalClientId,
+            seq: UniversalSequenceNumber,
+            opArgs: undefined,
+        });
         currentSequenceNumber = 0;
         mergeTree.startCollaboration(
             localClientId,

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -52,29 +52,29 @@ describe.skip("obliterate", () => {
                 false,
                 undefined as any,
             );
-            insertText(
-                client.mergeTree,
-                0,
+            insertText({
+                mergeTree: client.mergeTree,
+                pos: 0,
                 refSeq,
-                remoteClientId + 1,
-                refSeq + 2,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                clientId: remoteClientId + 1,
+                seq: refSeq + 2,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
             assert.equal(client.getText(), "");
         });
         it("removes text for insert then obliterate", () => {
-            insertText(
-                client.mergeTree,
-                0,
+            insertText({
+                mergeTree: client.mergeTree,
+                pos: 0,
                 refSeq,
-                remoteClientId + 1,
-                refSeq + 1,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                clientId: remoteClientId + 1,
+                seq: refSeq + 1,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
             client.obliterateRange(
                 0,
                 "hello world".length,
@@ -99,16 +99,16 @@ describe.skip("obliterate", () => {
                 false,
                 undefined as any,
             );
-            insertText(
-                client.mergeTree,
-                5,
+            insertText({
+                mergeTree: client.mergeTree,
+                pos: 5,
                 refSeq,
-                remoteClientId + 1,
-                refSeq + 2,
-                " world",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                clientId: remoteClientId + 1,
+                seq: refSeq + 2,
+                text: " world",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
             assert.equal(client.getText(), "hello world");
         });
         it("does not expand to include text inserted at end", () => {
@@ -121,16 +121,16 @@ describe.skip("obliterate", () => {
                 false,
                 undefined as any,
             );
-            insertText(
-                client.mergeTree,
-                5,
+            insertText({
+                mergeTree: client.mergeTree,
+                pos: 5,
                 refSeq,
-                remoteClientId + 1,
-                refSeq + 2,
-                "hello",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                clientId: remoteClientId + 1,
+                seq: refSeq + 2,
+                text: "hello",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
             assert.equal(client.getText(), "hello world");
         });
     });
@@ -146,16 +146,16 @@ describe.skip("obliterate", () => {
                 false,
                 undefined as any,
             );
-            insertText(
-                client.mergeTree,
-                0,
+            insertText({
+                mergeTree: client.mergeTree,
+                pos: 0,
                 refSeq,
-                remoteClientId,
-                refSeq + 2,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                clientId: remoteClientId,
+                seq: refSeq + 2,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
             assert.equal(client.getText(), "");
         });
     });

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -29,29 +29,29 @@ describe.skip("obliterate", () => {
     });
 
     it("removes text", () => {
-        client.obliterateRange(
-            0,
-            client.getLength(),
+        client.obliterateRange({
+            start: 0,
+            end: client.getLength(),
             refSeq,
-            localClientId,
-            refSeq + 1,
-            false,
-            undefined as any,
-        );
+            clientId: localClientId,
+            seq: refSeq + 1,
+            overwrite: false,
+            opArgs: undefined as any,
+        });
         assert.equal(client.getText(), "");
     });
 
     describe("concurrent obliterate and insert", () => {
         it("removes text for obliterate then insert", () => {
-            client.obliterateRange(
-                0,
-                client.getLength(),
+            client.obliterateRange({
+                start: 0,
+                end: client.getLength(),
                 refSeq,
-                remoteClientId,
-                refSeq + 1,
-                false,
-                undefined as any,
-            );
+                clientId: remoteClientId,
+                seq: refSeq + 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
             insertText({
                 mergeTree: client.mergeTree,
                 pos: 0,
@@ -75,30 +75,30 @@ describe.skip("obliterate", () => {
                 props: undefined,
                 opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
             });
-            client.obliterateRange(
-                0,
-                "hello world".length,
+            client.obliterateRange({
+                start: 0,
+                end: "hello world".length,
                 refSeq,
-                remoteClientId,
-                refSeq + 2,
-                false,
-                undefined as any,
-            );
+                clientId: remoteClientId,
+                seq: refSeq + 2,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
             assert.equal(client.getText(), "");
         });
     });
 
     describe("endpoint behavior", () => {
         it("does not expand to include text inserted at start", () => {
-            client.obliterateRange(
-                5,
-                client.getLength(),
+            client.obliterateRange({
+                start: 5,
+                end: client.getLength(),
                 refSeq,
-                remoteClientId,
-                refSeq + 1,
-                false,
-                undefined as any,
-            );
+                clientId: remoteClientId,
+                seq: refSeq + 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
             insertText({
                 mergeTree: client.mergeTree,
                 pos: 5,
@@ -112,15 +112,15 @@ describe.skip("obliterate", () => {
             assert.equal(client.getText(), "hello world");
         });
         it("does not expand to include text inserted at end", () => {
-            client.obliterateRange(
-                0,
-                5,
+            client.obliterateRange({
+                start: 0,
+                end: 5,
                 refSeq,
-                remoteClientId,
-                refSeq + 1,
-                false,
-                undefined as any,
-            );
+                clientId: remoteClientId,
+                seq: refSeq + 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
             insertText({
                 mergeTree: client.mergeTree,
                 pos: 5,
@@ -137,15 +137,15 @@ describe.skip("obliterate", () => {
 
     describe("local obliterate with concurrent inserts", () => {
         it("removes range when pending local obliterate op", () => {
-            client.obliterateRange(
-                0,
-                "hello world".length,
+            client.obliterateRange({
+                start: 0,
+                end: "hello world".length,
                 refSeq,
-                localClientId,
-                UnassignedSequenceNumber,
-                false,
-                undefined as any,
-            );
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
             insertText({
                 mergeTree: client.mergeTree,
                 pos: 0,

--- a/packages/dds/merge-tree/src/test/partialLength.spec.ts
+++ b/packages/dds/merge-tree/src/test/partialLength.spec.ts
@@ -97,58 +97,58 @@ describe("partial lengths", () => {
 
     describe("a single inserted element", () => {
         it("includes length of local insert for local view", () => {
-            insertText(
+            insertText({
                 mergeTree,
-                0,
-                0,
-                localClientId,
-                1,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                pos: 0,
+                refSeq: 0,
+                clientId: localClientId,
+                seq: 1,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             validatePartialLengths(localClientId, [{ seq: 1, len: 17 }]);
         });
         it("includes length of local insert for remote view", () => {
-            insertText(
+            insertText({
                 mergeTree,
-                0,
-                0,
-                localClientId,
-                1,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                pos: 0,
+                refSeq: 0,
+                clientId: localClientId,
+                seq: 1,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             validatePartialLengths(remoteClientId, [{ seq: 1, len: 17 }]);
         });
         it("includes length of remote insert for local view", () => {
-            insertText(
+            insertText({
                 mergeTree,
-                0,
-                0,
-                remoteClientId,
-                1,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                pos: 0,
+                refSeq: 0,
+                clientId: remoteClientId,
+                seq: 1,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             validatePartialLengths(localClientId, [{ seq: 1, len: 17 }]);
         });
         it("includes length of remote insert for remote view", () => {
-            insertText(
+            insertText({
                 mergeTree,
-                0,
-                0,
-                remoteClientId,
-                1,
-                "more ",
-                undefined,
-                { op: { type: MergeTreeDeltaType.INSERT } },
-            );
+                pos: 0,
+                refSeq: 0,
+                clientId: remoteClientId,
+                seq: 1,
+                text: "more ",
+                props: undefined,
+                opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+            });
 
             validatePartialLengths(remoteClientId, [{ seq: 1, len: 17 }]);
         });
@@ -246,16 +246,16 @@ describe("partial lengths", () => {
 
         it("is correct for different heights", () => {
             for (let i = 0; i < 100; i++) {
-                insertText(
+                insertText({
                     mergeTree,
-                    0,
-                    i,
-                    localClientId,
-                    i + 1,
-                    "a",
-                    undefined,
-                    { op: { type: MergeTreeDeltaType.INSERT } },
-                );
+                    pos: 0,
+                    refSeq: i,
+                    clientId: localClientId,
+                    seq: i + 1,
+                    text: "a",
+                    props: undefined,
+                    opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+                });
 
                 validatePartialLengths(localClientId, [{ seq: i + 1, len: i + 13 }]);
                 validatePartialLengths(remoteClientId, [{ seq: i + 1, len: i + 13 }]);

--- a/packages/dds/merge-tree/src/test/partialLength.spec.ts
+++ b/packages/dds/merge-tree/src/test/partialLength.spec.ts
@@ -9,7 +9,7 @@ import { MergeTree } from "../mergeTree";
 import { MergeTreeDeltaType } from "../ops";
 import { PartialSequenceLengths } from "../partialLengths";
 import { TextSegment } from "../textSegment";
-import { insertText } from "./testUtils";
+import { insertSegments, insertText } from "./testUtils";
 
 describe("partial lengths", () => {
     let mergeTree: MergeTree;
@@ -73,13 +73,15 @@ describe("partial lengths", () => {
     beforeEach(() => {
         PartialSequenceLengths.options.verify = true;
         mergeTree = new MergeTree();
-        mergeTree.insertSegments(
-            0,
-            [TextSegment.make("hello world!")],
-            0,
-            localClientId,
-            0,
-            undefined);
+        insertSegments({
+            mergeTree,
+            pos: 0,
+            segments: [TextSegment.make("hello world!")],
+            refSeq: 0,
+            clientId: localClientId,
+            seq: 0,
+            opArgs: undefined,
+        });
 
         mergeTree.startCollaboration(
             localClientId,
@@ -207,38 +209,42 @@ describe("partial lengths", () => {
 
     describe("aggregation", () => {
         it("includes lengths from multiple permutations in single tree", () => {
-            mergeTree.insertSegments(
-                0,
-                [TextSegment.make("1")],
-                0,
-                localClientId,
-                1,
-                undefined,
-            );
-            mergeTree.insertSegments(
-                0,
-                [TextSegment.make("2")],
-                1,
-                remoteClientId,
-                2,
-                undefined,
-            );
-            mergeTree.insertSegments(
-                0,
-                [TextSegment.make("3")],
-                2,
-                localClientId,
-                3,
-                undefined,
-            );
-            mergeTree.insertSegments(
-                0,
-                [TextSegment.make("4")],
-                3,
-                remoteClientId,
-                4,
-                undefined,
-            );
+            insertSegments({
+                mergeTree,
+                pos: 0,
+                segments: [TextSegment.make("1")],
+                refSeq: 0,
+                clientId: localClientId,
+                seq: 1,
+                opArgs: undefined,
+            });
+            insertSegments({
+                mergeTree,
+                pos: 0,
+                segments: [TextSegment.make("2")],
+                refSeq: 1,
+                clientId: remoteClientId,
+                seq: 2,
+                opArgs: undefined,
+            });
+            insertSegments({
+                mergeTree,
+                pos: 0,
+                segments: [TextSegment.make("3")],
+                refSeq: 2,
+                clientId: localClientId,
+                seq: 3,
+                opArgs: undefined,
+            });
+            insertSegments({
+                mergeTree,
+                pos: 0,
+                segments: [TextSegment.make("4")],
+                refSeq: 3,
+                clientId: remoteClientId,
+                seq: 4,
+                opArgs: undefined,
+            });
 
             validatePartialLengths(localClientId, [{ seq: 4, len: 16 }]);
             validatePartialLengths(remoteClientId, [{ seq: 4, len: 16 }]);

--- a/packages/dds/merge-tree/src/test/partialLength.spec.ts
+++ b/packages/dds/merge-tree/src/test/partialLength.spec.ts
@@ -9,7 +9,7 @@ import { MergeTree } from "../mergeTree";
 import { MergeTreeDeltaType } from "../ops";
 import { PartialSequenceLengths } from "../partialLengths";
 import { TextSegment } from "../textSegment";
-import { insertSegments, insertText } from "./testUtils";
+import { insertSegments, insertText, markRangeRemoved } from "./testUtils";
 
 describe("partial lengths", () => {
     let mergeTree: MergeTree;
@@ -158,50 +158,58 @@ describe("partial lengths", () => {
 
     describe("a single removed segment", () => {
         it("includes result of local delete for local view", () => {
-            mergeTree.markRangeRemoved(
-                0,
-                12,
-                0,
-                localClientId,
-                1,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 12,
+                refSeq: 0,
+                clientId: localClientId,
+                seq: 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             validatePartialLengths(localClientId, [{ seq: 0, len: 0 }]);
         });
         it("includes result of local delete for remote view", () => {
-            mergeTree.markRangeRemoved(
-                0,
-                12,
-                0,
-                localClientId,
-                1,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 12,
+                refSeq: 0,
+                clientId: localClientId,
+                seq: 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             validatePartialLengths(remoteClientId, [{ seq: 1, len: 0 }]);
         });
         it("includes result of remote delete for local view", () => {
-            mergeTree.markRangeRemoved(
-                0,
-                12,
-                0,
-                remoteClientId,
-                1,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 12,
+                refSeq: 0,
+                clientId: remoteClientId,
+                seq: 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             validatePartialLengths(localClientId, [{ seq: 1, len: 0 }]);
         });
         it("includes result of remote delete for remote view", () => {
-            mergeTree.markRangeRemoved(
-                0,
-                12,
-                0,
-                remoteClientId,
-                1,
-                false,
-                undefined as any);
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 12,
+                refSeq: 0,
+                clientId: remoteClientId,
+                seq: 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             validatePartialLengths(remoteClientId, [{ seq: 0, len: 0 }]);
         });
@@ -274,69 +282,75 @@ describe("partial lengths", () => {
 
     describe("concurrent, overlapping deletes", () => {
         it("concurrent remote changes are visible to local", () => {
-            mergeTree.markRangeRemoved(
-                0,
-                10,
-                0,
-                remoteClientId,
-                1,
-                false,
-                undefined as any,
-            );
-            mergeTree.markRangeRemoved(
-                0,
-                10,
-                0,
-                remoteClientId + 1,
-                2,
-                false,
-                undefined as any,
-            );
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 10,
+                refSeq: 0,
+                clientId: remoteClientId,
+                seq: 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 10,
+                refSeq: 0,
+                clientId: remoteClientId + 1,
+                seq: 2,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             validatePartialLengths(localClientId, [{ seq: 1, len: 2 }]);
         });
         it("concurrent local and remote changes are visible", () => {
-            mergeTree.markRangeRemoved(
-                0,
-                10,
-                0,
-                localClientId,
-                1,
-                false,
-                undefined as any,
-            );
-            mergeTree.markRangeRemoved(
-                0,
-                10,
-                0,
-                remoteClientId,
-                2,
-                false,
-                undefined as any,
-            );
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 10,
+                refSeq: 0,
+                clientId: localClientId,
+                seq: 1,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 10,
+                refSeq: 0,
+                clientId: remoteClientId,
+                seq: 2,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             validatePartialLengths(localClientId, [{ seq: 0, len: 2 }]);
             validatePartialLengths(remoteClientId, [{ seq: 0, len: 2 }]);
         });
         it("concurrent remote and unsequenced local changes are visible", () => {
-            mergeTree.markRangeRemoved(
-                0,
-                10,
-                0,
-                localClientId,
-                UnassignedSequenceNumber,
-                false,
-                undefined as any,
-            );
-            mergeTree.markRangeRemoved(
-                0,
-                10,
-                0,
-                remoteClientId,
-                2,
-                false,
-                undefined as any,
-            );
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 10,
+                refSeq: 0,
+                clientId: localClientId,
+                seq: UnassignedSequenceNumber,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
+            markRangeRemoved({
+                mergeTree,
+                start: 0,
+                end: 10,
+                refSeq: 0,
+                clientId: remoteClientId,
+                seq: 2,
+                overwrite: false,
+                opArgs: undefined as any,
+            });
 
             validatePartialLengths(localClientId, [{ seq: 0, len: 2 }]);
             validatePartialLengths(remoteClientId, [{ seq: 0, len: 2 }]);

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -121,15 +121,15 @@ export class TestClient extends Client {
     /**
      * @internal
      */
-    public obliterateRange(
-        start: number,
-        end: number,
-        refSeq: number,
-        clientId: number,
-        seq: number,
-        overwrite = false,
-        opArgs: IMergeTreeDeltaOpArgs,
-    ): void {
+    public obliterateRange({ start, end, refSeq, clientId, seq, overwrite = false, opArgs }: {
+        start: number;
+        end: number;
+        refSeq: number;
+        clientId: number;
+        seq: number;
+        overwrite?: boolean;
+        opArgs: IMergeTreeDeltaOpArgs;
+    }): void {
         this.mergeTree.markRangeRemoved(start, end, refSeq, clientId, seq, overwrite, opArgs);
     }
 

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -97,6 +97,30 @@ export function insertSegments({
     mergeTree.insertSegments(pos, segments, refSeq, clientId, seq, opArgs);
 }
 
+interface MarkRangeRemovedArgs {
+    mergeTree: MergeTree;
+    start: number;
+    end: number;
+    refSeq: number;
+    clientId: number;
+    seq: number;
+    overwrite: boolean;
+    opArgs: IMergeTreeDeltaOpArgs;
+}
+
+export function markRangeRemoved({
+    mergeTree,
+    start,
+    end,
+    refSeq,
+    clientId,
+    seq,
+    overwrite = false,
+    opArgs,
+}: MarkRangeRemovedArgs): void {
+    mergeTree.markRangeRemoved(start, end, refSeq, clientId, seq, overwrite, opArgs);
+}
+
 export function nodeOrdinalsHaveIntegrity(block: IMergeBlock): boolean {
     const olen = block.ordinal.length;
     for (let i = 0; i < block.childCount; i++) {

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -37,16 +37,27 @@ export function insertMarker(
     mergeTree.insertSegments(pos, [Marker.make(behaviors, props)], refSeq, clientId, seq, opArgs);
 }
 
-export function insertText(
-    mergeTree: MergeTree,
-    pos: number,
-    refSeq: number,
-    clientId: number,
-    seq: number,
-    text: string,
-    props?: PropertySet,
-    opArgs?: IMergeTreeDeltaOpArgs,
-) {
+interface InsertTextArgs {
+    mergeTree: MergeTree;
+    pos: number;
+    refSeq: number;
+    clientId: number;
+    seq: number;
+    text: string;
+    props?: PropertySet;
+    opArgs?: IMergeTreeDeltaOpArgs;
+}
+
+export function insertText({
+    mergeTree,
+    pos,
+    refSeq,
+    clientId,
+    seq,
+    text,
+    props,
+    opArgs,
+}: InsertTextArgs) {
     mergeTree.insertSegments(pos, [TextSegment.make(text, props)], refSeq, clientId, seq, opArgs);
 }
 

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "assert";
 import fs from "fs";
 import {
     IMergeBlock,
+    ISegment,
     Marker,
 } from "../mergeTreeNodes";
 import { IMergeTreeDeltaOpArgs } from "../mergeTreeDeltaCallback";
@@ -72,6 +73,28 @@ export function insertText({
     opArgs,
 }: InsertTextArgs) {
     mergeTree.insertSegments(pos, [TextSegment.make(text, props)], refSeq, clientId, seq, opArgs);
+}
+
+interface InsertSegmentsArgs {
+    mergeTree: MergeTree;
+    pos: number;
+    segments: ISegment[];
+    refSeq: number;
+    clientId: number;
+    seq: number;
+    opArgs: IMergeTreeDeltaOpArgs | undefined;
+}
+
+export function insertSegments({
+    mergeTree,
+    pos,
+    segments,
+    refSeq,
+    clientId,
+    seq,
+    opArgs,
+}: InsertSegmentsArgs): void {
+    mergeTree.insertSegments(pos, segments, refSeq, clientId, seq, opArgs);
 }
 
 export function nodeOrdinalsHaveIntegrity(block: IMergeBlock): boolean {

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -26,14 +26,27 @@ export function loadTextFromFileWithMarkers(filename: string, mergeTree: MergeTr
     return loadText(content, mergeTree, segLimit, true);
 }
 
-export function insertMarker(
-    mergeTree: MergeTree,
-    pos: number,
-    refSeq: number,
-    clientId: number,
-    seq: number,
-    behaviors: ReferenceType, props: PropertySet | undefined, opArgs: IMergeTreeDeltaOpArgs,
-) {
+interface InsertMarkerArgs {
+    mergeTree: MergeTree;
+    pos: number;
+    refSeq: number;
+    clientId: number;
+    seq: number;
+    behaviors: ReferenceType;
+    props: PropertySet | undefined;
+    opArgs: IMergeTreeDeltaOpArgs;
+}
+
+export function insertMarker({
+    mergeTree,
+    pos,
+    refSeq,
+    clientId,
+    seq,
+    behaviors,
+    props,
+    opArgs,
+}: InsertMarkerArgs) {
     mergeTree.insertSegments(pos, [Marker.make(behaviors, props)], refSeq, clientId, seq, opArgs);
 }
 


### PR DESCRIPTION
## Description

Change the signature of helper functions taking in a large number of arguments to accept a single object, allowing us to give names to all arguments when passing them in.

[ado 2058](https://dev.azure.com/fluidframework/internal/_workitems/edit/2058/)