### PR TITLE
Unpin oclif/core

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -73,7 +73,7 @@
     "@fluid-tools/version-tools": "^0.4.7000",
     "@fluidframework/build-tools": "^0.4.7000",
     "@fluidframework/bundle-size-tools": "^0.4.7000",
-    "@oclif/core": "~1.9.5",
+    "@oclif/core": "^1.9.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.1",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -68,7 +68,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@oclif/core": "~1.9.5",
+    "@oclif/core": "^1.9.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.1",

--- a/tools/telemetry-generator/package.json
+++ b/tools/telemetry-generator/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/test-driver-definitions": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
-    "@oclif/core": "1.12.0"
+    "@oclif/core": "^1.12.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.24.0",


### PR DESCRIPTION
## Description

I was mistaken [before](https://github.com/microsoft/FluidFramework/pull/11703) regarding us having issues with versions >=1.13 of oclif/core because they started targeting ES2020. The issue was probably that I ran my tests with node 12 instead of 14.

This PR doesn't intend to change the actual versions being used right now, just unpinning the dependencies.
