### PR TITLE
Update the Garbage Collection (GC) documents as per the change from root data store -> aliasing

### DIFF
--- a/packages/runtime/container-runtime/garbageCollection.md
+++ b/packages/runtime/container-runtime/garbageCollection.md
@@ -1,27 +1,29 @@
 # Garbage Collection
-Garbage collection (GC) is the process by which Fluid Framework performs automatic memory management. GC will run periodically and safely delete objects that are not used. The only responsibility of the users of Fluid Framework is to add and remove references to Fluid objects correctly.
+Garbage collection (GC) is the process by which Fluid Framework safely delete objects that are not used. The only responsibility of the users of Fluid Framework is to add and remove references to Fluid objects correctly.
 
 ## Why have Garbage Collection?
-GC reduces the size of the Fluid file, the in-memory content and the summary that is uploaded to / downloaded from the server. It saves COGS on the server and it makes containers load time faster as there is less data to download and process.
+GC reduces the size of the Fluid file at rest, the in-memory content and the summary that is uploaded to / downloaded from the server. It saves COGS on the server and it makes containers load faster as there is less data to download and process.
 
 ## What do I need to do?
-All Fluid objects that are in use must be marked as referenced so that they are not deleted by GC. Similarly, references to all unused Fluid objects should be removed so that they can be deleted by GC. It is the responsibility of the users of Fluid Framework to correctly add and remove references to Fluid objects.
+All Fluid objects that are in use must be properly referenced so that they are not deleted by GC. Similarly, references to all unused Fluid objects should be removed so that they can be deleted by GC. It is the responsibility of the users of Fluid Framework to correctly add and remove references to Fluid objects.
 
 ## How do I reference / unreference Fluid objects?
-Currently, the only Fluid objects that are eligible for GC are data stores and attachment blobs. The following sections describe how you can mark them as referenced or unreferenced.
+Currently, the only Fluid objects that are eligible for GC are data stores and attachment blobs. The following sections describe how you can mark them as referenced or unreferenced. These sections speak of a "referenced DDS" which refers to a DDS that is created by a referenced data store.
 ### Data stores
-There are 2 ways to add reference to data stores:
-  - Store the data stores's ([IFluidHandle](../../../common/lib/core-interfaces/src/handles.ts)) in a referenced DDS that supports handle in its data. For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
+There are 2 ways to reference a data store:
+  - Store the data stores's handle (see [IFluidHandle](../../../common/lib/core-interfaces/src/handles.ts)) in a referenced DDS that supports handle in its data. For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
+
+    Note that storing a handle of any of a data store's DDS will also mark the data store as referenced.
   - Alias the data store. Aliased data stores are rooted in the container, i.e., they are always referenced and cannot be unreferenced later. Aliased data stores can never be deleted so only do so if you want them to live forever.
 
-To remove reference to a data store, remove all its IFluidHandles from any referenced DDSes. The data store then becomes eligible for GC.
+Once there are no more referenced DDSes in the container containing a handle to a particular data store, that data store is unreferenced and is eligible for GC.
 
-> Note that there should be at least one aliased data store with at least one DDS in a container. This is the starting point for GC to look for other referenced objects in the container.
+> Note: There should be at least one aliased data store with at least one DDS in a container. This is the starting point for GC to look for other referenced objects in the container.
 
 ### Attachment blobs
-The only way to reference attachment blobs is to store its IFluidHandle in a referenced DDS similar to data stores.
+The only way to reference an attachment blob is to store its IFluidHandle in a referenced DDS similar to data stores.
 
-To remove reference to an attachment blob, remove all its IFluidHandles from any referenced DDSes. The attachment blob then becomes eligible for GC.
+Once there are no more referenced DDSes in the container containing a handle to a particular attachment blob, that attachment blob is unreferenced and is eligible for GC.
 
 ## GC algorithm
 The GC algorithm runs in two phases:
@@ -29,10 +31,8 @@ The GC algorithm runs in two phases:
 ### Mark phase
 In this phase, the GC algorithm identifies all Fluid objects that are unreferenced and marks them as such:
 1. It starts at the root (aliased) data stores and marks them and all their DDSes as referenced.
-    > Note: Currently all DDSes are considered as root so they are always referenced. This may change in the future.
-2. It finds the handles stored in DDSes from #1 and marks the objects corresponding to the handles as referenced.
-3. It finds the handles stored in DDSes from #2 and marks the objects corresponding to the handles as referenced and so on until it has scanned all objects.
-4. All the objects in the system that are not marked as referenced in the above steps are marked as unreferenced. The unreferenced state of the object and timestamp of when it is unreferenced is added to the summary. This is used to determine how long the object has been unreferenced for and is used for the sweep phase.
+2. It recursively finds the handles stored in referenced DDSes and marks the objects corresponding to the handles as referenced until is has scanned all objects.
+3. All the objects in the system that are not marked as referenced are marked as unreferenced. The unreferenced state of the object and timestamp of when it is unreferenced is added to the summary. The timestamp is used to determine how long the object has been unreferenced for and is used for the sweep phase.
 
 Mark phase is enabled by default for a container. It is enabled during creation of the container runtime and remains enabled throughout its lifetime. Basically, this setting is persisted in the summary and cannot be changed.
 
@@ -41,6 +41,6 @@ If you wish to disable this, set the `gcAllowed` option to `false` in `IGCRuntim
 See `IGCRuntimeOptions` in [containerRuntime.ts](./src/containerRuntime.ts) for more options to control GC behavior.
 
 ### Sweep phase
-In this phase, the GC algorithm identifies all Fluid objects that have been unreferenced for a specific amount of time (`deleteTimeout`) and deletes them. Deleted objects are removed from the Fluid file and cannot be brought back (revived).
+In this phase, the GC algorithm identifies all Fluid objects that have been unreferenced for a specific amount of time (typically 30-40 days) and deletes them. Objects are only swept once the GC system is sure that they could never be referenced again by any active clients, i.e., clients that have the object in memory and could reference it.
 
 GC sweep phase has not been enabled yet. More details will be added here when sweep is enabled.

--- a/packages/runtime/container-runtime/garbageCollection.md
+++ b/packages/runtime/container-runtime/garbageCollection.md
@@ -1,28 +1,38 @@
 # Garbage Collection
-Garbage collection (GC) identifies Fluid objects that are not used and deletes them from the Fluid document. This reduces the size of the Fluid file, the in-memory content and the summary that is uploaded to / downloaded from the server. It also makes processing faster as there is less data to process.
+Garbage collection (GC) is the process by which Fluid Framework performs automatic memory management. GC will run periodically and safely delete objects that are not used. The only responsibility of the users of Fluid Framework is to add and remove references to Fluid objects correctly.
 
-Before understanding the details of how GC works, lets take a look at how to add a reference to Fluid objects when they are in use and remove the reference when they are not in use.
+## Why have Garbage Collection?
+GC reduces the size of the Fluid file, the in-memory content and the summary that is uploaded to / downloaded from the server. It saves COGS on the server and it makes containers load time faster as there is less data to download and process.
 
-## Fluid object references
-- All Fluid objects that are in use must be marked as referenced so that they are not deleted by GC. There are 2 ways to mark objects as referenced:
-  - Create them as `root`. These objects are always referenced and cannot be marked unreferenced later. For example, `root` data stores are always referenced.
+## What do I need to do?
+All Fluid objects that are in use must be marked as referenced so that they are not deleted by GC. Similarly, references to all unused Fluid objects should be removed so that they can be deleted by GC. It is the responsibility of the users of Fluid Framework to correctly add and remove references to Fluid objects.
 
-    `Root` objects can never be deleted so be careful and only create them if they should live forever.
-  - Store a handle ([IFluidHandle](../../../common/lib/core-interfaces/src/handles.ts)) to the object in a referenced DDS that supports handle in its data. For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
-- All references to unused Fluid objects should be removed so that they can be deleted by GC. To remove an object's reference, all its handles should be removed from referenced DDSes.
+## How do I reference / unreference Fluid objects?
+Currently, the only Fluid objects that are eligible for GC are data stores and attachment blobs. The following sections describe how you can mark them as referenced or unreferenced.
+### Data stores
+There are 2 ways to add reference to data stores:
+  - Store the data stores's ([IFluidHandle](../../../common/lib/core-interfaces/src/handles.ts)) in a referenced DDS that supports handle in its data. For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
+  - Alias the data store. Aliased data stores are rooted in the container, i.e., they are always referenced and cannot be unreferenced later. Aliased data stores can never be deleted so only do so if you want them to live forever.
 
-> Note that there should be at least one `root` data store with one or more DDSes in a Fluid document so that other objects' handles can be stored in it.
+To remove reference to a data store, remove all its IFluidHandles from any referenced DDSes. The data store then becomes eligible for GC.
+
+> Note that there should be at least one aliased data store with at least one DDS in a container. This is the starting point for GC to look for other referenced objects in the container.
+
+### Attachment blobs
+The only way to reference attachment blobs is to store its IFluidHandle in a referenced DDS similar to data stores.
+
+To remove reference to an attachment blob, remove all its IFluidHandles from any referenced DDSes. The attachment blob then becomes eligible for GC.
 
 ## GC algorithm
 The GC algorithm runs in two phases:
 
 ### Mark phase
 In this phase, the GC algorithm identifies all Fluid objects that are unreferenced and marks them as such:
-- It starts at the root data stores and marks them, and all their DDSes as referenced.
+1. It starts at the root (aliased) data stores and marks them and all their DDSes as referenced.
     > Note: Currently all DDSes are considered as root so they are always referenced. This may change in the future.
-- It finds the handles stored in DDSes from #1 and marks the objects corresponding to the handles as referenced.
-- It finds the handles stored in DDSes from #2 and marks the objects corresponding to the handles as referenced and so on until it has scanned all objects.
-- All the objects in the system that are not marked as referenced in the above steps are marked as unreferenced.
+2. It finds the handles stored in DDSes from #1 and marks the objects corresponding to the handles as referenced.
+3. It finds the handles stored in DDSes from #2 and marks the objects corresponding to the handles as referenced and so on until it has scanned all objects.
+4. All the objects in the system that are not marked as referenced in the above steps are marked as unreferenced. The unreferenced state of the object and timestamp of when it is unreferenced is added to the summary. This is used to determine how long the object has been unreferenced for and is used for the sweep phase.
 
 Mark phase is enabled by default for a container. It is enabled during creation of the container runtime and remains enabled throughout its lifetime. Basically, this setting is persisted in the summary and cannot be changed.
 
@@ -31,11 +41,6 @@ If you wish to disable this, set the `gcAllowed` option to `false` in `IGCRuntim
 See `IGCRuntimeOptions` in [containerRuntime.ts](./src/containerRuntime.ts) for more options to control GC behavior.
 
 ### Sweep phase
-In this phase, the GC algorithm identifies all Fluid objects that have been unreferenced for a specific amount of time (`deleteTimeout`) and deletes them:
-- For the objects marked as unreferenced in the mark phase, a timer is started which runs for `deleteTimeout` amount of time.
-- When the above timer expires, the corresponding object is marked as `expired`.
-- If an object becomes referenced before the timer expires, the timer is cleared, and the object's unreferenced state is removed.
-- When sweep runs, it finds all `expired` objects and deletes them.
-- Deleted objects are removed from the Fluid file and cannot be brought back (revived).
+In this phase, the GC algorithm identifies all Fluid objects that have been unreferenced for a specific amount of time (`deleteTimeout`) and deletes them. Deleted objects are removed from the Fluid file and cannot be brought back (revived).
 
-GC sweep phase has not been enabled yet.
+GC sweep phase has not been enabled yet. More details will be added here when sweep is enabled.


### PR DESCRIPTION
## Description
There were recent changes to root data stores where the only way to make a data store as root is by aliasing it. Updated the `garbageCollection.md` document to reflect this change. Also, tried to organize it a little better to reflect the reasons behind doing GC and what are the responsibilities of consumers of Fluid framework.

The eventual goal is for this document to become part of documentation in fluidframework.com

## Does this introduce a breaking change?
No, this is just a documentation change.

[AB#2163](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2163)
