### PR TITLE
build: Update dependency on `@fluid-tools/api-markdown-documenter`

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -28,9 +28,9 @@
       }
     },
     "@fluid-tools/api-markdown-documenter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fluid-tools/api-markdown-documenter/-/api-markdown-documenter-0.4.0.tgz",
-      "integrity": "sha512-Z0XsE4vY7voBhTzuLAIj+rXo+/fmGFnlTDKl/BwY9AFTb5QdSO7EMa3oCmbTH+1juulOjM5KHbhes8MoaATBqA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fluid-tools/api-markdown-documenter/-/api-markdown-documenter-0.5.0.tgz",
+      "integrity": "sha512-CJBAZpZ2N9M8MVHwlCGt+VvaokuvJObkphj5a0cLng81ZDf83zjZglbmjUzbj8aGeBHUz3ipujzdv8s2VKRVUA==",
       "requires": {
         "@microsoft/api-documenter": "7.19.2",
         "@microsoft/api-extractor-model": "^7.23.0",
@@ -198,9 +198,9 @@
       }
     },
     "@rushstack/node-core-library": {
-      "version": "3.51.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.51.1.tgz",
-      "integrity": "sha512-xLoUztvGpaT5CphDexDPt2WbBx8D68VS5tYOkwfr98p90y0f/wepgXlTA/q5MUeZGGucASiXKp5ysdD+GPYf9A==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.0.tgz",
+      "integrity": "sha512-FXk3eDtTHKnaUq+fLyNY867ioRhMa6CJDJO5hZ3wuGlxm184nckAFiU+hx027AodjpnqjX6pYF0zZGq7k7P/vg==",
       "requires": {
         "@types/node": "12.20.24",
         "colors": "~1.2.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
     "start": "hugo server"
   },
   "dependencies": {
-    "@fluid-tools/api-markdown-documenter": "^0.4.0",
+    "@fluid-tools/api-markdown-documenter": "^0.5.0",
     "@microsoft/api-extractor-model": "^7.23.0",
     "@tylerbu/dl-cli": "1.1.2-tylerbu-0",
     "@tylerbu/markdown-magic": "^2.4.0-tylerbu-1",


### PR DESCRIPTION
Picks up a fix that improves default rendering of links to call-signature and index-signature items.

Example: 

![image](https://user-images.githubusercontent.com/54606601/193153746-5076deac-7f50-4b6b-82a4-628a9a05afbc.png)

(the typo in the above example is being fixed in #12199)
