### PR TITLE
fix(build-tools): Make the default bundle directory deterministic in docs

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -580,9 +580,7 @@ USAGE
 
 FLAGS
   -v, --verbose      Verbose logging.
-  --dirname=<value>  [default:
-                     C:\Users\sdeshpande\Documents\FluidFramework\build-tools\packages\build-cli\lib\commands\run]
-                     Directory
+  --dirname=<value>  [default: current directory] Directory containing bundle stats input
 
 DESCRIPTION
   Generate a report from input bundle stats collected through the collect bundleStats command.

--- a/build-tools/packages/build-cli/src/commands/run/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/run/bundleStats.ts
@@ -12,9 +12,7 @@ export default class RunBundlestats extends BaseCommand<typeof RunBundlestats.fl
 
     static flags = {
         dirname: Flags.string({
-            description: "Directory",
-            // eslint-disable-next-line unicorn/prefer-module
-            default: __dirname,
+            description: "[default: current directory] Directory containing bundle stats input",
             required: false,
         }),
         ...BaseCommand.flags,
@@ -22,6 +20,9 @@ export default class RunBundlestats extends BaseCommand<typeof RunBundlestats.fl
 
     public async run(): Promise<void> {
         const flags = this.processedFlags;
-        execSync(`npx danger ci -d ${flags.dirname}/lib/dangerfile.js`, { stdio: "inherit" });
+        // eslint-disable-next-line unicorn/prefer-module
+        const dirname = flags.dirname ?? __dirname;
+
+        execSync(`npx danger ci -d ${dirname}/lib/dangerfile.js`, { stdio: "inherit" });
     }
 }


### PR DESCRIPTION
The `run bundleStats` command was using oclifs default argument feature for a default directory, but this causes the help and readme for the command to be based on the path of the user's machine. This fixes the logic to handle setting a default without using oclif.

[AB#1961](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1961)