### PR TITLE
Add driver version prop to IConnect message

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -120,7 +120,6 @@ export interface IConnect {
     supportedFeatures?: Record<string, any>;
     tenantId: string;
     token: string | null;
-    // @deprecated
     versions: string[];
 }
 

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -111,6 +111,7 @@ export type ICommittedProposal = {
 // @public
 export interface IConnect {
     client: IClient;
+    driverVersion?: string;
     epoch?: string;
     id: string;
     mode: ConnectionMode;
@@ -119,6 +120,7 @@ export interface IConnect {
     supportedFeatures?: Record<string, any>;
     tenantId: string;
     token: string | null;
+    // @deprecated
     versions: string[];
 }
 

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -36,8 +36,6 @@ export interface IConnect {
 
     /**
      * Semver list of protocol versions supported by the client ordered in priority of use
-     * @deprecated This is not used on server or client, so it will be removed in future. Server
-     * will be using the driver version to block/allow features.
      */
     versions: string[];
 

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -36,8 +36,16 @@ export interface IConnect {
 
     /**
      * Semver list of protocol versions supported by the client ordered in priority of use
+     * @deprecated This is not used on server or client, so it will be removed in future. Server
+     * will be using the driver version to block/allow features.
      */
     versions: string[];
+
+    /**
+     * Version of the driver which is connecting. It can be used at server to record in telemetry or
+     * to block/allow specific driver version for specific features.
+     */
+    driverVersion?: string;
 
     /**
      * Connection mode of client.


### PR DESCRIPTION
## Description

Add driver version prop to IConnect message. It can be used at server to record in telemetry or to block/allow specific driver version for specific features.