### PR TITLE
Enable timeout ensureSynchronized everywhere (Solution #1)

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -214,6 +214,10 @@ export class LoaderContainerTracker implements IOpProcessingController {
     processOutgoing(...containers: IContainer[]): Promise<void>;
     reset(): void;
     resumeProcessing(...containers: IContainer[]): IContainer[];
+    // (undocumented)
+    setDefaultWaitTimeout(timeoutMs: number): void;
+    // (undocumented)
+    setScaledDefaultWaitTimeout(testTimeout: number): void;
 }
 
 // @public
@@ -321,6 +325,8 @@ export class TestObjectProvider implements ITestObjectProvider {
     reset(): void;
     // (undocumented)
     resetLoaderContainerTracker(syncSummarizerClients?: boolean): void;
+    // (undocumented)
+    setScaledDefaultWaitTimeout(timeout: number): void;
     // (undocumented)
     updateDocumentId(resolvedUrl: IResolvedUrl | undefined): void;
     // (undocumented)

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -84,8 +84,10 @@ function executePerPropertyTreeType(codeDetails: IFluidCodeDetails,
     describe("Local state", () => {
         let propertyTree;
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             opProcessingController = new LoaderContainerTracker();
+            opProcessingController.setScaledDefaultWaitTimeout(this.timeout());
+
             deltaConnectionServer = LocalDeltaConnectionServer.create();
             urlResolver = new LocalResolver();
 

--- a/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
@@ -12,987 +12,992 @@ import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
-	createAndAttachContainer,
-	createLoader,
-	ITestFluidObject,
-	TestFluidObjectFactory,
-	LoaderContainerTracker,
+    createAndAttachContainer,
+    createLoader,
+    ITestFluidObject,
+    TestFluidObjectFactory,
+    LoaderContainerTracker,
 } from "@fluidframework/test-utils";
 import { DeterministicRandomGenerator } from "@fluid-experimental/property-common";
 import * as _ from "lodash";
 import {
-	StringArrayProperty,
-	PropertyFactory,
-	ArrayProperty,
-	NamedProperty,
+    StringArrayProperty,
+    PropertyFactory,
+    ArrayProperty,
+    NamedProperty,
     Int32Property,
 } from "@fluid-experimental/property-properties";
 import { assert } from "@fluidframework/common-utils";
 import { SharedPropertyTree } from "../propertyTree";
 
 function createLocalLoader(
-	packageEntries: Iterable<[IFluidCodeDetails, TestFluidObjectFactory]>,
-	deltaConnectionServer: ILocalDeltaConnectionServer,
-	urlResolver: IUrlResolver,
-	options?: ILoaderOptions,
+    packageEntries: Iterable<[IFluidCodeDetails, TestFluidObjectFactory]>,
+    deltaConnectionServer: ILocalDeltaConnectionServer,
+    urlResolver: IUrlResolver,
+    options?: ILoaderOptions,
 ): IHostLoader {
-	const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
+    const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
 
-	return createLoader(packageEntries, documentServiceFactory, urlResolver, undefined, options);
+    return createLoader(packageEntries, documentServiceFactory, urlResolver, undefined, options);
 }
 
 function createDerivedGuid(referenceGuid: string, identifier: string) {
-	const hash = crypto.createHash("sha1");
-	hash.write(`${referenceGuid}:${identifier}`);
-	hash.end();
+    const hash = crypto.createHash("sha1");
+    hash.write(`${referenceGuid}:${identifier}`);
+    hash.end();
 
-	const hexHash = hash.digest("hex");
-	return (
-		`${hexHash.substr(0, 8)}-${hexHash.substr(8, 4)}-` +
-		`${hexHash.substr(12, 4)}-${hexHash.substr(16, 4)}-${hexHash.substr(20, 12)}`
-	);
+    const hexHash = hash.digest("hex");
+    return (
+        `${hexHash.substr(0, 8)}-${hexHash.substr(8, 4)}-` +
+        `${hexHash.substr(12, 4)}-${hexHash.substr(16, 4)}-${hexHash.substr(20, 12)}`
+    );
 }
 console.assert = (condition: boolean, ...data: any[]) => {
-	assert(!!condition, "Console Assert");
+    assert(!!condition, "Console Assert");
 };
 
 function getFunctionSource(fun: any): string {
-	let source = fun.toString() as string;
-	source = source.replace(/^.*=>\s*{?\n?\s*/m, "");
-	source = source.replace(/}\s*$/m, "");
-	source = source.replace(/^\s*/gm, "");
+    let source = fun.toString() as string;
+    source = source.replace(/^.*=>\s*{?\n?\s*/m, "");
+    source = source.replace(/}\s*$/m, "");
+    source = source.replace(/^\s*/gm, "");
 
-	return source;
+    return source;
 }
 
 describe("PropertyDDS", () => {
     const documentId = "localServerTest";
-		const documentLoadUrl = `fluid-test://localhost/${documentId}`;
-		const propertyDdsId = "PropertyTree";
-		const codeDetails: IFluidCodeDetails = {
-			package: "localServerTestPackage",
-			config: {},
-		};
-		const factory = new TestFluidObjectFactory([[propertyDdsId, SharedPropertyTree.getFactory()]]);
+    const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+    const propertyDdsId = "PropertyTree";
+    const codeDetails: IFluidCodeDetails = {
+        package: "localServerTestPackage",
+        config: {},
+    };
+    const factory = new TestFluidObjectFactory([[propertyDdsId, SharedPropertyTree.getFactory()]]);
 
-		let deltaConnectionServer: ILocalDeltaConnectionServer;
-		let urlResolver: LocalResolver;
-		let opProcessingController: LoaderContainerTracker;
-		let container1: IContainer;
-		let container2: IContainer;
-		let dataObject1: ITestFluidObject;
-		let dataObject2: ITestFluidObject;
-		let sharedPropertyTree1: SharedPropertyTree;
-		let sharedPropertyTree2: SharedPropertyTree;
+    let deltaConnectionServer: ILocalDeltaConnectionServer;
+    let urlResolver: LocalResolver;
+    let opProcessingController: LoaderContainerTracker;
+    let container1: IContainer;
+    let container2: IContainer;
+    let dataObject1: ITestFluidObject;
+    let dataObject2: ITestFluidObject;
+    let sharedPropertyTree1: SharedPropertyTree;
+    let sharedPropertyTree2: SharedPropertyTree;
 
-		let errorHandler: (Error) => void;
+    let errorHandler: (Error) => void;
 
-		async function createContainer(): Promise<IContainer> {
-			const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
-			opProcessingController.add(loader);
-			return createAndAttachContainer(codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
-		}
+    async function createContainer(): Promise<IContainer> {
+        const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
+        opProcessingController.add(loader);
+        return createAndAttachContainer(codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
+    }
 
-		async function loadContainer(): Promise<IContainer> {
-			const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
-			opProcessingController.add(loader);
-			return loader.resolve({ url: documentLoadUrl });
-		}
+    async function loadContainer(): Promise<IContainer> {
+        const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
+        opProcessingController.add(loader);
+        return loader.resolve({ url: documentLoadUrl });
+    }
 
-		function createRandomTests(
-			operations: {
-				getParameters: (random: DeterministicRandomGenerator) => Record<string, number | (() => void)>;
-				op: (parameters: Record<string, any>) => Promise<void>;
-				probability: number;
-			}[],
-			final: () => Promise<void>,
-			count = 100,
-			startTest = 0,
-			maxOperations = 30,
-		) {
-			for (let i = startTest; i < count; i++) {
-                const seed = createDerivedGuid("", String(i));
-                it(`Generated Test Case #${i} (seed: ${seed})`, async function() {
-					this.timeout(10000);
-					let testString = "";
+    function createRandomTests(
+        operations: {
+            getParameters: (random: DeterministicRandomGenerator) => Record<string, number | (() => void)>;
+            op: (parameters: Record<string, any>) => Promise<void>;
+            probability: number;
+        }[],
+        final: () => Promise<void>,
+        count = 100,
+        startTest = 0,
+        maxOperations = 30,
+    ) {
+        for (let i = startTest; i < count; i++) {
+            const seed = createDerivedGuid("", String(i));
+            it(`Generated Test Case #${i} (seed: ${seed})`, async function() {
+                this.timeout(10000);
+                opProcessingController.setDefaultWaitTimeout(9000);
 
-					errorHandler = (err) => {
-						console.error(`Failed Test code: ${testString}`);
-					};
-					const random = new DeterministicRandomGenerator(seed);
-					const operationCumSums = [] as number[];
-					for (const operation of operations) {
-						operationCumSums.push(
-							(operationCumSums[operationCumSums.length - 1] ?? 0) + operation.probability,
-						);
-					}
+                let testString = "";
 
-					try {
-						const numOperations = random.irandom(maxOperations);
-						const maxCount = operationCumSums[operationCumSums.length - 1];
-						for (const j of _.range(numOperations)) {
-							const operationId = 1 + random.irandom(maxCount);
-							const selectedOperation = _.sortedIndex(operationCumSums, operationId);
-
-							const parameters = operations[selectedOperation].getParameters(random);
-
-							// Create the source code for the test
-							let operationSource = getFunctionSource(operations[selectedOperation].op.toString());
-							for (const [key, value] of Object.entries(parameters)) {
-								const valueString = _.isFunction(value) ? getFunctionSource(value) : value.toString();
-								operationSource = operationSource.replace(
-									new RegExp(`parameters.${key}\\(?\\)?`),
-									valueString,
-								);
-							}
-							testString += operationSource;
-
-							await operations[selectedOperation].op(parameters);
-						}
-
-						testString += getFunctionSource(final);
-						await final();
-					} catch (e) {
-						console.error(`Failed Test code: ${testString}`);
-						throw e;
-					}
-				});
-			}
-		}
-
-        async function setupContainers(mode = true) {
-            opProcessingController = new LoaderContainerTracker();
-            deltaConnectionServer = LocalDeltaConnectionServer.create();
-            urlResolver = new LocalResolver();
-
-            // Create a Container for the first client.
-            container1 = await createContainer();
-            dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
-            sharedPropertyTree1 = await dataObject1.getSharedObject<SharedPropertyTree>(propertyDdsId);
-            (sharedPropertyTree1 as any).__id = 1; // Add an id to simplify debugging via conditional breakpoints
-
-            // Load the Container that was created by the first client.
-            container2 = await loadContainer();
-            dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
-            sharedPropertyTree2 = await dataObject2.getSharedObject<SharedPropertyTree>(propertyDdsId);
-            (sharedPropertyTree2 as any).__id = 2; // Add an id to simplify debugging via conditional breakpoints
-
-            if (mode) {
-                // Submitting empty changeset to make sure both trees are in "write" mode, so the tests could control
-                // which commits are being synced at every point of time.
-                sharedPropertyTree1.commit(true);
-                sharedPropertyTree2.commit(true);
-            }
-
-            // Attach error handlers to make debugging easier and ensure that internal failures cause the test to fail
-            errorHandler = (err) => { }; // This enables the create random tests function to register its own handler
-            container1.on("closed", (err: any) => {
-                if (err !== undefined) {
-                    errorHandler(err);
-                    throw err;
+                errorHandler = (err) => {
+                    console.error(`Failed Test code: ${testString}`);
+                };
+                const random = new DeterministicRandomGenerator(seed);
+                const operationCumSums = [] as number[];
+                for (const operation of operations) {
+                    operationCumSums.push(
+                        (operationCumSums[operationCumSums.length - 1] ?? 0) + operation.probability,
+                    );
                 }
-            });
-            container2.on("closed", (err: any) => {
-                if (err !== undefined) {
-                    errorHandler(err);
-                    throw err;
+
+                try {
+                    const numOperations = random.irandom(maxOperations);
+                    const maxCount = operationCumSums[operationCumSums.length - 1];
+                    for (const j of _.range(numOperations)) {
+                        const operationId = 1 + random.irandom(maxCount);
+                        const selectedOperation = _.sortedIndex(operationCumSums, operationId);
+
+                        const parameters = operations[selectedOperation].getParameters(random);
+
+                        // Create the source code for the test
+                        let operationSource = getFunctionSource(operations[selectedOperation].op.toString());
+                        for (const [key, value] of Object.entries(parameters)) {
+                            const valueString = _.isFunction(value) ? getFunctionSource(value) : value.toString();
+                            operationSource = operationSource.replace(
+                                new RegExp(`parameters.${key}\\(?\\)?`),
+                                valueString,
+                            );
+                        }
+                        testString += operationSource;
+
+                        await operations[selectedOperation].op(parameters);
+                    }
+
+                    testString += getFunctionSource(final);
+                    await final();
+                } catch (e) {
+                    console.error(`Failed Test code: ${testString}`);
+                    throw e;
                 }
             });
         }
+    }
 
-        function rebaseTests() {
-            describe("with non overlapping inserts", () => {
-                let ACount: number;
-                let CCount: number;
+    async function setupContainers(timeout: number, mode = true) {
+        opProcessingController = new LoaderContainerTracker();
+        // Some test needs to wait longer, set the base to 500ms instead of the default 250ms
+        deltaConnectionServer = LocalDeltaConnectionServer.create();
+        urlResolver = new LocalResolver();
 
-                beforeEach(async function() {
-                    this.timeout(10000);
-                    // Insert and prepare an array within the container
-                    sharedPropertyTree1.root.insert("array", PropertyFactory.create("String", "array"));
+        // Create a Container for the first client.
+        container1 = await createContainer();
+        dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+        sharedPropertyTree1 = await dataObject1.getSharedObject<SharedPropertyTree>(propertyDdsId);
+        (sharedPropertyTree1 as any).__id = 1; // Add an id to simplify debugging via conditional breakpoints
 
-                    const array = sharedPropertyTree1.root.get("array") as StringArrayProperty;
-                    array.push("B1");
-                    array.push("B2");
-                    array.push("B3");
-                    sharedPropertyTree1.commit();
+        // Load the Container that was created by the first client.
+        container2 = await loadContainer();
+        dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+        sharedPropertyTree2 = await dataObject2.getSharedObject<SharedPropertyTree>(propertyDdsId);
+        (sharedPropertyTree2 as any).__id = 2; // Add an id to simplify debugging via conditional breakpoints
 
-                    ACount = 0;
-                    CCount = 0;
+        if (mode) {
+            // Submitting empty changeset to make sure both trees are in "write" mode, so the tests could control
+            // which commits are being synced at every point of time.
+            sharedPropertyTree1.commit(true);
+            sharedPropertyTree2.commit(true);
+        }
 
-                    // Make sure both shared trees are in sync
-                    await opProcessingController.ensureSynchronized();
-                    await opProcessingController.pauseProcessing();
-                });
+        // Attach error handlers to make debugging easier and ensure that internal failures cause the test to fail
+        errorHandler = (err) => { }; // This enables the create random tests function to register its own handler
+        container1.on("closed", (err: any) => {
+            if (err !== undefined) {
+                errorHandler(err);
+                throw err;
+            }
+        });
+        container2.on("closed", (err: any) => {
+            if (err !== undefined) {
+                errorHandler(err);
+                throw err;
+            }
+        });
+    }
 
-                afterEach(() => {
-                    const result = _.range(1, ACount + 1)
-                        .map((i) => `A${i}`)
-                        .concat(["B1", "B2", "B3"])
-                        .concat(_.range(1, CCount + 1).map((i) => `C${i}`));
+    function rebaseTests() {
+        describe("with non overlapping inserts", () => {
+            let ACount: number;
+            let CCount: number;
 
-                    const array1 = sharedPropertyTree1.root.get("array") as StringArrayProperty;
-                    const array2 = sharedPropertyTree2.root.get("array") as StringArrayProperty;
-                    for (const array of [array1, array2]) {
-                        for (const [i, value] of result.entries()) {
-                            expect(array.get(i)).to.equal(value);
-                        }
-                    }
-                });
+            beforeEach(async function() {
+                this.timeout(10000);
+                opProcessingController.setDefaultWaitTimeout(9800);
 
-                function insertInArray(tree: SharedPropertyTree, letter: string) {
-                    const array = tree.root.get("array") as StringArrayProperty;
+                // Insert and prepare an array within the container
+                sharedPropertyTree1.root.insert("array", PropertyFactory.create("String", "array"));
 
-                    // Find the insert position
-                    let insertPosition: number;
-                    let insertString: string;
-                    if (letter === "A") {
-                        // We insert all As in front of B1
-                        const values: string[] = array.getValues();
-                        insertPosition = values.indexOf("B1");
+                const array = sharedPropertyTree1.root.get("array") as StringArrayProperty;
+                array.push("B1");
+                array.push("B2");
+                array.push("B3");
+                sharedPropertyTree1.commit();
 
-                        // For these letters we can just use the position to get the number for the inserted string
-                        insertString = `A${insertPosition + 1}`;
+                ACount = 0;
+                CCount = 0;
 
-                        ACount++;
-                    } else {
-                        // Alway insert B at the end
-                        insertPosition = array.getLength();
-
-                        // Get the number from the previous entry
-                        const previous = array.get(insertPosition - 1) as string;
-                        const entryNumber = previous[0] === "B" ? 1 : Number.parseInt(previous[1], 10) + 1;
-                        insertString = `C${entryNumber}`;
-
-                        CCount++;
-                    }
-
-                    array.insert(insertPosition, insertString);
-                    tree.commit();
-                }
-
-                it("Should work when doing two batches with synchronization inbetween", async () => {
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-
-                    await opProcessingController.ensureSynchronized();
-
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree2, "C");
-
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                it("Should work when doing two batches without synchronization inbetween", async () => {
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree2, "C");
-
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                it("Should work when creating local branches with different remote heads", async () => {
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree1, "A");
-
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                it("Should work when synchronizing after each operation", async () => {
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.ensureSynchronized();
-
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                it("Should work when synchronizing after pairs of operations", async () => {
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.ensureSynchronized();
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                it("works with overlapping sequences", async () => {
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.processOutgoing(container2);
-
-                    // Insert five operations to make this overlap with the insert position of C
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.processIncoming(container1);
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.processIncoming(container2);
-
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                it("Should work when the remote head points to a change that is not the reference change", async () => {
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.processOutgoing(container2);
-                    insertInArray(sharedPropertyTree1, "A");
-                    await opProcessingController.processOutgoing(container1);
-                    insertInArray(sharedPropertyTree2, "C");
-                    await opProcessingController.processIncoming(container2);
-                    insertInArray(sharedPropertyTree2, "C");
-                    insertInArray(sharedPropertyTree2, "C");
-
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                describe("Randomized Tests", () => {
-                    const count = 100;
-                    const startTest = 0;
-                    const logTest = true;
-
-                    for (let i = startTest; i < count; i++) {
-                        const seed = createDerivedGuid("", String(i));
-                        it(`Generated Test Case #${i} (seed: ${seed})`, async () => {
-                            const random = new DeterministicRandomGenerator(seed);
-                            let testString = "";
-
-                            const numOperations = random.irandom(30);
-                            for (const j of _.range(numOperations)) {
-                                const operation = random.irandom(6);
-                                switch (operation) {
-                                    case 0:
-                                        insertInArray(sharedPropertyTree1, "A");
-                                        if (logTest) {
-                                            testString += 'insertInArray(sharedPropertyTree1, "A");\n';
-                                        }
-                                        break;
-                                    case 1:
-                                        insertInArray(sharedPropertyTree2, "C");
-                                        if (logTest) {
-                                            testString += 'insertInArray(sharedPropertyTree2, "C");\n';
-                                        }
-                                        break;
-                                    case 2:
-                                        await opProcessingController.processOutgoing(container1);
-                                        if (logTest) {
-                                            testString +=
-                                                "await opProcessingController.processOutgoing(container1);\n";
-                                        }
-                                        break;
-                                    case 3:
-                                        await opProcessingController.processIncoming(container1);
-                                        if (logTest) {
-                                            testString +=
-                                                "await opProcessingController.processIncoming(container1);\n";
-                                        }
-                                        break;
-                                    case 4:
-                                        await opProcessingController.processOutgoing(container2);
-                                        if (logTest) {
-                                            testString +=
-                                                "await opProcessingController.processOutgoing(container2);\n";
-                                        }
-                                        break;
-                                    case 5:
-                                        await opProcessingController.processIncoming(container2);
-                                        if (logTest) {
-                                            testString +=
-                                                "await opProcessingController.processIncoming(container2);\n";
-                                        }
-                                        break;
-                                    default:
-                                        throw new Error("Should never happen");
-                                }
-                            }
-
-                            await opProcessingController.ensureSynchronized();
-                            if (logTest) {
-                                testString +=
-                                    "await opProcessingController.ensureSynchronized();\n";
-                            }
-                        });
-                    }
-                });
+                // Make sure both shared trees are in sync
+                await opProcessingController.ensureSynchronized();
+                await opProcessingController.pauseProcessing();
             });
 
-            describe("with inserts and deletes at arbitrary positions", () => {
-                let createdProperties: Set<string>;
-                let deletedProperties: Set<string>;
-                beforeEach(async () => {
-                    createdProperties = new Set();
-                    deletedProperties = new Set();
-                    (PropertyFactory as any)._reregister({
-                        typeid: "test:namedEntry-1.0.0",
-                        inherits: ["NamedProperty"],
-                        properties: [],
-                    });
+            afterEach(() => {
+                const result = _.range(1, ACount + 1)
+                    .map((i) => `A${i}`)
+                    .concat(["B1", "B2", "B3"])
+                    .concat(_.range(1, CCount + 1).map((i) => `C${i}`));
 
-                    await opProcessingController.pauseProcessing();
-                    sharedPropertyTree1.root.insert("array", PropertyFactory.create("test:namedEntry-1.0.0", "array"));
-                    sharedPropertyTree1.commit();
-
-                    // // Making sure that both trees are in write mode.
-                    // sharedPropertyTree2.commit(true);
-                    // Make sure both shared trees are in sync
-                    await opProcessingController.ensureSynchronized();
-                });
-                afterEach(async () => {
-                    // We expect the internal representation to be the same between both properties
-                    expect((sharedPropertyTree1 as any).remoteTipView).to.deep.equal(
-                        (sharedPropertyTree2 as any).remoteTipView,
-                    );
-
-                    // We expect the property tree to be the same between both
-                    expect(sharedPropertyTree1.root.serialize()).to.deep.equal(sharedPropertyTree2.root.serialize());
-
-                    // We expect the property tree to correspond to the remote tip view
-                    expect((sharedPropertyTree1 as any).remoteTipView).to.deep.equal(
-                        sharedPropertyTree2.root.serialize());
-
-                    // We expect all properties from the set to be present
-                    const array = sharedPropertyTree1.root.get<ArrayProperty>("array");
-                    assert(array !== undefined, "property undefined");
-
-                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-                    for (const property of array.getValues() as any[]) {
-                        expect(!deletedProperties.has(property.guid)).to.be.true;
-                        expect(createdProperties.has(property.guid)).to.be.true;
-                        createdProperties.delete(property.guid);
-                    }
-                    expect(createdProperties.size).to.equal(0);
-                });
-                function insertProperties(tree: SharedPropertyTree, index: number, count = 1, commit = true) {
-                    for (let i = 0; i < count; i++) {
-                        const property = PropertyFactory.create<NamedProperty>("test:namedEntry-1.0.0");
-                        tree.root.get<ArrayProperty>("array")?.insert(index + i, property);
-                        createdProperties.add(property.getGuid());
-                    }
-
-                    if (commit) {
-                        tree.commit();
+                const array1 = sharedPropertyTree1.root.get("array") as StringArrayProperty;
+                const array2 = sharedPropertyTree2.root.get("array") as StringArrayProperty;
+                for (const array of [array1, array2]) {
+                    for (const [i, value] of result.entries()) {
+                        expect(array.get(i)).to.equal(value);
                     }
                 }
-                function removeProperties(tree: SharedPropertyTree, index: number, count = 1, commit = true) {
-                    const array = tree.root.get<ArrayProperty>("array");
-                    assert(array !== undefined, "property undefined");
+            });
 
-                    for (let i = 0; i < count; i++) {
-                        if (index >= array.getLength()) {
-                            break;
+            function insertInArray(tree: SharedPropertyTree, letter: string) {
+                const array = tree.root.get("array") as StringArrayProperty;
+
+                // Find the insert position
+                let insertPosition: number;
+                let insertString: string;
+                if (letter === "A") {
+                    // We insert all As in front of B1
+                    const values: string[] = array.getValues();
+                    insertPosition = values.indexOf("B1");
+
+                    // For these letters we can just use the position to get the number for the inserted string
+                    insertString = `A${insertPosition + 1}`;
+
+                    ACount++;
+                } else {
+                    // Alway insert B at the end
+                    insertPosition = array.getLength();
+
+                    // Get the number from the previous entry
+                    const previous = array.get(insertPosition - 1) as string;
+                    const entryNumber = previous[0] === "B" ? 1 : Number.parseInt(previous[1], 10) + 1;
+                    insertString = `C${entryNumber}`;
+
+                    CCount++;
+                }
+
+                array.insert(insertPosition, insertString);
+                tree.commit();
+            }
+
+            it("Should work when doing two batches with synchronization inbetween", async () => {
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+
+                await opProcessingController.ensureSynchronized();
+
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree2, "C");
+
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("Should work when doing two batches without synchronization inbetween", async () => {
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree2, "C");
+
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("Should work when creating local branches with different remote heads", async () => {
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree1, "A");
+
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("Should work when synchronizing after each operation", async () => {
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.ensureSynchronized();
+
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("Should work when synchronizing after pairs of operations", async () => {
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.ensureSynchronized();
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("works with overlapping sequences", async () => {
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.processOutgoing(container2);
+
+                // Insert five operations to make this overlap with the insert position of C
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.processIncoming(container1);
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.processIncoming(container2);
+
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("Should work when the remote head points to a change that is not the reference change", async () => {
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.processOutgoing(container2);
+                insertInArray(sharedPropertyTree1, "A");
+                await opProcessingController.processOutgoing(container1);
+                insertInArray(sharedPropertyTree2, "C");
+                await opProcessingController.processIncoming(container2);
+                insertInArray(sharedPropertyTree2, "C");
+                insertInArray(sharedPropertyTree2, "C");
+
+                await opProcessingController.ensureSynchronized();
+            });
+
+            describe("Randomized Tests", () => {
+                const count = 100;
+                const startTest = 0;
+                const logTest = true;
+
+                for (let i = startTest; i < count; i++) {
+                    const seed = createDerivedGuid("", String(i));
+                    it(`Generated Test Case #${i} (seed: ${seed})`, async () => {
+                        const random = new DeterministicRandomGenerator(seed);
+                        let testString = "";
+
+                        const numOperations = random.irandom(30);
+                        for (const j of _.range(numOperations)) {
+                            const operation = random.irandom(6);
+                            switch (operation) {
+                                case 0:
+                                    insertInArray(sharedPropertyTree1, "A");
+                                    if (logTest) {
+                                        testString += 'insertInArray(sharedPropertyTree1, "A");\n';
+                                    }
+                                    break;
+                                case 1:
+                                    insertInArray(sharedPropertyTree2, "C");
+                                    if (logTest) {
+                                        testString += 'insertInArray(sharedPropertyTree2, "C");\n';
+                                    }
+                                    break;
+                                case 2:
+                                    await opProcessingController.processOutgoing(container1);
+                                    if (logTest) {
+                                        testString +=
+                                            "await opProcessingController.processOutgoing(container1);\n";
+                                    }
+                                    break;
+                                case 3:
+                                    await opProcessingController.processIncoming(container1);
+                                    if (logTest) {
+                                        testString +=
+                                            "await opProcessingController.processIncoming(container1);\n";
+                                    }
+                                    break;
+                                case 4:
+                                    await opProcessingController.processOutgoing(container2);
+                                    if (logTest) {
+                                        testString +=
+                                            "await opProcessingController.processOutgoing(container2);\n";
+                                    }
+                                    break;
+                                case 5:
+                                    await opProcessingController.processIncoming(container2);
+                                    if (logTest) {
+                                        testString +=
+                                            "await opProcessingController.processIncoming(container2);\n";
+                                    }
+                                    break;
+                                default:
+                                    throw new Error("Should never happen");
+                            }
                         }
-                        const property = array.get<NamedProperty>(index);
-                        assert(property !== undefined, "property undefined");
-                        array.remove(index);
-                        createdProperties.delete(property.getGuid());
-                        deletedProperties.add(property.getGuid());
-                    }
-                    if (commit) {
-                        tree.commit();
-                    }
+
+                        await opProcessingController.ensureSynchronized();
+                        if (logTest) {
+                            testString +=
+                                "await opProcessingController.ensureSynchronized();\n";
+                        }
+                    });
+                }
+            });
+        });
+
+        describe("with inserts and deletes at arbitrary positions", () => {
+            let createdProperties: Set<string>;
+            let deletedProperties: Set<string>;
+            beforeEach(async () => {
+                createdProperties = new Set();
+                deletedProperties = new Set();
+                (PropertyFactory as any)._reregister({
+                    typeid: "test:namedEntry-1.0.0",
+                    inherits: ["NamedProperty"],
+                    properties: [],
+                });
+
+                await opProcessingController.pauseProcessing();
+                sharedPropertyTree1.root.insert("array", PropertyFactory.create("test:namedEntry-1.0.0", "array"));
+                sharedPropertyTree1.commit();
+
+                // // Making sure that both trees are in write mode.
+                // sharedPropertyTree2.commit(true);
+                // Make sure both shared trees are in sync
+                await opProcessingController.ensureSynchronized();
+            });
+            afterEach(async () => {
+                // We expect the internal representation to be the same between both properties
+                expect((sharedPropertyTree1 as any).remoteTipView).to.deep.equal(
+                    (sharedPropertyTree2 as any).remoteTipView,
+                );
+
+                // We expect the property tree to be the same between both
+                expect(sharedPropertyTree1.root.serialize()).to.deep.equal(sharedPropertyTree2.root.serialize());
+
+                // We expect the property tree to correspond to the remote tip view
+                expect((sharedPropertyTree1 as any).remoteTipView).to.deep.equal(
+                    sharedPropertyTree2.root.serialize());
+
+                // We expect all properties from the set to be present
+                const array = sharedPropertyTree1.root.get<ArrayProperty>("array");
+                assert(array !== undefined, "property undefined");
+
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+                for (const property of array.getValues() as any[]) {
+                    expect(!deletedProperties.has(property.guid)).to.be.true;
+                    expect(createdProperties.has(property.guid)).to.be.true;
+                    createdProperties.delete(property.guid);
+                }
+                expect(createdProperties.size).to.equal(0);
+            });
+            function insertProperties(tree: SharedPropertyTree, index: number, count = 1, commit = true) {
+                for (let i = 0; i < count; i++) {
+                    const property = PropertyFactory.create<NamedProperty>("test:namedEntry-1.0.0");
+                    tree.root.get<ArrayProperty>("array")?.insert(index + i, property);
+                    createdProperties.add(property.getGuid());
                 }
 
-                it("inserting properties into both trees", async () => {
-                    insertProperties(sharedPropertyTree1, 0);
-                    insertProperties(sharedPropertyTree1, 1);
-                    insertProperties(sharedPropertyTree2, 0);
-                    insertProperties(sharedPropertyTree2, 1);
+                if (commit) {
+                    tree.commit();
+                }
+            }
+            function removeProperties(tree: SharedPropertyTree, index: number, count = 1, commit = true) {
+                const array = tree.root.get<ArrayProperty>("array");
+                assert(array !== undefined, "property undefined");
+
+                for (let i = 0; i < count; i++) {
+                    if (index >= array.getLength()) {
+                        break;
+                    }
+                    const property = array.get<NamedProperty>(index);
+                    assert(property !== undefined, "property undefined");
+                    array.remove(index);
+                    createdProperties.delete(property.getGuid());
+                    deletedProperties.add(property.getGuid());
+                }
+                if (commit) {
+                    tree.commit();
+                }
+            }
+
+            it("inserting properties into both trees", async () => {
+                insertProperties(sharedPropertyTree1, 0);
+                insertProperties(sharedPropertyTree1, 1);
+                insertProperties(sharedPropertyTree2, 0);
+                insertProperties(sharedPropertyTree2, 1);
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("inserting properties in one tree and deleting in the other", async () => {
+                insertProperties(sharedPropertyTree1, 0);
+                insertProperties(sharedPropertyTree1, 1);
+                await opProcessingController.ensureSynchronized();
+                removeProperties(sharedPropertyTree2, 0);
+                removeProperties(sharedPropertyTree2, 0);
+                await opProcessingController.ensureSynchronized();
+            });
+
+            it("inserting properties in one tree and deleting in both", async () => {
+                insertProperties(sharedPropertyTree1, 0);
+                insertProperties(sharedPropertyTree1, 1);
+                await opProcessingController.ensureSynchronized();
+                removeProperties(sharedPropertyTree1, 0);
+                removeProperties(sharedPropertyTree2, 0);
+                await opProcessingController.ensureSynchronized();
+            });
+            it("Multiple inserts in sequence in tree 1", async () => {
+                insertProperties(sharedPropertyTree1, 0, 1, true);
+                insertProperties(sharedPropertyTree1, 0, 1, true);
+                insertProperties(sharedPropertyTree1, 1, 1, true);
+                insertProperties(sharedPropertyTree2, 0, 1, true);
+
+                await opProcessingController.ensureSynchronized();
+            });
+
+            describe("Random tests", () => {
+                createRandomTests(
+                    [
+                        {
+                            getParameters: (random: DeterministicRandomGenerator) => {
+                                const tree = random.irandom(2) === 0 ?
+                                    () => sharedPropertyTree1 :
+                                    () => sharedPropertyTree2;
+                                const array = tree().root.get<ArrayProperty>("array");
+                                return {
+                                    position: random.irandom(array?.getLength()) || 0,
+                                    count: (random.irandom(3)) + 1,
+                                    tree,
+                                };
+                            },
+                            op: async (parameters) => {
+                                insertProperties(parameters.tree(), parameters.position, parameters.count, true);
+                            },
+                            probability: 1,
+                        },
+                        {
+                            getParameters: (random: DeterministicRandomGenerator) => {
+                                const tree = random.irandom(2) === 0 ?
+                                    () => sharedPropertyTree1 : () => sharedPropertyTree2;
+                                const array = tree().root.get<ArrayProperty>("array");
+                                return {
+                                    position: random.irandom(array?.getLength()) || 0,
+                                    count: (random.irandom(3)) + 1,
+                                    tree,
+                                };
+                            },
+                            op: async (parameters) => {
+                                removeProperties(parameters.tree(), parameters.position, parameters.count, true);
+                            },
+                            probability: 1,
+                        },
+                        {
+                            getParameters: (random: DeterministicRandomGenerator) => {
+                                const container = random.irandom(2) === 0 ? () => container1 : () => container2;
+                                return {
+                                    container,
+                                };
+                            },
+                            op: async (parameters) => {
+                                await opProcessingController.processOutgoing(parameters.container());
+                            },
+                            probability: 1,
+                        },
+                        {
+                            getParameters: (random: DeterministicRandomGenerator) => {
+                                const container = random.irandom(2) === 0 ? () => container1 : () => container2;
+                                return {
+                                    container,
+                                };
+                            },
+                            op: async (parameters) => {
+                                await opProcessingController.processIncoming(parameters.container());
+                            },
+                            probability: 1,
+                        },
+                    ],
+                    async () => {
+                        await opProcessingController.ensureSynchronized();
+                    },
+                    1000,
+                    0,
+                    25,
+                );
+            });
+            describe("Failed Random Tests", () => {
+                it("Test Failure 1", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    insertProperties(sharedPropertyTree1, 3, 3, true);
+                    insertProperties(sharedPropertyTree1, 6, 2, true);
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
+                    insertProperties(sharedPropertyTree1, 2, 2, true);
+                    insertProperties(sharedPropertyTree1, 8, 2, true);
+                    insertProperties(sharedPropertyTree1, 2, 2, true);
+                    insertProperties(sharedPropertyTree1, 16, 3, true);
+                    insertProperties(sharedPropertyTree1, 9, 1, true);
+                    insertProperties(sharedPropertyTree1, 4, 2, true);
+                    insertProperties(sharedPropertyTree1, 13, 3, true);
+                    insertProperties(sharedPropertyTree1, 9, 3, true);
+                    insertProperties(sharedPropertyTree1, 16, 2, true);
+                    insertProperties(sharedPropertyTree1, 12, 2, true);
+                    insertProperties(sharedPropertyTree2, 0, 2, true);
+                    insertProperties(sharedPropertyTree1, 12, 2, true);
+                    insertProperties(sharedPropertyTree1, 12, 3, true);
+                    insertProperties(sharedPropertyTree1, 25, 3, true);
                     await opProcessingController.ensureSynchronized();
                 });
 
-                it("inserting properties in one tree and deleting in the other", async () => {
-                    insertProperties(sharedPropertyTree1, 0);
-                    insertProperties(sharedPropertyTree1, 1);
-                    await opProcessingController.ensureSynchronized();
-                    removeProperties(sharedPropertyTree2, 0);
-                    removeProperties(sharedPropertyTree2, 0);
-                    await opProcessingController.ensureSynchronized();
-                });
-
-                it("inserting properties in one tree and deleting in both", async () => {
-                    insertProperties(sharedPropertyTree1, 0);
-                    insertProperties(sharedPropertyTree1, 1);
-                    await opProcessingController.ensureSynchronized();
-                    removeProperties(sharedPropertyTree1, 0);
-                    removeProperties(sharedPropertyTree2, 0);
-                    await opProcessingController.ensureSynchronized();
-                });
-                it("Multiple inserts in sequence in tree 1", async () => {
+                it("Test Failure 2", async () => {
                     insertProperties(sharedPropertyTree1, 0, 1, true);
                     insertProperties(sharedPropertyTree1, 0, 1, true);
                     insertProperties(sharedPropertyTree1, 1, 1, true);
+                    insertProperties(sharedPropertyTree1, 1, 1, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 2, 1, true);
+                    insertProperties(sharedPropertyTree1, 4, 1, true);
+                    insertProperties(sharedPropertyTree1, 2, 1, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 6, 1, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 6, 1, true);
+                    insertProperties(sharedPropertyTree1, 9, 1, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 2, 1, true);
+                    insertProperties(sharedPropertyTree1, 9, 1, true);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 4, 1, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 3, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+
+                it("Test Failure 3", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
                     insertProperties(sharedPropertyTree2, 0, 1, true);
 
                     await opProcessingController.ensureSynchronized();
                 });
 
-                describe("Random tests", () => {
-                    createRandomTests(
-                        [
-                            {
-                                getParameters: (random: DeterministicRandomGenerator) => {
-                                    const tree = random.irandom(2) === 0 ?
-                                        () => sharedPropertyTree1 :
-                                        () => sharedPropertyTree2;
-                                    const array = tree().root.get<ArrayProperty>("array");
-                                    return {
-                                        position: random.irandom(array?.getLength()) || 0,
-                                        count: (random.irandom(3)) + 1,
-                                        tree,
-                                    };
-                                },
-                                op: async (parameters) => {
-                                    insertProperties(parameters.tree(), parameters.position, parameters.count, true);
-                                },
-                                probability: 1,
-                            },
-                            {
-                                getParameters: (random: DeterministicRandomGenerator) => {
-                                    const tree = random.irandom(2) === 0 ?
-                                        () => sharedPropertyTree1 : () => sharedPropertyTree2;
-                                    const array = tree().root.get<ArrayProperty>("array");
-                                    return {
-                                        position: random.irandom(array?.getLength()) || 0,
-                                        count: (random.irandom(3)) + 1,
-                                        tree,
-                                    };
-                                },
-                                op: async (parameters) => {
-                                    removeProperties(parameters.tree(), parameters.position, parameters.count, true);
-                                },
-                                probability: 1,
-                            },
-                            {
-                                getParameters: (random: DeterministicRandomGenerator) => {
-                                    const container = random.irandom(2) === 0 ? () => container1 : () => container2;
-                                    return {
-                                        container,
-                                    };
-                                },
-                                op: async (parameters) => {
-                                    await opProcessingController.processOutgoing(parameters.container());
-                                },
-                                probability: 1,
-                            },
-                            {
-                                getParameters: (random: DeterministicRandomGenerator) => {
-                                    const container = random.irandom(2) === 0 ? () => container1 : () => container2;
-                                    return {
-                                        container,
-                                    };
-                                },
-                                op: async (parameters) => {
-                                    await opProcessingController.processIncoming(parameters.container());
-                                },
-                                probability: 1,
-                            },
-                        ],
-                        async () => {
-                            await opProcessingController.ensureSynchronized();
-                        },
-                        1000,
-                        0,
-                        25,
-                    );
+                it("Test Failure 4", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    insertProperties(sharedPropertyTree2, 1, 1, true);
+
+                    await opProcessingController.ensureSynchronized();
                 });
-                describe("Failed Random Tests", () => {
-                    it("Test Failure 1", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        insertProperties(sharedPropertyTree1, 3, 3, true);
-                        insertProperties(sharedPropertyTree1, 6, 2, true);
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
-                        insertProperties(sharedPropertyTree1, 2, 2, true);
-                        insertProperties(sharedPropertyTree1, 8, 2, true);
-                        insertProperties(sharedPropertyTree1, 2, 2, true);
-                        insertProperties(sharedPropertyTree1, 16, 3, true);
-                        insertProperties(sharedPropertyTree1, 9, 1, true);
-                        insertProperties(sharedPropertyTree1, 4, 2, true);
-                        insertProperties(sharedPropertyTree1, 13, 3, true);
-                        insertProperties(sharedPropertyTree1, 9, 3, true);
-                        insertProperties(sharedPropertyTree1, 16, 2, true);
-                        insertProperties(sharedPropertyTree1, 12, 2, true);
-                        insertProperties(sharedPropertyTree2, 0, 2, true);
-                        insertProperties(sharedPropertyTree1, 12, 2, true);
-                        insertProperties(sharedPropertyTree1, 12, 3, true);
-                        insertProperties(sharedPropertyTree1, 25, 3, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
 
-                    it("Test Failure 2", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 1, 1, true);
-                        insertProperties(sharedPropertyTree1, 1, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 2, 1, true);
-                        insertProperties(sharedPropertyTree1, 4, 1, true);
-                        insertProperties(sharedPropertyTree1, 2, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 6, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 6, 1, true);
-                        insertProperties(sharedPropertyTree1, 9, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 2, 1, true);
-                        insertProperties(sharedPropertyTree1, 9, 1, true);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 4, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 3, 1, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test Failure 5", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 8, true);
+                    removeProperties(sharedPropertyTree1, 4, 3, true);
 
-                    it("Test Failure 3", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test Failure 6", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
+                    removeProperties(sharedPropertyTree1, 0, 2, true);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    removeProperties(sharedPropertyTree2, 0, 1, true);
 
-                    it("Test Failure 4", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        insertProperties(sharedPropertyTree2, 1, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test Failure 7", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 8, true);
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree1, 1, 4, true);
+                    await opProcessingController.processOutgoing(container1);
+                    removeProperties(sharedPropertyTree1, 4, 3, true);
+                    removeProperties(sharedPropertyTree1, 0, 2, true);
+                    insertProperties(sharedPropertyTree1, 0, 4, true);
 
-                    it("Test Failure 5", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 8, true);
-                        removeProperties(sharedPropertyTree1, 4, 3, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test Failure 8", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processIncoming(container1);
+                    removeProperties(sharedPropertyTree2, 0, 3, true);
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
 
-                    it("Test Failure 6", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
-                        removeProperties(sharedPropertyTree1, 0, 2, true);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        removeProperties(sharedPropertyTree2, 0, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test Failure 9", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 9, true);
+                    insertProperties(sharedPropertyTree2, 4, 1, true);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 1, 2, true);
 
-                    it("Test Failure 7", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 8, true);
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree1, 1, 4, true);
-                        await opProcessingController.processOutgoing(container1);
-                        removeProperties(sharedPropertyTree1, 4, 3, true);
-                        removeProperties(sharedPropertyTree1, 0, 2, true);
-                        insertProperties(sharedPropertyTree1, 0, 4, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test Failure 10", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processIncoming(container1);
+                    removeProperties(sharedPropertyTree2, 0, 3, true);
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    removeProperties(sharedPropertyTree1, 0, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 11", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 6, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 4, 2, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 12", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processOutgoing(container2);
+                    removeProperties(sharedPropertyTree2, 2, 2, true);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 1, 2, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 13", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 1, 3, true);
+                    removeProperties(sharedPropertyTree2, 4, 1, true);
+                    insertProperties(sharedPropertyTree2, 4, 3, true);
+                    insertProperties(sharedPropertyTree1, 1, 2, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 14", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    await opProcessingController.processOutgoing(container1);
+                    insertProperties(sharedPropertyTree2, 0, 2, true);
+                    await opProcessingController.processIncoming(container2);
+                    removeProperties(sharedPropertyTree2, 0, 1, true);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 15", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processIncoming(container1);
+                    insertProperties(sharedPropertyTree2, 0, 2, true);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
+                    removeProperties(sharedPropertyTree1, 1, 3, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 16", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    await opProcessingController.processOutgoing(container1);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    removeProperties(sharedPropertyTree2, 0, 1, true);
+                    removeProperties(sharedPropertyTree1, 0, 3, true);
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 2, 2, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 17", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    await opProcessingController.processOutgoing(container1);
+                    insertProperties(sharedPropertyTree1, 2, 4, true);
+                    removeProperties(sharedPropertyTree1, 0, 3, true);
+                    removeProperties(sharedPropertyTree1, 1, 3, true);
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
 
-                    it("Test Failure 8", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processIncoming(container1);
-                        removeProperties(sharedPropertyTree2, 0, 3, true);
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 1, 1, true);
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 18", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processIncoming(container1);
+                    removeProperties(sharedPropertyTree2, 0, 3, true);
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    removeProperties(sharedPropertyTree1, 1, 2, true);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
 
-                    it("Test Failure 9", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 9, true);
-                        insertProperties(sharedPropertyTree2, 4, 1, true);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 1, 2, true);
+                    await opProcessingController.ensureSynchronized();
+                });
+                it("Test Failure 19", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    insertProperties(sharedPropertyTree2, 0, 1, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processIncoming(container2);
+                    removeProperties(sharedPropertyTree2, 1, 3, true);
+                    await opProcessingController.processOutgoing(container1);
+                    removeProperties(sharedPropertyTree1, 0, 1, true);
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    removeProperties(sharedPropertyTree2, 0, 2, true);
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                    it("Test Failure 10", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processIncoming(container1);
-                        removeProperties(sharedPropertyTree2, 0, 3, true);
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        removeProperties(sharedPropertyTree1, 0, 1, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 11", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 6, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 4, 2, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 12", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processOutgoing(container2);
-                        removeProperties(sharedPropertyTree2, 2, 2, true);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 1, 2, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 13", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 1, 3, true);
-                        removeProperties(sharedPropertyTree2, 4, 1, true);
-                        insertProperties(sharedPropertyTree2, 4, 3, true);
-                        insertProperties(sharedPropertyTree1, 1, 2, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 14", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        await opProcessingController.processOutgoing(container1);
-                        insertProperties(sharedPropertyTree2, 0, 2, true);
-                        await opProcessingController.processIncoming(container2);
-                        removeProperties(sharedPropertyTree2, 0, 1, true);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 15", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processIncoming(container1);
-                        insertProperties(sharedPropertyTree2, 0, 2, true);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
-                        removeProperties(sharedPropertyTree1, 1, 3, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 16", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        await opProcessingController.processOutgoing(container1);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        removeProperties(sharedPropertyTree2, 0, 1, true);
-                        removeProperties(sharedPropertyTree1, 0, 3, true);
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 2, 2, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 17", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        await opProcessingController.processOutgoing(container1);
-                        insertProperties(sharedPropertyTree1, 2, 4, true);
-                        removeProperties(sharedPropertyTree1, 0, 3, true);
-                        removeProperties(sharedPropertyTree1, 1, 3, true);
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
+                it("Test Failure 20", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 2, true);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree2, 0, 2, true);
+                    await opProcessingController.processOutgoing(container2);
+                    removeProperties(sharedPropertyTree2, 1, 3, true);
+                    await opProcessingController.processIncoming(container1);
+                    removeProperties(sharedPropertyTree1, 1, 3, true);
+                    insertProperties(sharedPropertyTree1, 1, 2, true);
+                    removeProperties(sharedPropertyTree2, 0, 1, true);
 
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 1, 1, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 18", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processIncoming(container1);
-                        removeProperties(sharedPropertyTree2, 0, 3, true);
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        removeProperties(sharedPropertyTree1, 1, 2, true);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
+                it("Test Failure 21", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 7, true);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree1, 4, 2, true);
+                    await opProcessingController.processOutgoing(container1);
+                    insertProperties(sharedPropertyTree2, 5, 1, true);
+                    removeProperties(sharedPropertyTree2, 6, 2, true);
+                    insertProperties(sharedPropertyTree1, 6, 1, true);
+                    removeProperties(sharedPropertyTree1, 8, 1, true);
+                    await opProcessingController.processOutgoing(container2);
+                    removeProperties(sharedPropertyTree1, 7, 2, true);
 
-                        await opProcessingController.ensureSynchronized();
-                    });
-                    it("Test Failure 19", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        insertProperties(sharedPropertyTree2, 0, 1, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processIncoming(container2);
-                        removeProperties(sharedPropertyTree2, 1, 3, true);
-                        await opProcessingController.processOutgoing(container1);
-                        removeProperties(sharedPropertyTree1, 0, 1, true);
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        removeProperties(sharedPropertyTree2, 0, 2, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test Failure 22", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 1, 2, true);
+                    removeProperties(sharedPropertyTree1, 0, 2, true);
+                    await opProcessingController.processOutgoing(container1);
+                    insertProperties(sharedPropertyTree1, 0, 1, true);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processIncoming(container1);
+                    await opProcessingController.ensureSynchronized();
+                    insertProperties(sharedPropertyTree1, 5, 2, true);
+                    await opProcessingController.processIncoming(container1);
+                    await opProcessingController.processOutgoing(container2);
+                    removeProperties(sharedPropertyTree2, 1, 1, true);
+                    removeProperties(sharedPropertyTree1, 6, 2, true);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree1, 3, 2, true);
+                    await opProcessingController.processOutgoing(container2);
+                    removeProperties(sharedPropertyTree2, 2, 3, true);
+                    removeProperties(sharedPropertyTree1, 3, 2, true);
+                    insertProperties(sharedPropertyTree2, 1, 3, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                    it("Test Failure 20", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 2, true);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree2, 0, 2, true);
-                        await opProcessingController.processOutgoing(container2);
-                        removeProperties(sharedPropertyTree2, 1, 3, true);
-                        await opProcessingController.processIncoming(container1);
-                        removeProperties(sharedPropertyTree1, 1, 3, true);
-                        insertProperties(sharedPropertyTree1, 1, 2, true);
-                        removeProperties(sharedPropertyTree2, 0, 1, true);
+                it("Test failure 23", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 4, true);
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    insertProperties(sharedPropertyTree2, 1, 3, true);
+                    removeProperties(sharedPropertyTree2, 0, 2, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test failure 24", async () => {
+                    insertProperties(sharedPropertyTree2, 0, 6, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processIncoming(container1);
+                    removeProperties(sharedPropertyTree2, 4, 1, true);
+                    removeProperties(sharedPropertyTree1, 3, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processIncoming(container1);
+                    removeProperties(sharedPropertyTree1, 2, 3, true);
 
-                    it("Test Failure 21", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 7, true);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree1, 4, 2, true);
-                        await opProcessingController.processOutgoing(container1);
-                        insertProperties(sharedPropertyTree2, 5, 1, true);
-                        removeProperties(sharedPropertyTree2, 6, 2, true);
-                        insertProperties(sharedPropertyTree1, 6, 1, true);
-                        removeProperties(sharedPropertyTree1, 8, 1, true);
-                        await opProcessingController.processOutgoing(container2);
-                        removeProperties(sharedPropertyTree1, 7, 2, true);
+                    await opProcessingController.ensureSynchronized();
+                });
 
-                        await opProcessingController.ensureSynchronized();
-                    });
-
-                    it("Test Failure 22", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 1, 2, true);
-                        removeProperties(sharedPropertyTree1, 0, 2, true);
-                        await opProcessingController.processOutgoing(container1);
-                        insertProperties(sharedPropertyTree1, 0, 1, true);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processIncoming(container1);
-                        await opProcessingController.ensureSynchronized();
-                        insertProperties(sharedPropertyTree1, 5, 2, true);
-                        await opProcessingController.processIncoming(container1);
-                        await opProcessingController.processOutgoing(container2);
-                        removeProperties(sharedPropertyTree2, 1, 1, true);
-                        removeProperties(sharedPropertyTree1, 6, 2, true);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree1, 3, 2, true);
-                        await opProcessingController.processOutgoing(container2);
-                        removeProperties(sharedPropertyTree2, 2, 3, true);
-                        removeProperties(sharedPropertyTree1, 3, 2, true);
-                        insertProperties(sharedPropertyTree2, 1, 3, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-
-                    it("Test failure 23", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 4, true);
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        insertProperties(sharedPropertyTree2, 1, 3, true);
-                        removeProperties(sharedPropertyTree2, 0, 2, true);
-                        await opProcessingController.ensureSynchronized();
-                    });
-
-                    it("Test failure 24", async () => {
-                        insertProperties(sharedPropertyTree2, 0, 6, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processIncoming(container1);
-                        removeProperties(sharedPropertyTree2, 4, 1, true);
-                        removeProperties(sharedPropertyTree1, 3, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processIncoming(container1);
-                        removeProperties(sharedPropertyTree1, 2, 3, true);
-
-                        await opProcessingController.ensureSynchronized();
-                    });
-
-                    it("Test failure 25", async () => {
-                        insertProperties(sharedPropertyTree1, 0, 3, true);
-                        await opProcessingController.processOutgoing(container2);
-                        await opProcessingController.processOutgoing(container1);
-                        insertProperties(sharedPropertyTree2, 0, 3, true);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree2, 2, 1, true);
-                        removeProperties(sharedPropertyTree2, 0, 1, true);
-                        await opProcessingController.processOutgoing(container1);
-                        await opProcessingController.processIncoming(container2);
-                        insertProperties(sharedPropertyTree1, 1, 2, true);
-                        removeProperties(sharedPropertyTree2, 1, 2, true);
-                        await opProcessingController.processIncoming(container1);
-                        await opProcessingController.ensureSynchronized();
-                    });
+                it("Test failure 25", async () => {
+                    insertProperties(sharedPropertyTree1, 0, 3, true);
+                    await opProcessingController.processOutgoing(container2);
+                    await opProcessingController.processOutgoing(container1);
+                    insertProperties(sharedPropertyTree2, 0, 3, true);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree2, 2, 1, true);
+                    removeProperties(sharedPropertyTree2, 0, 1, true);
+                    await opProcessingController.processOutgoing(container1);
+                    await opProcessingController.processIncoming(container2);
+                    insertProperties(sharedPropertyTree1, 1, 2, true);
+                    removeProperties(sharedPropertyTree2, 1, 2, true);
+                    await opProcessingController.processIncoming(container1);
+                    await opProcessingController.ensureSynchronized();
                 });
             });
+        });
 
-            describe("Rebase with pending changes.", () => {
-                it("Int32", async () => {
-                    const val1 = 600;
-                    const val2 = 500;
+        describe("Rebase with pending changes.", () => {
+            it("Int32", async () => {
+                const val1 = 600;
+                const val2 = 500;
 
-                    await opProcessingController.pauseProcessing();
+                await opProcessingController.pauseProcessing();
 
-                    const prop = PropertyFactory.create<Int32Property>("Int32");
-                    sharedPropertyTree1.root.insert("int32Prop", prop);
+                const prop = PropertyFactory.create<Int32Property>("Int32");
+                sharedPropertyTree1.root.insert("int32Prop", prop);
 
-                    sharedPropertyTree1.commit();
-                    // Make sure both shared trees are in sync
-                    await opProcessingController.ensureSynchronized();
-                    await opProcessingController.pauseProcessing();
+                sharedPropertyTree1.commit();
+                // Make sure both shared trees are in sync
+                await opProcessingController.ensureSynchronized();
+                await opProcessingController.pauseProcessing();
 
-                    // Make local changes for both collaborators
-                    prop.setValue(val1);
-                    sharedPropertyTree2.root.get<Int32Property>("int32Prop")?.setValue(val2);
+                // Make local changes for both collaborators
+                prop.setValue(val1);
+                sharedPropertyTree2.root.get<Int32Property>("int32Prop")?.setValue(val2);
 
-                    sharedPropertyTree1.commit();
-                    await opProcessingController.ensureSynchronized();
-                    await opProcessingController.pauseProcessing();
+                sharedPropertyTree1.commit();
+                await opProcessingController.ensureSynchronized();
+                await opProcessingController.pauseProcessing();
 
-                    // This collaborator should still have pending changes after rebase the incoming commits
-                    expect(Object.keys(
-                        sharedPropertyTree2.root.getPendingChanges().getSerializedChangeSet()).length).to.not.equal(0);
+                // This collaborator should still have pending changes after rebase the incoming commits
+                expect(Object.keys(
+                    sharedPropertyTree2.root.getPendingChanges().getSerializedChangeSet()).length).to.not.equal(0);
 
-                    // Committing the new pending change
-                    sharedPropertyTree2.commit();
-                    await opProcessingController.ensureSynchronized();
+                // Committing the new pending change
+                sharedPropertyTree2.commit();
+                await opProcessingController.ensureSynchronized();
 
-                    // The pending change val2 should be now the new value cross collaborators
-                    expect(prop.getValue()).to.equal(val2);
-                });
+                // The pending change val2 should be now the new value cross collaborators
+                expect(prop.getValue()).to.equal(val2);
             });
-        }
+        });
+    }
 
-	describe("Rebasing", () => {
-        beforeEach(async () => {
-			await setupContainers();
-		});
+    describe("Rebasing", () => {
+        beforeEach(async function() {
+            await setupContainers(this.timeout());
+        });
 
-		rebaseTests();
-	});
+        rebaseTests();
+    });
 
     describe("Rebasing with reconnection", () => {
-        beforeEach(async () => {
-			await setupContainers(false);
-		});
+        beforeEach(async function() {
+            await setupContainers(this.timeout(), false);
+        });
 
-		rebaseTests();
-	});
+        rebaseTests();
+    });
 });

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -33068,7 +33068,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "1.9.1",
@@ -36397,7 +36397,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "2.0.0",
@@ -39506,7 +39506,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-glob": {
 			"version": "1.0.0",
@@ -41165,7 +41165,7 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -41236,7 +41236,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.7",
@@ -41357,7 +41357,7 @@
 		"isarray": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 		},
 		"isemail": {
 			"version": "3.2.0",
@@ -49145,7 +49145,7 @@
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -53307,7 +53307,7 @@
 		"read-pkg-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
@@ -53317,7 +53317,7 @@
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -53338,7 +53338,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -53357,7 +53357,7 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -53366,7 +53366,7 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"read-pkg": {
@@ -53385,7 +53385,7 @@
 		"readable-stream": {
 			"version": "1.0.34",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.1",
@@ -56792,7 +56792,7 @@
 		"string_decoder": {
 			"version": "0.10.31",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
@@ -58794,7 +58794,7 @@
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5022,7 +5022,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
 		"color-support": {
@@ -6077,7 +6077,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
 		"eslint-scope": {
@@ -6817,7 +6817,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
 		"has-symbols": {
@@ -7353,7 +7353,7 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
 			"dev": true
 		},
 		"is-plain-object": {
@@ -7392,7 +7392,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 			"dev": true
 		},
 		"is-text-path": {
@@ -7443,7 +7443,7 @@
 		"isarray": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
 			"dev": true
 		},
 		"isexe": {
@@ -9460,7 +9460,7 @@
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
@@ -10512,7 +10512,7 @@
 		"read-pkg-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
@@ -10522,7 +10522,7 @@
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -10543,7 +10543,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -10562,7 +10562,7 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -10571,7 +10571,7 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"parse-json": {
@@ -10612,7 +10612,7 @@
 		"readable-stream": {
 			"version": "1.0.34",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -11320,7 +11320,7 @@
 		"string_decoder": {
 			"version": "0.10.31",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
 			"dev": true
 		},
 		"strip-ansi": {
@@ -11639,7 +11639,7 @@
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"

--- a/packages/drivers/odsp-driver/src/test/test.ts
+++ b/packages/drivers/odsp-driver/src/test/test.ts
@@ -40,5 +40,5 @@ describe("Binary WireFormat perf", () => {
 
         const parseTime = performance.now() - start;
         console.log("Binary Format medium snapshot parse time ", parseTime);
-    });
+    }).timeout(3000); // This can take more time if running in parallel
 });

--- a/packages/test/local-server-tests/src/test/connectionMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/connectionMode.spec.ts
@@ -91,10 +91,11 @@ describe("Logging Last Connection Mode ", () => {
             codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
         loaderContainerTracker = new LoaderContainerTracker();
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
 
         // Create the first container, component and DDSes.
         container = await createContainer() as Container;

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -131,10 +131,11 @@ describe("Document Dirty", () => {
                 codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
         }
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             deltaConnectionServer = LocalDeltaConnectionServer.create();
             documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
             loaderContainerTracker = new LoaderContainerTracker();
+            loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
 
             // Create the first container, component and DDSes.
             container = await createContainer() as Container;
@@ -484,10 +485,11 @@ describe("Document Dirty", () => {
             // because we already assert that in the handler.
         }
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             deltaConnectionServer = LocalDeltaConnectionServer.create();
             documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
             loaderContainerTracker = new LoaderContainerTracker();
+            loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
 
             // Create the first container, component and DDSes.
             container = await createDetachedContainer() as Container;

--- a/packages/test/local-server-tests/src/test/localTestServer.spec.ts
+++ b/packages/test/local-server-tests/src/test/localTestServer.spec.ts
@@ -74,10 +74,11 @@ describe("LocalTestServer", () => {
         return loader.resolve({ url: documentLoadUrl });
     }
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         urlResolver = new LocalResolver();
         loaderContainerTracker = new LoaderContainerTracker();
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
 
         // Create a Container for the first client.
         container1 = await createContainer();

--- a/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
@@ -83,9 +83,10 @@ describe("No Delta Stream", () => {
         return container;
     }
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         loaderContainerTracker = new LoaderContainerTracker();
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
 
         // Create a Container for the first client.
         const container = await createContainer();

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -147,16 +147,16 @@ describe("Ops on Reconnect", () => {
         return container2Object1;
     }
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         urlResolver = new LocalResolver();
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
         loaderContainerTracker = new LoaderContainerTracker();
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
 
         // Wait for the attach ops to get processed.
         await loaderContainerTracker.ensureSynchronized();
     });
-
     afterEach(() => {
         loaderContainerTracker.reset();
     });

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -32,6 +32,9 @@ import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 
 describe(`Container Serialization Backwards Compatibility`, () => {
     const loaderContainerTracker = new LoaderContainerTracker();
+    beforeEach(function() {
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
+    });
     let filename: string;
     const contentFolder = "content/serializedContainerTestContent";
 

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -34,6 +34,9 @@ describeNoCompat(`Attach/Reference Api Tests For Attached Container`, (getTestOb
     let request: IRequest;
     let loader: Loader;
     const loaderContainerTracker = new LoaderContainerTracker();
+    beforeEach(function() {
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
+    });
 
     const createTestStatementForAttachedDetached = (name: string, attached: boolean) =>
         `${name} should be ${attached ? "Attached" : "Detached"}`;

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -122,7 +122,7 @@ describeFullCompat("blobs", (getTestObjectProvider) => {
         const container2 = await provider.loadTestContainer(testContainerConfig);
         const dataStore2 = await requestFluidObject<ITestDataObject>(container2, "default");
 
-        await provider.ensureSynchronized(this.timeout() / 3);
+        await provider.ensureSynchronized();
 
         const blobHandle = dataStore2._root.get<IFluidHandle<ArrayBufferLike>>(testKey);
         assert(blobHandle);
@@ -173,7 +173,7 @@ describeFullCompat("blobs", (getTestObjectProvider) => {
         // validate on remote container, local container, and container loaded from summary
         for (const container of [container1, container2, await provider.loadTestContainer(testContainerConfig)]) {
             const dataStore2 = await requestFluidObject<ITestDataObject>(container, "default");
-            await provider.ensureSynchronized(this.timeout() / 3);
+            await provider.ensureSynchronized();
             const handle = dataStore2._root.get<IFluidHandle<SharedString>>("sharedString");
             assert(handle);
             const sharedString2 = await handle.get();

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -74,6 +74,9 @@ describeNoCompat("Container", (getTestObjectProvider) => {
         const container = await loader.createDetachedContainer(codeDetails);
         await container.attach(provider.driver.createCreateNewRequest("containerTest"));
     });
+    beforeEach(function() {
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
+    });
     afterEach(() => {
         loaderContainerTracker.reset();
     });

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -127,7 +127,7 @@ describeFullCompat("SharedCounter", (getTestObjectProvider) => {
 
                 // do the increment
                 incrementer.increment(incrementAmount);
-                await provider.ensureSynchronized(this.timeout() / 3);
+                await provider.ensureSynchronized();
 
                 // event count is correct
                 assert.equal(eventCount1, expectedEventCount);

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -166,6 +166,9 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
     let loader: Loader;
     let request: IRequest;
     const loaderContainerTracker = new LoaderContainerTracker();
+    beforeEach(function() {
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
+    });
 
     async function createDetachedContainerAndGetRootDataStore() {
         const container: IContainer = await loader.createDetachedContainer(codeDetails);
@@ -608,7 +611,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             // Create and reference another dataStore
             const { peerDataStore: dataStore2 } = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             defaultDataStore.root.set("dataStore2", dataStore2.handle);
-            await provider.ensureSynchronized(this.timeout() / 3);
+            await provider.ensureSynchronized();
 
             const sharedMap1 = await dataStore2.getSharedObject<SharedMap>(sharedMapId);
             sharedMap1.set("0", "A");

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -247,7 +247,7 @@ describeFullCompat("SharedDirectory", (getTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey3", "/", "value3.1", "value3.2", undefined);
 
-                await provider.ensureSynchronized(this.timeout() / 3);
+                await provider.ensureSynchronized();
 
                 expectAllAfterValues("testKey3", "/", undefined);
             });
@@ -511,7 +511,7 @@ describeFullCompat("SharedDirectory", (getTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey3", "/testSubDir", "value3.1", "value3.2", undefined);
 
-                await provider.ensureSynchronized(this.timeout() / 3);
+                await provider.ensureSynchronized();
 
                 expectAllAfterValues("testKey3", "/testSubDir", undefined);
             });
@@ -576,7 +576,7 @@ describeFullCompat("SharedDirectory", (getTestObjectProvider) => {
             const root2SubDir = sharedDirectory2.createSubDirectory("testSubDir");
             root2SubDir.set("testKey2", "testValue2");
 
-            await provider.ensureSynchronized(this.timeout() / 2);
+            await provider.ensureSynchronized();
 
             assert.strictEqual(sharedDirectory1.getSubDirectory("testSubDir"), root1SubDir,
                 "Created two separate subdirectories in root1");

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -28,8 +28,8 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
     before(() => {
         provider = getTestObjectProvider();
     });
-
-    beforeEach(async () => {
+    beforeEach(async function() {
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
         const loader = new Loader({
             logger: provider.logger,
             urlResolver: provider.urlResolver,

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -95,16 +95,19 @@ const testDataObjectFactory = new DataObjectFactory(
 
 // REVIEW: enable compat testing?
 describeNoCompat("LocalLoader", (getTestObjectProvider) => {
-    let provider: ITestObjectProvider;
-    before(() => {
-        provider = getTestObjectProvider();
-    });
     const codeDetails: IFluidCodeDetails = {
         package: "localLoaderTestPackage",
         config: {},
     };
-
     const loaderContainerTracker = new LoaderContainerTracker();
+    beforeEach(function() {
+        loaderContainerTracker.setScaledDefaultWaitTimeout(this.timeout());
+    });
+
+    let provider: ITestObjectProvider;
+    before(() => {
+        provider = getTestObjectProvider();
+    });
 
     afterEach(() => {
         loaderContainerTracker.reset();

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -29,6 +29,9 @@
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "test": "npm run test:mocha",
+    "test:mocha": "mocha --unhandled-rejections=strict  --recursive dist/test/*.spec.js --exit --project src/test/tsconfig.json -r node_modules/@fluidframework/mocha-test-setup",
+    "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace",
@@ -69,6 +72,7 @@
     "@fluidframework/driver-utils": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/local-driver": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/map": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
+    "@fluidframework/mocha-test-setup": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/protocol-definitions": "^1.0.0",
     "@fluidframework/request-handler": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
     "@fluidframework/routerlicious-driver": ">=2.0.0-internal.1.3.0 <2.0.0-internal.2.0.0",
@@ -94,6 +98,7 @@
     "@types/random-js": "^1.0.31",
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",
+    "cross-env": "^7.0.2",
     "diff": "^3.5.0",
     "eslint": "~8.6.0",
     "mocha": "^10.0.0",
@@ -105,6 +110,13 @@
   },
   "typeValidation": {
     "version": "2.0.0",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_LoaderContainerTracker": {
+        "forwardCompat": false
+      },
+      "ClassDeclaration_TestObjectProvider": {
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -1,0 +1,99 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { timeoutPromise, defaultTimeoutDurationMs } from "../timeoutUtils";
+
+describe("TimeoutPromise", () => {
+    it("Timeout with no options", async () => {
+        try {
+            await timeoutPromise(() => {});
+            assert(false, "should have timed out");
+        } catch (e: any) {
+            assert(e.message.startsWith("Timed out"), "expected timeout error message");
+        }
+    });
+
+    it("Timeout with no duration", async () => {
+        try {
+            await timeoutPromise(() => { }, {});
+            assert(false, "should have timed out");
+        } catch (e: any) {
+            assert(e.message.startsWith("Timed out"), "expected timeout error message");
+        }
+    });
+
+    it("Timeout with duration", async () => {
+        try {
+            await timeoutPromise(() => { }, { durationMs: 1 });
+            assert(false, "should have timed out");
+        } catch {
+
+        }
+    });
+
+    it("Timeout with zero duration", async () => {
+        try {
+            await timeoutPromise((resolve) => {
+                setTimeout(resolve, defaultTimeoutDurationMs + 50);
+            }, { durationMs: 0 });
+        } catch {
+            assert(false, "should not have timed out");
+        }
+    });
+
+    it("Timeout with negative duration", async () => {
+        try {
+            await timeoutPromise((resolve) => {
+                setTimeout(resolve, defaultTimeoutDurationMs + 50);
+            }, { durationMs: -1 });
+        } catch {
+            assert(false, "should not have timed out");
+        }
+    });
+
+    it("Timeout with Infinity duration", async () => {
+        try {
+            await timeoutPromise((resolve) => {
+                setTimeout(resolve, defaultTimeoutDurationMs + 50);
+            }, { durationMs: Infinity });
+        } catch {
+            assert(false, "should not have timed out");
+        }
+    });
+
+    it("no timeout", async () => {
+        try {
+            await timeoutPromise((resolve) => { setTimeout(resolve, 1); }, { durationMs: 100 });
+        } catch {
+            assert(false, "should not have timed out");
+        }
+    });
+
+    it("Timeout with no reject option", async () => {
+        try {
+            const value = await timeoutPromise(() => {}, {
+                durationMs: 1,
+                reject: false,
+                value: 1,
+            });
+            assert(value === 1, "expect timeout to return value given in option");
+        } catch {
+            assert(false, "should not have timed out");
+        }
+    });
+
+    it("Timeout rejection with error option", async () => {
+        try {
+            await timeoutPromise(() => {}, {
+                durationMs: 1,
+                errorMsg: "hello",
+            });
+            assert(false, "should have timed out");
+        } catch (e: any) {
+            assert(e.message.startsWith("hello"), "expected timeout reject error message given in option");
+        }
+    });
+});

--- a/packages/test/test-utils/src/test/tsconfig.json
+++ b/packages/test/test-utils/src/test/tsconfig.json
@@ -3,10 +3,12 @@
     "compilerOptions": {
         "rootDir": "./",
         "outDir": "../../dist/test",
+        "types": [
+            "mocha",
+        ],
         "declaration": false,
         "declarationMap": false,
         "skipLibCheck": true,
-        "noEmit": true,
     },
     "include": [
         "./**/*"

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.ts
@@ -383,6 +383,7 @@ declare function get_old_ClassDeclaration_LoaderContainerTracker():
 declare function use_current_ClassDeclaration_LoaderContainerTracker(
     use: TypeOnly<current.LoaderContainerTracker>);
 use_current_ClassDeclaration_LoaderContainerTracker(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LoaderContainerTracker());
 
 /*
@@ -551,6 +552,7 @@ declare function get_old_ClassDeclaration_TestObjectProvider():
 declare function use_current_ClassDeclaration_TestObjectProvider(
     use: TypeOnly<current.TestObjectProvider>);
 use_current_ClassDeclaration_TestObjectProvider(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestObjectProvider());
 
 /*

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -140,7 +140,7 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
     private readonly expectedEvents: ({ index: number; event: ITelemetryGenericEvent | undefined; } | undefined)[] = [];
     private readonly unexpectedErrors: ITelemetryBaseEvent[] = [];
 
-    public registerExpectedEvent(... orderedExpectedEvents: ITelemetryGenericEvent[]) {
+    public registerExpectedEvent(...orderedExpectedEvents: ITelemetryGenericEvent[]) {
         if (this.expectedEvents.length !== 0) {
             // we don't have to error here. just no reason not to. given the events must be
             // ordered it could be tricky to figure out problems around multiple registrations.
@@ -148,7 +148,7 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
                 "Expected events already registered.\n"
                 + "Call reportAndClearTrackedEvents to clear them before registering more");
         }
-        this.expectedEvents.push(... orderedExpectedEvents.map((event, index) => ({ index, event })));
+        this.expectedEvents.push(...orderedExpectedEvents.map((event, index) => ({ index, event })));
     }
 
     send(event: ITelemetryBaseEvent): void {
@@ -219,14 +219,14 @@ export class TestObjectProvider implements ITestObjectProvider {
         if (this._logger === undefined) {
             this._logger = new EventAndErrorTrackingLogger(
                 ChildLogger.create(getTestLogger?.(), undefined,
-                {
-                    all: {
-                        driverType: this.driver.type,
-                        driverEndpointName: this.driver.endpointName,
-                        driverTenantName: this.driver.tenantName,
-                        driverUserIndex: this.driver.userIndex,
-                    },
-                }));
+                    {
+                        all: {
+                            driverType: this.driver.type,
+                            driverEndpointName: this.driver.endpointName,
+                            driverTenantName: this.driver.tenantName,
+                            driverUserIndex: this.driver.userIndex,
+                        },
+                    }));
         }
         return this._logger;
     }
@@ -261,6 +261,10 @@ export class TestObjectProvider implements ITestObjectProvider {
         return this._loaderContainerTracker;
     }
 
+    public setScaledDefaultWaitTimeout(timeout: number) {
+        return this._loaderContainerTracker.setScaledDefaultWaitTimeout(timeout);
+    }
+
     /**
      * Create a loader. Containers created/loaded through this loader will be added to the OpProcessingController.
      *
@@ -280,7 +284,7 @@ export class TestObjectProvider implements ITestObjectProvider {
         }
 
         const loader = new this.LoaderConstructor({
-            ... loaderProps,
+            ...loaderProps,
             logger: multiSinkLogger,
             codeLoader: loaderProps?.codeLoader ?? new LocalCodeLoader(packageEntries),
             urlResolver: loaderProps?.urlResolver ?? this.urlResolver,
@@ -394,10 +398,9 @@ export class TestObjectProvider implements ITestObjectProvider {
     }
 
     public async ensureSynchronized(timeoutDuration?: number): Promise<void> {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        return !timeoutDuration
-            ? this._loaderContainerTracker.ensureSynchronized()
-            : this._loaderContainerTracker.ensureSynchronizedWithTimeout?.(timeoutDuration);
+        return this._loaderContainerTracker.ensureSynchronizedWithTimeout
+            ? this._loaderContainerTracker.ensureSynchronizedWithTimeout(timeoutDuration)
+            : this._loaderContainerTracker.ensureSynchronized();
     }
 
     public async waitContainerToCatchUp(container: IContainer) {

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -43,6 +43,11 @@ function createCompatSuite(
 
                     Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
                 });
+
+                beforeEach(function() {
+                    provider.setScaledDefaultWaitTimeout(this.timeout());
+                });
+
                 tests.bind(this)((options?: ITestObjectProviderOptions) => {
                     resetAfterEach = options?.resetAfterEach ?? true;
                     if (options?.syncSummarizer === true) {


### PR DESCRIPTION
Provide the mocha test timeout `LoaderContainerTracker` to limit how long to wait for `ensureSynchronized`.  Currently it is set to half of test time.  The purpose is to provide a better error message and stack if `ensureSynchronized` got stuck.

Also, change the behavior for `timeoutPromise`, when duration is <=0 or Infinity.  Instead of waiting for the default amount, it will now mean it won't timeout at all.   This is so that we can avoid timeout when debugging.

Fix [AB#2175](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2175)