### PR TITLE
Fix url deps and add eslint rules to disallow core nodejs modules on main branch

### DIFF
--- a/packages/drivers/local-driver/.eslintrc.js
+++ b/packages/drivers/local-driver/.eslintrc.js
@@ -4,13 +4,27 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
-    }
-}
+    rules: {
+        "@typescript-eslint/strict-boolean-expressions": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["url", "events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "url", "events"] },
+                ],
+            },
+        },
+    ],
+};

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -69,6 +69,7 @@
     "@fluidframework/server-services-core": "^0.1037.2001",
     "@fluidframework/server-test-utils": "^0.1037.2001",
     "jsrsasign": "^10.5.25",
+    "url": "^0.11.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/drivers/routerlicious-urlResolver/.eslintrc.js
+++ b/packages/drivers/routerlicious-urlResolver/.eslintrc.js
@@ -4,25 +4,37 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
+    rules: {
         "@typescript-eslint/strict-boolean-expressions": "off",
         "unicorn/filename-case": [
             "error",
             {
-                "cases": {
-                    "camelCase": true,
-                    "pascalCase": true
+                cases: {
+                    camelCase: true,
+                    pascalCase: true,
                 },
-                "ignore": [
-                    /.*routerlicious-urlResolver\.spec\.ts/,
-                ]
-            }
+                ignore: [/.*routerlicious-urlResolver\.spec\.ts/],
+            },
         ],
-    }
-}
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["url"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert"] },
+                ],
+            },
+        },
+    ],
+};

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -41,7 +41,8 @@
     "@fluidframework/core-interfaces": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/driver-definitions": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/protocol-definitions": "^1.0.0",
-    "nconf": "^0.11.4"
+    "nconf": "^0.11.4",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",

--- a/packages/loader/container-loader/.eslintrc.js
+++ b/packages/loader/container-loader/.eslintrc.js
@@ -4,12 +4,25 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
-    }
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events", "url"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "events", "url"] },
+                ],
+            },
+        },
+    ],
+};

--- a/packages/test/test-end-to-end-tests/.eslintrc.js
+++ b/packages/test/test-end-to-end-tests/.eslintrc.js
@@ -4,14 +4,28 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "rules": {
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    parserOptions: {
+        project: ["./src/test/tsconfig.json"],
+    },
+    rules: {
         "prefer-arrow-callback": "off",
         "@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["url"] }],
     },
-    "parserOptions": {
-        "project": [ "./src/test/tsconfig.json" ]
-    }
-}
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": [
+                    "error",
+                    { allow: ["assert", "url"] },
+                ],
+            },
+        },
+    ],
+};

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -111,6 +111,7 @@
     "sinon": "^7.4.2",
     "start-server-and-test": "^1.11.7",
     "tinylicious": "^0.4.89251",
+    "url": "^0.11.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/tools/fetch-tool/.eslintrc.js
+++ b/packages/tools/fetch-tool/.eslintrc.js
@@ -8,5 +8,7 @@ module.exports = {
         require.resolve("@fluidframework/eslint-config-fluid")
     ],
     "rules": {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", {"allow": ["child_process","fs","url","util"]}],
     }
 }


### PR DESCRIPTION
Affects the following packages:

moving this fix from LTS to main

packages\drivers\local-driver
packages\drivers\routerlicious-urlResolver
packages\test\test-end-to-end-tests
packages\tools\fetch-tool - removed unnecessary url import since it's a browser api now
packages\loader\container-loader - url has already been added to main, so I didnt need to do this