### PR TITLE
Tombstone implementation without touching the datastoreContext class

### DIFF
--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -114,6 +114,11 @@ export interface ISnapshotTree {
      * Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
      */
     unreferenced?: true;
+
+    /**
+     * Indicates that this tree is tombstoned. If this is not present, the tree is considered not tombstoned.
+     */
+    tombstoned?: true;
 }
 
 export interface ISnapshotTreeEx extends ISnapshotTree {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -119,6 +119,7 @@ export interface IFluidDataStoreContextProps {
     readonly createSummarizerNodeFn: CreateChildSummarizerNodeFn;
     readonly writeGCDataAtRoot: boolean;
     readonly pkg?: Readonly<string[]>;
+    readonly tombstoned?: boolean;
 }
 
 /** Properties necessary for creating a local FluidDataStoreContext */

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -119,7 +119,6 @@ export interface IFluidDataStoreContextProps {
     readonly createSummarizerNodeFn: CreateChildSummarizerNodeFn;
     readonly writeGCDataAtRoot: boolean;
     readonly pkg?: Readonly<string[]>;
-    readonly tombstoned?: boolean;
 }
 
 /** Properties necessary for creating a local FluidDataStoreContext */

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -10,6 +10,7 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
 
  export class DataStoreContexts implements Iterable<[string, FluidDataStoreContext]>, IDisposable {
     private readonly notBoundContexts = new Set<string>();
+    private readonly tombstonedContexts = new Set<string>();
 
     /** Attached and loaded context proxies */
     private readonly _contexts = new Map<string, FluidDataStoreContext>();
@@ -168,4 +169,17 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
         this.ensureDeferred(id);
         this.resolveDeferred(id);
     }
+
+    public tombstone(id: string) {
+        assert(!this.tombstonedContexts.has(id), "Tombstoned dataStore already tombstoned");
+        this.delete(id);
+        this.tombstonedContexts.add(id);
+    }
+
+    // private validateNotTombstoned(id: string) {
+    //     if (this.tombstonedContexts.has(id)) {
+    //         const request = { url: id, message: "This datastore has been tombstoned!" };
+    //         throw responseToException(create404Response(request), request);
+    //     }
+    // }
 }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -131,10 +131,11 @@ export class DataStores implements IDisposable {
                 unreferencedDataStoreCount++;
             }
 
-            if (value.tombstoned) {
-                this.contexts.tombstone(key);
-                continue;
-            }
+            // Potentially one way of tombstoning on load
+            // if (value.tombstoned) {
+            //     this.contexts.tombstone(key);
+            //     continue;
+            // }
 
             // If we have a detached container, then create local data store contexts.
             if (this.runtime.attachState !== AttachState.Detached) {


### PR DESCRIPTION
The first run implemented tombstoning by putting a tombstone flag in the `DatastoreContext` class. https://github.com/microsoft/FluidFramework/pull/12259

This Implements tombstoning by effectively deleting the tombstoned datastore from the runtime and noting it in the `DatastoreContexts` object.

[AB#2128](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2128)

- Mark datastores as tombstone when the GC algorithm detects they are sweep ready.

Future work:
- Mark datastores as tombstone during load when they are tombstoned in the summary.

Note:
- It was determined we would need to do the work to put the tombstone flag in the `DataStoreContext` class was required anyway.