### PR TITLE
[TaskManager] Fix assert error when sending a volunteer op before a complete op is acknowledged

### DIFF
--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -229,7 +229,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
                 const pendingIds = this.pendingCompletedTasks.get(taskId);
                 assert(pendingIds !== undefined && pendingIds.length > 0, "pendingIds is empty");
                 const removed = pendingIds.shift();
-                assert(removed === pendingOp.messageId, "Removed complete op id does not match");
+                assert(removed === messageId, "Removed complete op id does not match");
             }
 
             // For clients in queue, we need to remove them from the queue and raise the proper events.

--- a/packages/dds/task-manager/src/test/taskManager.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.spec.ts
@@ -234,11 +234,13 @@ describe("TaskManager", () => {
                 containerRuntimeFactory.processAllMessages();
                 await volunteerTaskP;
 
+                taskManager2.subscribeToTask(taskId);
                 taskManager1.complete(taskId);
                 const volunteerTaskP2 = taskManager1.volunteerForTask(taskId);
                 containerRuntimeFactory.processAllMessages();
                 await volunteerTaskP2;
-                assert.ok(taskManager1.assigned(taskId), "Should be assigned");
+                assert.ok(taskManager1.assigned(taskId), "taskManager1 should be assigned");
+                assert.ok(!taskManager2.queued(taskId), "taskManager 2 should not be assigned");
             });
         });
 

--- a/packages/dds/task-manager/src/test/taskManager.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.spec.ts
@@ -227,6 +227,19 @@ describe("TaskManager", () => {
                 assert.ok(!taskManager1.queued(taskId), "Should not be queued");
                 assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
             });
+
+            it("Can volunteer for a task immediately after it was completed", async () => {
+                const taskId = "taskId";
+                const volunteerTaskP = taskManager1.volunteerForTask(taskId);
+                containerRuntimeFactory.processAllMessages();
+                await volunteerTaskP;
+
+                taskManager1.complete(taskId);
+                const volunteerTaskP2 = taskManager1.volunteerForTask(taskId);
+                containerRuntimeFactory.processAllMessages();
+                await volunteerTaskP2;
+                assert.ok(taskManager1.assigned(taskId), "Should be assigned");
+            });
         });
 
         describe("Subscribing to a task", () => {


### PR DESCRIPTION
## Description

This PR fixes an assert error if `voulnteerForTask()` is called before a pending complete op is acknowledged.
## Reviewer Guidance

Would you expect the behavior in this scenario to be different? Should we ignore the volunteer op in this scenario?

## Any relevant logs or outputs

Before the change the newly added test would throw:

```
Error: Removed complete op id does not match
```

## Other information or known dependencies

[AB#2124](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2124)
