### PR TITLE
Binary snapshots: Proper recovery when strings have \0 in them

### DIFF
--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -510,7 +510,7 @@ export class NodeCore {
         assert(length === stringBuffer.length, "properly encoded");
 
         const result = Uint8ArrayToString(stringBuffer, "utf-8").split(String.fromCharCode(0));
-        if (result.length === stringsToResolve.length) {
+        if (result.length === stringsToResolve.length + 1) {
             // All is good, we expect all the cases to get here
             for (let i = 0; i < stringsToResolve.length; i++) {
                 stringsToResolve[i].content = result[i];

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -507,15 +507,16 @@ export class NodeCore {
             stringBuffer[length] = 0;
             length++;
         }
+        assert(length === stringBuffer.length, "properly encoded");
 
-        if (length === stringBuffer.length) {
+        const result = Uint8ArrayToString(stringBuffer, "utf-8").split(String.fromCharCode(0));
+        if (result.length === stringsToResolve.length) {
             // All is good, we expect all the cases to get here
-            const result = Uint8ArrayToString(stringBuffer, "utf-8").split(String.fromCharCode(0));
-            assert(result.length === stringsToResolve.length + 1, 0x3e9 /* String content has \0 chars! */);
             for (let i = 0; i < stringsToResolve.length; i++) {
                 stringsToResolve[i].content = result[i];
             }
         } else {
+            // String content has \0 chars!
             // Recovery code
             logger.sendErrorEvent({ eventName: "StringParsingError" });
             for (const el of stringsToResolve) {


### PR DESCRIPTION
Accidently noticed wrong check while pointing to this this code as an example in some unrelated case.