### PR TITLE
adding events dep to client packages that use events to LTS

### DIFF
--- a/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
@@ -4,15 +4,18 @@
  */
 
 module.exports = {
-	extends: ["@fluidframework/eslint-config-fluid"],
-    "parserOptions": {
-        "project": ["./tsconfig.json"]
+    extends: ["@fluidframework/eslint-config-fluid"],
+    parserOptions: {
+        project: ["./tsconfig.json"],
     },
-	rules: {
-		"@typescript-eslint/strict-boolean-expressions": "off",
+    rules: {
+        "@typescript-eslint/strict-boolean-expressions": "off",
         "import/no-internal-modules": "off",
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/unbound-method": "off"
-	},
+        "@typescript-eslint/unbound-method": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
 };

--- a/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
@@ -18,4 +18,14 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert","events"] }],
+            },
+        },
+    ],
 };

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -66,6 +66,7 @@
     "@fluidframework/tinylicious-driver": "^1.3.0",
     "@fluidframework/view-interfaces": "^1.3.0",
     "@types/uuid": "^8.3.0",
+    "events": "^3.1.0",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.21",
     "react": "^16.10.2",

--- a/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
@@ -4,16 +4,19 @@
  */
 
 module.exports = {
-	extends: ["@fluidframework/eslint-config-fluid"],
-    "parserOptions": {
-        "project": ["./tsconfig.json"]
+    extends: ["@fluidframework/eslint-config-fluid"],
+    parserOptions: {
+        project: ["./tsconfig.json"],
     },
-	rules: {
-		"@typescript-eslint/strict-boolean-expressions": "off",
+    rules: {
+        "@typescript-eslint/strict-boolean-expressions": "off",
         "import/no-internal-modules": "off",
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/unbound-method": "off",
-        "import/no-unassigned-import": "off"
-	},
+        "import/no-unassigned-import": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
 };

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -68,6 +68,7 @@
     "@material-ui/lab": "^4.0.0-alpha.16",
     "@material-ui/styles": "^4.1.1",
     "@types/uuid": "^8.3.0",
+    "events": "^3.1.0",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.21",
     "react": "^16.10.2",

--- a/experimental/framework/data-objects/.eslintrc.js
+++ b/experimental/framework/data-objects/.eslintrc.js
@@ -14,4 +14,14 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert","events"] }],
+            },
+        },
+    ],
 };

--- a/experimental/framework/data-objects/.eslintrc.js
+++ b/experimental/framework/data-objects/.eslintrc.js
@@ -4,13 +4,14 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json"],
     },
-    "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
-    }
-}
+    rules: {
+        "@typescript-eslint/strict-boolean-expressions": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -36,7 +36,8 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/datastore-definitions": "^1.3.0",
     "@fluidframework/map": "^1.3.0",
-    "@fluidframework/runtime-definitions": "^1.3.0"
+    "@fluidframework/runtime-definitions": "^1.3.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",

--- a/packages/common/container-definitions/.eslintrc.js
+++ b/packages/common/container-definitions/.eslintrc.js
@@ -4,11 +4,12 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/types/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/types/tsconfig.json"],
     },
-    "rules": {}
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/common/container-definitions/.eslintrc.js
+++ b/packages/common/container-definitions/.eslintrc.js
@@ -12,4 +12,14 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert","events"] }],
+            },
+        },
+    ],
 };

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -42,7 +42,8 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^1.3.0",
     "@fluidframework/driver-definitions": "^1.3.0",
-    "@fluidframework/protocol-definitions": "^0.1028.2000"
+    "@fluidframework/protocol-definitions": "^0.1028.2000",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",

--- a/packages/dds/matrix/.eslintrc.js
+++ b/packages/dds/matrix/.eslintrc.js
@@ -4,14 +4,15 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
+    rules: {
         "@typescript-eslint/no-shadow": "off",
         "space-before-function-paren": "off", // Off because it conflicts with typescript-formatter
-    }
-}
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/dds/matrix/.eslintrc.js
+++ b/packages/dds/matrix/.eslintrc.js
@@ -15,4 +15,17 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "events"] },
+                ],
+            },
+        },
+    ],
 };

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -71,6 +71,7 @@
     "@fluidframework/shared-object-base": "^1.3.0",
     "@fluidframework/telemetry-utils": "^1.3.0",
     "@tiny-calc/nano": "0.0.0-alpha.5",
+    "events": "^3.1.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/dds/quorum/.eslintrc.js
+++ b/packages/dds/quorum/.eslintrc.js
@@ -4,10 +4,12 @@
  */
 
 module.exports = {
-    "extends": [
-        "@fluidframework/eslint-config-fluid/strict"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: ["@fluidframework/eslint-config-fluid/strict"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/dds/quorum/.eslintrc.js
+++ b/packages/dds/quorum/.eslintrc.js
@@ -12,4 +12,14 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert","events"] }],
+            },
+        },
+    ],
 };

--- a/packages/dds/quorum/package.json
+++ b/packages/dds/quorum/package.json
@@ -67,7 +67,8 @@
     "@fluidframework/driver-utils": "^1.3.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^1.3.0",
-    "@fluidframework/shared-object-base": "^1.3.0"
+    "@fluidframework/shared-object-base": "^1.3.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^1.3.0",

--- a/packages/dds/task-manager/.eslintrc.js
+++ b/packages/dds/task-manager/.eslintrc.js
@@ -12,4 +12,17 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "events"] },
+                ],
+            },
+        },
+    ],
 };

--- a/packages/dds/task-manager/.eslintrc.js
+++ b/packages/dds/task-manager/.eslintrc.js
@@ -4,10 +4,12 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -69,7 +69,8 @@
     "@fluidframework/driver-utils": "^1.3.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/runtime-definitions": "^1.3.0",
-    "@fluidframework/shared-object-base": "^1.3.0"
+    "@fluidframework/shared-object-base": "^1.3.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@^1.2.0",

--- a/packages/drivers/iframe-driver/.eslintrc.js
+++ b/packages/drivers/iframe-driver/.eslintrc.js
@@ -4,10 +4,11 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "rules": {
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    rules: {
         "@typescript-eslint/strict-boolean-expressions": "off",
-    }
-}
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/drivers/iframe-driver/.eslintrc.js
+++ b/packages/drivers/iframe-driver/.eslintrc.js
@@ -11,4 +11,14 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert","events"] }],
+            },
+        },
+    ],
 };

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -40,7 +40,8 @@
     "@fluidframework/driver-utils": "^1.3.0",
     "@fluidframework/protocol-definitions": "^0.1028.2000",
     "@fluidframework/telemetry-utils": "^1.3.0",
-    "comlink": "^4.3.0"
+    "comlink": "^4.3.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",

--- a/packages/drivers/local-driver/.eslintrc.js
+++ b/packages/drivers/local-driver/.eslintrc.js
@@ -14,4 +14,14 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert","events"] }],
+            },
+        },
+    ],
 };

--- a/packages/drivers/local-driver/.eslintrc.js
+++ b/packages/drivers/local-driver/.eslintrc.js
@@ -4,13 +4,14 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
-    }
-}
+    rules: {
+        "@typescript-eslint/strict-boolean-expressions": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -68,6 +68,7 @@
     "@fluidframework/server-services-client": "^0.1036.5000",
     "@fluidframework/server-services-core": "^0.1036.5000",
     "@fluidframework/server-test-utils": "^0.1036.5000",
+    "events": "^3.1.0",
     "jsrsasign": "^10.5.25",
     "uuid": "^8.3.1"
   },

--- a/packages/framework/undo-redo/.eslintrc.js
+++ b/packages/framework/undo-redo/.eslintrc.js
@@ -15,4 +15,17 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "events"] },
+                ],
+            },
+        },
+    ],
 };

--- a/packages/framework/undo-redo/.eslintrc.js
+++ b/packages/framework/undo-redo/.eslintrc.js
@@ -4,14 +4,15 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
+    rules: {
         "@typescript-eslint/no-use-before-define": "off",
-        "no-case-declarations": "off"
-    }
-}
+        "no-case-declarations": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -63,7 +63,8 @@
     "@fluidframework/map": "^1.3.0",
     "@fluidframework/matrix": "^1.3.0",
     "@fluidframework/merge-tree": "^1.3.0",
-    "@fluidframework/sequence": "^1.3.0"
+    "@fluidframework/sequence": "^1.3.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",

--- a/packages/loader/container-loader/.eslintrc.js
+++ b/packages/loader/container-loader/.eslintrc.js
@@ -12,4 +12,17 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "events"] },
+                ],
+            },
+        },
+    ],
 };

--- a/packages/loader/container-loader/.eslintrc.js
+++ b/packages/loader/container-loader/.eslintrc.js
@@ -4,12 +4,12 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
-    }
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -73,6 +73,7 @@
     "@fluidframework/telemetry-utils": "^1.3.0",
     "abort-controller": "^3.0.0",
     "double-ended-queue": "^2.1.0-0",
+    "events": "^3.1.0",
     "lodash": "^4.17.21",
     "uuid": "^8.3.1"
   },

--- a/packages/runtime/container-runtime/.eslintrc.js
+++ b/packages/runtime/container-runtime/.eslintrc.js
@@ -4,13 +4,14 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
+    rules: {
         "@typescript-eslint/strict-boolean-expressions": "off",
-    }
-}
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/runtime/container-runtime/.eslintrc.js
+++ b/packages/runtime/container-runtime/.eslintrc.js
@@ -14,4 +14,17 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "events"] },
+                ],
+            },
+        },
+    ],
 };

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -77,6 +77,7 @@
     "@fluidframework/runtime-utils": "^1.3.0",
     "@fluidframework/telemetry-utils": "^1.3.0",
     "double-ended-queue": "^2.1.0-0",
+    "events": "^3.1.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -71,6 +71,7 @@
     "@fluidframework/runtime-utils": "^1.3.0",
     "@fluidframework/telemetry-utils": "^1.3.0",
     "axios": "^0.26.0",
+    "events": "^3.1.0",
     "jsrsasign": "^10.5.25",
     "uuid": "^8.3.1"
   },

--- a/packages/test/functional-tests/.eslintrc.js
+++ b/packages/test/functional-tests/.eslintrc.js
@@ -9,4 +9,17 @@ module.exports = {
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "events"] },
+                ],
+            },
+        },
+    ],
 };

--- a/packages/test/functional-tests/.eslintrc.js
+++ b/packages/test/functional-tests/.eslintrc.js
@@ -4,8 +4,9 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "rules": {}
-}
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+};

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -55,6 +55,9 @@
     ],
     "temp-directory": "nyc/.nyc_output"
   },
+  "dependencies": {
+    "events": "^3.1.0"
+  },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",
     "@fluidframework/common-utils": "^0.32.1",


### PR DESCRIPTION
Affects the following packages:

@fluid-experimental/partial-checkout
@fluid-experimental/property-inspector
@fluid-experimental/data-objects
@fluidframework/container-definitions
@fluidframework/matrix
@fluid-experimental/quorum
@fluid-experimental/task-manager
@fluidframework/iframe-driver
@fluidframework/local-driver
@fluidframework/undo-redo
@fluidframework/container-loader
@fluidframework/container-runtime
@fluidframework/test-runtime-utils - already has import/no-nodejs-modules rule
@fluid-internal/functional-tests