### PR TITLE
AnchorSet: forget deleted anchor

### DIFF
--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -54,8 +54,6 @@ describe("AnchorSet", () => {
         assert.equal(anchors.locate(anchor3), undefined);
         assert.doesNotThrow(() => anchors.forget(anchor3));
         assert.throws(() => anchors.locate(anchor3));
-        assert.doesNotThrow(() => anchors.forget(anchor3));
-        assert.throws(() => anchors.locate(anchor3));
     });
 
     it("can rebase over delete parent node", () => {

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -51,6 +51,8 @@ describe("AnchorSet", () => {
         checkEquality(anchors.locate(anchor1), makePath([fieldFoo, 4], [fieldBar, 4]));
         checkEquality(anchors.locate(anchor2), path2);
         assert.equal(anchors.locate(anchor3), undefined);
+        assert.doesNotThrow(() => anchors.forget(anchor3));
+        assert.throws(() => anchors.locate(anchor3));
     });
 
     it("can rebase over move", () => {

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -412,7 +412,6 @@ class PathNode implements UpPath {
     }
 
     public removeRef(count = 1): void {
-        assert(!this.deleted, 0x357 /* PathNode must not be deleted */);
         this.refCount -= count;
         if (this.refCount < 1) {
             assert(
@@ -420,7 +419,7 @@ class PathNode implements UpPath {
                 0x358 /* PathNode Refcount should not be negative. */,
             );
 
-            if (this.children.size === 0) {
+            if (this.children.size === 0 && !this.deleted) {
                 this.deleteThis();
             }
         }

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -412,6 +412,7 @@ class PathNode implements UpPath {
     }
 
     public removeRef(count = 1): void {
+        assert(!this.deleted, 0x357 /* PathNode must not be deleted */);
         this.refCount -= count;
         if (this.refCount < 1) {
             assert(
@@ -419,7 +420,7 @@ class PathNode implements UpPath {
                 0x358 /* PathNode Refcount should not be negative. */,
             );
 
-            if (this.children.size === 0 && !this.deleted) {
+            if (this.children.size === 0) {
                 this.deleteThis();
             }
         }


### PR DESCRIPTION
It seems that AnchorSet is not finished. I tried to reflect my questions in tests here.

Questions so far:
- how one can forget deleted anchors?
Otherwise, as now `anchors.forget` just asserts for such anchors, there will be an "anchor leak" in EditableTree
- what should happen with children if parent node gets deleted?