### PR TITLE
Handle error object inside the IOdspSocketError

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -62,6 +62,12 @@ export interface IOdspSocketError {
      * The client should wait this many seconds before retrying its request
      */
     retryAfter?: number;
+
+    /**
+     * Any error supplied by the socket containing codes and inner errors with further
+     * details about the error.
+     */
+    error?: any;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -7,7 +7,7 @@ import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { NonRetryableError } from "@fluidframework/driver-utils";
 import { OdspError } from "@fluidframework/odsp-driver-definitions";
-import { IFluidErrorBase } from "@fluidframework/telemetry-utils";
+import { getCircularReplacer, IFluidErrorBase } from "@fluidframework/telemetry-utils";
 import { IOdspSocketError } from "./contracts";
 import { pkgVersion as driverVersion } from "./packageVersion";
 
@@ -24,8 +24,9 @@ export function errorObjectFromSocketError(socketError: IOdspSocketError, handle
             message,
             socketError.code,
             socketError.retryAfter,
-            undefined,
-            socketError.error ? JSON.stringify({ error: socketError.error }) : undefined,
+            undefined, // response from http request
+            socketError.error ?
+                JSON.stringify({ error: socketError.error }, getCircularReplacer()) : undefined, // responseText
         );
 
         error.addTelemetryProperties({ odspError: true, relayServiceError: true });

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -23,7 +23,10 @@ export function errorObjectFromSocketError(socketError: IOdspSocketError, handle
         const error = createOdspNetworkError(
             message,
             socketError.code,
-            socketError.retryAfter);
+            socketError.retryAfter,
+            undefined,
+            socketError.error ? JSON.stringify({ error: socketError.error }) : undefined,
+        );
 
         error.addTelemetryProperties({ odspError: true, relayServiceError: true });
         return error;

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -109,6 +109,37 @@ describe("Odsp Error", () => {
         }
     });
 
+    it("errorObjectFromSocketError with inner errors", async () => {
+        const socketError: IOdspSocketError = {
+            message: "testMessage",
+            code: 400,
+            error: {
+                code: "notAllowed",
+                innerError: {
+                    code: "ipBlocked",
+                    innerError: {
+                        code: "SurelyBlocked",
+                    },
+                },
+                message: "Blocking due to policy",
+            },
+        };
+        const networkError = errorObjectFromSocketError(socketError, "error");
+        console.log(networkError);
+        if (networkError.errorType !== DriverErrorType.genericNetworkError) {
+            assert.fail("networkError should be a genericNetworkError");
+        } else {
+            assert(networkError.message.includes("error"), "error message should include handler name");
+            assert(networkError.message.includes("testMessage"), "error message should include socket error message");
+            assert.equal(networkError.canRetry, false);
+            assert.equal(networkError.statusCode, 400);
+            assert.equal(networkError.getTelemetryProperties().innerMostErrorCode, "SurelyBlocked",
+                "Innermost error code should be correct");
+            assert.equal(networkError.facetCodes?.length, 3,
+                "3 facet codes should be there");
+        }
+    });
+
     it("errorObjectFromSocketError with retryAfter", async () => {
         const socketError: IOdspSocketError = {
             message: "testMessage",

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -125,7 +125,6 @@ describe("Odsp Error", () => {
             },
         };
         const networkError = errorObjectFromSocketError(socketError, "error");
-        console.log(networkError);
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
         } else {


### PR DESCRIPTION
## Description

Handle error object inside the IOdspSocketError. Extract info from that socket error and set it as innerMostErrorCode and facetcaodes just like other odsp errors.