### PR TITLE
GC: Persist SweepTimeout to summary and support using a shorter duration for testing

### DIFF
--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -53,10 +53,13 @@ export class LocalDocumentService implements IDocumentService {
             this.documentId,
             new GitManager(new TestHistorian(this.localDeltaConnectionServer.testDbFactory.testDatabase)),
             new TelemetryNullLogger(),
-            { minBlobSize: 2048 }, // Test blob aggregation.
-            undefined,
-            undefined,
-            undefined,
+            {
+                minBlobSize: 2048, // Test blob aggregation
+                maximumCacheDurationMs: 0, // This essentially disables the snapshot cache
+            },
+            undefined /* driverPolicies */,
+            undefined /* blobCache */,
+            undefined /* snapshotTreeCache */,
             new GitManager(new TestHistorian(this.localDeltaConnectionServer.testDbFactory.testDatabase)));
     }
 

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -176,7 +176,7 @@ class BlobOnlyStorage implements IDocumentStorageService {
             // some browsers may not populate stack unless exception is thrown
             throw new Error("BlobOnlyStorage not implemented method used");
         } catch (err) {
-            this.logger.sendErrorEvent({ eventName: "BlobOnlyStorageWrongCall" }, err);
+            this.logger.sendTelemetryEvent({ eventName: "BlobOnlyStorageWrongCall" }, err);
             throw err;
         }
     }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -30,6 +30,7 @@
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "qt": "npm run tsc; npm run build:test; npm run test",
     "test": "npm run test:mocha",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "test:mocha": "mocha --ignore 'dist/test/types/*' --recursive dist/test -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -995,6 +995,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const pendingRuntimeState = context.pendingLocalState as IPendingRuntimeState | undefined;
         const baseSnapshot: ISnapshotTree | undefined = pendingRuntimeState?.baseSnapshot ?? context.baseSnapshot;
 
+        //* Test to prove this doesn't get persisted as undefined?
+        // Note: This will be undefined in a new (created detached) Interactive client.
+        // But we only need it for the Summarizer, which always loads from that summary generated for attach.
+        const maximumCacheDurationMs = _storage?.policies?.maximumCacheDurationMs;
+
         this.garbageCollector = GarbageCollector.create({
             runtime: this,
             gcOptions: this.runtimeOptions.gcOptions,
@@ -1008,6 +1013,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             readAndParseBlob: async <T>(id: string) => readAndParse<T>(this.storage, id),
             getContainerDiagnosticId: () => this.context.id,
             activeConnection: () => this.deltaManager.active,
+            snapshotCacheExpiryMs: maximumCacheDurationMs,
         });
 
         const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -131,8 +131,10 @@ import {
     extractSummaryMetadataMessage,
     IContainerRuntimeMetadata,
     ICreateContainerMetadata,
+    IGCMetadata,
     ISummaryMetadataMessage,
     metadataBlobName,
+    SnapshotCacheDurationPolicy,
     wrapSummaryInChannelsTree,
 } from "./summaryFormat";
 import { SummaryCollection } from "./summaryCollection";
@@ -995,10 +997,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const pendingRuntimeState = context.pendingLocalState as IPendingRuntimeState | undefined;
         const baseSnapshot: ISnapshotTree | undefined = pendingRuntimeState?.baseSnapshot ?? context.baseSnapshot;
 
-        //* Test to prove this doesn't get persisted as undefined?
-        // Note: This will be undefined in a new (created detached) Interactive client.
-        // But we only need it for the Summarizer, which always loads from that summary generated for attach.
-        const maximumCacheDurationMs = _storage?.policies?.maximumCacheDurationMs;
+        // Note: This will be indeterminate for a new (created detached) Interactive client.
+        const maximumCacheDurationMs: SnapshotCacheDurationPolicy =
+            _storage?.policies !== undefined
+                ? _storage.policies.maximumCacheDurationMs ?? "none"
+                : "indeterminate";
 
         this.garbageCollector = GarbageCollector.create({
             runtime: this,

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -544,10 +544,7 @@ export class GarbageCollector implements IGarbageCollector {
             );
             this.sessionExpiryTimer.start();
 
-            // TEMPORARY: Hardcode a default of 5 days which will be >= the policy's value in the ODSP driver.
-            // This unblocks the Sweep Log (see logSweepEvents function).
-            // This will be removed before sweep is fully implemented.
-            const snapshotCacheExpiryMs = createParams.snapshotCacheExpiryMs ?? 5 * 24 * 60 * 60 * 1000;
+            const snapshotCacheExpiryMs = createParams.snapshotCacheExpiryMs;
 
             /**
              * Sweep timeout is the time after which unreferenced content can be swept.
@@ -590,7 +587,7 @@ export class GarbageCollector implements IGarbageCollector {
          * 3. Sweep should be enabled for this container (this.sweepEnabled). This can be overridden via runSweep
          * feature flag.
          */
-        this.shouldRunSweep = false; // disable while TEMPORARY measure hardcoding snapshotCacheExpiryMs is here
+        this.shouldRunSweep = false; // disable TEMPORARILY until Sweep Timeout constituents are persisted to snapshot
             // this.shouldRunGC
             // && this.sweepTimeoutMs !== undefined
             // && (this.mc.config.getBoolean(runSweepKey) ?? this.sweepEnabled);

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -99,14 +99,19 @@ export interface IGCMetadata {
      * - A value greater than 0 means GC is enabled.
      */
     readonly gcFeature?: GCVersion;
-    /** If this is present, the session for this container will expire after this time and the container will close */
-    readonly sessionExpiryTimeoutMs?: number;
     /**
      * Tells whether the GC sweep phase is enabled for this container.
      * - True means sweep phase is enabled.
      * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
      */
-    readonly sweepEnabled?: boolean;
+     readonly sweepEnabled?: boolean;
+
+    /** If this is present, the session for this container will expire after this time and the container will close */
+    readonly sessionExpiryTimeoutMs?: number;
+    /** Maximum duration a snapshot may be cached and then loaded from for this container */
+    readonly maxSnapshotCacheDurationMs?: number;
+    /** The buffer used to compute Sweep Timeout for this container */
+    readonly sweepTimeoutBufferMs?: number;
 }
 
 /** The properties of an ISequencedDocumentMessage to be stored in the metadata blob in summary. */

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -109,7 +109,7 @@ export interface IGCMetadata {
     /** If this is present, the session for this container will expire after this time and the container will close */
     readonly sessionExpiryTimeoutMs?: number;
     /** Maximum duration a snapshot may be cached and then loaded from for this container */
-    readonly maxSnapshotCacheDurationMs?: number;
+    readonly maxSnapshotCacheDurationMs?: number | "none";
     /** The buffer used to compute Sweep Timeout for this container */
     readonly sweepTimeoutBufferMs?: number;
 }

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -90,6 +90,14 @@ export interface ICreateContainerMetadata {
     createContainerTimestamp?: number;
 }
 
+/**
+ * Used to convey the maximum duration a snapshot may be cached and then loaded from for this container.
+ * If a number, then it's that duration in ms
+ * If "none", then there is no maximum gauranteed
+ * If "indeterminate", then the value is not yet known (e.g this is the case for initial snapshot used when attaching)
+*/
+export type SnapshotCacheDurationPolicy = number | "none" | "indeterminate";
+
 export type GCVersion = number;
 export interface IGCMetadata {
     /**
@@ -104,12 +112,17 @@ export interface IGCMetadata {
      * - True means sweep phase is enabled.
      * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
      */
-     readonly sweepEnabled?: boolean;
+    readonly sweepEnabled?: boolean;
 
     /** If this is present, the session for this container will expire after this time and the container will close */
     readonly sessionExpiryTimeoutMs?: number;
-    /** Maximum duration a snapshot may be cached and then loaded from for this container */
-    readonly maxSnapshotCacheDurationMs?: number | "none";
+    /**
+     * Maximum duration a snapshot may be cached and then loaded from for this container.
+     * If a number, then it's that duration in ms
+     * If "none", then there is no maximum imposed
+     * If "indeterminate", then the value is not yet known (this is the case for initial snapshot used when attaching)
+    */
+    readonly maxSnapshotCacheDurationMs?: SnapshotCacheDurationPolicy;
     /** The buffer used to compute Sweep Timeout for this container */
     readonly sweepTimeoutBufferMs?: number;
 }

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -24,6 +24,7 @@
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
     "start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",
+    "qt": "npm run build:test && npm run test:realsvc:local",
     "test": "npm run test:realsvc",
     "test:realsvc": "npm run test:realsvc:local && npm run test:realsvc:tinylicious",
     "test:realsvc:frs": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=frs --timeout=20s",

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -133,6 +133,12 @@ function getDocumentIdStrategy(type?: TestDriverTypes): IDocumentIdStrategy {
  * any expected events that have not occurred.
  */
 export class EventAndErrorTrackingLogger extends TelemetryLogger {
+    /** Even if these error events are logged, tests should still be allowed to pass */
+    private readonly allowedErrors: string[] = [
+        // This log was removed in current version as unnecessary, but it's still present in previous versions
+        "fluid:telemetry:Container:NoRealStorageInDetachedContainer",
+    ];
+
     constructor(private readonly baseLogger: ITelemetryBaseLogger) {
         super();
     }
@@ -185,7 +191,7 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
         const unexpectedErrors = this.unexpectedErrors.splice(0, this.unexpectedErrors.length);
         return {
             expectedNotFound,
-            unexpectedErrors,
+            unexpectedErrors: unexpectedErrors.filter((event) => !this.allowedErrors.includes(event.eventName)),
         };
     }
 }

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -40,13 +40,10 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     /** Asserts that matchEvents is true, and prints the actual/expected output if not */
     assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
         const actualEvents = this.events;
+        const detailedOutput = JSON.stringify({ "expected events": expectedEvents, "actual events": actualEvents })
+            .replace(/("\w+ events":)\[/, "\n$1\n[");
         if (!this.matchEvents(expectedEvents)) {
-            throw new Error(`${message}
-expected:
-${JSON.stringify(expectedEvents)}
-
-actual:
-${JSON.stringify(actualEvents)}`);
+            throw new Error(`${message}\n${detailedOutput}`);
         }
     }
 
@@ -66,27 +63,20 @@ ${JSON.stringify(actualEvents)}`);
     /** Asserts that matchAnyEvent is true, and prints the actual/expected output if not */
     assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
         const actualEvents = this.events;
+        const detailedOutput = JSON.stringify({ "expected events": expectedEvents, "actual events": actualEvents })
+        .replace("\" events\":[", " events:\n[");
         if (!this.matchAnyEvent(expectedEvents)) {
-            throw new Error(`${message}
-expected:
-${JSON.stringify(expectedEvents)}
-
-actual:
-${JSON.stringify(actualEvents)}`);
-            }
+            throw new Error(`${message}\n${detailedOutput}`);
+        }
     }
 
     /** Asserts that matchAnyEvent is false for the given events, and prints the actual/expected output if not */
     assertMatchNone(disallowedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
         const actualEvents = this.events;
+        const detailedOutput = { "disallowed events": disallowedEvents, "actual events": actualEvents };
         if (this.matchAnyEvent(disallowedEvents)) {
-            throw new Error(`${message}
-disallowed events:
-${JSON.stringify(disallowedEvents)}
-
-actual:
-${JSON.stringify(actualEvents)}`);
-            }
+            throw new Error(`${message}\n${JSON.stringify(detailedOutput)}`);
+        }
     }
 
     private getMatchedEventsCount(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): number {


### PR DESCRIPTION
## Important update

This PR seems to have a fatal problem: The initial summary (created while detached) cannot include the driver's snapshot cache policy. So we have to persist some placeholder value and depend on a later summary to fill it in. But this means that there is no authoritative value, as different sessions could have different policies in effect.

Discussing this with Navin, we'll see what the outcome is.  One possibility is to close this in favor of #12419 

## Description

This does a few key things:
* Plumbs the Snapshot Cache Expiry value in from the driver
* Persists that value, along with the value used for the buffer, so all 3 Sweep Timeout constituents are persisted
* Ensures Snapshot Cache policy is consistent with other config state

It does _not_ change the logic around overriding Session Expiry, and uses a very simple scheme for overriding buffer, tying it to whether SnapshotCache is 0 or not.

We can iterate on strategy for setting these values for new containers over time - the important part is to get the values persisted and always use those values for existing containers.

See previous PR #12044

## Reviewer Guidance

* Still need to update unit tests
* Still need to write some e2e tests to try out shrinking the timeout (now we can test sweep in e2e tests!)
* We may consider porting part of this back to internal.1.4 so that release uses the persisted values if present. I think this is optional though. Or maybe we port the whole change. 🤷‍♂️

## Does this introduce a breaking change?

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
> If there are no breaking changes, delete this section.

## Any relevant logs or outputs

> -   Use this section to provide either screenshots or output of logs as code snippets

## Other information or known dependencies

> -   Any other information or known dependencies that is important to this PR.
> -   Links to internal bug/work tracker items.
> -   TODO that are to be done after this PR.
