### PR TITLE
Tree: Add symbolIsFieldKey

### DIFF
--- a/packages/dds/tree/src/test/tree/globalFieldKeySymbol.spec.ts
+++ b/packages/dds/tree/src/test/tree/globalFieldKeySymbol.spec.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { GlobalFieldKey } from "../../schema-stored";
+import { keyFromSymbol, symbolFromKey, symbolIsFieldKey } from "../../tree";
+import { brand } from "../../util";
+
+const key1 = brand<GlobalFieldKey>("testKey");
+const key2 = brand<GlobalFieldKey>("testKey2");
+
+describe("globalFieldKeySymbol", () => {
+    it("symbolFromKey", () => {
+        assert.equal(symbolFromKey(key1), symbolFromKey(key1));
+        assert.notEqual(symbolFromKey(key1), symbolFromKey(key2));
+    });
+    it("keyFromSymbol", () => {
+        const sym1 = symbolFromKey(key1);
+        const sym2 = symbolFromKey(key2);
+        assert.equal(keyFromSymbol(sym1), key1);
+        assert.equal(keyFromSymbol(sym2), key2);
+    });
+    it("symbolIsFieldKey", () => {
+        const sym1 = Symbol("not a field");
+        const sym2 = symbolFromKey(key2);
+        assert.equal(symbolIsFieldKey(sym1), false);
+        assert.equal(symbolIsFieldKey(sym2), true);
+    });
+});

--- a/packages/dds/tree/src/tree/globalFieldKeySymbol.ts
+++ b/packages/dds/tree/src/tree/globalFieldKeySymbol.ts
@@ -39,3 +39,10 @@ export function symbolFromKey(key: GlobalFieldKey): GlobalFieldKeySymbol {
 export function keyFromSymbol(key: GlobalFieldKeySymbol): GlobalFieldKey {
     return keyMap.get(key) ?? fail("missing key for symbol");
 }
+
+/**
+ * @returns true iff `key` is a {@link GlobalFieldKeySymbol}.
+ */
+export function symbolIsFieldKey(key: symbol): key is GlobalFieldKeySymbol {
+    return keyMap.has(key as GlobalFieldKeySymbol);
+}


### PR DESCRIPTION
## Description

Adds `symbolIsFieldKey` which is necessary for APIs like EditableTree which need to interpret attempts to access or modify properties keys with symbols as either field access or not. Since the set of symbols code might test an object for is unknown, it's impossible to implement such APIs with a way to tell if a symbol is a field key.