### PR TITLE
GC refactor - Moved garbageCollection.ts and associated files into a sub-directory

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -157,7 +157,7 @@ import {
     IGarbageCollectionRuntime,
     IGarbageCollector,
     IGCStats,
-} from "./garbageCollection";
+} from "./gc";
 import {
     channelToDataStore,
     IDataStoreAliasMessage,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -52,7 +52,7 @@ import {
 } from "./dataStoreContext";
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summaryFormat";
 import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
-import { GCNodeType } from "./garbageCollection";
+import { GCNodeType } from "./gc";
 
 type PendingAliasResolve = (success: boolean) => void;
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollector.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollector.ts
@@ -5,18 +5,16 @@
 
 import { ITelemetryLogger, ITelemetryPerformanceEvent } from "@fluidframework/common-definitions";
 import { assert, LazyPromise, Timer } from "@fluidframework/common-utils";
-import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { ClientSessionExpiredError, DataProcessingError, UsageError } from "@fluidframework/container-utils";
 import { IRequestHeader } from "@fluidframework/core-interfaces";
 import {
     cloneGCData,
-    concatGarbageCollectionStates,
     concatGarbageCollectionData,
     IGCResult,
     runGarbageCollection,
     unpackChildNodesGCDetails,
 } from "@fluidframework/garbage-collector";
-import { ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { SummaryType } from "@fluidframework/protocol-definitions";
 import {
     gcBlobKey,
     IGarbageCollectionData,
@@ -24,7 +22,6 @@ import {
     IGarbageCollectionDetailsBase,
     ISummarizeResult,
     ITelemetryContext,
-    IGarbageCollectionNodeData,
 } from "@fluidframework/runtime-definitions";
 import {
     mergeStats,
@@ -40,9 +37,8 @@ import {
     TelemetryDataTag,
 } from "@fluidframework/telemetry-utils";
 
-import { IGCRuntimeOptions, RuntimeHeaders } from "./containerRuntime";
-import { getSummaryForDatastores } from "./dataStores";
-import { SweepReadyUsageDetectionHandler } from "./gcSweepReadyUsageDetection";
+import { IGCRuntimeOptions, RuntimeHeaders } from "../containerRuntime";
+import { getSummaryForDatastores } from "../dataStores";
 import {
     getGCVersion,
     GCVersion,
@@ -51,260 +47,33 @@ import {
     ReadFluidDataStoreAttributes,
     dataStoreAttributesBlobName,
     IGCMetadata,
-} from "./summaryFormat";
-
-/** This is the current version of garbage collection. */
-const GCVersion = 1;
-
-// The key for the GC tree in summary.
-export const gcTreeKey = "gc";
-// They prefix for GC blobs in the GC tree in summary.
-export const gcBlobPrefix = "__gc";
-
-// Feature gate key to turn GC on / off.
-export const runGCKey = "Fluid.GarbageCollection.RunGC";
-// Feature gate key to turn GC sweep on / off.
-export const runSweepKey = "Fluid.GarbageCollection.RunSweep";
-// Feature gate key to turn GC test mode on / off.
-export const gcTestModeKey = "Fluid.GarbageCollection.GCTestMode";
-// Feature gate key to write GC data at the root of the summary tree.
-const writeAtRootKey = "Fluid.GarbageCollection.WriteDataAtRoot";
-// Feature gate key to expire a session after a set period of time.
-export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
-// Feature gate key to disable expiring session after a set period of time, even if expiry value is present.
-export const disableSessionExpiryKey = "Fluid.GarbageCollection.DisableSessionExpiry";
-// Feature gate key to write the gc blob as a handle if the data is the same.
-export const trackGCStateKey = "Fluid.GarbageCollection.TrackGCState";
-// Feature gate key to turn GC sweep log off.
-export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
-
-// One day in milliseconds.
-export const oneDayMs = 1 * 24 * 60 * 60 * 1000;
-
-export const defaultInactiveTimeoutMs = 7 * oneDayMs; // 7 days
-export const defaultSessionExpiryDurationMs = 30 * oneDayMs; // 30 days
-
-/** The statistics of the system state after a garbage collection run. */
-export interface IGCStats {
-    /** The number of nodes in the container. */
-    nodeCount: number;
-    /** The number of data stores in the container. */
-    dataStoreCount: number;
-    /** The number of attachment blobs in the container. */
-    attachmentBlobCount: number;
-    /** The number of unreferenced nodes in the container. */
-    unrefNodeCount: number;
-    /** The number of unreferenced data stores in the container. */
-    unrefDataStoreCount: number;
-    /** The number of unreferenced attachment blobs in the container. */
-    unrefAttachmentBlobCount: number;
-    /** The number of nodes whose reference state updated since last GC run. */
-    updatedNodeCount: number;
-    /** The number of data stores whose reference state updated since last GC run. */
-    updatedDataStoreCount: number;
-    /** The number of attachment blobs whose reference state updated since last GC run. */
-    updatedAttachmentBlobCount: number;
-}
-
-/** The types of GC nodes in the GC reference graph. */
-export const GCNodeType = {
-    // Nodes that are for data stores.
-    DataStore: "DataStore",
-    // Nodes that are within a data store. For example, DDS nodes.
-    SubDataStore: "SubDataStore",
-    // Nodes that are for attachment blobs, i.e., blobs uploaded via BlobManager.
-    Blob: "Blob",
-    // Nodes that are neither of the above. For example, root node.
-    Other: "Other",
-};
-export type GCNodeType = typeof GCNodeType[keyof typeof GCNodeType];
-
-/** Defines the APIs for the runtime object to be passed to the garbage collector. */
-export interface IGarbageCollectionRuntime {
-    /** Before GC runs, called to notify the runtime to update any pending GC state. */
-    updateStateBeforeGC(): Promise<void>;
-    /** Returns the garbage collection data of the runtime. */
-    getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    /** After GC has run, called to notify the runtime of routes that are used in it. */
-    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
-    /** After GC has run, called to delete objects in the runtime whose routes are unused. */
-    deleteUnusedRoutes(unusedRoutes: string[]): void;
-    /** Returns a referenced timestamp to be used to track unreferenced nodes. */
-    getCurrentReferenceTimestampMs(): number | undefined;
-    /** Returns the type of the GC node. */
-    getNodeType(nodePath: string): GCNodeType;
-    /** Called when the runtime should close because of an error. */
-    closeFn: (error?: ICriticalContainerError) => void;
-}
-
-/** Defines the contract for the garbage collector. */
-export interface IGarbageCollector {
-    /** Tells whether GC should run or not. */
-    readonly shouldRunGC: boolean;
-    /** Tells whether the GC state in summary needs to be reset in the next summary. */
-    readonly summaryStateNeedsReset: boolean;
-    /** Tells whether GC data should be written to the root of the summary tree. */
-    readonly writeDataAtRoot: boolean;
-    readonly trackGCState: boolean;
-    /** Run garbage collection and update the reference / used state of the system. */
-    collectGarbage(
-        options: { logger?: ITelemetryLogger; runSweep?: boolean; fullGC?: boolean; },
-    ): Promise<IGCStats | undefined>;
-    /** Summarizes the GC data and returns it as a summary tree. */
-    summarize(
-        fullTree: boolean,
-        trackState: boolean,
-        telemetryContext?: ITelemetryContext,
-    ): ISummarizeResult | undefined;
-    /** Returns the garbage collector specific metadata to be written into the summary. */
-    getMetadata(): IGCMetadata;
-    /** Returns a map of each node id to its base GC details in the base summary. */
-    getBaseGCDetails(): Promise<Map<string, IGarbageCollectionDetailsBase>>;
-    /** Called when the latest summary of the system has been refreshed. */
-    latestSummaryStateRefreshed(result: RefreshSummaryResult, readAndParseBlob: ReadAndParseBlob): Promise<void>;
-    /** Called when a node is updated. Used to detect and log when an inactive node is changed or loaded. */
-    nodeUpdated(
-        nodePath: string,
-        reason: "Loaded" | "Changed",
-        timestampMs?: number,
-        packagePath?: readonly string[],
-        requestHeaders?: IRequestHeader,
-    ): void;
-    /** Called when a reference is added to a node. Used to identify nodes that were referenced between summaries. */
-    addedOutboundReference(fromNodePath: string, toNodePath: string): void;
-    setConnectionState(connected: boolean, clientId?: string): void;
-    dispose(): void;
-}
-
-/** Parameters necessary for creating a GarbageCollector. */
-export interface IGarbageCollectorCreateParams {
-    readonly runtime: IGarbageCollectionRuntime;
-    readonly gcOptions: IGCRuntimeOptions;
-    readonly baseLogger: ITelemetryLogger;
-    readonly existing: boolean;
-    readonly metadata: IContainerRuntimeMetadata | undefined;
-    readonly baseSnapshot: ISnapshotTree | undefined;
-    readonly isSummarizerClient: boolean;
-    readonly getNodePackagePath: (nodePath: string) => Promise<readonly string[] | undefined>;
-    readonly getLastSummaryTimestampMs: () => number | undefined;
-    readonly readAndParseBlob: ReadAndParseBlob;
-    readonly activeConnection: () => boolean;
-    readonly getContainerDiagnosticId: () => string;
-    readonly snapshotCacheExpiryMs?: number;
-}
-
-/** The state of node that is unreferenced. */
-export const UnreferencedState = {
-    /** The node is active, i.e., it can become referenced again. */
-    Active: "Active",
-    /** The node is inactive, i.e., it should not become referenced. */
-    Inactive: "Inactive",
-    /** The node is ready to be deleted by the sweep phase. */
-    SweepReady: "SweepReady",
-} as const;
-export type UnreferencedState = typeof UnreferencedState[keyof typeof UnreferencedState];
-
-/** The event that is logged when unreferenced node is used after a certain time. */
-interface IUnreferencedEventProps {
-    usageType: "Changed" | "Loaded" | "Revived";
-    state: UnreferencedState;
-    id: string;
-    type: GCNodeType;
-    unrefTime: number;
-    age: number;
-    completedGCRuns: number;
-    fromId?: string;
-    timeout?: number;
-    lastSummaryTime?: number;
-    externalRequest?: boolean;
-    viaHandle?: boolean;
-}
-
-/**
- * Helper class that tracks the state of an unreferenced node such as the time it was unreferenced and if it can
- * be deleted by the sweep phase.
- */
-export class UnreferencedStateTracker {
-    private _state: UnreferencedState = UnreferencedState.Active;
-    public get state(): UnreferencedState {
-        return this._state;
-    }
-
-    /** Timer to indicate when an unreferenced object is considered Inactive */
-    private readonly inactiveTimer: TimerWithNoDefaultTimeout;
-    /** Timer to indicate when an unreferenced object is Sweep-Ready */
-    private readonly sweepTimer: TimerWithNoDefaultTimeout;
-
-    constructor(
-        public readonly unreferencedTimestampMs: number,
-        /** The time after which node transitions to Inactive state. */
-        private readonly inactiveTimeoutMs: number,
-        /** The current reference timestamp used to track how long this node has been unreferenced for. */
-        currentReferenceTimestampMs: number,
-        /** The time after which node transitions to SweepReady state; undefined if session expiry is disabled. */
-        private readonly sweepTimeoutMs: number | undefined,
-    ) {
-        if (this.sweepTimeoutMs !== undefined) {
-            assert(this.inactiveTimeoutMs <= this.sweepTimeoutMs,
-                0x3b0 /* inactive timeout must not be greater than the sweep timeout */);
-        }
-
-        this.sweepTimer = new TimerWithNoDefaultTimeout(
-            () => {
-                this._state = UnreferencedState.SweepReady;
-                assert(!this.inactiveTimer.hasTimer, 0x3b1 /* inactiveTimer still running after sweepTimer fired! */);
-            },
-        );
-
-        this.inactiveTimer = new TimerWithNoDefaultTimeout(() => {
-            this._state = UnreferencedState.Inactive;
-
-            // After the node becomes inactive, start the sweep timer after which the node will be ready for sweep.
-            if (this.sweepTimeoutMs !== undefined) {
-                this.sweepTimer.restart(this.sweepTimeoutMs - this.inactiveTimeoutMs);
-            }
-        });
-        this.updateTracking(currentReferenceTimestampMs);
-    }
-
-    /* Updates the unreferenced state based on the provided timestamp. */
-    public updateTracking(currentReferenceTimestampMs: number) {
-        const unreferencedDurationMs = currentReferenceTimestampMs - this.unreferencedTimestampMs;
-
-        // If the node has been unreferenced for sweep timeout amount of time, update the state to SweepReady.
-        if (this.sweepTimeoutMs !== undefined && unreferencedDurationMs >= this.sweepTimeoutMs) {
-            this._state = UnreferencedState.SweepReady;
-            this.clearTimers();
-            return;
-        }
-
-        // If the node has been unreferenced for inactive timeoutMs amount of time, update the state to inactive.
-        // Also, start a timer for the sweep timeout.
-        if (unreferencedDurationMs >= this.inactiveTimeoutMs) {
-            this._state = UnreferencedState.Inactive;
-            this.inactiveTimer.clear();
-
-            if (this.sweepTimeoutMs !== undefined) {
-                this.sweepTimer.restart(this.sweepTimeoutMs - unreferencedDurationMs);
-            }
-            return;
-        }
-
-        // The node is still active. Ensure the inactive timer is running with the proper remaining duration.
-        this.inactiveTimer.restart(this.inactiveTimeoutMs - unreferencedDurationMs);
-    }
-
-    private clearTimers() {
-        this.inactiveTimer.clear();
-        this.sweepTimer.clear();
-    }
-
-    /** Stop tracking this node. Reset the unreferenced timers and state, if any. */
-    public stopTracking() {
-        this.clearTimers();
-        this._state = UnreferencedState.Active;
-    }
-}
+} from "../summaryFormat";
+import { SweepReadyUsageDetectionHandler } from "./gcSweepReadyUsageDetection";
+import {
+    defaultInactiveTimeoutMs,
+    defaultSessionExpiryDurationMs,
+    disableSessionExpiryKey,
+    disableSweepLogKey,
+    gcBlobPrefix,
+    GCNodeType,
+    gcTreeKey,
+    gcTestModeKey,
+    generateSortedGCState,
+    getGCStateFromSnapshot,
+    IGarbageCollector,
+    IGarbageCollectorCreateParams,
+    IGarbageCollectionRuntime,
+    IGCStats,
+    IUnreferencedEventProps,
+    latestGCVersion,
+    oneDayMs,
+    runGCKey,
+    runSessionExpiryKey,
+    trackGCStateKey,
+    UnreferencedState,
+    writeAtRootKey,
+} from "./gcDefinitions";
+import { UnreferencedStateTracker } from "./gcUnreferencedStateTracker";
 
 /**
  * The garbage collector for the container runtime. It consolidates the garbage collection functionality and maintains
@@ -401,7 +170,7 @@ export class GarbageCollector implements IGarbageCollector {
     private initialStateNeedsReset: boolean = false;
 
     // The current GC version that this container is running.
-    private readonly currentGCVersion = GCVersion;
+    private readonly currentGCVersion = latestGCVersion;
     // This is the version of GC data in the latest summary being tracked.
     private latestSummaryGCVersion: GCVersion;
 
@@ -1465,61 +1234,5 @@ export class GarbageCollector implements IGarbageCollector {
             }
         }
         this.pendingEventsQueue = [];
-    }
-}
-
-/**
- * Gets the garbage collection state from the given snapshot tree. The GC state may be written into multiple blobs.
- * Merge the GC state from all such blobs and return the merged GC state.
- */
-async function getGCStateFromSnapshot(
-    gcSnapshotTree: ISnapshotTree,
-    readAndParseBlob: ReadAndParseBlob,
-): Promise<IGarbageCollectionState> {
-    let rootGCState: IGarbageCollectionState = { gcNodes: {} };
-    for (const key of Object.keys(gcSnapshotTree.blobs)) {
-        // Skip blobs that do not start with the GC prefix.
-        if (!key.startsWith(gcBlobPrefix)) {
-            continue;
-        }
-
-        const blobId = gcSnapshotTree.blobs[key];
-        if (blobId === undefined) {
-            continue;
-        }
-        const gcState = await readAndParseBlob<IGarbageCollectionState>(blobId);
-        assert(gcState !== undefined, 0x2ad /* "GC blob missing from snapshot" */);
-        // Merge the GC state of this blob into the root GC state.
-        rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
-    }
-    return rootGCState;
-}
-
-function generateSortedGCState(gcState: IGarbageCollectionState): IGarbageCollectionState {
-    const sortableArray: [string, IGarbageCollectionNodeData][] = Object.entries(gcState.gcNodes);
-    sortableArray.sort(([a], [b]) => a.localeCompare(b));
-    const sortedGCState: IGarbageCollectionState = { gcNodes: {} };
-    for (const [nodeId, nodeData] of sortableArray) {
-        nodeData.outboundRoutes.sort();
-        sortedGCState.gcNodes[nodeId] = nodeData;
-    }
-    return sortedGCState;
-}
-
-/** A wrapper around common-utils Timer that requires the timeout when calling start/restart */
-class TimerWithNoDefaultTimeout extends Timer {
-    constructor(
-        private readonly callback: () => void,
-    ) {
-        // The default timeout/handlers will never be used since start/restart pass overrides below
-        super(0, () => { throw new Error("DefaultHandler should not be used"); });
-    }
-
-    start(timeoutMs: number) {
-        super.start(timeoutMs, this.callback);
-    }
-
-    restart(timeoutMs: number): void {
-        super.restart(timeoutMs, this.callback);
     }
 }

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -1,0 +1,228 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { assert } from "@fluidframework/common-utils";
+import { ICriticalContainerError } from "@fluidframework/container-definitions";
+import { IRequestHeader } from "@fluidframework/core-interfaces";
+import { concatGarbageCollectionStates } from "@fluidframework/garbage-collector";
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import {
+    IGarbageCollectionData,
+    IGarbageCollectionState,
+    IGarbageCollectionDetailsBase,
+    ISummarizeResult,
+    ITelemetryContext,
+    IGarbageCollectionNodeData,
+} from "@fluidframework/runtime-definitions";
+import { ReadAndParseBlob, RefreshSummaryResult } from "@fluidframework/runtime-utils";
+
+import { IGCRuntimeOptions } from "../containerRuntime";
+import { IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
+
+/** This is the current version of garbage collection. */
+export const latestGCVersion = 1;
+
+// The key for the GC tree in summary.
+export const gcTreeKey = "gc";
+// They prefix for GC blobs in the GC tree in summary.
+export const gcBlobPrefix = "__gc";
+
+// Feature gate key to turn GC on / off.
+export const runGCKey = "Fluid.GarbageCollection.RunGC";
+// Feature gate key to turn GC sweep on / off.
+export const runSweepKey = "Fluid.GarbageCollection.RunSweep";
+// Feature gate key to turn GC test mode on / off.
+export const gcTestModeKey = "Fluid.GarbageCollection.GCTestMode";
+// Feature gate key to write GC data at the root of the summary tree.
+export const writeAtRootKey = "Fluid.GarbageCollection.WriteDataAtRoot";
+// Feature gate key to expire a session after a set period of time.
+export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
+// Feature gate key to disable expiring session after a set period of time, even if expiry value is present.
+export const disableSessionExpiryKey = "Fluid.GarbageCollection.DisableSessionExpiry";
+// Feature gate key to write the gc blob as a handle if the data is the same.
+export const trackGCStateKey = "Fluid.GarbageCollection.TrackGCState";
+// Feature gate key to turn GC sweep log off.
+export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
+
+// One day in milliseconds.
+export const oneDayMs = 1 * 24 * 60 * 60 * 1000;
+
+export const defaultInactiveTimeoutMs = 7 * oneDayMs; // 7 days
+export const defaultSessionExpiryDurationMs = 30 * oneDayMs; // 30 days
+
+/** The statistics of the system state after a garbage collection run. */
+export interface IGCStats {
+    /** The number of nodes in the container. */
+    nodeCount: number;
+    /** The number of data stores in the container. */
+    dataStoreCount: number;
+    /** The number of attachment blobs in the container. */
+    attachmentBlobCount: number;
+    /** The number of unreferenced nodes in the container. */
+    unrefNodeCount: number;
+    /** The number of unreferenced data stores in the container. */
+    unrefDataStoreCount: number;
+    /** The number of unreferenced attachment blobs in the container. */
+    unrefAttachmentBlobCount: number;
+    /** The number of nodes whose reference state updated since last GC run. */
+    updatedNodeCount: number;
+    /** The number of data stores whose reference state updated since last GC run. */
+    updatedDataStoreCount: number;
+    /** The number of attachment blobs whose reference state updated since last GC run. */
+    updatedAttachmentBlobCount: number;
+}
+
+/** The types of GC nodes in the GC reference graph. */
+export const GCNodeType = {
+    // Nodes that are for data stores.
+    DataStore: "DataStore",
+    // Nodes that are within a data store. For example, DDS nodes.
+    SubDataStore: "SubDataStore",
+    // Nodes that are for attachment blobs, i.e., blobs uploaded via BlobManager.
+    Blob: "Blob",
+    // Nodes that are neither of the above. For example, root node.
+    Other: "Other",
+};
+export type GCNodeType = typeof GCNodeType[keyof typeof GCNodeType];
+
+/** Defines the APIs for the runtime object to be passed to the garbage collector. */
+export interface IGarbageCollectionRuntime {
+    /** Before GC runs, called to notify the runtime to update any pending GC state. */
+    updateStateBeforeGC(): Promise<void>;
+    /** Returns the garbage collection data of the runtime. */
+    getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
+    /** After GC has run, called to notify the runtime of routes that are used in it. */
+    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
+    /** After GC has run, called to delete objects in the runtime whose routes are unused. */
+    deleteUnusedRoutes(unusedRoutes: string[]): void;
+    /** Returns a referenced timestamp to be used to track unreferenced nodes. */
+    getCurrentReferenceTimestampMs(): number | undefined;
+    /** Returns the type of the GC node. */
+    getNodeType(nodePath: string): GCNodeType;
+    /** Called when the runtime should close because of an error. */
+    closeFn: (error?: ICriticalContainerError) => void;
+}
+
+/** Defines the contract for the garbage collector. */
+export interface IGarbageCollector {
+    /** Tells whether GC should run or not. */
+    readonly shouldRunGC: boolean;
+    /** Tells whether the GC state in summary needs to be reset in the next summary. */
+    readonly summaryStateNeedsReset: boolean;
+    /** Tells whether GC data should be written to the root of the summary tree. */
+    readonly writeDataAtRoot: boolean;
+    readonly trackGCState: boolean;
+    /** Run garbage collection and update the reference / used state of the system. */
+    collectGarbage(
+        options: { logger?: ITelemetryLogger; runSweep?: boolean; fullGC?: boolean; },
+    ): Promise<IGCStats | undefined>;
+    /** Summarizes the GC data and returns it as a summary tree. */
+    summarize(
+        fullTree: boolean,
+        trackState: boolean,
+        telemetryContext?: ITelemetryContext,
+    ): ISummarizeResult | undefined;
+    /** Returns the garbage collector specific metadata to be written into the summary. */
+    getMetadata(): IGCMetadata;
+    /** Returns a map of each node id to its base GC details in the base summary. */
+    getBaseGCDetails(): Promise<Map<string, IGarbageCollectionDetailsBase>>;
+    /** Called when the latest summary of the system has been refreshed. */
+    latestSummaryStateRefreshed(result: RefreshSummaryResult, readAndParseBlob: ReadAndParseBlob): Promise<void>;
+    /** Called when a node is updated. Used to detect and log when an inactive node is changed or loaded. */
+    nodeUpdated(
+        nodePath: string,
+        reason: "Loaded" | "Changed",
+        timestampMs?: number,
+        packagePath?: readonly string[],
+        requestHeaders?: IRequestHeader,
+    ): void;
+    /** Called when a reference is added to a node. Used to identify nodes that were referenced between summaries. */
+    addedOutboundReference(fromNodePath: string, toNodePath: string): void;
+    setConnectionState(connected: boolean, clientId?: string): void;
+    dispose(): void;
+}
+
+/** Parameters necessary for creating a GarbageCollector. */
+export interface IGarbageCollectorCreateParams {
+    readonly runtime: IGarbageCollectionRuntime;
+    readonly gcOptions: IGCRuntimeOptions;
+    readonly baseLogger: ITelemetryLogger;
+    readonly existing: boolean;
+    readonly metadata: IContainerRuntimeMetadata | undefined;
+    readonly baseSnapshot: ISnapshotTree | undefined;
+    readonly isSummarizerClient: boolean;
+    readonly getNodePackagePath: (nodePath: string) => Promise<readonly string[] | undefined>;
+    readonly getLastSummaryTimestampMs: () => number | undefined;
+    readonly readAndParseBlob: ReadAndParseBlob;
+    readonly activeConnection: () => boolean;
+    readonly getContainerDiagnosticId: () => string;
+    readonly snapshotCacheExpiryMs?: number;
+}
+
+/** The state of node that is unreferenced. */
+export const UnreferencedState = {
+    /** The node is active, i.e., it can become referenced again. */
+    Active: "Active",
+    /** The node is inactive, i.e., it should not become referenced. */
+    Inactive: "Inactive",
+    /** The node is ready to be deleted by the sweep phase. */
+    SweepReady: "SweepReady",
+} as const;
+export type UnreferencedState = typeof UnreferencedState[keyof typeof UnreferencedState];
+
+/** The event that is logged when unreferenced node is used after a certain time. */
+export interface IUnreferencedEventProps {
+    usageType: "Changed" | "Loaded" | "Revived";
+    state: UnreferencedState;
+    id: string;
+    type: GCNodeType;
+    unrefTime: number;
+    age: number;
+    completedGCRuns: number;
+    fromId?: string;
+    timeout?: number;
+    lastSummaryTime?: number;
+    externalRequest?: boolean;
+    viaHandle?: boolean;
+}
+
+/**
+ * Gets the garbage collection state from the given snapshot tree. The GC state may be written into multiple blobs.
+ * Merge the GC state from all such blobs and return the merged GC state.
+ */
+export async function getGCStateFromSnapshot(
+    gcSnapshotTree: ISnapshotTree,
+    readAndParseBlob: ReadAndParseBlob,
+): Promise<IGarbageCollectionState> {
+    let rootGCState: IGarbageCollectionState = { gcNodes: {} };
+    for (const key of Object.keys(gcSnapshotTree.blobs)) {
+        // Skip blobs that do not start with the GC prefix.
+        if (!key.startsWith(gcBlobPrefix)) {
+            continue;
+        }
+
+        const blobId = gcSnapshotTree.blobs[key];
+        if (blobId === undefined) {
+            continue;
+        }
+        const gcState = await readAndParseBlob<IGarbageCollectionState>(blobId);
+        assert(gcState !== undefined, 0x2ad /* "GC blob missing from snapshot" */);
+        // Merge the GC state of this blob into the root GC state.
+        rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
+    }
+    return rootGCState;
+}
+
+export function generateSortedGCState(gcState: IGarbageCollectionState): IGarbageCollectionState {
+    const sortableArray: [string, IGarbageCollectionNodeData][] = Object.entries(gcState.gcNodes);
+    sortableArray.sort(([a], [b]) => a.localeCompare(b));
+    const sortedGCState: IGarbageCollectionState = { gcNodes: {} };
+    for (const [nodeId, nodeData] of sortableArray) {
+        nodeData.outboundRoutes.sort();
+        sortedGCState.gcNodes[nodeId] = nodeData;
+    }
+    return sortedGCState;
+}

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -22,7 +22,7 @@ import { ReadAndParseBlob, RefreshSummaryResult } from "@fluidframework/runtime-
 import { IGCRuntimeOptions } from "../containerRuntime";
 import { IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
 
-/** This is the current version of garbage collection. */
+/** This is the latest version of garbage collection. */
 export const latestGCVersion = 1;
 
 // The key for the GC tree in summary.

--- a/packages/runtime/container-runtime/src/gc/gcSweepReadyUsageDetection.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSweepReadyUsageDetection.ts
@@ -11,7 +11,7 @@ import {
     LoggingError,
     MonitoringContext,
 } from "@fluidframework/telemetry-utils";
-import { oneDayMs } from "./garbageCollection";
+import { oneDayMs } from "./gcDefinitions";
 
 /**
  * Feature Gate Key -

--- a/packages/runtime/container-runtime/src/gc/gcUnreferencedStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcUnreferencedStateTracker.ts
@@ -1,0 +1,111 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert, Timer } from "@fluidframework/common-utils";
+import { UnreferencedState } from "./gcDefinitions";
+
+/** A wrapper around common-utils Timer that requires the timeout when calling start/restart */
+class TimerWithNoDefaultTimeout extends Timer {
+    constructor(
+        private readonly callback: () => void,
+    ) {
+        // The default timeout/handlers will never be used since start/restart pass overrides below
+        super(0, () => { throw new Error("DefaultHandler should not be used"); });
+    }
+
+    start(timeoutMs: number) {
+        super.start(timeoutMs, this.callback);
+    }
+
+    restart(timeoutMs: number): void {
+        super.restart(timeoutMs, this.callback);
+    }
+}
+
+/**
+ * Helper class that tracks the state of an unreferenced node such as the time it was unreferenced and if it can
+ * be deleted by the sweep phase.
+ */
+ export class UnreferencedStateTracker {
+    private _state: UnreferencedState = UnreferencedState.Active;
+    public get state(): UnreferencedState {
+        return this._state;
+    }
+
+    /** Timer to indicate when an unreferenced object is considered Inactive */
+    private readonly inactiveTimer: TimerWithNoDefaultTimeout;
+    /** Timer to indicate when an unreferenced object is Sweep-Ready */
+    private readonly sweepTimer: TimerWithNoDefaultTimeout;
+
+    constructor(
+        public readonly unreferencedTimestampMs: number,
+        /** The time after which node transitions to Inactive state. */
+        private readonly inactiveTimeoutMs: number,
+        /** The current reference timestamp used to track how long this node has been unreferenced for. */
+        currentReferenceTimestampMs: number,
+        /** The time after which node transitions to SweepReady state; undefined if session expiry is disabled. */
+        private readonly sweepTimeoutMs: number | undefined,
+    ) {
+        if (this.sweepTimeoutMs !== undefined) {
+            assert(this.inactiveTimeoutMs <= this.sweepTimeoutMs,
+                0x3b0 /* inactive timeout must not be greater than the sweep timeout */);
+        }
+
+        this.sweepTimer = new TimerWithNoDefaultTimeout(
+            () => {
+                this._state = UnreferencedState.SweepReady;
+                assert(!this.inactiveTimer.hasTimer, 0x3b1 /* inactiveTimer still running after sweepTimer fired! */);
+            },
+        );
+
+        this.inactiveTimer = new TimerWithNoDefaultTimeout(() => {
+            this._state = UnreferencedState.Inactive;
+
+            // After the node becomes inactive, start the sweep timer after which the node will be ready for sweep.
+            if (this.sweepTimeoutMs !== undefined) {
+                this.sweepTimer.restart(this.sweepTimeoutMs - this.inactiveTimeoutMs);
+            }
+        });
+        this.updateTracking(currentReferenceTimestampMs);
+    }
+
+    /* Updates the unreferenced state based on the provided timestamp. */
+    public updateTracking(currentReferenceTimestampMs: number) {
+        const unreferencedDurationMs = currentReferenceTimestampMs - this.unreferencedTimestampMs;
+
+        // If the node has been unreferenced for sweep timeout amount of time, update the state to SweepReady.
+        if (this.sweepTimeoutMs !== undefined && unreferencedDurationMs >= this.sweepTimeoutMs) {
+            this._state = UnreferencedState.SweepReady;
+            this.clearTimers();
+            return;
+        }
+
+        // If the node has been unreferenced for inactive timeoutMs amount of time, update the state to inactive.
+        // Also, start a timer for the sweep timeout.
+        if (unreferencedDurationMs >= this.inactiveTimeoutMs) {
+            this._state = UnreferencedState.Inactive;
+            this.inactiveTimer.clear();
+
+            if (this.sweepTimeoutMs !== undefined) {
+                this.sweepTimer.restart(this.sweepTimeoutMs - unreferencedDurationMs);
+            }
+            return;
+        }
+
+        // The node is still active. Ensure the inactive timer is running with the proper remaining duration.
+        this.inactiveTimer.restart(this.inactiveTimeoutMs - unreferencedDurationMs);
+    }
+
+    private clearTimers() {
+        this.inactiveTimer.clear();
+        this.sweepTimer.clear();
+    }
+
+    /** Stop tracking this node. Reset the unreferenced timers and state, if any. */
+    public stopTracking() {
+        this.clearTimers();
+        this._state = UnreferencedState.Active;
+    }
+}

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export {
+    gcBlobPrefix,
+    GCNodeType,
+    gcTreeKey,
+    IGarbageCollectionRuntime,
+    IGarbageCollector,
+    IGCStats,
+} from "./gcDefinitions";
+export { GarbageCollector } from "./garbageCollection";

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -11,4 +11,4 @@ export {
     IGarbageCollector,
     IGCStats,
 } from "./gcDefinitions";
-export { GarbageCollector } from "./garbageCollection";
+export { GarbageCollector } from "./garbageCollector";

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -31,7 +31,7 @@ export {
     gcTreeKey,
     IGarbageCollectionRuntime,
     IGCStats,
-} from "./garbageCollection";
+} from "./gc";
 export {
     IPendingFlush,
     IPendingFlushMode,

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -8,7 +8,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import { ISequencedDocumentMessage, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
-import { gcTreeKey } from "./garbageCollection";
+import { gcTreeKey } from "./gc";
 
 type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
 interface IFluidDataStoreAttributes0 {

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1,10 +1,10 @@
-/* eslint-disable import/no-internal-modules */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 
 /* eslint-disable max-len */
+/* eslint-disable import/no-internal-modules */
 
 import { strict as assert } from "assert";
 import { SinonFakeTimers, useFakeTimers } from "sinon";

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -30,7 +30,7 @@ import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
 import { Timer } from "@fluidframework/common-utils";
 import { dataStoreAttributesBlobName, GCVersion, IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
 import { IGCRuntimeOptions } from "../containerRuntime";
-import { GarbageCollector } from "../gc/garbageCollection";
+import { GarbageCollector } from "../gc/garbageCollector";
 import {
     defaultSessionExpiryDurationMs,
     gcBlobPrefix,

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-internal-modules */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -27,9 +28,11 @@ import {
 } from "@fluidframework/telemetry-utils";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
 import { Timer } from "@fluidframework/common-utils";
+import { dataStoreAttributesBlobName, GCVersion, IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
+import { IGCRuntimeOptions } from "../containerRuntime";
+import { GarbageCollector } from "../gc/garbageCollection";
 import {
     defaultSessionExpiryDurationMs,
-    GarbageCollector,
     gcBlobPrefix,
     GCNodeType,
     gcTreeKey,
@@ -44,9 +47,7 @@ import {
     defaultInactiveTimeoutMs,
     gcTestModeKey,
     disableSweepLogKey,
-} from "../garbageCollection";
-import { dataStoreAttributesBlobName, GCVersion, IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
-import { IGCRuntimeOptions } from "../containerRuntime";
+} from "../gc/gcDefinitions";
 
 /** @see - sweepReadyUsageDetectionSetting */
 const SweepReadyUsageDetectionKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection";

--- a/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-internal-modules */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -13,8 +14,8 @@ import {
     skipClosureForXDaysKey,
     closuresMapLocalStorageKey,
     SweepReadyUsageDetectionHandler,
-} from "../gcSweepReadyUsageDetection";
-import { oneDayMs } from "../garbageCollection";
+} from "../gc/gcSweepReadyUsageDetection";
+import { oneDayMs } from "../gc/gcDefinitions";
 
 describe("Garbage Collection Tests", () => {
     let clock: SinonFakeTimers;

--- a/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
@@ -1,10 +1,10 @@
-/* eslint-disable import/no-internal-modules */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 
 /* eslint-disable max-len */
+/* eslint-disable import/no-internal-modules */
 
 import { strict as assert } from "assert";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";

--- a/packages/runtime/container-runtime/src/test/gcUnreferencedStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcUnreferencedStateTracker.spec.ts
@@ -1,10 +1,10 @@
-/* eslint-disable import/no-internal-modules */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 
 /* eslint-disable max-len */
+/* eslint-disable import/no-internal-modules */
 
 import { strict as assert } from "assert";
 import { SinonFakeTimers, SinonSpy, useFakeTimers, spy } from "sinon";

--- a/packages/runtime/container-runtime/src/test/gcUnreferencedStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcUnreferencedStateTracker.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-internal-modules */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
@@ -7,10 +8,8 @@
 
 import { strict as assert } from "assert";
 import { SinonFakeTimers, SinonSpy, useFakeTimers, spy } from "sinon";
-import {
-    UnreferencedState,
-    UnreferencedStateTracker,
-} from "../garbageCollection";
+import { UnreferencedState } from "../gc/gcDefinitions";
+import { UnreferencedStateTracker } from "../gc/gcUnreferencedStateTracker";
 
 describe("Garbage Collection Tests", () => {
     let clock: SinonFakeTimers;


### PR DESCRIPTION
## Description
Refactored garbage collector files:
- Moved all gc related files into a sub-directory named "gc" under "container-runtime".
- Moved all constants, interfaces, types and utility functions from "garbageCollection.ts" -> "gcDefinitions.ts".
- Moved "UnreferencedStateTracker" class from "garbageCollection.ts" -> "gcUnreferencedStateTracker.ts".
- Renamed "garbageCollection.ts" -> "garbageCollector.ts".

Once this PR goes in, we can move more functionality out of the GarbageCollector class if needed.


## Reviewer Guidance
This is just a refactor. There is no logic change here. I would love your feedback on if this there is a better way to do this kind of refactoring. Also, should the GC unit tests be moved into this new folder as well?

## Does this introduce a breaking change?
No, this is just a refactor.
