### PR TITLE
Move IAnyDriverError to driver-definitions

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -6,7 +6,7 @@
 
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { EventEmitterWithErrorHandling } from '@fluidframework/telemetry-utils';
-import { IAnyDriverError } from '@fluidframework/driver-utils';
+import { IAnyDriverError } from '@fluidframework/driver-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IConnect } from '@fluidframework/protocol-definitions';
 import { IConnected } from '@fluidframework/protocol-definitions';

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -68,6 +68,12 @@ export enum FetchSource {
     noCache = "noCache"
 }
 
+// @public
+export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
+    // (undocumented)
+    readonly errorType: string;
+}
+
 // @public (undocumented)
 export interface IAuthorizationError extends IDriverErrorBase {
     // (undocumented)
@@ -118,7 +124,7 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
     // (undocumented)
     (event: "nack", listener: (documentId: string, message: INack[]) => void): any;
     // (undocumented)
-    (event: "disconnect", listener: (reason: any) => void): any;
+    (event: "disconnect", listener: (reason: IAnyDriverError) => void): any;
     // (undocumented)
     (event: "op", listener: (documentId: string, messages: ISequencedDocumentMessage[]) => void): any;
     // (undocumented)

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -216,7 +216,7 @@ export const getRetryDelayFromError: (error: any) => number | undefined;
 // @public
 export const getRetryDelaySecondsFromError: (error: any) => number | undefined;
 
-// @public
+// @public @deprecated
 export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
     // (undocumented)
     readonly errorType: string;

--- a/packages/common/driver-definitions/src/driverError.ts
+++ b/packages/common/driver-definitions/src/driverError.ts
@@ -93,6 +93,19 @@ export enum DriverErrorType {
 }
 
 /**
+ * Interface describing errors and warnings raised by any driver code.
+ * Not expected to be implemented by a class or an object literal, but rather used in place of
+ * any or unknown in various function signatures that pass errors around.
+ *
+ * "Any" in the interface name is a nod to the fact that errorType has lost its type constraint.
+ * It will be either DriverErrorType or the specific driver's specialized error type enum,
+ * but we can't reference a specific driver's error type enum in this code.
+ */
+export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
+    readonly errorType: string;
+}
+
+/**
  * Base interface for all errors and warnings
  */
 export interface IDriverErrorBase {

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -20,6 +20,7 @@ import {
     ITokenClaims,
     IVersion,
 } from "@fluidframework/protocol-definitions";
+import { IAnyDriverError } from "./driverError";
 import { IResolvedUrl } from "./urlResolver";
 
 export interface IDeltasFetchResult {
@@ -170,7 +171,7 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
 
 export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
     (event: "nack", listener: (documentId: string, message: INack[]) => void);
-    (event: "disconnect", listener: (reason: any) => void);
+    (event: "disconnect", listener: (reason: IAnyDriverError) => void);
     (event: "op", listener: (documentId: string, messages: ISequencedDocumentMessage[]) => void);
     (event: "signal", listener: (message: ISignalMessage) => void);
     (event: "pong", listener: (latency: number) => void);

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -5,10 +5,11 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
+    IAnyDriverError,
     IDocumentDeltaConnection,
     IDocumentDeltaConnectionEvents,
 } from "@fluidframework/driver-definitions";
-import { createGenericNetworkError, IAnyDriverError } from "@fluidframework/driver-utils";
+import { createGenericNetworkError } from "@fluidframework/driver-utils";
 import {
     ConnectionMode,
     IClientConfiguration,

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -6,8 +6,8 @@
 import { ITelemetryLogger, IEvent } from "@fluidframework/common-definitions";
 import { assert, performance, Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
+import { IAnyDriverError } from "@fluidframework/driver-definitions";
 import { OdspError } from "@fluidframework/odsp-driver-definitions";
-import { IAnyDriverError } from "@fluidframework/driver-utils";
 import { IFluidErrorBase, loggerToMonitoringContext } from "@fluidframework/telemetry-utils";
 import {
     IClient,

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -5,8 +5,7 @@
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
-import { IDocumentDeltaConnection } from "@fluidframework/driver-definitions";
-import { IAnyDriverError } from "@fluidframework/driver-utils";
+import { IAnyDriverError, IDocumentDeltaConnection } from "@fluidframework/driver-definitions";
 import { IClient, IConnect } from "@fluidframework/protocol-definitions";
 import type { io as SocketIOClientStatic } from "socket.io-client";
 import { errorObjectFromSocketError, IR11sSocketError } from "./errorUtils";

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -18,6 +18,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { GenericError, UsageError } from "@fluidframework/container-utils";
 import {
+    IAnyDriverError,
     IDocumentService,
     IDocumentDeltaConnection,
     IDocumentDeltaConnectionEvents,
@@ -27,7 +28,6 @@ import {
     createWriteError,
     createGenericNetworkError,
     getRetryDelayFromError,
-    IAnyDriverError,
     waitForConnectedState,
     DeltaStreamConnectionForbiddenError,
     logNetworkFailure,

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -38,8 +38,11 @@ export function isOnline(): OnlineStatus {
  * "Any" in the interface name is a nod to the fact that errorType has lost its type constraint.
  * It will be either DriverErrorType or the specific driver's specialized error type enum,
  * but we can't reference a specific driver's error type enum in this code.
- */
- export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
+ *
+ * @deprecated - In favour of {@link @fluidframework/driver-definitions#IAnyDriverError} so that
+ * it can used from the base to upper layers.
+*/
+export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
     readonly errorType: string;
 }
 

--- a/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
+++ b/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
@@ -4,7 +4,11 @@
  */
 
 import { IDisposable } from "@fluidframework/common-definitions";
-import { IDocumentDeltaConnection, IDocumentDeltaConnectionEvents } from "@fluidframework/driver-definitions";
+import {
+    IAnyDriverError,
+    IDocumentDeltaConnection,
+    IDocumentDeltaConnectionEvents,
+} from "@fluidframework/driver-definitions";
 import {
     ConnectionMode,
     IClientConfiguration,
@@ -16,7 +20,6 @@ import {
     ITokenClaims,
 } from "@fluidframework/protocol-definitions";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { IAnyDriverError } from "@fluidframework/driver-utils";
 
 // This is coppied from alfred.  Probably should clean this up.
 const DefaultServiceConfiguration: IClientConfiguration = {


### PR DESCRIPTION
## Description

Move IAnyDriverError to driver-definitions because it needs to be used in layers below loader. 