### PR TITLE
Fix creating compact snapshots when no ops are provided

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -143,9 +143,11 @@ export function convertToCompactSnapshot(snapshotContents: ISnapshotContents): U
     const rootNode = builder.addNode();
     assert(snapshotContents.sequenceNumber !== undefined, 0x21c /* "Seq number should be provided" */);
 
-    const latestSequenceNumber = snapshotContents.latestSequenceNumber ??
-        snapshotContents.ops.length > 0 ?
-        snapshotContents.ops[snapshotContents.ops.length - 1].sequenceNumber : snapshotContents.sequenceNumber;
+    let latestSequenceNumber = snapshotContents.latestSequenceNumber;
+    if (latestSequenceNumber === undefined) {
+        latestSequenceNumber = snapshotContents.ops.length > 0 ?
+            snapshotContents.ops[snapshotContents.ops.length - 1].sequenceNumber : snapshotContents.sequenceNumber;
+    }
 
     writeSnapshotProps(rootNode, latestSequenceNumber);
 

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -115,4 +115,26 @@ describe("Snapshot Format Conversion Tests", () => {
         assert.deepStrictEqual(compactSnapshot2.buffer, compactSnapshot.buffer,
             "Compact representation should remain same");
     });
+
+    it("Conversion test with empty ops", async () => {
+        const snapshotContents: ISnapshotContents = {
+            snapshotTree,
+            blobs,
+            ops: [],
+            sequenceNumber: 0,
+            latestSequenceNumber: 2,
+        };
+        const compactSnapshot = convertToCompactSnapshot(snapshotContents);
+        const result = parseCompactSnapshotResponse(compactSnapshot, new TelemetryUTLogger());
+        assert.deepStrictEqual(result.snapshotTree, snapshotTree, "Tree structure should match");
+        assert.deepStrictEqual(result.blobs, blobs, "Blobs content should match");
+        assert.deepStrictEqual(result.ops, [], "Ops should match");
+        assert(result.sequenceNumber === 0, "Seq number should match");
+        assert(result.latestSequenceNumber === 2, "Latest sequence number should match");
+        assert(result.snapshotTree.id = snapshotContents.snapshotTree.id, "Snapshot id should match");
+        // Convert to compact snapshot again and then match to previous one.
+        const compactSnapshot2 = convertToCompactSnapshot(result);
+        assert.deepStrictEqual(compactSnapshot2.buffer, compactSnapshot.buffer,
+            "Compact representation should remain same");
+    });
 });


### PR DESCRIPTION
The `latestSequenceNumber` line was compiled down to 
```typescript
    const latestSequenceNumber = ((_a = snapshotContents.latestSequenceNumber) !== null && _a !== void 0 ? _a : snapshotContents.ops.length > 0) ?
        snapshotContents.ops[snapshotContents.ops.length - 1].sequenceNumber : snapshotContents.sequenceNumber;
```
So if `latestSequenceNumber` was provided and the length of `ops` was 0, it was calling `snapshotContents.ops[snapshotContents.ops.length - 1].sequenceNumber`, which would throw an error.
Rewriting that logic so it's easier to read and adding a test for this case.