### PR TITLE
Use globalThis instead of try catch

### DIFF
--- a/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
+++ b/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
@@ -74,16 +74,8 @@ export class SweepReadyUsageDetectionHandler {
         localStorageOverride?: Pick<Storage, "getItem" | "setItem">,
     ) {
         const noopStorage = { getItem: () => null, setItem: () => {} };
-        if (localStorageOverride !== undefined) {
-            this.localStorage = localStorageOverride;
-        } else {
-            try {
-                // localStorage is not defined in Node environment so this throws
-                this.localStorage = localStorage ?? noopStorage;
-            } catch (error) {
-                this.localStorage = noopStorage;
-            }
-        }
+        // localStorage is not defined in Node environment, so fall back to noopStorage if needed.
+        this.localStorage = localStorageOverride ?? globalThis.localStorage ?? noopStorage;
 
         if (this.localStorage === noopStorage) {
             // This means the Skip Closure Period logic will not work.

--- a/packages/utils/telemetry-utils/src/config.ts
+++ b/packages/utils/telemetry-utils/src/config.ts
@@ -142,11 +142,9 @@ function stronglyTypedParse(input: ConfigTypes): StronglyTypedValue | undefined 
     return defaultReturn;
 }
 
-/** Referencing the `sessionStorage` variable can throw in some environments such as Node */
+/** `sessionStorage` is undefined in some environments such as Node */
 const safeSessionStorage = (): Storage | undefined => {
-    try {
-        return sessionStorage !== null ? sessionStorage : undefined;
-    } catch { return undefined; }
+    return globalThis.sessionStorage;
 };
 
 /**


### PR DESCRIPTION
## Description

This avoids detecting browser specific globals using try catch and instead uses globalThis.

This was done to simplify the code and avoid unneeded exceptions during startup of tests which is annoying when debugging caught exception.

## Reviewer Guidance

I'd like confirmation that depending on globalThis is ok for us (its a moderately new feature), and that our test coverage is sufficient to detect if this breaks anything important.

This is an area of the code I don't normally work on, so don't trust me to know its requirements or test coverage.