### PR TITLE
Remove assert in getting relayServiceSessionId in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -187,8 +187,6 @@ export class OdspDocumentService implements IDocumentService {
                     throw new Error("Disconnected while uploading summary (attempt to perform flush())");
                 },
                 () => {
-                    assert(this.relayServiceTenantAndSessionId !== undefined,
-                        0x37b /* relayServiceTenantAndSessionId should be present */);
                     return this.relayServiceTenantAndSessionId;
                 },
                 this.mc.config.getNumber("Fluid.Driver.Odsp.snapshotFormatFetchType"),

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert, performance } from "@fluidframework/common-utils";
+import { performance } from "@fluidframework/common-utils";
 import {
     ChildLogger,
     IFluidErrorBase,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -93,7 +93,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
         private readonly hostPolicy: HostStoragePolicyInternal,
         private readonly epochTracker: EpochTracker,
         private readonly flushCallback: () => Promise<FlushResult>,
-        private readonly relayServiceTenantAndSessionId: () => string,
+        private readonly relayServiceTenantAndSessionId: () => string | undefined,
         private readonly snapshotFormatFetchType?: SnapshotFormatSupportType,
     ) {
         super(loggerToMonitoringContext(logger).config);

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -94,8 +94,13 @@ export class OdspSummaryUploadManager {
                 this.forceAccessTokenViaAuthorizationHeader,
             );
             headers["Content-Type"] = "application/json";
-            headers["If-Match"] = `fluid:sessionid=${
-                this.relayServiceTenantAndSessionId()}${parentHandle ? `;containerid=${parentHandle}` : ""}`;
+            const relayServiceTenantAndSessionId = this.relayServiceTenantAndSessionId();
+            // This would be undefined in case of summary is uploaded in detached container with attachment
+            // blobs flow where summary is uploaded without connecting to push.
+            if (relayServiceTenantAndSessionId !== undefined) {
+                headers["If-Match"] = `fluid:sessionid=${
+                    relayServiceTenantAndSessionId}${parentHandle ? `;containerid=${parentHandle}` : ""}`;
+            }
 
             const postBody = JSON.stringify(snapshot);
 

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -39,7 +39,7 @@ export class OdspSummaryUploadManager {
         logger: ITelemetryLogger,
         private readonly epochTracker: EpochTracker,
         private readonly forceAccessTokenViaAuthorizationHeader: boolean,
-        private readonly relayServiceTenantAndSessionId: () => string,
+        private readonly relayServiceTenantAndSessionId: () => string | undefined,
     ) {
         this.mc = loggerToMonitoringContext(logger);
     }


### PR DESCRIPTION
## Description

Remove assert in getting relayServiceSessionId in odsp driver as it could be undefined in case of detached container with attachment blobs flow where summary could be uploaded without connecting to push. This is just for mitigation as we may need to think of different fix.