### PR TITLE
Propagate disconnected reason during 'disconnected' event

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -233,8 +233,8 @@ export class PerformanceEvent {
     static timedExecAsync<T>(logger: ITelemetryLogger, event: ITelemetryGenericEvent, callback: (event: PerformanceEvent) => Promise<T>, markers?: IPerformanceEventMarkers): Promise<T>;
 }
 
-// @public (undocumented)
-export function raiseConnectedEvent(logger: ITelemetryLogger, emitter: EventEmitter, connected: boolean, clientId?: string): void;
+// @public
+export function raiseConnectedEvent(logger: ITelemetryLogger, emitter: EventEmitter, connected: boolean, clientId?: string, disconnectedReason?: string): void;
 
 // @public (undocumented)
 export function safeRaiseEvent(emitter: EventEmitter, logger: ITelemetryLogger, event: string, ...args: any[]): void;

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -20,7 +20,7 @@ export interface IConnectionStateHandlerInputs {
     logger: ITelemetryLogger;
     /** Log to telemetry any change in state, included to Connecting */
     connectionStateChanged:
-        (value: ConnectionState, oldState: ConnectionState, disconnectedReason?: string | undefined) => void;
+        (value: ConnectionState, oldState: ConnectionState, reason?: string | undefined) => void;
     /** Whether to expect the client to join in write mode on next connection */
     shouldClientJoinWrite: () => boolean;
     /** (Optional) How long should we wait on our previous client's Leave op before transitioning to Connected again */
@@ -109,9 +109,9 @@ class ConnectionStateHandlerPassThrough implements IConnectionStateHandler, ICon
     public connectionStateChanged(
         value: ConnectionState,
         oldState: ConnectionState,
-        disconnectedReason?: string | undefined,
+        reason?: string | undefined,
     ) {
-        return this.inputs.connectionStateChanged(value, oldState, disconnectedReason);
+        return this.inputs.connectionStateChanged(value, oldState, reason);
     }
     public shouldClientJoinWrite() { return this.inputs.shouldClientJoinWrite(); }
     public get maxClientLeaveWaitTime() { return this.inputs.maxClientLeaveWaitTime; }
@@ -141,11 +141,7 @@ class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
         return this._connectionState;
     }
 
-    public connectionStateChanged(
-        value: ConnectionState,
-        oldState: ConnectionState,
-        disconnectedReason?: string | undefined,
-    ) {
+    public connectionStateChanged(value: ConnectionState, oldState: ConnectionState, reason?: string | undefined) {
         switch (value) {
             case ConnectionState.Connected:
                 assert(this._connectionState === ConnectionState.CatchingUp, 0x3e1 /* connectivity transitions */);
@@ -168,7 +164,7 @@ class ConnectionStateCatchup extends ConnectionStateHandlerPassThrough {
             default:
         }
         this._connectionState = value;
-        this.inputs.connectionStateChanged(value, oldState, disconnectedReason);
+        this.inputs.connectionStateChanged(value, oldState, reason);
     }
 
     private readonly transitionToConnectedState = () => {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -637,7 +637,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     }
                     this.logConnectionStateChangeTelemetry(value, oldState, reason);
                     if (this._lifecycleState === "loaded") {
-                        this.propagateConnectionState(false /* initial transition */);
+                        this.propagateConnectionState(false /* initial transition */, reason);
                     }
                 },
                 shouldClientJoinWrite: () => this._deltaManager.connectionManager.shouldJoinWrite(),
@@ -1610,7 +1610,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         }
     }
 
-    private propagateConnectionState(initialTransition: boolean) {
+    private propagateConnectionState(initialTransition: boolean, reason?: string) {
         // When container loaded, we want to propagate initial connection state.
         // After that, we communicate only transitions to Connected & Disconnected states, skipping all other states.
         // This can be changed in the future, for example we likely should add "CatchingUp" event on Container.
@@ -1633,7 +1633,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         this.setContextConnectedState(state, this._deltaManager.connectionManager.readOnlyInfo.readonly ?? false);
         this.protocolHandler.setConnectionState(state, this.clientId);
-        raiseConnectedEvent(this.mc.logger, this, state, this.clientId);
+        raiseConnectedEvent(this.mc.logger, this, state, this.clientId, reason);
 
         if (logOpsOnReconnect) {
             this.mc.logger.sendTelemetryEvent(

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -631,13 +631,16 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.connectionStateHandler = createConnectionStateHandler(
             {
                 logger: this.mc.logger,
-                connectionStateChanged: (value, oldState, disconnectedReason) => {
+                connectionStateChanged: (value, oldState, reason) => {
                     if (value === ConnectionState.Connected) {
                         this._clientId = this.connectionStateHandler.pendingClientId;
                     }
-                    this.logConnectionStateChangeTelemetry(value, oldState, disconnectedReason);
+                    this.logConnectionStateChangeTelemetry(value, oldState, reason);
                     if (this._lifecycleState === "loaded") {
-                        this.propagateConnectionState(false /* initial transition */, disconnectedReason);
+                        this.propagateConnectionState(
+                            false /* initial transition */,
+                            value === ConnectionState.Disconnected ? reason : undefined /* disconnectedReason */,
+                        );
                     }
                 },
                 shouldClientJoinWrite: () => this._deltaManager.connectionManager.shouldJoinWrite(),

--- a/packages/utils/telemetry-utils/src/events.ts
+++ b/packages/utils/telemetry-utils/src/events.ts
@@ -23,6 +23,14 @@ export function safeRaiseEvent(
     }
 }
 
+/**
+ * Raises events pertaining to the connection
+ * @param logger - The logger to log telemetry
+ * @param emitter - The event emitter instance
+ * @param connected - A boolean tracking whether the connection was in a connected state or not
+ * @param clientId - The ID of the client
+ * @param disconnectedReason - The reason for the connection to be disconnected (Used for telemetry purposes only)
+ */
 export function raiseConnectedEvent(
     logger: ITelemetryLogger,
     emitter: EventEmitter,

--- a/packages/utils/telemetry-utils/src/events.ts
+++ b/packages/utils/telemetry-utils/src/events.ts
@@ -28,7 +28,7 @@ export function safeRaiseEvent(
  * @param logger - The logger to log telemetry
  * @param emitter - The event emitter instance
  * @param connected - A boolean tracking whether the connection was in a connected state or not
- * @param clientId - The ID of the client
+ * @param clientId - The connected/disconnected clientId
  * @param disconnectedReason - The reason for the connection to be disconnected (Used for telemetry purposes only)
  */
 export function raiseConnectedEvent(

--- a/packages/utils/telemetry-utils/src/events.ts
+++ b/packages/utils/telemetry-utils/src/events.ts
@@ -27,12 +27,13 @@ export function raiseConnectedEvent(
     logger: ITelemetryLogger,
     emitter: EventEmitter,
     connected: boolean,
-    clientId?: string) {
+    clientId?: string,
+    disconnectedReason?: string) {
     try {
         if (connected) {
             emitter.emit(connectedEventName, clientId);
         } else {
-            emitter.emit(disconnectedEventName);
+            emitter.emit(disconnectedEventName, disconnectedReason);
         }
     } catch (error) {
         logger.sendErrorEvent({ eventName: "RaiseConnectedEventError" }, error);


### PR DESCRIPTION
## Description

The container emits a `disconnected` event in event of a connection loss but it doesn't emit any additional details about why the connection was disconnected. This information is already available in the container in the form of `reason` and is also logged in Fluid Framework's telemetry but isn't accessible to the host that integrates with the Fluid Framework.

This change propagates `reason` when a `disconnected` event is raised by the container.

## Other information or known dependencies

- The Microsoft Loop team is relying on this change to measure and improve connectivity reliability across Microsoft Loop experiences
- The **next steps** here would be to instrument in the host experience cases where we don't restore connection within an appropriate time and keep track of the disconnected reason that contribute to the loss of connection
