### PR TITLE
Disable `@typescript-eslint/unified-signatures` rule in shared eslint config

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -51,13 +51,20 @@ module.exports = {
     ],
     reportUnusedDisableDirectives: true,
     rules: {
-        // The @rushstack rules are documented in the package README:
-        // https://www.npmjs.com/package/@rushstack/eslint-plugin
+        /**
+         * The @rushstack rules are documented in the package README:
+         * {@link https://www.npmjs.com/package/@rushstack/eslint-plugin}
+         */
         "@rushstack/no-new-null": "warn",
 
-        // RATIONALE: Harmless.  Our guideline is to only use leading underscores on private members
-        //            when required to avoid a conflict between private fields and a public property.
-        // Docs: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
+        /**
+         * RATIONALE: Harmless.
+         *
+         * Our guideline is to only use leading underscores on private members when required to avoid a conflict
+         * between private fields and a public property.
+         *
+         * Docs: {@link https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md}
+         */
         "@typescript-eslint/naming-convention": [
             "error",
             {
@@ -68,7 +75,9 @@ module.exports = {
             },
         ],
 
-        // Encourages minimal disabling of eslint rules, while still permitting whole-file exclusions.
+        /**
+         * Encourages minimal disabling of eslint rules, while still permitting whole-file exclusions.
+         */
         "eslint-comments/disable-enable-pair": [
             "error",
             {
@@ -97,14 +106,18 @@ module.exports = {
             },
         ],
 
-        // Note: this can be replaced altogether by `@typescript-eslint/no-unused-vars`,
-        // but that rule covers many more scenarios than this one does, and there are many violations,
-        // currently in the repository, so it has not been enabled yet.
+        /**
+         * Note: this can be replaced altogether by `@typescript-eslint/no-unused-vars`,
+         * but that rule covers many more scenarios than this one does, and there are many violations
+         * currently in the repository, so it has not been enabled yet.
+         */
         "unused-imports/no-unused-imports": "error",
 
         "valid-typeof": "error",
 
-        // Catches a common coding mistake where "resolve" and "reject" are confused.
+        /**
+         * Catches a common coding mistake where "resolve" and "reject" are confused.
+         */
         "promise/param-names": "warn",
 
         "unicorn/better-regex": "error",
@@ -123,26 +136,49 @@ module.exports = {
         "unicorn/prefer-ternary": "error",
         "unicorn/prefer-type-error": "error",
 
-        // DISABLED INTENTIONALLY
-        // Disabled because we don't require that all variable declarations be explicitly typed.
+        // #region DISABLED INTENTIONALLY
+
+        /**
+         * Disabled because we don't require that all variable declarations be explicitly typed.
+         */
         "@rushstack/typedef-var": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/explicit-member-accessibility": "off",
-        "@typescript-eslint/indent": "off", // Off because it conflicts with typescript-formatter
+
+        /**
+         * Disabled because we will lean on the formatter (i.e. prettier) to enforce indentation policy.
+         */
+        "@typescript-eslint/indent": "off",
         "@typescript-eslint/member-ordering": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-parameter-properties": "off",
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/typedef": "off",
+
+        /**
+         * Disabled because we want to encourage documenting different events separately.
+         */
+        "@typescript-eslint/unified-signatures": "off",
         "func-call-spacing": "off", // Off because it conflicts with typescript-formatter
         "no-empty": "off",
         "no-void": "off",
         "require-atomic-updates": "off",
-        "dot-notation": "off", // Superseded by @typescript-eslint/dot-notation
-        "no-unused-expressions": "off", // Superseded by @typescript-eslint/no-unused-expressions
 
-        // FORMATTING RULES
+        /**
+         * Superseded by `@typescript-eslint/dot-notation`.
+         */
+        "dot-notation": "off",
+
+        /**
+         * Superseded by `@typescript-eslint/no-unused-expressions`.
+         */
+        "no-unused-expressions": "off",
+
+        // #endregion
+
+        // #region FORMATTING RULES
+
         "@typescript-eslint/brace-style": [
             "error",
             "1tbs",
@@ -188,7 +224,13 @@ module.exports = {
         "space-unary-ops": "error",
         "switch-colon-spacing": "error",
 
-        // This rule ensures that our Intellisense looks good by verifying the TSDoc syntax.
+        // #endregion
+
+        // #region DOCUMENTATION RULES
+
+        /**
+         * This rule ensures that our Intellisense looks good by verifying the TSDoc syntax.
+         */
         "tsdoc/syntax": "error",
 
         // #region eslint-plugin-jsdoc rules
@@ -258,6 +300,8 @@ module.exports = {
          * See <https://github.com/gajus/eslint-plugin-jsdoc#user-content-eslint-plugin-jsdoc-rules-require-returns-description>
          */
         "jsdoc/require-returns-description": "error",
+
+        // #endregion
 
         // #endregion
 

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -337,7 +337,7 @@
             }
         ],
         "@typescript-eslint/unified-signatures": [
-            "error"
+            "off"
         ],
         "array-bracket-spacing": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -337,7 +337,7 @@
             }
         ],
         "@typescript-eslint/unified-signatures": [
-            "error"
+            "off"
         ],
         "array-bracket-spacing": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -357,7 +357,7 @@
             "off"
         ],
         "@typescript-eslint/unified-signatures": [
-            "error"
+            "off"
         ],
         "array-bracket-spacing": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -375,7 +375,7 @@
             "off"
         ],
         "@typescript-eslint/unified-signatures": [
-            "error"
+            "off"
         ],
         "array-bracket-spacing": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -337,7 +337,7 @@
             }
         ],
         "@typescript-eslint/unified-signatures": [
-            "error"
+            "off"
         ],
         "array-bracket-spacing": [
             "error"


### PR DESCRIPTION
See [here](https://typescript-eslint.io/rules/unified-signatures/) for rule details.

Disabling this rule to encourage documenting events separately from one another, even if they have the same callback signature.

Example improvement to generated docs:
![image](https://user-images.githubusercontent.com/54606601/193153949-f214157f-1562-49b3-a220-a3ccdaed80ee.png)

(the typo in the above example is being fixed in #12199)

Also updated documentation in the config to make it easier to read / navigate.