### PR TITLE
run prettier on files with unused eslint warnings

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -8,7 +8,11 @@
 import { fail, strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import {
-    NamedTreeSchema, namedTreeSchema, ValueSchema, fieldSchema, SchemaData,
+    NamedTreeSchema,
+    namedTreeSchema,
+    ValueSchema,
+    fieldSchema,
+    SchemaData,
     TreeSchemaIdentifier,
     InMemoryStoredSchemaRepository,
 } from "../../../schema-stored";
@@ -16,12 +20,28 @@ import { IEditableForest, initializeForest } from "../../../forest";
 import { JsonableTree, EmptyKey, Value, rootFieldKey } from "../../../tree";
 import { brand, Brand, clone } from "../../../util";
 import {
-    defaultSchemaPolicy, getEditableTreeContext, EditableTree, buildForest, getTypeSymbol, UnwrappedEditableField,
-    proxyTargetSymbol, emptyField, FieldKinds, valueSymbol, EditableTreeOrPrimitive, isPrimitiveValue, Multiplicity, singleTextCursorNew,
+    defaultSchemaPolicy,
+    getEditableTreeContext,
+    EditableTree,
+    buildForest,
+    getTypeSymbol,
+    UnwrappedEditableField,
+    proxyTargetSymbol,
+    emptyField,
+    FieldKinds,
+    valueSymbol,
+    EditableTreeOrPrimitive,
+    isPrimitiveValue,
+    Multiplicity,
+    singleTextCursorNew,
 } from "../../../feature-libraries";
 
+import {
+    getFieldKind,
+    getFieldSchema,
+    getPrimaryField,
 // eslint-disable-next-line import/no-internal-modules
-import { getFieldKind, getFieldSchema, getPrimaryField } from "../../../feature-libraries/editable-tree/utilities";
+} from "../../../feature-libraries/editable-tree/utilities";
 
 // TODO: Use typed schema (ex: typedTreeSchema), here, and derive the types below from them programmatically.
 
@@ -58,7 +78,11 @@ const complexPhoneSchema = namedTreeSchema({
 const phonesSchema = namedTreeSchema({
     name: brand("Test:Phones-1.0.0"),
     localFields: {
-        [EmptyKey]: fieldSchema(FieldKinds.sequence, [stringSchema.name, int32Schema.name, complexPhoneSchema.name]),
+        [EmptyKey]: fieldSchema(FieldKinds.sequence, [
+            stringSchema.name,
+            int32Schema.name,
+            complexPhoneSchema.name,
+        ]),
     },
     extraLocalFields: emptyField,
 });
@@ -102,7 +126,17 @@ const optionalChildSchema = namedTreeSchema({
 
 const emptyNode: JsonableTree = { type: optionalChildSchema.name };
 
-const schemaTypes: Set<NamedTreeSchema> = new Set([optionalChildSchema, stringSchema, float32Schema, int32Schema, complexPhoneSchema, phonesSchema, addressSchema, mapStringSchema, personSchema]);
+const schemaTypes: Set<NamedTreeSchema> = new Set([
+    optionalChildSchema,
+    stringSchema,
+    float32Schema,
+    int32Schema,
+    complexPhoneSchema,
+    phonesSchema,
+    addressSchema,
+    mapStringSchema,
+    personSchema,
+]);
 
 const schemaMap: Map<TreeSchemaIdentifier, NamedTreeSchema> = new Map();
 for (const named of schemaTypes) {
@@ -146,28 +180,40 @@ const person: JsonableTree = {
         name: [{ value: "Adam", type: stringSchema.name }],
         age: [{ value: 35, type: int32Schema.name }],
         salary: [{ value: 10420.2, type: float32Schema.name }],
-        friends: [{ fields: {
-            Mat: [{ type: stringSchema.name, value: "Mat" }],
-        }, type: mapStringSchema.name }],
-        address: [{
-            fields: {
-                street: [{ value: "treeStreet", type: stringSchema.name }],
-                phones: [{
-                    type: phonesSchema.name,
-                    fields: {
-                        [EmptyKey]: [
-                            { type: stringSchema.name, value: "+49123456778" },
-                            { type: int32Schema.name, value: 123456879 },
-                            { type: complexPhoneSchema.name, fields: {
-                                number: [{ value: "012345", type: stringSchema.name }],
-                                prefix: [{ value: "0123", type: stringSchema.name }],
-                            } },
-                        ],
-                    },
-                }],
+        friends: [
+            {
+                fields: {
+                    Mat: [{ type: stringSchema.name, value: "Mat" }],
+                },
+                type: mapStringSchema.name,
             },
-            type: addressSchema.name,
-        }],
+        ],
+        address: [
+            {
+                fields: {
+                    street: [{ value: "treeStreet", type: stringSchema.name }],
+                    phones: [
+                        {
+                            type: phonesSchema.name,
+                            fields: {
+                                [EmptyKey]: [
+                                    { type: stringSchema.name, value: "+49123456778" },
+                                    { type: int32Schema.name, value: 123456879 },
+                                    {
+                                        type: complexPhoneSchema.name,
+                                        fields: {
+                                            number: [{ value: "012345", type: stringSchema.name }],
+                                            prefix: [{ value: "0123", type: stringSchema.name }],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+                type: addressSchema.name,
+            },
+        ],
     },
 };
 
@@ -224,7 +270,8 @@ function expectTreeEquals(inputField: UnwrappedEditableField, expected: Jsonable
         const fields = expected.fields ?? {};
         assert.equal(key in fields, true);
         const field: JsonableTree[] = fields[key];
-        const isSequence = getFieldKind(getFieldSchema(type, key)).multiplicity === Multiplicity.Sequence;
+        const isSequence =
+            getFieldKind(getFieldSchema(type, key)).multiplicity === Multiplicity.Sequence;
         // implicit sequence
         if (isSequence) {
             expectTreeSequence(subNode, field);
@@ -251,7 +298,10 @@ describe("editable-tree", () => {
         assert.equal(Object.keys(proxy).length, 5);
         assert.equal(proxy[getTypeSymbol](), personSchema);
         assert.equal(proxy.address[getTypeSymbol](), addressSchema);
-        assert.equal((proxy.address.phones[2] as ComplexPhoneType)[getTypeSymbol](), complexPhoneSchema);
+        assert.equal(
+            (proxy.address.phones[2] as ComplexPhoneType)[getTypeSymbol](),
+            complexPhoneSchema,
+        );
         assert.equal(proxy[getTypeSymbol]("name", true), stringSchema.name);
         assert.equal(proxy.address[getTypeSymbol]("phones", true), phonesSchema.name);
     });
@@ -284,7 +334,10 @@ describe("editable-tree", () => {
         // Check empty field does not show up:
         assert.equal("child" in emptyOptional, false);
 
-        const fullOptional = buildTestProxy({ type: optionalChildSchema.name, fields: { child: [{ type: int32Schema.name, value: 1 }] } }) as object;
+        const fullOptional = buildTestProxy({
+            type: optionalChildSchema.name,
+            fields: { child: [{ type: int32Schema.name, value: 1 }] },
+        }) as object;
         // Check full field does show up:
         assert("child" in fullOptional);
 
@@ -374,7 +427,12 @@ describe("editable-tree", () => {
             treeSchema: schemaMap,
             globalFieldSchema: new Map([[rootFieldKey, rootSchema]]),
         };
-        const forest = setupForest(schemaData, [{ type: optionalChildSchema.name, fields: { child: [{ type: int32Schema.name, value: 1 }] } }]);
+        const forest = setupForest(schemaData, [
+            {
+                type: optionalChildSchema.name,
+                fields: { child: [{ type: int32Schema.name, value: 1 }] },
+            },
+        ]);
         const context = getEditableTreeContext(forest);
         assert.equal((context.root as EditableTree).child, 1);
         context.free();
@@ -386,11 +444,18 @@ describe("editable-tree", () => {
             treeSchema: schemaMap,
             globalFieldSchema: new Map([[rootFieldKey, rootSchema]]),
         };
-        const forest = setupForest(schemaData, [{ type: optionalChildSchema.name, fields: { child: [{ type: int32Schema.name, value: undefined }] } }]);
+        const forest = setupForest(schemaData, [
+            {
+                type: optionalChildSchema.name,
+                fields: { child: [{ type: int32Schema.name, value: undefined }] },
+            },
+        ]);
         const context = getEditableTreeContext(forest);
-        assert.throws(() => ((context.root as EditableTree).child),
+        assert.throws(
+            () => (context.root as EditableTree).child,
             (e) => validateAssertionError(e, "undefined` values not allowed for primitive field"),
-            "Expected exception was not thrown");
+            "Expected exception was not thrown",
+        );
         context.free();
     });
 
@@ -412,7 +477,12 @@ describe("editable-tree", () => {
         }
         // Non-empty
         {
-            const forest = setupForest(schemaData, [{ type: phonesSchema.name, fields: { [EmptyKey]: [{ type: int32Schema.name, value: 1 }] } }]);
+            const forest = setupForest(schemaData, [
+                {
+                    type: phonesSchema.name,
+                    fields: { [EmptyKey]: [{ type: int32Schema.name, value: 1 }] },
+                },
+            ]);
             const context = getEditableTreeContext(forest);
             assert.deepStrictEqual(context.root, [1]);
             context.free();
@@ -483,15 +553,22 @@ describe("editable-tree", () => {
         }
         assert.equal(proxy.address!.phones![0], "+49123456778");
         assert.deepEqual(Object.keys(proxy.address!.phones!), ["0", "1", "2"]);
-        assert.deepEqual(Object.getOwnPropertyNames(proxy.address!.phones), ["0", "1", "2", "length"]);
-        const act = proxy.address!.phones!.map((phone: EditableTreeOrPrimitive): Value | UnwrappedEditableField => {
-            if (isPrimitiveValue(phone)) {
-                return phone;
-            } else {
-                const cloned = clone(phone);
-                return cloned;
-            }
-        });
+        assert.deepEqual(Object.getOwnPropertyNames(proxy.address!.phones), [
+            "0",
+            "1",
+            "2",
+            "length",
+        ]);
+        const act = proxy.address!.phones!.map(
+            (phone: EditableTreeOrPrimitive): Value | UnwrappedEditableField => {
+                if (isPrimitiveValue(phone)) {
+                    return phone;
+                } else {
+                    const cloned = clone(phone);
+                    return cloned;
+                }
+            },
+        );
         assert.deepEqual(act, expectedPhones);
     });
 
@@ -506,7 +583,7 @@ describe("editable-tree", () => {
     });
 
     it("delete property", () => {
-        const proxy = buildTestProxy(emptyNode) as { child?: unknown; };
+        const proxy = buildTestProxy(emptyNode) as { child?: unknown };
         assert.throws(() => {
             delete proxy.child;
         }, "Not implemented");

--- a/packages/dds/tree/src/test/feature-libraries/treeTextCursorLegacy.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/treeTextCursorLegacy.spec.ts
@@ -8,8 +8,11 @@ import { jsonSchemaData } from "../../domains";
 import { defaultSchemaPolicy, ObjectForest, singleTextCursorNew } from "../../feature-libraries";
 
 // Allow importing from this specific file which is being tested:
-/* eslint-disable-next-line import/no-internal-modules */
-import { jsonableTreeFromCursor, singleTextCursor } from "../../feature-libraries/treeTextCursorLegacy";
+import {
+    jsonableTreeFromCursor,
+    singleTextCursor,
+// eslint-disable-next-line import/no-internal-modules
+} from "../../feature-libraries/treeTextCursorLegacy";
 import { initializeForest, ITreeCursor, TreeNavigationResult } from "../../forest";
 import { InMemoryStoredSchemaRepository } from "../../schema-stored";
 import { cursorTestCases } from "../cursor.spec";
@@ -18,20 +21,21 @@ import { testCursors, testJsonableTreeCursor } from "../cursorLegacy.spec";
 // Tests for TextCursor and jsonableTreeFromCursor.
 // Checks to make sure singleTextCursor and test datasets are working properly,
 // since its used in the below test suite to test other formats.
-testJsonableTreeCursor(
-    "textTreeFormat",
-    singleTextCursor,
-    jsonableTreeFromCursor,
-);
+testJsonableTreeCursor("textTreeFormat", singleTextCursor, jsonableTreeFromCursor);
 
 // TODO: put these in a better place / unify with object forest tests.
 testJsonableTreeCursor(
     "object-forest cursor",
     (data): ITreeCursor => {
-        const forest = new ObjectForest(new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchemaData));
+        const forest = new ObjectForest(
+            new InMemoryStoredSchemaRepository(defaultSchemaPolicy, jsonSchemaData),
+        );
         initializeForest(forest, [singleTextCursorNew(data)]);
         const cursor = forest.allocateCursor();
-        assert.equal(forest.tryMoveCursorTo(forest.root(forest.rootField), cursor), TreeNavigationResult.Ok);
+        assert.equal(
+            forest.tryMoveCursorTo(forest.root(forest.rootField), cursor),
+            TreeNavigationResult.Ok,
+        );
         return cursor;
     },
     jsonableTreeFromCursor,

--- a/packages/dds/tree/src/test/sequence-change-family/sequenceChangeRebaser.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/sequenceChangeRebaser.fuzz.spec.ts
@@ -37,17 +37,10 @@ describe.skip("SequenceChangeRebaser - Fuzz", () => {
                 const innerRandom = makeRandom(seed);
                 const changes = new Set<T.LocalChangeset>();
                 for (let j = 0; j < batchSize; j++) {
-                    const change = generateRandomChange(
-                        innerRandom.integer(1, 1000000),
-                        pathGen,
-                    );
+                    const change = generateRandomChange(innerRandom.integer(1, 1000000), pathGen);
                     changes.add(change);
                 }
-                const output = verifyChangeRebaser(
-                    sequenceChangeRebaser,
-                    changes,
-                    isEquivalent,
-                );
+                const output = verifyChangeRebaser(sequenceChangeRebaser, changes, isEquivalent);
                 expectKnownFailures(output);
             });
         }
@@ -72,11 +65,7 @@ describe.skip("SequenceChangeRebaser - Fuzz", () => {
                         assert(error instanceof Error && error.message === "Not implemented");
                     }
                 }
-                const output = verifyChangeRebaser(
-                    sequenceChangeRebaser,
-                    changes,
-                    isEquivalent,
-                );
+                const output = verifyChangeRebaser(sequenceChangeRebaser, changes, isEquivalent);
                 expectKnownFailures(output);
             });
         }
@@ -86,18 +75,18 @@ describe.skip("SequenceChangeRebaser - Fuzz", () => {
         const type: TreeSchemaIdentifier = brand("Node");
         const insertChange = asForest([
             2,
-            { type: "Insert", id: 0, content: [{ type, value: 42 }, { type, value: 43 }] },
+            {
+                type: "Insert",
+                id: 0,
+                content: [
+                    { type, value: 42 },
+                    { type, value: 43 },
+                ],
+            },
         ]);
-        const deleteChange = asForest([
-            1,
-            { type: "Delete", id: 0, count: 2 },
-        ]);
+        const deleteChange = asForest([1, { type: "Delete", id: 0, count: 2 }]);
         const changes = new Set<T.LocalChangeset>([insertChange, deleteChange]);
-        const output = verifyChangeRebaser(
-            sequenceChangeRebaser,
-            changes,
-            isEquivalent,
-        );
+        const output = verifyChangeRebaser(sequenceChangeRebaser, changes, isEquivalent);
         assert.deepEqual(output, noFailure);
     });
 });
@@ -117,5 +106,8 @@ function isEquivalent(a: T.LocalChangeset, b: T.LocalChangeset): boolean {
 }
 
 const deltaToJSON = (delta: Delta.Root): string =>
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    JSON.stringify(delta, (key, value): Jsonable => value instanceof Map ? Array.from(value.entries()) : value);
+    JSON.stringify(
+        delta,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        (key, value): Jsonable => (value instanceof Map ? Array.from(value.entries()) : value),
+    );

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -26,23 +26,23 @@ import { mapFieldMarks, mapMarkList, mapTreeFromCursor } from "../feature-librar
 // Testing utilities
 
 export function deepFreeze<T>(object: T): void {
-	// Retrieve the property names defined on object
-	const propNames: (keyof T)[] = Object.getOwnPropertyNames(object) as (keyof T)[];
-	// Freeze properties before freezing self
-	for (const name of propNames) {
-		const value = object[name];
-		if (typeof value === "object") {
-			deepFreeze(value);
-		}
-	}
-	Object.freeze(object);
+    // Retrieve the property names defined on object
+    const propNames: (keyof T)[] = Object.getOwnPropertyNames(object) as (keyof T)[];
+    // Freeze properties before freezing self
+    for (const name of propNames) {
+        const value = object[name];
+        if (typeof value === "object") {
+            deepFreeze(value);
+        }
+    }
+    Object.freeze(object);
 }
 
 export class MockDependent extends SimpleObservingDependent {
-	public readonly tokens: (InvalidationToken | undefined)[] = [];
-	public constructor(name: string = "MockDependent") {
-		super((token) => this.tokens.push(token), name);
-	}
+    public readonly tokens: (InvalidationToken | undefined)[] = [];
+    public constructor(name: string = "MockDependent") {
+        super((token) => this.tokens.push(token), name);
+    }
 }
 
 /**
@@ -97,13 +97,16 @@ export class TestTreeProvider {
      * _i_ is the index of the tree in order of creation.
      */
     public async createTree(): Promise<ISharedTree> {
-        const container = this.trees.length === 0
-        ? await this.provider.makeTestContainer()
-        : await this.provider.loadTestContainer();
+        const container =
+            this.trees.length === 0
+                ? await this.provider.makeTestContainer()
+                : await this.provider.loadTestContainer();
 
         this._containers.push(container);
         const dataObject = await requestFluidObject<ITestFluidObject>(container, "/");
-        return this._trees[this.trees.length] = await dataObject.getSharedObject<ISharedTree>(TestTreeProvider.treeId);
+        return (this._trees[this.trees.length] = await dataObject.getSharedObject<ISharedTree>(
+            TestTreeProvider.treeId,
+        ));
     }
 
     /**
@@ -132,10 +135,11 @@ export class TestTreeProvider {
         this.provider = new TestObjectProvider(
             Loader,
             driver,
-            () => new TestContainerRuntimeFactory(
-                "@fluid-example/test-dataStore",
-                new TestFluidObjectFactory(registry),
-            ),
+            () =>
+                new TestContainerRuntimeFactory(
+                    "@fluid-example/test-dataStore",
+                    new TestFluidObjectFactory(registry),
+                ),
         );
 
         return new Proxy(this, {
@@ -160,13 +164,17 @@ export class TestTreeProvider {
  * @returns a function which will remove the spy function when invoked. Should be called exactly once
  * after the spy is no longer needed.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function spyOnMethod(methodClass: Function, methodName: string, spy: () => void): () => void {
+export function spyOnMethod(
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    methodClass: Function,
+    methodName: string,
+    spy: () => void,
+): () => void {
     const { prototype } = methodClass;
     const method = prototype[methodName];
     assert(typeof method === "function", `Method does not exist: ${methodName}`);
 
-    const methodSpy = function(this: unknown, ...args: unknown[]): unknown {
+    const methodSpy = function (this: unknown, ...args: unknown[]): unknown {
         spy();
         return method.call(this, ...args);
     };

--- a/packages/dds/tree/src/tree/anchorSet.ts
+++ b/packages/dds/tree/src/tree/anchorSet.ts
@@ -121,10 +121,7 @@ export class AnchorSet {
         const parent = path.parent ?? this.root;
         const parentPath = this.trackInner(parent);
 
-        const child = parentPath.getOrCreateChild(
-            path.parentField,
-            path.parentIndex,
-        );
+        const child = parentPath.getOrCreateChild(path.parentField, path.parentIndex);
 
         // Now that child is added (if needed), remove the extra ref that we added in the recursive call.
         parentPath.removeRef();
@@ -190,7 +187,8 @@ export class AnchorSet {
             0x352 /* moveChildren is a no-op and should not be called if there is no src or dst */,
         );
 
-        const srcParent = srcStart === undefined ? undefined : this.find(srcStart.parent ?? this.root);
+        const srcParent =
+            srcStart === undefined ? undefined : this.find(srcStart.parent ?? this.root);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const srcChildren = srcParent?.children?.get(srcStart!.parentField);
         // Sorted list of PathNodes to move from src to dst.
@@ -201,13 +199,19 @@ export class AnchorSet {
             let numberBeforeMove = 0;
             let numberToMove = 0;
             let index = 0;
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            while (index < srcChildren.length && srcChildren[index].parentIndex < srcStart!.parentIndex) {
+            while (
+                index < srcChildren.length &&
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                srcChildren[index].parentIndex < srcStart!.parentIndex
+            ) {
                 numberBeforeMove++;
                 index++;
             }
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            while (index < srcChildren.length && srcChildren[index].parentIndex < srcStart!.parentIndex + count) {
+            while (
+                index < srcChildren.length &&
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                srcChildren[index].parentIndex < srcStart!.parentIndex + count
+            ) {
                 numberToMove++;
                 index++;
             }
@@ -306,7 +310,11 @@ export class AnchorSet {
             },
             onInsert: (start: number, content: Delta.ProtoNode[]): void => {
                 assert(parentField !== undefined, 0x3a8 /* Must be in a field to insert */);
-                this.moveChildren(content.length, undefined, { parent, parentField, parentIndex: start });
+                this.moveChildren(content.length, undefined, {
+                    parent,
+                    parentField,
+                    parentIndex: start,
+                });
             },
             onMoveOut: (start: number, count: number, id: Delta.MoveId): void => {
                 assert(parentField !== undefined, 0x3a9 /* Must be in a field to move out */);
@@ -314,7 +322,8 @@ export class AnchorSet {
             },
             onMoveIn: (start: number, count: number, id: Delta.MoveId): void => {
                 assert(parentField !== undefined, 0x3aa /* Must be in a field to move in */);
-                const srcPath = moveTable.get(id) ?? fail("Must visit a move in after its move out");
+                const srcPath =
+                    moveTable.get(id) ?? fail("Must visit a move in after its move out");
                 this.moveChildren(count, srcPath, { parent, parentField, parentIndex: start });
             },
             onSetValue: (value: Value): void => {},
@@ -456,10 +465,7 @@ class PathNode implements UpPath {
         assert(this.status !== Status.Disposed, "PathNode must not be disposed");
         this.refCount -= count;
         if (this.refCount < 1) {
-            assert(
-                this.refCount === 0,
-                0x358 /* PathNode Refcount should not be negative. */,
-            );
+            assert(this.refCount === 0, 0x358 /* PathNode Refcount should not be negative. */);
 
             if (this.children.size === 0) {
                 this.disposeThis();
@@ -517,10 +523,7 @@ class PathNode implements UpPath {
         // TODO: should do more optimized search (ex: binary search or better) using child.parentIndex()
         // Note that this is the index in the list of child paths, not the index within the field
         const childIndex = field?.indexOf(child);
-        assert(
-            childIndex !== undefined,
-            0x35c /* child must be parented to be removed */,
-        );
+        assert(childIndex !== undefined, 0x35c /* child must be parented to be removed */);
         field?.splice(childIndex, 1);
         if (field?.length === 0) {
             this.afterEmptyField(key);

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -8,7 +8,7 @@ import structuredClone from "@ungap/structured-clone";
 /**
  * Make all transitive properties in T readonly
  */
- export type RecursiveReadonly<T> = {
+export type RecursiveReadonly<T> = {
     readonly [P in keyof T]: RecursiveReadonly<T[P]>;
 };
 
@@ -65,7 +65,13 @@ export function makeArray<T>(size: number, filler: (index: number) => T): T[] {
  * @param same - Called for items in `a` and `b`.
  * @returns false iff any of the call backs returned false.
  */
-export function compareSets<T>({ a, b, aExtra, bExtra, same }: {
+export function compareSets<T>({
+    a,
+    b,
+    aExtra,
+    bExtra,
+    same,
+}: {
     a: ReadonlySet<T> | ReadonlyMap<T, unknown>;
     b: ReadonlySet<T> | ReadonlyMap<T, unknown>;
     aExtra?: (t: T) => boolean;
@@ -98,13 +104,13 @@ export function compareSets<T>({ a, b, aExtra, bExtra, same }: {
  * Gets the list associated with the provided key, if it exists.
  * Otherwise, creates an entry with an empty list, and returns that list.
  */
- export function getOrAddEmptyToMap<K, V>(map: Map<K, V[]>, key: K): V[] {
-	let collection = map.get(key);
-	if (collection === undefined) {
-		collection = [];
-		map.set(key, collection);
-	}
-	return collection;
+export function getOrAddEmptyToMap<K, V>(map: Map<K, V[]>, key: K): V[] {
+    let collection = map.get(key);
+    if (collection === undefined) {
+        collection = [];
+        map.set(key, collection);
+    }
+    return collection;
 }
 
 /**
@@ -113,8 +119,14 @@ export function compareSets<T>({ a, b, aExtra, bExtra, same }: {
  * Note that this does not robustly forbid non json comparable data via type checking,
  * but instead mostly restricts access to it.
  */
-// eslint-disable-next-line @rushstack/no-new-null
-export type JsonCompatible = string | number | boolean | null | JsonCompatible[] | JsonCompatibleObject;
+export type JsonCompatible =
+    | string
+    | number
+    | boolean
+    // eslint-disable-next-line @rushstack/no-new-null
+    | null
+    | JsonCompatible[]
+    | JsonCompatibleObject;
 
 /**
  * Use for Json object compatible data.
@@ -122,7 +134,7 @@ export type JsonCompatible = string | number | boolean | null | JsonCompatible[]
  * Note that this does not robustly forbid non json comparable data via type checking,
  * but instead mostly restricts access to it.
  */
-export type JsonCompatibleObject = { [P in string]: JsonCompatible; };
+export type JsonCompatibleObject = { [P in string]: JsonCompatible };
 
 /**
  * Use for readonly view of Json compatible data.
@@ -137,12 +149,14 @@ export type JsonCompatibleReadOnly =
     // eslint-disable-next-line @rushstack/no-new-null
     | null
     | readonly JsonCompatibleReadOnly[]
-    | { readonly [P in string]: JsonCompatibleReadOnly | undefined; };
+    | { readonly [P in string]: JsonCompatibleReadOnly | undefined };
 
 /**
  * Returns if a particular json compatible value is an object.
  * Does not include `null` or arrays.
  */
-export function isJsonObject(value: JsonCompatibleReadOnly): value is { readonly [P in string]: JsonCompatibleReadOnly | undefined; } {
+export function isJsonObject(
+    value: JsonCompatibleReadOnly,
+): value is { readonly [P in string]: JsonCompatibleReadOnly | undefined } {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Description

This PR runs the prettier on the remaining files of `packages/dds/tree/src`, which had unused `eslint-disable` warnings. The `eslint-disable` warnings were manually moved to the correct lines for these files.

This PR is a portion of #11613, as it was suggested that the prettier should be run in several PRs.

## Reviewer Guidance
Should the addition of prettier in the `lint` and `lint:fix` scripts in `/packages/dds/tree/package.json` to enforce prettier be included in this PR?