### PR TITLE
Update GC to support 5 day snapshot cache expiry

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -544,10 +544,10 @@ export class GarbageCollector implements IGarbageCollector {
             );
             this.sessionExpiryTimer.start();
 
-            // TEMPORARY: Hardcode a default of 2 days which is the value used in the ODSP driver.
+            // TEMPORARY: Hardcode a default of 5 days which will be >= the policy's value in the ODSP driver.
             // This unblocks the Sweep Log (see logSweepEvents function).
             // This will be removed before sweep is fully implemented.
-            const snapshotCacheExpiryMs = createParams.snapshotCacheExpiryMs ?? 2 * 24 * 60 * 60 * 1000;
+            const snapshotCacheExpiryMs = createParams.snapshotCacheExpiryMs ?? 5 * 24 * 60 * 60 * 1000;
 
             /**
              * Sweep timeout is the time after which unreferenced content can be swept.

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -269,7 +269,7 @@ describe("Garbage Collection Tests", () => {
 
         describe("Session Expiry and Sweep Timeout", () => {
             const testOverrideSessionExpiryMsKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
-            const defaultSnapshotCacheExpiryMs = 2 * 24 * 60 * 60 * 1000;
+            const defaultSnapshotCacheExpiryMs = 5 * 24 * 60 * 60 * 1000;
             beforeEach(() => {
                 injectedSettings[runSessionExpiryKey] = true;
                 injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout


### PR DESCRIPTION
Part of the plan documented [here](https://microsoft.sharepoint-df.com/:fl:/s/54e45b67-b090-4b62-ba82-a7be9987bef7/EZahQHhp6SdOo8ry90BuEC0BTKr6W1T80O6vTZ-he0p6_A?e=HX9n9K&nav=cz0lMkZzaXRlcyUyRjU0ZTQ1YjY3LWIwOTAtNGI2Mi1iYTgyLWE3YmU5OTg3YmVmNyZkPWIhdUVoeU4yRk9jRUNzOFhfeVNLSUxCWlJWaFZXc2p2OUlobENZWkp6SFoyeHFkclhtVUVxMlJiVG51Zm9oT0RQNSZmPTAxVlBNQkw0RVdVRkFIUTJQSkU1SEtIU1hTNjVBRzRFQk4mYz0lMkYmZmx1aWQ9MSZhPUxvb3BBcHAmcD0lNDBmbHVpZHglMkZsb29wLXBhZ2UtY29udGFpbmVyJng9JTdCJTIydyUyMiUzQSUyMlQwUlRVSHh0YVdOeWIzTnZablF1YzJoaGNtVndiMmx1ZEMxa1ppNWpiMjE4WWlGMVJXaDVUakpHVDJORlEzTTRXRjk1VTB0SlRFSmFVbFpvVmxkemFuWTVTV2hzUTFsYVNucElXako0Y1dSeVdHMVZSWEV5VW1KVWJuVm1iMmhQUkZBMWZEQXhWbEJOUWt3MFFrMWFRa2RXTWtnME0wdFdSVmxMUlZVM1ZsRllNamRHTlV3JTNEJTIyJTJDJTIyaSUyMiUzQSUyMjgwMmI0ZDdhLTBmMTktNDIzMy04YmUxLTFiNTcxMDcyODljNCUyMiU3RA%3D%3D).

The driver's policy will be changing from 2 days to 5 days, and I want GC in all interim releases to be able to handle either. GC having a larger value than the driver uses is safe, but not the other way around, so setting it to 5 proactively is safe.

(Same as #12285 but into main -- probably should have done it in reverse order)