### PR TITLE
Azure client audience e2e fixes.

### DIFF
--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -2,14 +2,15 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { v4 as uuid } from "uuid";
 
-import { generateUser } from "@fluidframework/server-services-client";
-import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
 import {
     AzureClient,
     AzureLocalConnectionConfig,
     AzureRemoteConnectionConfig,
 } from "@fluidframework/azure-client";
+import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
+
 import { createAzureTokenProvider } from "./AzureTokenFactory";
 
 /**
@@ -21,6 +22,10 @@ export function createAzureClient(userID?: string, userName?: string): AzureClie
     const tenantId = useAzure
         ? (process.env.azure__fluid__relay__service__tenantId as string)
         : "frs-client-tenant";
+    const user = {
+        id: userID ?? uuid(),
+        name: userName ?? uuid(),
+    };
 
     // use AzureClient remote mode will run against live Azure Fluid Relay.
     // Default to running Tinylicious for PR validation
@@ -33,7 +38,7 @@ export function createAzureClient(userID?: string, userName?: string): AzureClie
               type: "remote",
           }
         : {
-              tokenProvider: new InsecureTokenProvider("fooBar", generateUser()),
+              tokenProvider: new InsecureTokenProvider("fooBar", user),
               endpoint: "http://localhost:7071",
               type: "local",
           };

--- a/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
@@ -11,7 +11,7 @@ import { SharedMap } from "@fluidframework/map";
 import { timeoutPromise } from "@fluidframework/test-utils";
 
 import { createAzureClient } from "./AzureClientFactory";
-import { waitForMyself } from "./utils";
+import { waitForMember } from "./utils";
 
 describe("Fluid audience", () => {
     const connectTimeoutMs = 1000;
@@ -49,7 +49,7 @@ describe("Fluid audience", () => {
         );
 
         /* This is a workaround for a known bug, we should have one member (self) upon container connection */
-        const myself = await waitForMyself(services.audience, "test-user-id-1");
+        const myself = await waitForMember(services.audience, "test-user-id-1");
         assert.notStrictEqual(myself, undefined, "We should have myself at this point.");
 
         const members = services.audience.getMembers();
@@ -79,13 +79,14 @@ describe("Fluid audience", () => {
         );
 
         /* This is a workaround for a known bug, we should have one member (self) upon container connection */
-        const originalSelf = await waitForMyself(services.audience, "test-user-id-1");
+        const originalSelf = await waitForMember(services.audience, "test-user-id-1");
         assert.notStrictEqual(originalSelf, undefined, "We should have myself at this point.");
 
         const client2 = createAzureClient("test-user-id-2", "test-user-name-2");
         const { services: servicesGet } = await client2.getContainer(containerId, schema);
 
-        const partner = await waitForMyself(servicesGet.audience, "test-user-id-2");
+        /* This is a workaround for a known bug, we should have one member (self) upon container connection */
+        const partner = await waitForMember(servicesGet.audience, "test-user-id-2");
         assert.notStrictEqual(partner, undefined, "We should have partner at this point.");
 
         const members = servicesGet.audience.getMembers();
@@ -116,7 +117,8 @@ describe("Fluid audience", () => {
         const client2 = createAzureClient("test-user-id-2", "test-user-name-2");
         const { services: servicesGet } = await client2.getContainer(containerId, schema);
 
-        const partner = await waitForMyself(servicesGet.audience, "test-user-id-2");
+        /* This is a workaround for a known bug, we should have one member (self) upon container connection */
+        const partner = await waitForMember(servicesGet.audience, "test-user-id-2");
         assert.notStrictEqual(partner, undefined, "We should have partner at this point.");
 
         let members = servicesGet.audience.getMembers();

--- a/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
@@ -3,11 +3,13 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "node:assert";
+
+import { AzureClient } from "@fluidframework/azure-client";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map";
 import { timeoutPromise } from "@fluidframework/test-utils";
-import { AzureClient } from "@fluidframework/azure-client";
+
 import { createAzureClient } from "./AzureClientFactory";
 import { waitForMyself } from "./utils";
 
@@ -17,7 +19,7 @@ describe("Fluid audience", () => {
     let schema: ContainerSchema;
 
     beforeEach(() => {
-        client = createAzureClient();
+        client = createAzureClient("test-user-id-1", "test-user-name-1");
         schema = {
             initialObjects: {
                 map1: SharedMap,
@@ -47,7 +49,7 @@ describe("Fluid audience", () => {
         );
 
         /* This is a workaround for a known bug, we should have one member (self) upon container connection */
-        const myself = await waitForMyself(services.audience);
+        const myself = await waitForMyself(services.audience, "test-user-id-1");
         assert.notStrictEqual(myself, undefined, "We should have myself at this point.");
 
         const members = services.audience.getMembers();
@@ -77,17 +79,17 @@ describe("Fluid audience", () => {
         );
 
         /* This is a workaround for a known bug, we should have one member (self) upon container connection */
-        const originalSelf = await waitForMyself(services.audience);
+        const originalSelf = await waitForMyself(services.audience, "test-user-id-1");
         assert.notStrictEqual(originalSelf, undefined, "We should have myself at this point.");
 
-        const client2 = createAzureClient("test-id-2", "test-user-name-2");
+        const client2 = createAzureClient("test-user-id-2", "test-user-name-2");
         const { services: servicesGet } = await client2.getContainer(containerId, schema);
+
+        const partner = await waitForMyself(servicesGet.audience, "test-user-id-2");
+        assert.notStrictEqual(partner, undefined, "We should have partner at this point.");
 
         const members = servicesGet.audience.getMembers();
         assert.strictEqual(members.size, 2, "We should have two members at this point.");
-
-        const partner = servicesGet.audience.getMyself();
-        assert.notStrictEqual(partner, undefined, "We should have other-self at this point.");
 
         assert.notStrictEqual(
             partner?.userId,
@@ -111,8 +113,11 @@ describe("Fluid audience", () => {
             errorMsg: "container connect() timeout",
         });
 
-        const client2 = createAzureClient("test-id-2", "test-user-name-2");
+        const client2 = createAzureClient("test-user-id-2", "test-user-name-2");
         const { services: servicesGet } = await client2.getContainer(containerId, schema);
+
+        const partner = await waitForMyself(servicesGet.audience, "test-user-id-2");
+        assert.notStrictEqual(partner, undefined, "We should have partner at this point.");
 
         let members = servicesGet.audience.getMembers();
         assert.strictEqual(members.size, 2, "We should have two members at this point.");

--- a/azure/packages/test/end-to-end-tests/src/test/utils.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/utils.ts
@@ -2,15 +2,19 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { IMember } from "fluid-framework";
+
 import { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
 import { ISharedMap, IValueChanged } from "@fluidframework/map";
 
-export const waitForMyself = async (audience: IAzureAudience): Promise<AzureMember> => {
+export const waitForMyself = async (
+    audience: IAzureAudience,
+    userId: string,
+): Promise<AzureMember> => {
     return new Promise((resolve) => {
-        const handler = (): void => {
-            const value = audience.getMyself();
-            if (value) {
-                resolve(value);
+        const handler = (clientId: string, member: IMember): void => {
+            if (member.userId === userId) {
+                resolve(member as AzureMember);
             }
         };
         audience.on("memberAdded", handler);

--- a/azure/packages/test/end-to-end-tests/src/test/utils.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/utils.ts
@@ -7,14 +7,19 @@ import { IMember } from "fluid-framework";
 import { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
 import { ISharedMap, IValueChanged } from "@fluidframework/map";
 
-export const waitForMyself = async (
+export const waitForMember = async (
     audience: IAzureAudience,
     userId: string,
 ): Promise<AzureMember> => {
+    const allMembers = audience.getMembers();
+    const member = allMembers.get(userId);
+    if (member !== undefined) {
+        return member;
+    }
     return new Promise((resolve) => {
-        const handler = (clientId: string, member: IMember): void => {
-            if (member.userId === userId) {
-                resolve(member as AzureMember);
+        const handler = (clientId: string, newMember: IMember): void => {
+            if (newMember.userId === userId) {
+                resolve(newMember as AzureMember);
             }
         };
         audience.on("memberAdded", handler);


### PR DESCRIPTION
Our test cases are failing since all audience members resolved before `getMySelf` can actually return myself. In other words clientId on the container is not available by the time all audience members (including self) have been added. We have couple of different issues in play here, including the one where mySelf is not available by the time container was loaded for the existing document). Falling back to audience validation user members only, until we sort these other issues out.