### PR TITLE
Recommend esbenp.prettier-vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,8 @@
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "dbaeumer.vscode-eslint",
-        "editorconfig.editorconfig"
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []


### PR DESCRIPTION
## Description

This recommends a vs-code extension which provides support for using prettier as a code formatter.
Since some (and soon to be more) of our packages use prettier for formatting, having this extension can be handy.

This does NOT set prettier as the default formatter or enable format on save: both of these are settings you might want if working on packages using prettier, but would not want for other packages.

## Reviewer Guidance

If you think this will cause problems for anyone, that would be great to know. The only case I can think of is maybe people with format on save enabled, but no formatters available for files which exist in our repo but are not prettier formatted. This seems like an edge case people can work around by not installing the recommended extension or fixing their strange settings, but maybe there is some other worse case we should worry about?