### PR TITLE
Keep references on unacked removed segments

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1175,8 +1175,6 @@ export interface SegmentGroup {
     // (undocumented)
     previousProps?: PropertySet[];
     // (undocumented)
-    removedReferences?: LocalReferencePosition[];
-    // (undocumented)
     segments: ISegment[];
 }
 

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -431,7 +431,9 @@ export class LocalReferenceCollection {
         for (const iterable of refs) {
             for (const lref of iterable) {
                 assertLocalReferences(lref);
-                if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
+                if (refTypeIncludesFlag(lref, ReferenceType.StayOnRemove)) {
+                    continue;
+                } else if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
                     lref.callbacks?.beforeSlide?.(lref);
                     precedingRef = precedingRef === undefined
                         ? beforeRefs.unshift(lref)?.first
@@ -464,7 +466,9 @@ export class LocalReferenceCollection {
         for (const iterable of refs) {
             for (const lref of iterable) {
                 assertLocalReferences(lref);
-                if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
+                if (refTypeIncludesFlag(lref, ReferenceType.StayOnRemove)) {
+                    continue;
+                } else if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
                     lref.callbacks?.beforeSlide?.(lref);
                     afterRefs.push(lref);
                     lref.link(this.segment, lastOffset, afterRefs.last);

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -898,24 +898,28 @@ export class MergeTree {
      * Otherwise eventual consistency is not guaranteed.
      * See `packages\dds\merge-tree\REFERENCEPOSITIONS.md`
      */
-    private slideReferences(segment: ISegment, refsToSlide: Iterable<LocalReferencePosition>) {
+    private slideAckedRemovedSegmentReferences(segment: ISegment) {
         assert(
             isRemovedAndAcked(segment),
             0x2f1 /* slideReferences from a segment which has not been removed and acked */);
-        assert(!!segment.localRefs, 0x2f2 /* Ref not in the segment localRefs */);
+        if (segment.localRefs?.empty !== false) {
+            return;
+        }
         const newSegment = this._getSlideToSegment(segment);
         if (newSegment) {
             const localRefs = newSegment.localRefs ??= new LocalReferenceCollection(newSegment);
             if (newSegment.ordinal < segment.ordinal) {
-                localRefs.addAfterTombstones(refsToSlide);
+                localRefs.addAfterTombstones(segment.localRefs);
             } else {
-                localRefs.addBeforeTombstones(refsToSlide);
+                localRefs.addBeforeTombstones(segment.localRefs);
             }
         } else {
-            for (const ref of refsToSlide) {
-                ref.callbacks?.beforeSlide?.(ref);
-                segment.localRefs?.removeLocalRef(ref);
-                ref.callbacks?.afterSlide?.(ref);
+            for (const ref of segment.localRefs) {
+                if (!refTypeIncludesFlag(ref, ReferenceType.StayOnRemove)) {
+                    ref.callbacks?.beforeSlide?.(ref);
+                    segment.localRefs?.removeLocalRef(ref);
+                    ref.callbacks?.afterSlide?.(ref);
+                }
             }
         }
         // TODO is it required to update the path lengths?
@@ -923,39 +927,6 @@ export class MergeTree {
             this.blockUpdatePathLengths(newSegment.parent, TreeMaintenanceSequenceNumber,
                 LocalClientId);
         }
-    }
-
-    private updateSegmentRefsAfterMarkRemoved(segment: ISegment, pending: boolean):
-        LocalReferencePosition[] | undefined {
-        if (!segment.localRefs || segment.localRefs.empty) {
-            return undefined;
-        }
-        const refsToSlide: LocalReferencePosition[] = [];
-        const removedRefs: LocalReferencePosition[] = [];
-        for (const lref of segment.localRefs) {
-            if (refTypeIncludesFlag(lref, ReferenceType.StayOnRemove)) {
-                continue;
-            } if (refTypeIncludesFlag(lref, ReferenceType.SlideOnRemove)) {
-                if (!pending) {
-                    refsToSlide.push(lref);
-                }
-            } else {
-                // since we are pending, don't actually remove it,
-                // return the set of refs that will be removed on ack
-                //
-                if (!pending) {
-                    segment.localRefs.removeLocalRef(lref);
-                }
-                removedRefs.push(lref);
-            }
-        }
-        // Rethink implementation of keeping and sliding refs once other reference
-        // changes are complete. This works but is fragile and possibly slow.
-        if (!pending) {
-            this.slideReferences(segment, refsToSlide);
-        }
-        // return only the refs that have been entirely removed
-        return removedRefs.length > 0 ? removedRefs : undefined;
     }
 
     private blockLength(node: IMergeBlock, refSeq: number, clientId: number) {
@@ -1283,7 +1254,7 @@ export class MergeTree {
                 overwrite = overlappingRemove || overwrite;
 
                 if (!overlappingRemove && opArgs.op.type === MergeTreeDeltaType.REMOVE) {
-                    this.updateSegmentRefsAfterMarkRemoved(pendingSegment, false);
+                    this.slideAckedRemovedSegmentReferences(pendingSegment);
                 }
                 if (MergeTree.options.zamboniSegments) {
                     this.addToLRUSet(pendingSegment, seq);
@@ -1949,8 +1920,7 @@ export class MergeTree {
         // these segments are already viewed as being removed locally and are not event-ed
         // so can slide non-StayOnRemove refs immediately
         localOverlapWithRefs.forEach(
-            (s) => this.slideReferences(s, Array.from(s.localRefs!)
-                .filter((localRef) => !refTypeIncludesFlag(localRef, ReferenceType.StayOnRemove))),
+            (s) => this.slideAckedRemovedSegmentReferences(s),
         );
         // opArgs == undefined => test code
         if (this.mergeTreeDeltaCallback && removedSegments.length > 0) {
@@ -1961,19 +1931,14 @@ export class MergeTree {
                     deltaSegments: removedSegments,
                 });
         }
-        const pending = this.collabWindow.collaborating && clientId === this.collabWindow.clientId;
         // these events are newly removed
         // so we slide after eventing in case the consumer wants to make reference
         // changes at remove time, like add a ref to track undo redo.
-        removedSegments.forEach((rSeg) => {
-            const removedRefs = this.updateSegmentRefsAfterMarkRemoved(rSeg.segment, pending);
-            if (segmentGroup && removedRefs) {
-                if (!segmentGroup.removedReferences) {
-                    segmentGroup.removedReferences = [];
-                }
-                segmentGroup.removedReferences.push(...removedRefs);
-            }
-        });
+        if (!this.collabWindow.collaborating || clientId !== this.collabWindow.clientId) {
+            removedSegments.forEach((rSeg) => {
+                this.slideAckedRemovedSegmentReferences(rSeg.segment);
+            });
+        }
 
         if (this.collabWindow.collaborating && (seq !== UnassignedSequenceNumber)) {
             if (MergeTree.options.zamboniSegments) {
@@ -2014,16 +1979,6 @@ export class MergeTree {
 
                 for (let updateNode = segment.parent; updateNode !== undefined; updateNode = updateNode.parent) {
                     this.blockUpdateLength(updateNode, UnassignedSequenceNumber, this.collabWindow.clientId);
-                }
-            }
-            if (pendingSegmentGroup.removedReferences) {
-                for (const ref of pendingSegmentGroup.removedReferences) {
-                    const seg = ref.getSegment();
-                    if (!seg) {
-                        throw new Error("Cannot rollback reference without segment");
-                    }
-                    const localRefs = seg.localRefs ??= new LocalReferenceCollection(seg);
-                    localRefs.addLocalRef(ref, ref.getOffset());
                 }
             }
         } else if (op.type === MergeTreeDeltaType.INSERT || op.type === MergeTreeDeltaType.ANNOTATE) {

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -15,7 +15,6 @@ import {
 } from "./constants";
 import {
      LocalReferenceCollection,
-     LocalReferencePosition,
 } from "./localReference";
 import {
     IMergeTreeDeltaOpArgs,
@@ -301,7 +300,6 @@ export interface MergeTreeStats {
 export interface SegmentGroup {
     segments: ISegment[];
     previousProps?: PropertySet[];
-    removedReferences?: LocalReferencePosition[];
     localSeq: number;
 }
 

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -146,7 +146,7 @@ const treeFactories: ITestTreeFactory[] = [
                 remove,
                 UniversalSequenceNumber,
                 localClientId,
-                UnassignedSequenceNumber,
+                UniversalSequenceNumber,
                 false,
                 undefined as any);
             initialText = initialText.substring(remove);
@@ -157,7 +157,7 @@ const treeFactories: ITestTreeFactory[] = [
                 initialText.length,
                 UniversalSequenceNumber,
                 localClientId,
-                UnassignedSequenceNumber,
+                UniversalSequenceNumber,
                 false,
                 undefined as any);
             initialText = initialText.substring(0, initialText.length - remove);


### PR DESCRIPTION
## Description
This change reduces complexity around how we handle references on removed segements. Specifically on unacked removes we will just leave the references in place, and then only on acknowledgment will we manage them based on their reference type. I've also encapsulated some of the logic around how reference types are handled, so it is less distributed in the code. 

[AB#1845](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1845)