### PR TITLE
fix(build-tools): Generate commit messages for bumps consistently

### DIFF
--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -14,6 +14,7 @@ import { bumpVersionScheme } from "@fluid-tools/version-tools";
 import {
     generateBumpDepsBranchName,
     generateBumpVersionBranchName,
+    generateCommitMessage,
     generateReleaseBranchName,
     getPreReleaseDependencies,
     getReleaseSourceForReleaseGroup,
@@ -587,18 +588,14 @@ export const checkShouldCommit: StateHandlerFunction = async (
         return true;
     }
 
-    const version = releaseVersion;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const newVersion = bumpVersionScheme(version, bumpType!);
-
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const branchName = generateBumpVersionBranchName(releaseGroup!, bumpType!, releaseVersion!);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const commitMsg = generateCommitMessage(releaseGroup!, bumpType!, releaseVersion!);
 
     await context.createBranch(branchName);
-
     log.verbose(`Created bump branch: ${branchName}`);
 
-    const commitMsg = `[bump] ${releaseGroup}: ${version} => ${newVersion} (${bumpType})\n\nPost-release ${bumpType} bump of ${releaseGroup}.`;
     await context.gitRepo.commit(commitMsg, `Error committing to ${branchName}`);
     BaseStateHandler.signalSuccess(machine, state);
     return true;
@@ -635,9 +632,9 @@ export const checkShouldCommitReleasedDepsBump: StateHandlerFunction = async (
     await context.gitRepo.createBranch(branchName);
 
     log.verbose(`Created bump branch: ${branchName}`);
-    log.info(`BUMP: ${releaseGroup}: Bumped prerelease dependencies to release versions.`);
+    log.info(`${releaseGroup}: Bumped prerelease dependencies to release versions.`);
 
-    const commitMsg = `[bump] ${releaseGroup}: update prerelease dependencies to release versions`;
+    const commitMsg = `[dependencies] ${releaseGroup}: update prerelease dependencies to release versions`;
     await context.gitRepo.commit(commitMsg, `Error committing to ${branchName}`);
     BaseStateHandler.signalSuccess(machine, state);
     return true;

--- a/build-tools/packages/build-cli/src/lib/branches.ts
+++ b/build-tools/packages/build-cli/src/lib/branches.ts
@@ -53,6 +53,7 @@ export async function createBumpBranch(
  * @param releaseGroupOrPackage - The release group or independent package to generate a branch name for.
  * @param bumpType - The bump type.
  * @param version - The current version of the release group or package.
+ * @param scheme - The version scheme to use. If this is omitted the scheme will be detected using detectVersionScheme.
  * @returns The generated branch name.
  *
  * @remarks
@@ -147,6 +148,35 @@ export function generateReleaseBranchName(releaseGroup: ReleaseGroup, version: s
 
     const releaseBranch = branchPath.join("/");
     return releaseBranch;
+}
+
+/**
+ * Generates an appropriate commit message when bumping a release group or package.
+ *
+ * @param releaseGroupOrPackage - The release group or independent package to generate a branch name for.
+ * @param bumpType - The bump type.
+ * @param version - The current version of the release group or package.
+ * @param scheme - The version scheme to use. If this is omitted the scheme will be detected using detectVersionScheme.
+ * @returns The generated branch name.
+ *
+ * @remarks
+ *
+ * Generated branch names are of the form `bump_deps_<RELEASEGROUP>_<BUMPTYPE>`.
+ *
+ * @internal
+ */
+export function generateCommitMessage(
+    releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
+    bumpType: VersionBumpTypeExtended,
+    version: ReleaseVersion,
+    scheme?: VersionScheme,
+): string {
+    const newVersion = bumpVersionScheme(version, bumpType, scheme);
+    const name = isReleaseGroup(releaseGroupOrPackage)
+        ? releaseGroupOrPackage
+        : PackageName.getUnscopedName(releaseGroupOrPackage);
+    const message = `[bump] ${name}: ${version} => ${newVersion} (${bumpType})\n\nBumped ${name} from ${version} to ${newVersion}.`;
+    return message;
 }
 
 /**

--- a/build-tools/packages/build-cli/src/lib/index.ts
+++ b/build-tools/packages/build-cli/src/lib/index.ts
@@ -6,6 +6,7 @@
 export {
     generateBumpVersionBranchName,
     generateBumpDepsBranchName,
+    generateCommitMessage,
     createBumpBranch,
     getDefaultBumpTypeForBranch,
     getReleaseSourceForReleaseGroup,


### PR DESCRIPTION
Adds a function to centralize generating commit messages for bump PRs.