### PR TITLE
Update feed publishing logic to follow new guidelines

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -13,6 +13,9 @@ parameters:
 - name: feedName
   type: string
 
+- name: devFeedName
+  type: string
+
 - name: environment
   type: string
 
@@ -60,6 +63,7 @@ jobs:
             parameters:
               namespace: ${{ parameters.namespace }}
               artifactPath: scoped
+              devFeedName: ${{ parameters.devFeedName }}
               feedName: ${{ parameters.feedName }}
               customEndPoint: ${{ parameters.customEndPoint }}
               official: ${{ parameters.official }}
@@ -69,6 +73,7 @@ jobs:
               parameters:
                 namespace: false
                 artifactPath: non-scoped
+                devFeedName: ${{ parameters.devFeedName }}
                 feedName: ${{ parameters.feedName }}
                 official: ${{ parameters.official }}
                 customEndPoint: ${{ parameters.customEndPoint }}

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -10,6 +10,9 @@ parameters:
 - name: feedName
   type: string
 
+- name: devFeedName
+  type: string
+
 - name: official
   type: string
 
@@ -36,7 +39,8 @@ steps:
           echo Generating .npmrc for ${{ parameters.feedName }}
           echo "@fluidframework:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "@fluid-example:registry=${{ parameters.feedName }}" >> ./.npmrc
-          echo "@fluid-internal:registry=${{ parameters.feedName }}" >> ./.npmrc
+          echo "@fluid-msinternal:registry=${{ parameters.feedName }}" >> ./.npmrc
+          echo "@fluid-internal:registry=${{ parameters.devFeedName }}" >> ./.npmrc
           echo "@fluid-experimental:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
@@ -52,6 +56,8 @@ steps:
 
           echo Deleting @fluid-internal packages
           rm -f fluid-internal-*
+          echo Deleting @fluid-msinternal packages
+          rm -f fluid-msinternal-*
           echo Deleting @fluid-example packages
           rm -f fluid-example-*
     ${{ if eq(parameters.namespace, false) }}:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -27,6 +27,7 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
+      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
       feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
       official: false
       environment: test-package-build-feed
@@ -41,6 +42,7 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
+      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
       feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
       official: false
       environment: package-build-feed
@@ -55,6 +57,9 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
+      # internal/msinternal/example packages are deleted for official releases, but in case something goes wrong with that,
+      # using the `dev` registry is safe.
+      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
       feedName: https://registry.npmjs.org
       official: true
       environment: package-npmjs-feed


### PR DESCRIPTION
## Description

This updates registry configuration in our pipeline publish steps to follow the proposed new guidelines. The documentation on semantics of scoped packages can currently be found [here](https://github.com/Abe27342/FluidFramework/wiki#npm-package-scopes), and there is more information on our internal feed structure on the [FF Platform internal wiki](https://dev.azure.com/fluidframework/internal/_git/ff_internal?version=GBuser/absander/add-feeds-page&path=/docs/infrastructure/ado/feeds.md&_a=preview) (requires internal access).

Example [test publish](https://dev.azure.com/fluidframework/internal/_build/results?buildId=96285&view=results) (again, will require internal CI access). I verified the produced @fluid-internal/test-service-load showed up on the test feed.

Example [build publish](https://dev.azure.com/fluidframework/internal/_build/results?buildId=97413&view=results). I verified the produced @fluid-internal/test-service-load showed up on the dev feed.
