### PR TITLE
breaking.md cleanup - next

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,11 +15,11 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 - Avoid using code formatting in the title (it's fine to use in the body).
 - To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
-# 2.0.0
+# 2.0.0-internal.2.0.0
 
-## 3.0.0 Upcoming changes
-- [Signature from  `ISummarizerInternalsProvider.refreshLatestSummaryAck` interface has changed](#Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface)
-- [Move `TelemetryNullLogger` and `BaseTelemetryNullLogger` to telemetry-utils package](#Move-`TelemetryNullLogger`-and-`BaseTelemetryNullLogger`-to-telemetry-utils-package)
+## 2.0.0-internal.2.0.0 Upcoming changes
+- [Signature from  ISummarizerInternalsProvider.refreshLatestSummaryAck interface has changed](#Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface)
+- [Move TelemetryNullLogger and BaseTelemetryNullLogger to telemetry-utils package](#Move-`TelemetryNullLogger`-and-`BaseTelemetryNullLogger`-to-telemetry-utils-package)
 - [Minor event naming correction on IFluidContainerEvents](#IFluidContainerEvents-event-naming-correction)
 - [IDocumentStorageServicePolicies.maximumCacheDurationMs policy must be exactly 5 days if defined](#idocumentstorageservicepoliciesmaximumcachedurationms-policy-must-be-exactly-5-days-if-defined)
 
@@ -35,7 +35,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
     ):
 ```
 
-### Move `TelemetryNullLogger` and `BaseTelemetryNullLogger` to telemetry-utils package
+### Move TelemetryNullLogger and BaseTelemetryNullLogger to telemetry-utils package
 The utility classes `TelemetryNullLogger` and `BaseTelemetryNullLogger` are deprecated in the `@fluidframework/common-utils` package and have been moved to the `@fluidframework/telemetry-utils` package.  Please update your imports to take these from the new location.
 
 ### IFluidContainerEvents event naming correction
@@ -46,38 +46,24 @@ It's not a breaking change, but worth noting: we are now also exposing optional 
 Due to the dependency the Garbage Collection feature in the Runtime layer has on this policy, it must remain constant over time.
 So this has been codified in the type, switching from `number | undefined` to `FiveDaysMs | undefined` (with `type FiveDaysMs = 432000000`)
 
-## 3.0.0 Breaking changes
-- [Remove ISummaryConfigurationHeuristics.idleTime](#Remove-ISummaryConfigurationHeuristicsidleTime)
-- [Remove `IContainerRuntime.flush`](#remove-icontainerruntimeflush)
-- [Remove `ScheduleManager` and `DeltaScheduler`](#remove-schedulemanager-and-deltascheduler)
-
-### Remove ISummaryConfigurationHeuristics.idleTime
-`ISummaryConfigurationHeuristics.idleTime` has been removed. See [#10008](https://github.com/microsoft/FluidFramework/issues/10008)
-Please move all usage to the new `minIdleTime` and `maxIdleTime` properties in `ISummaryConfigurationHeuristics`.
-
-### Remove `IContainerRuntime.flush`
-`IContainerRuntime.flush` has been removed. If a more manual/ensured flushing process is needed, move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
-
-### Remove `ScheduleManager` and `DeltaScheduler`
-`ScheduleManager` and `DeltaScheduler` have been removed from the `@fluidframework/container-runtime` package as they are Fluid internal classes which should not be used.
-
-# 2.0.0
-
-## 2.0.0 Breaking changes
+## 2.0.0-internal.2.0.0 Breaking changes
+- [Update to React 17](#Update-to-React-17)
 - [IntervalCollection event semantics changed](#IntervalCollection-event-semantics-changed)
-- [Remove IFluidDataStoreChannel.
-bindToContext and related types](#remove-ifluiddatastorechannelbindtocontext-and-related-types)
+- [Remove IFluidDataStoreChannel.bindToContext and related types](#remove-ifluiddatastorechannelbindtocontext-and-related-types)
 - [MergeTree class no longer exported](#MergeTree-class-no-longer-exported)
 - [Marker.toString simplified](#markertostring-simplified)
-- [Remove `IContainerRuntimeBase.setFlushMode`](#remove-icontainerruntimebasesetflushmode)
-- [`getTextAndMarkers` changed to be a free function](#gettextandmarkers-changed-to-be-a-free-function)
+- [Remove IContainerRuntimeBase.setFlushMode](#remove-icontainerruntimebasesetflushmode)
+- [getTextAndMarkers changed to be a free function](#gettextandmarkers-changed-to-be-a-free-function)
 - [waitIntervalCollection removed](#waitintervalcollection-removed)
 - [OldestClientObserver moved to @fluid-experimental/oldest-client-observer](#oldestclientobserver-moved-to-@fluid-experimental/oldest-client-observer)
-- [Remove deprecated data structures from `@fluidframework/sequence`](#remove-deprecated-data-structures-from-fluidframeworksequence)
+- [Remove deprecated data structures from @fluidframework/sequence](#remove-deprecated-data-structures-from-fluidframeworksequence)
 - [Renamed lockTask to volunteerForTask from @fluid-experimental/task-manager](renamed-lockTask-to-volunteerForTask-from-@fluid-experimental/task-manager)
-- [Renamed haveTaskLock to assigned from @fluid-experimental/task-manager](renamed-haveTaskLock-to-assigned-from-@fluid-experimental/task-manager)
+- [Renamed haveTaskLock to assigned from @fluid-experimental/task-manager](renamed-haveTaskLock-to-assigned-from-@fluid-experimental/task-manager)/
+- [Remove ISummaryConfigurationHeuristics.idleTime](#Remove-ISummaryConfigurationHeuristicsidleTime)
+- [Remove IContainerRuntime.flush](#remove-icontainerruntimeflush)
+- [Remove ScheduleManager` and `DeltaScheduler](#remove-schedulemanager-and-deltascheduler)
 
-###  Update to React 17
+### Update to React 17
 The following packages use React and thus were impacted:
 - @fluidframework/view-adapters
 - @fluid-tools/webpack-fluid-loader
@@ -85,9 +71,6 @@ The following packages use React and thus were impacted:
 - @fluid-experimental/property-inspector-table
 
 Users of these packages may need to update to React 17, and/or take other action to ensure compatibility.
-
-### Remove `documentId` field from `MockFluidDataStoreContext`
-This field has been deprecated and will be removed in a future breaking change.
 
 ### IntervalCollection event semantics changed
 
@@ -108,7 +91,7 @@ More details can be found on `IIntervalCollectionEvent`'s doc comment.
 See previous ["Upcoming" change notice](#bindToContext-to-be-removed-from-IFluidDataStoreChannel) for info on how this removal was staged.
 
 ### MergeTree class no longer exported
-    The MergeTree class was deprecated and is no longer be exported. This should not affect usage as MergeTree is an internal class, and the public API exists on the Client class, which will continue to be exported and supported.
+The MergeTree class was deprecated and is no longer be exported. This should not affect usage as MergeTree is an internal class, and the public API exists on the Client class, which will continue to be exported and supported.
 
 ### Marker.toString simplified
 
@@ -116,16 +99,16 @@ In merge-tree, Marker's string representation returned by `toString` was simplif
 This new representation is used in the return value of `SharedString.getTextRangeWithMarkers`.
 The previous logic was moved to the public export `debugMarkerToString`.
 
-### Remove `IContainerRuntimeBase.setFlushMode`
+### Remove IContainerRuntimeBase.setFlushMode
 The `setFlushMode` has been removed from `IContainerRuntimeBase`. FlushMode is now an immutable property for the container runtime, optionally provided at creation time via the `IContainerRuntimeOptions` interface. Instead, batching when in `FlushMode.Immediate` should be done through usage of the `IContainerRuntimeBase.orderSequentially`. See [#9480](https://github.com/microsoft/FluidFramework/issues/9480#issuecomment-1084790977).
 
-### `getTextAndMarkers` changed to be a free function
+### getTextAndMarkers changed to be a free function
 
 `SharedString.getTextAndMarkers` involves a sizeable amount of model-specific logic.
 To improve bundle size, it will be converted to a free function so that this logic is tree-shakeable.
 The corresponding method on `IMergeTreeTexHelper` will also be removed.
 
-### `waitIntervalCollection` removed
+### waitIntervalCollection removed
 
 `SharedSegmentSequence.waitIntervalCollection` has been removed.
 Use `getIntervalCollection` instead, which has the same semantics but is synchronous.
@@ -133,7 +116,7 @@ Use `getIntervalCollection` instead, which has the same semantics but is synchro
 ### OldestClientObserver moved to @fluid-experimental/oldest-client-observer
 The `OldestClientObserver` class and its associated interfaces have been removed from @fluid-experimental/task-manager and moved to the new package @fluid-experimental/oldest-client-observer. Please migrate all imports to @fluid-experimental/oldest-client-observer.
 
-### Remove deprecated data structures from `@fluidframework/sequence`
+### Remove deprecated data structures from @fluidframework/sequence
 `SharedNumberSequence`, `SharedObjectSequence`, and `SharedMatrix` have been removed from `@fluidframework/sequence`. They are currently still available in `@fluid-experimental/sequence-deprecated.
 
 ### Renamed lockTask to volunteerForTask from @fluid-experimental/task-manager
@@ -141,6 +124,16 @@ The `OldestClientObserver` class and its associated interfaces have been removed
 
 ### Renamed haveTaskLock to assigned from @fluid-experimental/task-manager
 `TaskManager.haveTaskLock()` has been renamed `assigned()`. Please update all usages accordingly.
+
+### Remove ISummaryConfigurationHeuristics.idleTime
+`ISummaryConfigurationHeuristics.idleTime` has been removed. See [#10008](https://github.com/microsoft/FluidFramework/issues/10008)
+Please move all usage to the new `minIdleTime` and `maxIdleTime` properties in `ISummaryConfigurationHeuristics`.
+
+### Remove IContainerRuntime.flush
+`IContainerRuntime.flush` has been removed. If a more manual/ensured flushing process is needed, move all usage to `IContainerRuntimeBase.orderSequentially` if possible.
+
+### Remove ScheduleManager and DeltaScheduler
+`ScheduleManager` and `DeltaScheduler` have been removed from the `@fluidframework/container-runtime` package as they are Fluid internal classes which should not be used.
 
 # 2.0.0-internal.1.3.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,12 +18,12 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 # 2.0.0-internal.2.0.0
 
 ## 2.0.0-internal.2.0.0 Upcoming changes
-- [Signature from  ISummarizerInternalsProvider.refreshLatestSummaryAck interface has changed](#Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface)
+- [Signature from ISummarizerInternalsProvider.refreshLatestSummaryAck interface has changed](#Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface)
 - [Move TelemetryNullLogger and BaseTelemetryNullLogger to telemetry-utils package](#Move-`TelemetryNullLogger`-and-`BaseTelemetryNullLogger`-to-telemetry-utils-package)
 - [Minor event naming correction on IFluidContainerEvents](#IFluidContainerEvents-event-naming-correction)
 - [IDocumentStorageServicePolicies.maximumCacheDurationMs policy must be exactly 5 days if defined](#idocumentstorageservicepoliciesmaximumcachedurationms-policy-must-be-exactly-5-days-if-defined)
 
-### Change-ISummarizerInternalsProvider.refreshLatestSummaryAck-interface
+### Signature from ISummarizerInternalsProvider.refreshLatestSummaryAck interface has changed
 `ISummarizerInternalsProvider.refreshLatestSummaryAck` interface has been updated to now accept `IRefreshSummaryAckOptions` property instead.
 ```diff
     async refreshLatestSummaryAck(


### PR DESCRIPTION
## Description

This PR cleans up BREAKING.md to more closely follow our [guidelines](https://github.com/microsoft/FluidFramework/wiki/Communicating-breaking-changes) and to correct the versioning mistakes.

## Reviewer Guidance

- We should double check that all the breaking changes/upcoming changes belong in their respective sections.
- My understanding is that the latest section should be `2.0.0-internal.2.0.0` since that is the next major release. Please let me know if this is not correct.
- Currently our client packages are on version `2.0.0-internal.1.3.0`. Should this be `2.0.0-internal.2.0.0`? If so, we should create a follow up PR to bump the versions on next.

## Other information or known dependencies

Relevant info on versioning (internal): https://dev.azure.com/fluidframework/internal/_git/ff_internal?path=/docs/ffhot/release-branches.md&version=GBmain&line=1&_a=preview

Relevant PRs: 
https://github.com/microsoft/FluidFramework/pull/12169
https://github.com/microsoft/FluidFramework/pull/12161
https://github.com/microsoft/FluidFramework/pull/12281