### PR TITLE
Add support for version specific configs

### DIFF
--- a/packages/utils/telemetry-utils/src/config.ts
+++ b/packages/utils/telemetry-utils/src/config.ts
@@ -200,8 +200,9 @@ export class CachedConfigProvider implements IConfigProvider {
     }
 
     private getCacheEntry(name: string): StronglyTypedValue | undefined {
-        // Generate version specific name by appending package version.
-        const versionSpecificConfigName = `${name}-${pkgVersion}`;
+        // Generate version specific name by appending package version. Version specific setting always take
+        // precedence over general setting for a feature gate.
+        const versionSpecificConfigName = `${name}_${pkgVersion}`;
         if (!this.configCache.has(versionSpecificConfigName)) {
             for (const provider of this.orderedBaseProviders) {
                 const parsed = stronglyTypedParse(provider?.getRawConfig(versionSpecificConfigName) ??

--- a/packages/utils/telemetry-utils/src/test/config.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/config.spec.ts
@@ -10,6 +10,7 @@ import {
     IConfigProviderBase,
     inMemoryConfigProvider,
 } from "../config";
+import { pkgVersion } from "../packageVersion";
 
 describe("Config", () => {
     const getMockStore = ((settings: Record<string, string>): Storage => {
@@ -120,6 +121,27 @@ describe("Config", () => {
         assert.deepEqual(config.getBooleanArray("booleanArray"), [true, false, true]);
         assert.equal(config.getBooleanArray("badBooleanArray"), undefined);
         assert.equal(config.getBooleanArray("badBooleanArray2"), undefined);
+    });
+
+    it("Typing - custom provider - With version", () => {
+        const settings = {};
+        settings[`number-${pkgVersion}`] = 1;
+        settings[`string-${pkgVersion}`] = "string";
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        settings[`string`] = "string1";
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        settings["boolean"] = true;
+
+        const mockStore = untypedProvider(settings);
+        const config = new CachedConfigProvider(mockStore);
+
+        assert.equal(config.getNumber("number"), 1);
+
+        assert.equal(config.getString("string"), "string");
+        assert.equal(config.getString("badString"), undefined);
+
+        assert.equal(config.getBoolean("boolean"), true);
+        assert.equal(config.getBoolean("badBoolean"), undefined);
     });
 
     it("Void provider", () => {
@@ -254,6 +276,26 @@ describe("Config", () => {
         assert.deepEqual(config.getBooleanArray("booleanArray"), [true, false, true]);
         assert.equal(config.getBooleanArray("badBooleanArray"), undefined);
         assert.equal(config.getBooleanArray("badBooleanArray2"), undefined);
+    });
+
+    it("Typing - SettingsProvider - With version", () => {
+        const settings = {};
+        settings[`number-${pkgVersion}`] = 1;
+        settings[`string-${pkgVersion}`] = "string";
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        settings[`string`] = "string1";
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        settings["boolean"] = true;
+
+        const config = new CachedConfigProvider(new HybridSettingsProvider(settings));
+
+        assert.equal(config.getNumber("number"), 1);
+
+        assert.equal(config.getString("string"), "string");
+        assert.equal(config.getString("badString"), undefined);
+
+        assert.equal(config.getBoolean("boolean"), true);
+        assert.equal(config.getBoolean("badBoolean"), undefined);
     });
 
     // #endregion SettingsProvider

--- a/packages/utils/telemetry-utils/src/test/config.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/config.spec.ts
@@ -125,8 +125,8 @@ describe("Config", () => {
 
     it("Typing - custom provider - With version", () => {
         const settings = {
-            [`number-${pkgVersion}`]: 1,
-            [`string-${pkgVersion}`]: "string",
+            [`number_${pkgVersion}`]: 1,
+            [`string_${pkgVersion}`]: "string",
             string: "string1",
             boolean: true,
             badString: [],
@@ -281,8 +281,8 @@ describe("Config", () => {
 
     it("Typing - SettingsProvider - With version", () => {
         const settings = {
-            [`number-${pkgVersion}`]: 1,
-            [`string-${pkgVersion}`]: "string",
+            [`number_${pkgVersion}`]: 1,
+            [`string_${pkgVersion}`]: "string",
             string: "string1",
             boolean: true,
             badString: [],

--- a/packages/utils/telemetry-utils/src/test/config.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/config.spec.ts
@@ -124,13 +124,14 @@ describe("Config", () => {
     });
 
     it("Typing - custom provider - With version", () => {
-        const settings = {};
-        settings[`number-${pkgVersion}`] = 1;
-        settings[`string-${pkgVersion}`] = "string";
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        settings[`string`] = "string1";
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        settings["boolean"] = true;
+        const settings = {
+            [`number-${pkgVersion}`]: 1,
+            [`string-${pkgVersion}`]: "string",
+            string: "string1",
+            boolean: true,
+            badString: [],
+            badBoolean: "truthy",
+        };
 
         const mockStore = untypedProvider(settings);
         const config = new CachedConfigProvider(mockStore);
@@ -279,13 +280,14 @@ describe("Config", () => {
     });
 
     it("Typing - SettingsProvider - With version", () => {
-        const settings = {};
-        settings[`number-${pkgVersion}`] = 1;
-        settings[`string-${pkgVersion}`] = "string";
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        settings[`string`] = "string1";
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        settings["boolean"] = true;
+        const settings = {
+            [`number-${pkgVersion}`]: 1,
+            [`string-${pkgVersion}`]: "string",
+            string: "string1",
+            boolean: true,
+            badString: [],
+            badBoolean: "truthy",
+        };
 
         const config = new CachedConfigProvider(new HybridSettingsProvider(settings));
 


### PR DESCRIPTION
## Description

Add support for version specific configs to be fetched from control tower. If version specific config is not present, then fallback to general control tower settings.

So, in case you want to enable something with feature gate Fluid.X, then we can have a feature gate with name Fluid.X and enable it there. Now lets say a problem arises in specific version 0.59 and you want to disbale this feature immediately in 0.59 until patch is rolled out or even in case when you say if you disable this feature permanently in this version with rolling out the patch, then you can have another feaute gate with name Fluid.X_0.59 and disable it there and then it will remain enabled in other versions. 