### PR TITLE
Update PR/dev build numbers for Fluid internal versions

### DIFF
--- a/build-tools/packages/build-cli/test/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/buildVersion.test.ts
@@ -3,9 +3,11 @@
  * Licensed under the MIT License.
  */
 
+import { expect, test } from "@oclif/test";
 import { assert } from "chai";
+import * as semver from "semver";
 import { getSimpleVersion, getVersionsFromStrings, getIsLatest } from "@fluidframework/build-tools";
-import { getLatestReleaseFromList } from "@fluid-tools/version-tools";
+import { getVersionRange } from "@fluid-tools/version-tools";
 
 // Deliberately not sorted here; highest version is 0.59.3000
 const test_tags = [
@@ -56,6 +58,38 @@ describe("getSimpleVersion", () => {
             "0.16.0-beta.2.1.12345.0",
         );
         assert.equal(getSimpleVersion("0.16.0-beta", "12345.0", true, false), "0.16.0-beta");
+    });
+
+    describe("Fluid internal versions", () => {
+        it("dev/PR build versions", () => {
+            const input = "2.0.0-internal.1.3.0";
+            const expected = "2.0.0-dev.1.3.0.93923";
+            const result = getSimpleVersion(input, "93923", false, false);
+            expect(result).to.equal(expected);
+
+            const range = getVersionRange("2.0.0-internal.1.3.0", "^");
+            expect(semver.satisfies(result, range)).to.be.false;
+        });
+
+        it("release versions", () => {
+            const input = "2.0.0-internal.1.3.0";
+            const expected = "2.0.0-internal.1.3.0";
+            const result = getSimpleVersion(input, "93923", true, false);
+            expect(result).to.equal(expected);
+
+            const range = getVersionRange("2.0.0-internal.1.3.0", "^");
+            expect(semver.satisfies(result, range)).to.be.true;
+        });
+
+        it("simple patch scheme should throw with Fluid internal versions", () => {
+            const input = "2.0.0-internal.1.3.0";
+            expect(() => getSimpleVersion(input, "93923", false, true)).to.throw();
+        });
+
+        it("release + simple patch scheme should throw with Fluid internal versions", () => {
+            const input = "2.0.0-internal.1.3.0";
+            expect(() => getSimpleVersion(input, "93923", true, true)).to.throw();
+        });
     });
 });
 

--- a/build-tools/packages/build-tools/src/buildVersion/buildVersionLib.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersionLib.ts
@@ -19,7 +19,7 @@
 
 import child_process from "child_process";
 import fs from "fs";
-import { detectVersionScheme, getLatestReleaseFromList, isInternalVersionScheme } from "@fluid-tools/version-tools";
+import { changePreReleaseIdentifier, detectVersionScheme, getLatestReleaseFromList, isInternalVersionScheme } from "@fluid-tools/version-tools";
 import * as semver from "semver";
 import { Logger } from "../common/logging";
 
@@ -91,6 +91,16 @@ export function getSimpleVersion(fileVersion: string, argBuildNum: string, argRe
     // Azure DevOp pass in the build number as $(buildNum).$(buildAttempt).
     // Get the Build number and ignore the attempt number.
     const buildId = patch ? parseInt(argBuildNum.split('.')[0]) : undefined;
+
+    if(isInternalVersionScheme(fileVersion, /* allowPrereleases */ true)) {
+        if(patch) {
+            throw new Error(`Cannot use simple patch versioning with Fluid internal versions. Version: ${fileVersion}`);
+        }
+
+        if(!argRelease) {
+            fileVersion = changePreReleaseIdentifier(fileVersion, "dev");
+        }
+    }
 
     const { releaseVersion, prereleaseVersion } = parseFileVersion(fileVersion, buildId);
     const build_suffix = buildId ? "" : getBuildSuffix(argRelease, argBuildNum);

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -72,6 +72,10 @@ also available in the Fluid build and release tool (`flub`). This is accomplishe
 ```sh-session
 $ npm install -g @fluid-tools/version-tools
 $ fluv COMMAND
+running command...
+$ fluv (--version|-V)
+@fluid-tools/version-tools/0.4.7000
+$ fluv --help [COMMAND]
 USAGE
   $ fluv COMMAND
 ...
@@ -148,6 +152,8 @@ EXAMPLES
 
     $ fluv version 2.0.0-internal.1.0.0 --type current
 ```
+
+_See code: [src/commands/version.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/version-tools/src/commands/version.ts)_
 
 ## `fluv version latest`
 

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -13,6 +13,9 @@ export function bumpRange(range: string, bumpType: VersionBumpTypeExtended, prer
 // @public
 export function bumpVersionScheme(version: string | semver.SemVer | undefined, bumpType: VersionBumpTypeExtended, scheme?: VersionScheme): semver.SemVer;
 
+// @public (undocumented)
+export function changePreReleaseIdentifier(version: semver.SemVer | string, newIdentifier: string): string;
+
 // @public
 export function detectBumpType(v1: semver.SemVer | string | null, v2: semver.SemVer | string | null): VersionBumpType | undefined;
 

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./bumpTypes";
 export {
+    changePreReleaseIdentifier,
     getVersionRange,
     fromInternalScheme,
     isInternalVersionScheme,

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -291,7 +291,10 @@ export function getVersionRange(
     return range;
 }
 
-export function changePreReleaseIdentifier(version: semver.SemVer | string, newIdentifier: string): string {
+export function changePreReleaseIdentifier(
+    version: semver.SemVer | string,
+    newIdentifier: string,
+): string {
     const ver = semver.parse(version);
 
     if (ver === null) {

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -290,3 +290,34 @@ export function getVersionRange(
     }
     return range;
 }
+
+export function changePreReleaseIdentifier(version: semver.SemVer | string, newIdentifier: string): string {
+    const ver = semver.parse(version);
+
+    if (ver === null) {
+        throw new Error(`Can't parse version: ${version}`);
+    }
+
+    const pr = ver.prerelease;
+    if (pr.length < 1) {
+        throw new Error(`Version has no prerelease section: ${version}`);
+    }
+
+    const identifier = pr[0];
+
+    if (typeof identifier === "number") {
+        // eslint-disable-next-line unicorn/prefer-type-error
+        throw new Error(`Prerelease identifier is numeric; it should be a string: ${version}`);
+    }
+
+    const newPrereleaseSection = [newIdentifier, ...pr.slice(1)].join(".");
+    const newVersionString = `${ver.major}.${ver.minor}.${ver.patch}-${newPrereleaseSection}`;
+
+    const newVer = semver.parse(newVersionString)?.version;
+
+    if (newVer === null || newVer === undefined) {
+        throw new Error(`Can't parse new version string: ${version}`);
+    }
+
+    return newVer;
+}


### PR DESCRIPTION
Dev and PR builds using the Fluid internal version scheme were incorrectly getting picked up by our version ranges. The only reliable way we have found to get semver to do what we want is to use a different "prerelease identifier" for dev/PR builds. That is, the "internal" part of the prerelease string will be "dev" for dev/PR builds.

Example:

BEFORE:

`2.0.0-internal.1.3.0.87654`

AFTER:

`2.0.0-dev.1.3.0.87654`