### PR TITLE
Use GetFileById() instead of GetFileByUrl() to get sharing information for ODSP file

### DIFF
--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -16,6 +16,7 @@ describe("getFileLink", () => {
     const fileItemResponse = {
         webDavUrl: "fetchDavUrl",
         webUrl: "fetchWebUrl",
+        sharepointIds: { listItemUniqueId: "fetchFileId" },
     };
 
     it("should return share link with existing access", async () => {


### PR DESCRIPTION
## Description

This change is needed to ensure that odsp-driver can get file sharing information when used in Consumer scenarios. Currently we rely on GetFileUrl() method which does not work for Consumer because it does not support webDavUrl in Consumer format. The solution is to use GetFileById() method which works uniformaly for Consumer and Commercial segments

## Does this introduce a breaking change?

No breaking change, only internal implementation changes.

