### PR TITLE
fix(build-tools): Include .cjs files in policy-check

### DIFF
--- a/azure/prettier.config.cjs
+++ b/azure/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
     importOrder: [

--- a/build-tools/packages/build-cli/prettier.config.cjs
+++ b/build-tools/packages/build-cli/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
     importOrder: [

--- a/build-tools/packages/build-tools/prettier.config.cjs
+++ b/build-tools/packages/build-tools/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
     importOrder: [

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/copyrightFileHeader.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/copyrightFileHeader.ts
@@ -109,7 +109,7 @@ export const handlers: Handler[] = [
     },
     {
         name: "js-ts-copyright-file-header",
-        match: /(^|\/)[^/]+\.[jt]sx?$/i,
+        match: /(^|\/)[^/]+\.c?[jt]sx?$/i,
         handler: makeHandler({
             type: "JavaScript/TypeScript",
             headerStart: /(#![^\n]*\r?\n)?\/\*!\r?\n/, // Begins with optional hashbang followed by '/*!'

--- a/build-tools/packages/bundle-size-tools/prettier.config.cjs
+++ b/build-tools/packages/bundle-size-tools/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
     importOrder: [

--- a/build-tools/packages/version-tools/prettier.config.cjs
+++ b/build-tools/packages/version-tools/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
     importOrder: [

--- a/build-tools/prettier.config.cjs
+++ b/build-tools/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
     importOrder: [

--- a/common/build/build-common/prettier.config.cjs
+++ b/common/build/build-common/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 // Shared prettier configuration for use in across the fluid-framework repository.
 // Individual packages may extend this and override rules as needed, though for consistent formatting, package-local
 // overrides should be avoided unless absolutely necessary.

--- a/common/build/eslint-config-fluid/prettier.config.cjs
+++ b/common/build/eslint-config-fluid/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
 };

--- a/common/lib/common-definitions/prettier.config.cjs
+++ b/common/lib/common-definitions/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
 };

--- a/common/lib/common-utils/prettier.config.cjs
+++ b/common/lib/common-utils/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
 };

--- a/common/lib/protocol-definitions/prettier.config.cjs
+++ b/common/lib/protocol-definitions/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
 };

--- a/packages/dds/tree/prettier.config.cjs
+++ b/packages/dds/tree/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
 };

--- a/tools/api-markdown-documenter/prettier.config.cjs
+++ b/tools/api-markdown-documenter/prettier.config.cjs
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 module.exports = {
     ...require("@fluidframework/build-common/prettier.config.cjs"),
     importOrder: [


### PR DESCRIPTION
the `.cjs` file extension is being used increasingly to differentiate CommonJS vs. ESM. Policy check was ignoring these files; this should fix that.