### PR TITLE
Refactor a bit disconnect flow

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -29,17 +29,17 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     checkpointSequenceNumber: number | undefined;
     get claims(): ITokenClaims;
     get clientId(): string;
+    protected closeSocket(error: IAnyDriverError): void;
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;
-    protected disconnect(): void;
-    dispose(): void;
     // (undocumented)
-    protected disposeCore(err: IAnyDriverError): void;
+    protected disconnect(err: IAnyDriverError): void;
+    protected disconnectCore(): void;
+    dispose(): void;
     // (undocumented)
     get disposed(): boolean;
     protected _disposed: boolean;
-    protected disposeSocket(error: IAnyDriverError): void;
     // (undocumented)
     documentId: string;
     // (undocumented)

--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -32,7 +32,7 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;
-    protected disconnect(reason: IAnyDriverError): void;
+    protected disconnect(): void;
     dispose(): void;
     // (undocumented)
     protected disposeCore(err: IAnyDriverError): void;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -343,15 +343,22 @@ export class DocumentDeltaConnection
         // to prevent normal messages from being emitted.
         this._disposed = true;
 
+        // Let user of connection object know about disconnect. This has to happen in betwee setting _disposed and
+        // removing all listeners!
+        this.emit("disconnect", err);
+
+        // user of DeltaConnection should have processed "disconnect" event and removed all listeners.
+        assert(this.listenerCount("disconnect") === 0, "'disconnect` events should be processed synchronously");
+
         this.removeTrackedListeners();
-        this.disconnect(err);
+        this.disconnect();
     }
 
     /**
      * Disconnect from the websocket.
      * @param reason - reason for disconnect
      */
-    protected disconnect(reason: IAnyDriverError) {
+    protected disconnect() {
         this.socket.disconnect();
     }
 


### PR DESCRIPTION
Follow up to PR #12168 & PR #12105 
I believe this makes disconnect flow even more explicit.
And I also think this fixes issues with losing disconnect reasons - we were disconnecting listeners before raising "disconnect" event. This feels really strange, as I'd expect system not to work at all with this kind of bug.

Did not yet test it manually yet.