### PR TITLE
Remove unneeded exposure of bindToContext on IFluidDataStoreContext

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -33,16 +33,6 @@ import { TelemetryEventPropertyType } from '@fluidframework/common-definitions';
 // @public
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
-// @public @deprecated (undocumented)
-export enum BindState {
-    // (undocumented)
-    Binding = "Binding",
-    // (undocumented)
-    Bound = "Bound",
-    // (undocumented)
-    NotBound = "NotBound"
-}
-
 // @public (undocumented)
 export const blobCountPropertyName = "BlobCount";
 
@@ -164,8 +154,6 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     readonly attachState: AttachState;
     // (undocumented)
     readonly baseSnapshot: ISnapshotTree | undefined;
-    // @deprecated (undocumented)
-    bindToContext(): void;
     // (undocumented)
     readonly clientDetails: IClientDetails;
     // (undocumented)

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -277,8 +277,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     baseSnapshot: ISnapshotTree | undefined;
     // (undocumented)
-    bindToContext(): void;
-    // (undocumented)
     clientDetails: IClientDetails;
     // (undocumented)
     clientId: string | undefined;

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -57,10 +57,6 @@
   "typeValidation": {
     "version": "2.0.0",
     "broken": {
-      "RemovedInterfaceDeclaration_IDataStoreWithBindToContext_Deprecated": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
       "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
         "backCompat": false
       },

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -40,7 +40,6 @@ import {
     IQuorumClients,
 } from "@fluidframework/protocol-definitions";
 import {
-    BindState,
     CreateSummarizerNodeSource,
     IAttachMessage,
     IEnvelope,
@@ -155,7 +154,6 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private readonly contextsDeferred = new Map<string, Deferred<IChannelContext>>();
     private readonly pendingAttach = new Map<string, IAttachMessage>();
 
-    private bindState: BindState;
     private readonly deferredAttached = new Deferred<void>();
     private readonly localChannelContextQueue = new Map<string, LocalChannelContextBase>();
     private readonly notBoundedChannelContextSet = new Set<string>();
@@ -266,7 +264,6 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
         this.attachListener();
         // If exists on storage or loaded from a snapshot, it should already be bound.
-        this.bindState = existing ? BindState.Bound : BindState.NotBound;
         this._attachState = dataStoreContext.attachState;
 
         /**
@@ -460,12 +457,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
      * 2. Attaching the graph if the data store becomes attached.
      */
     public bindToContext() {
-        if (this.bindState !== BindState.NotBound) {
-            return;
-        }
-        this.bindState = BindState.Binding;
-        this.dataStoreContext.bindToContext();
-        this.bindState = BindState.Bound;
+        this.dataStoreContext.makeLocallyVisible();
     }
 
     public bind(handle: IFluidHandle): void {

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -195,13 +195,6 @@ export interface IContainerRuntimeBase extends
     getAudience(): IAudience;
 }
 
-/** @deprecated - Used only in deprecated API bindToContext */
-export enum BindState {
-    NotBound = "NotBound",
-    Binding = "Binding",
-    Bound = "Bound",
-}
-
 /**
  * Minimal interface a data store runtime need to provide for IFluidDataStoreContext to bind to control
  *
@@ -384,12 +377,6 @@ export interface IFluidDataStoreContext extends
      * @param content - Content of the signal.
      */
     submitSignal(type: string, content: any): void;
-
-    /**
-     * @deprecated - To be removed in favor of makeVisible.
-     * Register the runtime to the container
-     */
-    bindToContext(): void;
 
     /**
      * Called to make the data store locally visible in the container. This happens automatically for root data stores

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -104,10 +104,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
         throw new Error("Method not implemented.");
     }
 
-    public bindToContext(): void {
-        throw new Error("Method not implemented.");
-    }
-
     public setChannelDirty(address: string): void {
         throw new Error("Method not implemented.");
     }


### PR DESCRIPTION
## Description

We had to add bindToContext back into the internal.1.x release, and did so with the minimal changes relative to simply reverting the commit that had removed it.

This resulted in adding it back to `IFluidDataStoreContext` which is an internal interface we don't expect partners to implement based on current usage patterns.

This PR removes `bindToContext` from that layer, calling `makeLocallyVisible` directly instead of wrapping it.  We can also remove the `BindState` type since it's no longer used.

## Does this introduce a breaking change?

Technically yes (I still need to update BREAKING.md, once I get feedback on if this is worth it), but no external partner should be implementing this interface or calling this function at this level.
