### PR TITLE
ApplyStashedOps for SharedCounter 

### DIFF
--- a/api-report/counter.api.md
+++ b/api-report/counter.api.md
@@ -31,7 +31,7 @@ export interface ISharedCounterEvents extends ISharedObjectEvents {
 export class SharedCounter extends SharedObject<ISharedCounterEvents> implements ISharedCounter {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     // @internal (undocumented)
-    protected applyStashedOp(content: unknown): void;
+    protected applyStashedOp(op: unknown): void;
     static create(runtime: IFluidDataStoreRuntime, id?: string): SharedCounter;
     static getFactory(): IChannelFactory;
     increment(incrementAmount: number): void;

--- a/api-report/counter.api.md
+++ b/api-report/counter.api.md
@@ -30,8 +30,8 @@ export interface ISharedCounterEvents extends ISharedObjectEvents {
 // @public
 export class SharedCounter extends SharedObject<ISharedCounterEvents> implements ISharedCounter {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    // @internal
-    protected applyStashedOp(): void;
+    // @internal (undocumented)
+    protected applyStashedOp(content: unknown): void;
     static create(runtime: IFluidDataStoreRuntime, id?: string): SharedCounter;
     static getFactory(): IChannelFactory;
     increment(incrementAmount: number): void;

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import {
     IFluidDataStoreRuntime,
@@ -196,11 +197,12 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
     }
 
     /**
-     *
+     * {@inheritdoc @fluidframework/shared-object-base#SharedObjectCore.applyStashedOp}
      * @internal
      */
-    protected applyStashedOp(content: unknown) {
-        const counterContent = content as IIncrementOperation;
-        this.incrementCore(counterContent.incrementAmount);
+    protected applyStashedOp(op: unknown) {
+        const counterOp = op as IIncrementOperation;
+        assert(counterOp.type === "increment", "Op type is not increment");
+        this.incrementCore(counterOp.incrementAmount);
     }
 }

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -196,11 +196,11 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
     }
 
     /**
-     * Not implemented.
      *
      * @internal
      */
-    protected applyStashedOp() {
-        throw new Error("Not implemented");
+    protected applyStashedOp(content: unknown) {
+        const counterContent = content as IIncrementOperation;
+        this.incrementCore(counterContent.incrementAmount);
     }
 }

--- a/packages/dds/counter/src/test/counter.spec.ts
+++ b/packages/dds/counter/src/test/counter.spec.ts
@@ -14,6 +14,13 @@ import {
     MockStorage,
 } from "@fluidframework/test-runtime-utils";
 import { ISharedCounter, SharedCounter } from "..";
+import { CounterFactory } from "../counterFactory";
+
+class TestSharedCounter extends SharedCounter {
+    public testApplyStashedOp(content: unknown) {
+        this.applyStashedOp(content);
+    }
+}
 
 describe("SharedCounter", () => {
     let testCounter: ISharedCounter;
@@ -64,6 +71,15 @@ describe("SharedCounter", () => {
                 testCounter.increment(-3);
                 assert.ok(fired1, "The event for first increment was not fired");
                 assert.ok(fired2, "The event for second increment was not fired");
+            });
+
+            it("Applies a stashed op", () => {
+                const amt = 7;
+                const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+                const op = { type: "increment", incrementAmount: amt };
+                const counter1 = new TestSharedCounter("testCounter1", dataStoreRuntime1, CounterFactory.Attributes);
+                counter1.testApplyStashedOp(op);
+                assert.equal(counter1.value, amt);
             });
         });
 

--- a/packages/dds/counter/src/test/counter.spec.ts
+++ b/packages/dds/counter/src/test/counter.spec.ts
@@ -72,8 +72,10 @@ describe("SharedCounter", () => {
                 assert.ok(fired1, "The event for first increment was not fired");
                 assert.ok(fired2, "The event for second increment was not fired");
             });
+        });
 
-            it("Applies a stashed op", () => {
+        describe("applyStashedOp", () => {
+            it("Immediately applies the op's increment locally", () => {
                 const amt = 7;
                 const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
                 const op = { type: "increment", incrementAmount: amt };

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -293,8 +293,8 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
 
         await provider.ensureSynchronized();
-        assert.strictEqual(counter1.value, 8);
-        assert.strictEqual(counter2.value, 8);
+        assert.strictEqual(counter1.value, testIncrementValue + 3);
+        assert.strictEqual(counter2.value, testIncrementValue + 3);
     });
 
     it("resends delete op and can set after", async function() {

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -7,6 +7,7 @@ import assert from "assert";
 import { IContainer, IHostLoader } from "@fluidframework/container-definitions";
 import { SharedMap } from "@fluidframework/map";
 import { SharedCell } from "@fluidframework/cell";
+import { SharedCounter } from "@fluidframework/counter";
 import {
     ReferenceType,
     reservedMarkerIdKey,
@@ -33,10 +34,12 @@ import { DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
 const mapId = "map";
 const stringId = "sharedStringKey";
 const cellId = "cellKey";
+const counterId = "counterKey";
 const registry: ChannelFactoryRegistry = [
     [mapId, SharedMap.getFactory()],
     [stringId, SharedString.getFactory()],
-    [cellId, SharedCell.getFactory()]];
+    [cellId, SharedCell.getFactory()],
+    [counterId, SharedCounter.getFactory()]];
 
 const testContainerConfig: ITestContainerConfig = {
     fluidDataObjectType: DataObjectFactoryType.Test,
@@ -63,6 +66,7 @@ const lots = 30;
 const testKey = "test key";
 const testKey2 = "another test key";
 const testValue = "test value";
+const testIncrementValue = 5;
 
 const ensureContainerConnected = async (container: IContainer) => {
     if (container.connectionState !== ConnectionState.Connected) {
@@ -155,6 +159,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
     let map1: SharedMap;
     let string1: SharedString;
     let cell1: SharedCell;
+    let counter1: SharedCounter;
     let waitForSummary: () => Promise<void>;
 
     beforeEach(async () => {
@@ -169,6 +174,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         const dataStore1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         map1 = await dataStore1.getSharedObject<SharedMap>(mapId);
         cell1 = await dataStore1.getSharedObject<SharedCell>(cellId);
+        counter1 = await dataStore1.getSharedObject<SharedCounter>(counterId);
         string1 = await dataStore1.getSharedObject<SharedString>(stringId);
         string1.insertText(0, "hello");
 
@@ -219,6 +225,22 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(cell2.get(), testValue);
     });
 
+    it("resends counter op", async function() {
+        const pendingOps = await getPendingOps(provider, false, async (c, d, map) => {
+            const counter = await d.getSharedObject<SharedCounter>(counterId);
+            counter.increment(testIncrementValue);
+        });
+
+        // load container with pending ops, which should resend the op not sent by previous container
+        const container2 = await loader.resolve({ url }, pendingOps);
+        const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+        const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
+        await ensureContainerConnected(container2);
+        await provider.ensureSynchronized();
+        assert.strictEqual(counter1.value, testIncrementValue);
+        assert.strictEqual(counter2.value, testIncrementValue);
+    });
+
     it("doesn't resend successful op", async function() {
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {
             map.set(testKey, "something unimportant");
@@ -254,6 +276,25 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
         assert.strictEqual(cell1.get(), testValue);
         assert.strictEqual(cell2.get(), testValue);
+    });
+
+    it("doesn't resend successful counter op", async function() {
+        const pendingOps = await getPendingOps(provider, true, async (c, d, map) => {
+            const counter = await d.getSharedObject<SharedCounter>(counterId);
+            counter.increment(0);
+        });
+
+        counter1.increment(testIncrementValue);
+        await provider.ensureSynchronized();
+
+        // load with pending ops, which it should not resend because they were already sent successfully
+        const container2 = await loader.resolve({ url }, pendingOps);
+        const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+        const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
+
+        await provider.ensureSynchronized();
+        assert.strictEqual(counter1.value, testIncrementValue);
+        assert.strictEqual(counter2.value, testIncrementValue);
     });
 
     it("resends delete op and can set after", async function() {

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -281,7 +281,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
     it("doesn't resend successful counter op", async function() {
         const pendingOps = await getPendingOps(provider, true, async (c, d, map) => {
             const counter = await d.getSharedObject<SharedCounter>(counterId);
-            counter.increment(0);
+            counter.increment(3);
         });
 
         counter1.increment(testIncrementValue);
@@ -293,8 +293,8 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
 
         await provider.ensureSynchronized();
-        assert.strictEqual(counter1.value, testIncrementValue);
-        assert.strictEqual(counter2.value, testIncrementValue);
+        assert.strictEqual(counter1.value, 8);
+        assert.strictEqual(counter2.value, 8);
     });
 
     it("resends delete op and can set after", async function() {


### PR DESCRIPTION
Implement the applyStashedOps method for SharedCounter, using the SharedCell and SharedMap implementations as a reference point. 

[AB#1752](https://dev.azure.com/fluidframework/internal/_workitems/edit/1752)