### PR TITLE
added base telemetry types/interfaces

### DIFF
--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -7,6 +7,10 @@
 Proper support for tagged events will be assumed going forward. Only at the loader-runtime boundary do we retain
 a concession for backwards compatibility, but that's done outside of this interface.
 
+### ITelemetryBaseEvent extends ITelemetryBaseProperties
+
+`ITelemetryBaseEvent` now extends `ITelemetryBaseProperties` which now supports `null` values.
+
 ## Upcoming changes
 
 -   [ITelemetryProperties deprecated](#Deprecate-ITelemetryProperties)
@@ -14,8 +18,9 @@ a concession for backwards compatibility, but that's done outside of this interf
 ### Deprecate ITelemetryProperties
 
 The `ITelemetryProperties` interface has been deprecated from `logger.ts` in `@fluid-framework/common-definitions`.
-The property will be repurposed in the next major release to support flat arrays and objects.
+The property will be repurposed in the next major release for the Fluid Framework's internal logging APIs to support flat arrays and objects.
 Please migrate all usage to `ITelemetryBaseProperties` instead.
+Note that `ITelemetryBaseProperties` also allows `null` values, as compared to `ITelemetryProperties` which did not.
 
 ```diff
 - const event: ITelemetryProperties = {};

--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -6,3 +6,18 @@
 
 Proper support for tagged events will be assumed going forward. Only at the loader-runtime boundary do we retain
 a concession for backwards compatibility, but that's done outside of this interface.
+
+## Upcoming changes
+
+-   [ITelemetryProperties deprecated](#Deprecate-ITelemetryProperties)
+
+### Deprecate ITelemetryProperties
+
+The `ITelemetryProperties` interface has been deprecated from `logger.ts` in `@fluid-framework/common-definitions`.
+The property will be repurposed in the next major release to support flat arrays and objects.
+Please migrate all usage to `ITelemetryBaseProperties` instead.
+
+```diff
+- const event: ITelemetryProperties = {};
++ const event: ITelemetryBaseProperties = {};
+```

--- a/common/lib/common-definitions/api-report/common-definitions.api.md
+++ b/common/lib/common-definitions/api-report/common-definitions.api.md
@@ -196,7 +196,7 @@ export interface ILoggingError extends Error {
 }
 
 // @public
-export interface ITaggedBaseTelemetryProperty {
+export interface ITaggedBaseTelemetryPropertyValue {
     // (undocumented)
     tag: string;
     // (undocumented)
@@ -228,7 +228,7 @@ export interface ITelemetryBaseLogger {
 // @public (undocumented)
 export interface ITelemetryBaseProperties {
     // (undocumented)
-    [index: string]: TelemetryBaseEventPropertyValue | ITaggedBaseTelemetryProperty;
+    [index: string]: TelemetryBaseEventPropertyValue | ITaggedBaseTelemetryPropertyValue;
 }
 
 // @public

--- a/common/lib/common-definitions/api-report/common-definitions.api.md
+++ b/common/lib/common-definitions/api-report/common-definitions.api.md
@@ -196,7 +196,7 @@ export interface ILoggingError extends Error {
 }
 
 // @public
-export interface ITaggedBaseTelemetryPropertyType {
+export interface ITaggedBaseTelemetryProperty {
     // (undocumented)
     tag: string;
     // (undocumented)
@@ -212,7 +212,7 @@ export interface ITaggedTelemetryPropertyType {
 }
 
 // @public
-export interface ITelemetryBaseEvent extends ITelemetryProperties {
+export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
     // (undocumented)
     category: string;
     // (undocumented)
@@ -228,7 +228,7 @@ export interface ITelemetryBaseLogger {
 // @public (undocumented)
 export interface ITelemetryBaseProperties {
     // (undocumented)
-    [index: string]: TelemetryBaseEventPropertyType | ITaggedBaseTelemetryPropertyType;
+    [index: string]: TelemetryBaseEventPropertyValue | ITaggedBaseTelemetryProperty;
 }
 
 // @public
@@ -271,7 +271,7 @@ export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any
 } : L;
 
 // @public
-export type TelemetryBaseEventPropertyType = string | number | boolean | null | undefined;
+export type TelemetryBaseEventPropertyValue = string | number | boolean | null | undefined;
 
 // @public
 export type TelemetryEventCategory = "generic" | "error" | "performance";

--- a/common/lib/common-definitions/api-report/common-definitions.api.md
+++ b/common/lib/common-definitions/api-report/common-definitions.api.md
@@ -196,6 +196,14 @@ export interface ILoggingError extends Error {
 }
 
 // @public
+export interface ITaggedBaseTelemetryPropertyType {
+    // (undocumented)
+    tag: string;
+    // (undocumented)
+    value: TelemetryEventPropertyType;
+}
+
+// @public
 export interface ITaggedTelemetryPropertyType {
     // (undocumented)
     tag: string;
@@ -215,6 +223,12 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
 export interface ITelemetryBaseLogger {
     // (undocumented)
     send(event: ITelemetryBaseEvent): void;
+}
+
+// @public (undocumented)
+export interface ITelemetryBaseProperties {
+    // (undocumented)
+    [index: string]: TelemetryBaseEventPropertyType | ITaggedBaseTelemetryPropertyType;
 }
 
 // @public
@@ -245,7 +259,7 @@ export interface ITelemetryPerformanceEvent extends ITelemetryGenericEvent {
     duration?: number;
 }
 
-// @public
+// @public @deprecated
 export interface ITelemetryProperties {
     // (undocumented)
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
@@ -255,6 +269,9 @@ export interface ITelemetryProperties {
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any[] ? {
     [K in keyof L]: L[K] extends IEventThisPlaceHolder ? TThis : L[K];
 } : L;
+
+// @public
+export type TelemetryBaseEventPropertyType = string | number | boolean | null | undefined;
 
 // @public
 export type TelemetryEventCategory = "generic" | "error" | "performance";

--- a/common/lib/common-definitions/api-report/common-definitions.api.md
+++ b/common/lib/common-definitions/api-report/common-definitions.api.md
@@ -200,7 +200,7 @@ export interface ITaggedBaseTelemetryProperty {
     // (undocumented)
     tag: string;
     // (undocumented)
-    value: TelemetryEventPropertyType;
+    value: TelemetryBaseEventPropertyValue;
 }
 
 // @public

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -61,6 +61,10 @@
   },
   "typeValidation": {
     "version": "0.21.1000",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_ITelemetryBaseEvent": {
+        "backCompat": false
+      }
+    }
   }
 }

--- a/common/lib/common-definitions/src/index.ts
+++ b/common/lib/common-definitions/src/index.ts
@@ -22,14 +22,17 @@ export type {
 } from "./events";
 export type {
     ILoggingError,
+    ITaggedBaseTelemetryPropertyType,
     ITaggedTelemetryPropertyType,
     ITelemetryBaseEvent,
     ITelemetryBaseLogger,
+    ITelemetryBaseProperties,
     ITelemetryErrorEvent,
     ITelemetryGenericEvent,
     ITelemetryLogger,
     ITelemetryPerformanceEvent,
     ITelemetryProperties,
+    TelemetryBaseEventPropertyType,
     TelemetryEventCategory,
     TelemetryEventPropertyType,
 } from "./logger";

--- a/common/lib/common-definitions/src/index.ts
+++ b/common/lib/common-definitions/src/index.ts
@@ -22,7 +22,7 @@ export type {
 } from "./events";
 export type {
     ILoggingError,
-    ITaggedBaseTelemetryPropertyType,
+    ITaggedBaseTelemetryProperty,
     ITaggedTelemetryPropertyType,
     ITelemetryBaseEvent,
     ITelemetryBaseLogger,
@@ -32,7 +32,7 @@ export type {
     ITelemetryLogger,
     ITelemetryPerformanceEvent,
     ITelemetryProperties,
-    TelemetryBaseEventPropertyType,
+    TelemetryBaseEventPropertyValue,
     TelemetryEventCategory,
     TelemetryEventPropertyType,
 } from "./logger";

--- a/common/lib/common-definitions/src/index.ts
+++ b/common/lib/common-definitions/src/index.ts
@@ -22,7 +22,7 @@ export type {
 } from "./events";
 export type {
     ILoggingError,
-    ITaggedBaseTelemetryProperty,
+    ITaggedBaseTelemetryPropertyValue,
     ITaggedTelemetryPropertyType,
     ITelemetryBaseEvent,
     ITelemetryBaseLogger,

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -29,9 +29,30 @@ export interface ITaggedTelemetryPropertyType {
 
 /**
  * JSON-serializable properties, which will be logged with telemetry.
+ * @deprecated interface will be repurposed to support flat arrays and objects.
  */
 export interface ITelemetryProperties {
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
+}
+
+/**
+ * Set of properties defined for the base logger to use only primitive types.
+ */
+// eslint-disable-next-line @rushstack/no-new-null
+export type TelemetryBaseEventPropertyType = string | number | boolean | null | undefined;
+
+ /**
+ * A property to be logged to telemetry containing both the value and a tag. Tags are generic strings that can be used
+ * to mark pieces of information that should be organized or handled differently by loggers in various first or third
+ * party scenarios. For example, tags are used to mark PII that should not be stored in logs.
+ */
+export interface ITaggedBaseTelemetryPropertyType {
+    value: TelemetryEventPropertyType;
+    tag: string;
+}
+
+export interface ITelemetryBaseProperties {
+    [index: string]: TelemetryBaseEventPropertyType | ITaggedBaseTelemetryPropertyType;
 }
 
 /**

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -20,7 +20,7 @@ export type TelemetryEventPropertyType = string | number | boolean | undefined;
 /**
  * A property to be logged to telemetry containing both the value and a tag. Tags are generic strings that can be used
  * to mark pieces of information that should be organized or handled differently by loggers in various first or third
- * party scenarios. For example, tags are used to mark PII that should not be stored in logs.
+ * party scenarios. For example, tags are used to mark sensitive information that should not be stored in logs.
  */
 export interface ITaggedTelemetryPropertyType {
     value: TelemetryEventPropertyType;
@@ -29,7 +29,7 @@ export interface ITaggedTelemetryPropertyType {
 
 /**
  * JSON-serializable properties, which will be logged with telemetry.
- * @deprecated interface will be repurposed to support flat arrays and objects.
+ * @deprecated interface will be repurposed to support flat arrays and objects for FF internal logging APIs
  */
 export interface ITelemetryProperties {
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
@@ -39,20 +39,20 @@ export interface ITelemetryProperties {
  * Set of properties defined for the base logger to use only primitive types.
  */
 // eslint-disable-next-line @rushstack/no-new-null
-export type TelemetryBaseEventPropertyType = string | number | boolean | null | undefined;
+export type TelemetryBaseEventPropertyValue = string | number | boolean | null | undefined;
 
 /**
  * A property to be logged to telemetry containing both the value and a tag. Tags are generic strings that can be used
  * to mark pieces of information that should be organized or handled differently by loggers in various first or third
- * party scenarios. For example, tags are used to mark PII that should not be stored in logs.
+ * party scenarios. For example, tags are used to mark sensitive information that should not be stored in logs.
  */
-export interface ITaggedBaseTelemetryPropertyType {
+export interface ITaggedBaseTelemetryProperty {
     value: TelemetryEventPropertyType;
     tag: string;
 }
 
 export interface ITelemetryBaseProperties {
-    [index: string]: TelemetryBaseEventPropertyType | ITaggedBaseTelemetryPropertyType;
+    [index: string]: TelemetryBaseEventPropertyValue | ITaggedBaseTelemetryProperty;
 }
 
 /**
@@ -61,7 +61,7 @@ export interface ITelemetryBaseProperties {
  * @param category - category of the event, like "error", "performance", "generic", etc.
  * @param eventName - name of the event.
  */
-export interface ITelemetryBaseEvent extends ITelemetryProperties {
+export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
     category: string;
     eventName: string;
 }

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -47,7 +47,7 @@ export type TelemetryBaseEventPropertyValue = string | number | boolean | null |
  * party scenarios. For example, tags are used to mark sensitive information that should not be stored in logs.
  */
 export interface ITaggedBaseTelemetryProperty {
-    value: TelemetryEventPropertyType;
+    value: TelemetryBaseEventPropertyValue;
     tag: string;
 }
 

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -41,7 +41,7 @@ export interface ITelemetryProperties {
 // eslint-disable-next-line @rushstack/no-new-null
 export type TelemetryBaseEventPropertyType = string | number | boolean | null | undefined;
 
- /**
+/**
  * A property to be logged to telemetry containing both the value and a tag. Tags are generic strings that can be used
  * to mark pieces of information that should be organized or handled differently by loggers in various first or third
  * party scenarios. For example, tags are used to mark PII that should not be stored in logs.

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -46,13 +46,13 @@ export type TelemetryBaseEventPropertyValue = string | number | boolean | null |
  * to mark pieces of information that should be organized or handled differently by loggers in various first or third
  * party scenarios. For example, tags are used to mark sensitive information that should not be stored in logs.
  */
-export interface ITaggedBaseTelemetryProperty {
+export interface ITaggedBaseTelemetryPropertyValue {
     value: TelemetryBaseEventPropertyValue;
     tag: string;
 }
 
 export interface ITelemetryBaseProperties {
-    [index: string]: TelemetryBaseEventPropertyValue | ITaggedBaseTelemetryProperty;
+    [index: string]: TelemetryBaseEventPropertyValue | ITaggedBaseTelemetryPropertyValue;
 }
 
 /**

--- a/common/lib/common-definitions/src/test/types/validateCommonDefinitionsPrevious.ts
+++ b/common/lib/common-definitions/src/test/types/validateCommonDefinitionsPrevious.ts
@@ -251,6 +251,7 @@ declare function get_current_InterfaceDeclaration_ITelemetryBaseEvent():
 declare function use_old_InterfaceDeclaration_ITelemetryBaseEvent(
     use: TypeOnly<old.ITelemetryBaseEvent>);
 use_old_InterfaceDeclaration_ITelemetryBaseEvent(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryBaseEvent());
 
 /*


### PR DESCRIPTION
## Description

Adds new set of telemetry types and interfaces, identical to `ITelemetryProperties` (with the addition of `null`). `ITelemetryProperties` has been changed to deprecated, as it will be repurposed to support flat arrays and objects in a future release.

Added:
- TelemetryBaseEventPropertyType
- TaggedBaseTelemetryPropertyType
- ITelemetryBaseProperties

This PR is a subset of #12119, as it was suggested that the changes should be staged through multiple releases.

## Reviewer Guidance

### Questions
1. Is `common/lib/common-definitions/BREAKING.md` the correct location to add the "Upcoming" note? Or should this have been added into the `Upcoming.md` file in the root directory?
2. Should I specify the version for the "Upcoming" note? If so, is the version I should specify 0.21?
