### PR TITLE
Overwrite attach on FluidContainer rather than require class inheritance

### DIFF
--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -39,7 +39,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
-    constructor(container: IContainer, rootDataObject: RootDataObject, attach?: () => Promise<string>);
+    constructor(container: IContainer, rootDataObject: RootDataObject);
     attach(): Promise<string>;
     get attachState(): AttachState;
     connect(): Promise<void>;

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -39,7 +39,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
-    constructor(container: IContainer, rootDataObject: RootDataObject);
+    constructor(container: IContainer, rootDataObject: RootDataObject, attach?: () => Promise<string>);
     attach(): Promise<string>;
     get attachState(): AttachState;
     connect(): Promise<void>;

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -228,25 +228,19 @@ export class AzureClient {
         );
 
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
-        return new (class extends FluidContainer {
-            /**
-             * See {@link FluidContainer.attach}
-             *
-             * @remarks This is required since the FluidContainer doesn't have knowledge of how the attach will happen
-             * or the id that will be returned.
-             * This exists because we are projecting a separation of server responsibility to the end developer that
-             * doesn't exist in the framework.
-             */
-            public async attach(): Promise<string> {
-                if (this.attachState !== AttachState.Detached) {
-                    throw new Error("Cannot attach container. Container is not in detached state");
-                }
-                await container.attach(createNewRequest);
-                const resolved = container.resolvedUrl;
-                ensureFluidResolvedUrl(resolved);
-                return resolved.id;
+
+        const attach = async (): Promise<string> => {
+            if (container.attachState !== AttachState.Detached) {
+                throw new Error("Cannot attach container. Container is not in detached state");
             }
-        })(container, rootDataObject);
+            await container.attach(createNewRequest);
+            const resolved = container.resolvedUrl;
+            ensureFluidResolvedUrl(resolved);
+            return resolved.id;
+        };
+        const fluidContainer = new FluidContainer(container, rootDataObject);
+        fluidContainer.attach = attach;
+        return fluidContainer;
     }
     // #endregion
 }

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -229,6 +229,9 @@ export class AzureClient {
 
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
 
+        /**
+         * See {@link FluidContainer.attach}
+         */
         const attach = async (): Promise<string> => {
             if (container.attachState !== AttachState.Detached) {
                 throw new Error("Cannot attach container. Container is not in detached state");

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -185,12 +185,8 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     public constructor(
         private readonly container: IContainer,
         private readonly rootDataObject: RootDataObject,
-        attach?: () => Promise<string>,
     ) {
         super();
-        if (attach !== undefined) {
-            this.attach = attach;
-        }
         container.on("connected", this.connectedHandler);
         container.on("closed", this.disposedHandler);
         container.on("disconnected", this.disconnectedHandler);

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -185,8 +185,12 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     public constructor(
         private readonly container: IContainer,
         private readonly rootDataObject: RootDataObject,
+        attach?: () => Promise<string>,
     ) {
         super();
+        if (attach !== undefined) {
+            this.attach = attach;
+        }
         container.on("connected", this.connectedHandler);
         container.on("closed", this.disposedHandler);
         container.on("disconnected", this.disconnectedHandler);
@@ -197,7 +201,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     /**
      * {@inheritDoc IFluidContainer.isDirty}
      */
-     public get isDirty(): boolean {
+    public get isDirty(): boolean {
         return this.container.isDirty;
     }
 
@@ -218,7 +222,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     /**
      * {@inheritDoc IFluidContainer.connectionState}
      */
-     public get connectionState(): ConnectionState {
+    public get connectionState(): ConnectionState {
         return this.container.connectionState;
     }
 
@@ -242,7 +246,10 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
      * but internally this separation is not there.
      */
     public async attach(): Promise<string> {
-        throw new Error("Cannot attach container. Container is not in detached state");
+        if (this.container.attachState !== AttachState.Detached) {
+            throw new Error("Cannot attach container. Container is not in detached state.");
+        }
+        throw new Error("Cannot attach container. Attach method not provided.");
     }
 
     /**

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -77,18 +77,18 @@ export class TinyliciousClient {
 
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
 
-        const fluidContainer = new (class extends FluidContainer {
-            async attach() {
-                if (this.attachState !== AttachState.Detached) {
-                    throw new Error("Cannot attach container. Container is not in detached state");
-                }
-                const request = createTinyliciousCreateNewRequest();
-                await container.attach(request);
-                const resolved = container.resolvedUrl;
-                ensureFluidResolvedUrl(resolved);
-                return resolved.id;
+        const attach = async (): Promise<string> => {
+            if (container.attachState !== AttachState.Detached) {
+                throw new Error("Cannot attach container. Container is not in detached state.");
             }
-        })(container, rootDataObject);
+            const request = createTinyliciousCreateNewRequest();
+            await container.attach(request);
+            const resolved = container.resolvedUrl;
+            ensureFluidResolvedUrl(resolved);
+            return resolved.id;
+        };
+
+        const fluidContainer = new FluidContainer(container, rootDataObject, attach);
 
         const services = this.getContainerServices(container);
         return { container: fluidContainer, services };

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -77,6 +77,9 @@ export class TinyliciousClient {
 
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
 
+        /**
+         * See {@link FluidContainer.attach}
+         */
         const attach = async (): Promise<string> => {
             if (container.attachState !== AttachState.Detached) {
                 throw new Error("Cannot attach container. Container is not in detached state.");

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -88,7 +88,8 @@ export class TinyliciousClient {
             return resolved.id;
         };
 
-        const fluidContainer = new FluidContainer(container, rootDataObject, attach);
+        const fluidContainer = new FluidContainer(container, rootDataObject);
+        fluidContainer.attach = attach;
 
         const services = this.getContainerServices(container);
         return { container: fluidContainer, services };


### PR DESCRIPTION
This is a relatively small change, to reduce reliance on class inheritance.  This will align better with the model loading pattern which wants a separate attach function as well.

Longer term, I think it's probably appropriate to separate the attach method from FluidContainer entirely (i.e. createContainer returns it distinct from the fluidContainer).  This would also avoid the somewhat confusing current state that fluidContainer.attach() is always there but sometimes just invalid to call.  But that will be a breaking change, and is probably easier to manage after the model loading pattern is integrated.

UPDATE: Originally was passing attach in the constructor, but realized it's easier to just overwrite the member directly and avoids changing the API signature.  This approach also allows for updating the AzureClient simultaneously since we don't need to wait for a new version to publish.