### PR TITLE
Fix bad rebase on reconnection

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -73,7 +73,8 @@
     "@fluidframework/runtime-definitions": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/shared-object-base": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
-    "@ungap/structured-clone": "^0.3.4"
+    "@ungap/structured-clone": "^0.3.4",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluid-internal/stochastic-test-utils": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",

--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -39,18 +39,12 @@ export class EditManager<TChangeset, TChangeFamily extends ChangeFamily<any, TCh
     // The first change in this list is based on the last change in the trunk.
     // Every other change in this list is based on the change preceding it.
     private localChanges: TChangeset[] = [];
-    private localSessionId: SessionId | undefined;
 
     public constructor(
+        private readonly localSessionId: SessionId,
         public readonly changeFamily: TChangeFamily,
         public readonly anchors?: AnchorSet,
     ) { }
-
-    public setLocalSessionId(id: SessionId) {
-        assert(this.localSessionId === undefined || this.localSessionId === id,
-            0x3a1 /* Local session ID cannot be changed */);
-        this.localSessionId = id;
-    }
 
     public getTrunk(): readonly RecursiveReadonly<Commit<TChangeset>>[] {
         return this.trunk;

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -51,10 +51,10 @@ function editManagerFactory(rebaser?: ChangeRebaser<TestChange>): {
     const family = changeFamilyFactory(rebaser);
     const anchors = new TestAnchorSet();
     const manager = new EditManager<TestChange, ChangeFamily<unknown, TestChange>>(
+        localSessionId,
         family,
         anchors,
     );
-    manager.setLocalSessionId(localSessionId);
     return { manager, anchors };
 }
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -96,15 +96,8 @@ describe("SharedTree", () => {
 
             await provider.ensureSynchronized();
 
-            // Validate deletion
-            {
-                const readCursor = tree2.forest.allocateCursor();
-                const destination = tree2.forest.root(tree2.forest.rootField);
-                const cursorResult = tree2.forest.tryMoveCursorTo(destination, readCursor);
-                assert.equal(cursorResult, TreeNavigationResult.NotFound);
-                readCursor.free();
-                tree2.forest.forgetAnchor(destination);
-            }
+            assert.equal(getTestValue(tree1), undefined);
+            assert.equal(getTestValue(tree2), undefined);
         });
 
         it("can insert multiple nodes", async () => {
@@ -219,6 +212,9 @@ function getTestValue({ forest }: ISharedTree): TreeValue | undefined {
     const readCursor = forest.allocateCursor();
     const destination = forest.root(forest.rootField);
     const cursorResult = forest.tryMoveCursorTo(destination, readCursor);
+    if (cursorResult !== TreeNavigationResult.Ok) {
+        return undefined;
+    }
     const { value } = readCursor;
     readCursor.free();
     forest.forgetAnchor(destination);


### PR DESCRIPTION
This PR adds a stable client ID to each SharedTree client so that ops from a given client can be recognized as such despite potential reconnections by that client.

This is needed because the client ID given by the Fluid protocol is not stable across reconnections.

Updated a test to prevent regressions.