### PR TITLE
Add the Fix for Missing Ops Log, and telemetry for the Ops from the Last Service Summary

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -515,7 +515,7 @@ export class SummaryWriter implements ISummaryWriter {
             logTail;
 
         // Check the missing operations in the fullLogTail
-        const fullLogTailSequenceNumbers = fullLogTail.map((ms) => ms.sequenceNumber);
+        const fullLogTailSequenceNumbers = fullLogTail?.map((ms) => ms.sequenceNumber);
         const isSameSNInterval = fullLogTailSequenceNumbers &&
             fullLogTailSequenceNumbers.length > 0 &&
             fullLogTailSequenceNumbers.length === (to - from - 1) &&
@@ -565,7 +565,7 @@ export class SummaryWriter implements ISummaryWriter {
         missingOps?.forEach((op) => missingOpsSN.push(op.sequenceNumber));
         if (missingOpsSN.length > 0) {
             Lumberjack.info(`The missing ops from summary log tail: ${JSON.stringify(missingOpsSN)}`
-            , this.lumberProperties);
+                , this.lumberProperties);
         }
         return missingOps;
     }

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -534,12 +534,10 @@ export class SummaryWriter implements ISummaryWriter {
                     missingOpsSequenceNumbers.push(i);
                 }
             }
-            if (missingOpsSequenceNumbers.length > 0) {
-                Lumberjack.info(
-                    // eslint-disable-next-line max-len
-                    `FullLogTail missing ops from: ${from} exclusive, to: ${to} exclusive with sequence numbers: ${JSON.stringify(missingOpsSequenceNumbers)}`
-                    , this.lumberProperties);
-            }
+            Lumberjack.info(
+                // eslint-disable-next-line max-len
+                `FullLogTail missing ops from: ${from} exclusive, to: ${to} exclusive with sequence numbers: ${JSON.stringify(missingOpsSequenceNumbers)}`
+                , this.lumberProperties);
         }
 
         const logTailEntries: ITreeEntry[] = [

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -515,22 +515,23 @@ export class SummaryWriter implements ISummaryWriter {
             logTail;
 
         // Check the missing operations in the fullLogTail
-        const fullLogTailSequenceNumbers = fullLogTail?.map((ms) => ms.sequenceNumber);
-        const isSameSNInterval = fullLogTailSequenceNumbers &&
-            fullLogTailSequenceNumbers.length > 0 &&
-            fullLogTailSequenceNumbers.length === (to - from - 1) &&
-            from === fullLogTailSequenceNumbers[0] - 1 &&
-            to === fullLogTailSequenceNumbers[fullLogTailSequenceNumbers.length - 1] + 1;
-        if (!isSameSNInterval) {
+        const isMatchLogtailEntries = fullLogTail &&
+            fullLogTail.length > 0 &&
+            fullLogTail.length === (to - from - 1) &&
+            from === fullLogTail[0].sequenceNumber - 1 &&
+            to === fullLogTail[fullLogTail.length - 1].sequenceNumber + 1;
+        if (!isMatchLogtailEntries) {
             const missingOpsSequenceNumbers: number[] = [];
             const fullLogTailSequenceNumbersSet = new Set();
+            const fullLogTailSequenceNumbers = fullLogTail?.map((ms) => ms.sequenceNumber);
             fullLogTailSequenceNumbers.forEach((op) => fullLogTailSequenceNumbersSet.add(op));
             for (let i = from + 1; i < to; i++) {
                 if (!fullLogTailSequenceNumbersSet.has(i)) {
                     missingOpsSequenceNumbers.push(i);
                 }
             }
-            Lumberjack.error(`Missing ops in the fullLogTail: ${JSON.stringify(missingOpsSequenceNumbers)}`
+            Lumberjack.info(
+                `FullLogTail missing ops from: ${from} to: ${to} with op: ${JSON.stringify(missingOpsSequenceNumbers)}`
                 , this.lumberProperties);
         }
 

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -564,7 +564,7 @@ export class SummaryWriter implements ISummaryWriter {
         const missingOpsSN: number[] = [];
         missingOps?.forEach((op) => missingOpsSN.push(op.sequenceNumber));
         if (missingOpsSN.length > 0) {
-            Lumberjack.info(`Fetched ops from last summary log tail: ${JSON.stringify(missingOpsSN)}`
+            Lumberjack.info(`Fetched ops from last summary logtail: ${JSON.stringify(missingOpsSN)}`
                 , this.lumberProperties);
         }
         return missingOps;

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -515,16 +515,16 @@ export class SummaryWriter implements ISummaryWriter {
             logTail;
 
         // Check the missing operations in the fullLogTail. We would treat
-        // isMatchLogtailEntries as true when the fullLogTail's length is extact same as the requested range.
+        // isLogtailEntriesMatch as true when the fullLogTail's length is extact same as the requested range.
         // As well as the first SN of fullLogTail - 1 is equal to from,
         // and the last SN of fullLogTail + 1 is equal to to.
-        // For example, to: 2, from: 5, fullLogTail with SN [3, 4] is the true scenario.
-        const isMatchLogtailEntries = fullLogTail &&
+        // For example, from: 2, to: 5, fullLogTail with SN [3, 4] is the true scenario.
+        const isLogtailEntriesMatch = fullLogTail &&
             fullLogTail.length > 0 &&
             fullLogTail.length === (to - from - 1) &&
             from === fullLogTail[0].sequenceNumber - 1 &&
             to === fullLogTail[fullLogTail.length - 1].sequenceNumber + 1;
-        if (!isMatchLogtailEntries) {
+        if (!isLogtailEntriesMatch) {
             const missingOpsSequenceNumbers: number[] = [];
             const fullLogTailSequenceNumbersSet = new Set();
             const fullLogTailSequenceNumbers = fullLogTail?.map((ms) => ms.sequenceNumber);

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -534,9 +534,12 @@ export class SummaryWriter implements ISummaryWriter {
                     missingOpsSequenceNumbers.push(i);
                 }
             }
-            Lumberjack.info(
-                `FullLogTail missing ops from: ${from} to: ${to} with op: ${JSON.stringify(missingOpsSequenceNumbers)}`
-                , this.lumberProperties);
+            if (missingOpsSequenceNumbers.length > 0) {
+                Lumberjack.info(
+                    // eslint-disable-next-line max-len
+                    `FullLogTail missing ops from: ${from} exclusive, to: ${to} exclusive with sequence numbers: ${JSON.stringify(missingOpsSequenceNumbers)}`
+                    , this.lumberProperties);
+            }
         }
 
         const logTailEntries: ITreeEntry[] = [
@@ -565,11 +568,12 @@ export class SummaryWriter implements ISummaryWriter {
         const logtailSequenceNumbers = new Set();
         logTail.forEach((ms) => logtailSequenceNumbers.add(ms.sequenceNumber));
         const missingOps = lastSummaryMessages?.filter((ms) =>
-            !(logtailSequenceNumbers.has(ms.sequenceNumber)));
+            !(logtailSequenceNumbers.has(ms.sequenceNumber)) && ms.sequenceNumber > gt && ms.sequenceNumber < lt);
         const missingOpsSN: number[] = [];
         missingOps?.forEach((op) => missingOpsSN.push(op.sequenceNumber));
         if (missingOpsSN.length > 0) {
-            Lumberjack.info(`Fetched ops from last summary logtail: ${JSON.stringify(missingOpsSN)}`
+            // eslint-disable-next-line max-len
+            Lumberjack.info(`Fetched ops gt: ${gt} exclusive, lt: ${lt} exclusive of last summary logtail: ${JSON.stringify(missingOpsSN)}`
                 , this.lumberProperties);
         }
         return missingOps;

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -564,7 +564,7 @@ export class SummaryWriter implements ISummaryWriter {
         const missingOpsSN: number[] = [];
         missingOps?.forEach((op) => missingOpsSN.push(op.sequenceNumber));
         if (missingOpsSN.length > 0) {
-            Lumberjack.info(`The missing ops from summary log tail: ${JSON.stringify(missingOpsSN)}`
+            Lumberjack.info(`Fetched ops from last summary log tail: ${JSON.stringify(missingOpsSN)}`
                 , this.lumberProperties);
         }
         return missingOps;

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -518,6 +518,7 @@ export class SummaryWriter implements ISummaryWriter {
         // isMatchLogtailEntries as true when the fullLogTail's length is extact same as the requested range.
         // As well as the first SN of fullLogTail - 1 is equal to from,
         // and the last SN of fullLogTail + 1 is equal to to.
+        // For example, to: 2, from: 5, fullLogTail with SN [3, 4] is the true scenario
         const isMatchLogtailEntries = fullLogTail &&
             fullLogTail.length > 0 &&
             fullLogTail.length === (to - from - 1) &&

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -518,7 +518,7 @@ export class SummaryWriter implements ISummaryWriter {
         // isMatchLogtailEntries as true when the fullLogTail's length is extact same as the requested range.
         // As well as the first SN of fullLogTail - 1 is equal to from,
         // and the last SN of fullLogTail + 1 is equal to to.
-        // For example, to: 2, from: 5, fullLogTail with SN [3, 4] is the true scenario
+        // For example, to: 2, from: 5, fullLogTail with SN [3, 4] is the true scenario.
         const isMatchLogtailEntries = fullLogTail &&
             fullLogTail.length > 0 &&
             fullLogTail.length === (to - from - 1) &&

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -527,8 +527,7 @@ export class SummaryWriter implements ISummaryWriter {
         if (!isLogtailEntriesMatch) {
             const missingOpsSequenceNumbers: number[] = [];
             const fullLogTailSequenceNumbersSet = new Set();
-            const fullLogTailSequenceNumbers = fullLogTail?.map((ms) => ms.sequenceNumber);
-            fullLogTailSequenceNumbers.forEach((op) => fullLogTailSequenceNumbersSet.add(op));
+            fullLogTail?.map((op) => fullLogTailSequenceNumbersSet.add(op.sequenceNumber));
             for (let i = from + 1; i < to; i++) {
                 if (!fullLogTailSequenceNumbersSet.has(i)) {
                     missingOpsSequenceNumbers.push(i);

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -514,7 +514,10 @@ export class SummaryWriter implements ISummaryWriter {
             (missingOps.concat(logTail)).sort((op1, op2) => op1.sequenceNumber - op2.sequenceNumber) :
             logTail;
 
-        // Check the missing operations in the fullLogTail
+        // Check the missing operations in the fullLogTail. We would treat
+        // isMatchLogtailEntries as true when the fullLogTail's length is extact same as the requested range.
+        // As well as the first SN of fullLogTail - 1 is equal to from,
+        // and the last SN of fullLogTail + 1 is equal to to.
         const isMatchLogtailEntries = fullLogTail &&
             fullLogTail.length > 0 &&
             fullLogTail.length === (to - from - 1) &&


### PR DESCRIPTION
We use this pr to fix the wrong error logs that keep popping out for 
Missing ops in the fullLogTail: ...

When we get the fullLogTail, it will still pop out the error message. 
For example, if from = 5, and to = 9, the fullLogTailSequenceNumber = [5,6,7,8,9,10], it would return [6,7,8] as missing ops, which is not correct. This pr is to fix this case. 

Meanwhile, we would print the SN for the missingOpsSN for ops fetched from the last summary. 