### PR TITLE
[GC-stress] Updated CI config to run for ~90 minutes. There is a max 120 minutes limit for test to run.

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -20,10 +20,10 @@
             }
         },
         "gc_ci": {
-            "opRatePerMin": 240,
+            "opRatePerMin": 120,
             "progressIntervalMs": 5000,
             "numClients": 10,
-            "totalSendCount": 72000,
+            "totalSendCount": 10800,
             "inactiveTimeoutMs": [60000],
             "optionOverrides":{
                 "tinylicious":{


### PR DESCRIPTION
Note: This is for GC stress tests in a test/gc-stress branch.

With the current CI config, the test would run for 5 hours. However, there is a limit that the test can run for max 120 minutes and so, the test is timing out.