### PR TITLE
run prettier on tree package config files

### DIFF
--- a/packages/dds/tree/.eslintrc.js
+++ b/packages/dds/tree/.eslintrc.js
@@ -4,15 +4,13 @@
  */
 
 module.exports = {
-	extends: [
-        require.resolve("@fluidframework/eslint-config-fluid"), "prettier"
-    ],
-	parserOptions: {
-		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
-	},
-	rules: {
-		"@typescript-eslint/no-namespace": "off",
-		"@typescript-eslint/no-empty-interface": "off",
-		"@typescript-eslint/strict-boolean-expressions": "off",
-	},
+    extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
+    },
+    rules: {
+        "@typescript-eslint/no-namespace": "off",
+        "@typescript-eslint/no-empty-interface": "off",
+        "@typescript-eslint/strict-boolean-expressions": "off",
+    },
 };

--- a/packages/dds/tree/.mocharc.js
+++ b/packages/dds/tree/.mocharc.js
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-'use strict';
+"use strict";
 
-const getFluidTestMochaConfig = require('@fluidframework/mocha-test-setup/mocharc-common');
+const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
 
 const packageDir = __dirname;
 const config = getFluidTestMochaConfig(packageDir);

--- a/packages/dds/tree/tsconfig.esnext.json
+++ b/packages/dds/tree/tsconfig.esnext.json
@@ -1,7 +1,7 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "./lib",
-        "module": "esnext"
-    },
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "module": "esnext",
+  },
 }

--- a/packages/dds/tree/tsconfig.json
+++ b/packages/dds/tree/tsconfig.json
@@ -1,16 +1,12 @@
 {
-    "extends": "@fluidframework/build-common/ts-common-config.json",
-    "exclude": [
-        "src/test/**/*"
-    ],
-    "compilerOptions": {
-        "rootDir": "./src",
-        "outDir": "./dist",
-        "noImplicitAny": true,
-        "composite": true,
-        "preserveConstEnums": true
-    },
-    "include": [
-        "src/**/*"
-    ]
+  "extends": "@fluidframework/build-common/ts-common-config.json",
+  "exclude": ["src/test/**/*"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noImplicitAny": true,
+    "composite": true,
+    "preserveConstEnums": true,
+  },
+  "include": ["src/**/*"],
 }


### PR DESCRIPTION
## Description

This PR runs the prettier on the tree package configuration files in `packages/dds/tree`.

This PR is a portion of #11613, as it was suggested that the prettier should be run in several PRs.