### PR TITLE
Tree: Fix anchor rebase over delete

### DIFF
--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -56,7 +56,7 @@ describe("AnchorSet", () => {
         assert.throws(() => anchors.locate(anchor3));
     });
 
-    it("can rebase over delete parent node", () => {
+    it("can rebase over delete of parent node", () => {
         const [anchors, anchor1, anchor2, anchor3, anchor4] = setup();
         const deleteMark = {
             type: Delta.MarkType.Delete,
@@ -64,12 +64,10 @@ describe("AnchorSet", () => {
         };
 
         anchors.applyDelta(makeDelta(deleteMark, makePath([fieldFoo, 5])));
-        // TODO: what should happen with children and sibling anchors now?
-        // E.g. deleted parent in anchor1
-        checkEquality(anchors.locate(anchor1), makePath([fieldFoo, 5], [fieldBar, 4]));
+        assert.equal(anchors.locate(anchor4), undefined);
+        assert.equal(anchors.locate(anchor1), undefined);
         checkEquality(anchors.locate(anchor2), path2);
         checkEquality(anchors.locate(anchor3), path3);
-        assert.equal(anchors.locate(anchor4), undefined);
         assert.doesNotThrow(() => anchors.forget(anchor4));
         assert.throws(() => anchors.locate(anchor4));
     });

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -54,8 +54,6 @@ describe("AnchorSet", () => {
         assert.equal(anchors.locate(anchor3), undefined);
         assert.doesNotThrow(() => anchors.forget(anchor3));
         assert.throws(() => anchors.locate(anchor3));
-        assert.doesNotThrow(() => anchors.forget(anchor3));
-        assert.throws(() => anchors.locate(anchor3));
     });
 
     it("can rebase over delete parent node", () => {

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -51,6 +51,8 @@ describe("AnchorSet", () => {
         checkEquality(anchors.locate(anchor1), makePath([fieldFoo, 4], [fieldBar, 4]));
         checkEquality(anchors.locate(anchor2), path2);
         assert.equal(anchors.locate(anchor3), undefined);
+        assert.doesNotThrow(() => anchors.forget(anchor3));
+        assert.throws(() => anchors.locate(anchor3));
     });
 
     it("can rebase over move", () => {

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -80,7 +80,7 @@ export class AnchorSet {
 
         const path = this.anchorToPath.get(anchor);
         assert(path !== undefined, 0x3a6 /* Cannot locate anchor which is not in this AnchorSet */);
-        return path.deleted ? undefined : path;
+        return path.status === Status.Alive ? path : undefined;
     }
 
     public forget(anchor: Anchor): void {
@@ -147,7 +147,7 @@ export class AnchorSet {
     }
 
     /**
-     * Recursively marks the given `nodes` and their descendants as deleted.
+     * Recursively marks the given `nodes` and their descendants as disposed and pointing to a deleted node.
      * Node that this does NOT detach the nodes.
      */
     private deepDelete(nodes: readonly PathNode[]): void {
@@ -155,8 +155,8 @@ export class AnchorSet {
         while (stack.length > 0) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const node = stack.pop()!;
-            assert(!node.deleted, 0x353 /* PathNode must not be deleted */);
-            node.deleted = true;
+            assert(node.status === Status.Alive, "PathNode must be alive");
+            node.status = Status.Dead;
             for (const children of node.children.values()) {
                 stack.push(...children);
             }
@@ -341,6 +341,33 @@ export class AnchorSet {
 }
 
 /**
+ * Indicates the status of a `NodePath`.
+ */
+enum Status {
+    /**
+     * Indicates the `NodePath` is being maintained and corresponds to a valid
+     * (i.e., not deleted) node in the document.
+     */
+    Alive,
+    /**
+     * Indicates the `NodePath` is not being maintained by the `AnchorSet`.
+     * The `NodePath` may or may not correspond to a valid node in the document.
+     *
+     * Accessing such a node is invalid.
+     * Nodes in this state are retained to detect use-after-free bugs.
+     */
+    Disposed,
+    /**
+     * Indicates the `NodePath` corresponds to a deleted node in the document
+     * and is not being maintained by the `AnchorSet`.
+     *
+     * Accessing such a node is invalid.
+     * Nodes in this state are retained to detect use-after-free bugs.
+     */
+    Dead,
+}
+
+/**
  * Tree of anchors.
  *
  * Contains both child and parent pointers, which are kept in sync.
@@ -371,13 +398,7 @@ class PathNode implements UpPath {
      */
     private refCount = 1;
 
-    /**
-     * Whether the PathNode represents a document node that has been deleted.
-     *
-     * Used to determine whether an anchor can be resolved to a valid path
-     * (where "valid" means a path to an existing node).
-     */
-    public deleted = false;
+    public status: Status = Status.Alive;
 
     /**
      * PathNode arrays are kept sorted the PathNode's parentIndex for efficient search.
@@ -414,7 +435,7 @@ class PathNode implements UpPath {
     }
 
     public get parent(): UpPath | undefined {
-        assert(!this.deleted, 0x354 /* PathNode must not be deleted */);
+        assert(this.status !== Status.Disposed, "PathNode must not be disposed");
         assert(
             this.parentPath !== undefined,
             0x355 /* PathNode.parent is an UpPath API and thus should never be called on the root PathNode. */,
@@ -427,11 +448,12 @@ class PathNode implements UpPath {
     }
 
     public addRef(count = 1): void {
-        assert(!this.deleted, 0x356 /* PathNode must not be deleted */);
+        assert(this.status === Status.Alive, "PathNode must be alive");
         this.refCount += count;
     }
 
     public removeRef(count = 1): void {
+        assert(this.status !== Status.Disposed, "PathNode must not be disposed");
         this.refCount -= count;
         if (this.refCount < 1) {
             assert(
@@ -440,7 +462,7 @@ class PathNode implements UpPath {
             );
 
             if (this.children.size === 0) {
-                this.deleteThis();
+                this.disposeThis();
             }
         }
     }
@@ -450,7 +472,7 @@ class PathNode implements UpPath {
      * Creates child (with 1 ref) if needed.
      */
     public getOrCreateChild(key: FieldKey, index: number): PathNode {
-        assert(!this.deleted, 0x359 /* PathNode must not be deleted */);
+        assert(this.status === Status.Alive, "PathNode must be alive");
         let field = this.children.get(key);
         if (field === undefined) {
             field = [];
@@ -474,7 +496,7 @@ class PathNode implements UpPath {
      * Does NOT add a ref.
      */
     public tryGetChild(key: FieldKey, index: number): PathNode | undefined {
-        assert(!this.deleted, 0x35a /* PathNode must not be deleted */);
+        assert(this.status === Status.Alive, "PathNode must be alive");
         const field = this.children.get(key);
         if (field === undefined) {
             return undefined;
@@ -489,7 +511,7 @@ class PathNode implements UpPath {
      * the caller must ensure that the reference from child to parent is also removed (or the child is no longer used).
      */
     public removeChild(child: PathNode): void {
-        assert(!this.deleted, 0x35b /* PathNode must not be deleted */);
+        assert(this.status === Status.Alive, "PathNode must be alive");
         const key = child.parentField;
         const field = this.children.get(key);
         // TODO: should do more optimized search (ex: binary search or better) using child.parentIndex()
@@ -511,20 +533,20 @@ class PathNode implements UpPath {
      * (like the field in the map, and possibly this entire PathNode and its parents if they are no longer needed.)
      */
     public afterEmptyField(key: FieldKey): void {
-        assert(!this.deleted, 0x35d /* PathNode must not be deleted */);
+        assert(this.status === Status.Alive, "PathNode must be alive");
         this.children.delete(key);
         if (this.refCount === 0 && this.children.size === 0) {
-            this.deleteThis();
+            this.disposeThis();
         }
     }
 
     /**
-     * Removes this from parent, and sets this to deleted.
+     * Removes this from parent, and sets this to disposed.
      */
-    private deleteThis(): void {
-        assert(!this.deleted, 0x35e /* must not double delete PathNode */);
+    private disposeThis(): void {
+        assert(this.status !== Status.Disposed, "PathNode must be alive");
         this.parentPath?.removeChild(this);
 
-        this.deleted = true;
+        this.status = Status.Disposed;
     }
 }

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -412,7 +412,6 @@ class PathNode implements UpPath {
     }
 
     public removeRef(count = 1): void {
-        assert(!this.deleted, 0x357 /* PathNode must not be deleted */);
         this.refCount -= count;
         if (this.refCount < 1) {
             assert(
@@ -420,7 +419,7 @@ class PathNode implements UpPath {
                 0x358 /* PathNode Refcount should not be negative. */,
             );
 
-            if (this.children.size === 0) {
+            if (this.children.size === 0 && !this.deleted) {
                 this.deleteThis();
             }
         }

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -412,6 +412,7 @@ class PathNode implements UpPath {
     }
 
     public removeRef(count = 1): void {
+        assert(!this.deleted, 0x357 /* PathNode must not be deleted */);
         this.refCount -= count;
         if (this.refCount < 1) {
             assert(
@@ -419,7 +420,7 @@ class PathNode implements UpPath {
                 0x358 /* PathNode Refcount should not be negative. */,
             );
 
-            if (this.children.size === 0 && !this.deleted) {
+            if (this.children.size === 0) {
                 this.deleteThis();
             }
         }

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -146,9 +146,14 @@ export class AnchorSet {
         return parentPath?.tryGetChild(path.parentField, path.parentIndex);
     }
 
+    /**
+     * Recursively marks the given `nodes` and their descendants as deleted.
+     * Node that this does NOT detach the nodes.
+     */
     private deepDelete(nodes: readonly PathNode[]): void {
         const stack = [...nodes];
         while (stack.length > 0) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const node = stack.pop()!;
             assert(!node.deleted, 0x353 /* PathNode must not be deleted */);
             node.deleted = true;
@@ -366,6 +371,12 @@ class PathNode implements UpPath {
      */
     private refCount = 1;
 
+    /**
+     * Whether the PathNode represents a document node that has been deleted.
+     *
+     * Used to determine whether an anchor can be resolved to a valid path
+     * (where "valid" means a path to an existing node).
+     */
     public deleted = false;
 
     /**
@@ -508,7 +519,7 @@ class PathNode implements UpPath {
     }
 
     /**
-     * Removes this from parent, and sets this to deleated.
+     * Removes this from parent, and sets this to deleted.
      */
     private deleteThis(): void {
         assert(!this.deleted, 0x35e /* must not double delete PathNode */);


### PR DESCRIPTION
This PR fixes a bug in `AnchorSet`'s handling of deletions.