### PR TITLE
Rerun Publish Steps after Network Error 

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -27,7 +27,7 @@ parameters:
   type: string
   default:
 
-- name: maximumRetryIfNetworkError
+- name: maximumRetryAfterNetworkError
   type: number
   default: 3
 
@@ -106,51 +106,53 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          echo "Max : " $maximumRetryIfNetworkError
-          for i in $( seq 1 $maximumRetryIfNetworkError )
+
+          for i in $( seq 1 $maximumRetryAfterNetworkError )
           do
-            echo "i :" $i
-            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-            if grep -q "npm ERR!" "publish_log"
+          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+          if grep -q "npm ERR!" "publish_log"
+          then
+            if grep -q "network read ECONNRESET" "publish_log"
             then
-                if grep -q "network read ECONNRESET" "publish_log"
+              if ! $i -eq $maximumRetryAfterNetworkError
+              then
+                echo "Network Error Detected - Retry Process"
+                continue
+              else # 117
+                echo "Network Error Detected - Exit Process"
+                let t1+=1
+                exit $t1
+              fi # 117
+            else # 115
+              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+              then
+                let t1+=1
+              else # 125
+                echo Package has already been published.
+                local_f="${f}_local"
+                mv "$f" "$local_f"
+                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                npm pack $package_name
+                if cmp -s "$f" "$local_f"
                 then
-                  if ! $i -eq $maximumRetryIfNetworkError
-                  then
-                    echo "Network Error Detected"
-                    continue
-                  else
-                    echo "Final Network Error"
-                    exit $t1
-                  fi
-                else
-                  if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-                  then
-                    let t1+=1
-                  else
-                    echo Package has already been published.
-                    local_f="${f}_local"
-                    mv "$f" "$local_f"
-                    package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                    npm pack $package_name
-                    if cmp -s "$f" "$local_f"
-                    then
-                      echo Continuing as published package matches the current one that was attempting to be released.
-                    else
-                      echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                      let t1+=1
-                    fi
-                    rm "$f"
-                    mv "$local_f" "$f"
-                    exit $t1
-                  fi
-                fi
-            else
-              break
-            fi
-            rm publish_log
-          done
-        fi
+                  echo Continuing as published package matches the current one that was attempting to be released.
+                else # 134
+                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                  let t1+=1
+                fi # 134
+                rm "$f"
+                mv "$local_f" "$f"
+              fi # 125
+            fi # 115
+
+          else # 113
+            break
+          fi # 113
+          rm publish_log
+        fi # 108
       done
       rm ~/.npmrc
       exit $t1
+
+
+

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -95,12 +95,6 @@ steps:
         packages=*.tgz
         sorted=false
       fi
-
-      for testIdx in $( seq 1 $maximumRetryIfNetworkError )
-      do
-        echo "TESTIDX :" $testIdx
-      done
-
       for packageName in $packages
       do
         if [[ $sorted == true ]]; then
@@ -109,7 +103,6 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          echo "Max : " $maximumRetryIfNetworkError
           for i in $( seq 1 $maximumRetryIfNetworkError )
           do
             echo "i :" $i

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -106,7 +106,7 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          for i in {1..$maxIter}
+          for i in {1..$maximumRetryIfNetworkError}
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -106,12 +106,12 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          for i in {1..$maximumRetryIfNetworkError}
+          for i in $( seq 0 $maximumRetryIfNetworkError )
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then
                 if [ [grep -q "network read ECONNRESET" "publish_log"] && [! $i -eq $maximumRetryIfNetworkError] ]; then
-                  echo "Network Error"
+                  echo "Network Error Detected"
                   continue
                 else
                   if ! grep -q "You cannot publish over the previously published versions" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -27,7 +27,7 @@ parameters:
   type: string
   default:
 
-- name: maximumRetryAfterNetworkError
+- name: maximumRetryIfNetworkError
   type: number
   default: 3
 
@@ -106,53 +106,51 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-
-          for i in $( seq 1 $maximumRetryAfterNetworkError )
+          echo "Max : " $maximumRetryIfNetworkError
+          for i in $( seq 1 $maximumRetryIfNetworkError )
           do
-          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-          if grep -q "npm ERR!" "publish_log"
-          then
-            if grep -q "network read ECONNRESET" "publish_log"
+            echo "i :" $i
+            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+            if grep -q "npm ERR!" "publish_log"
             then
-              if ! $i -eq $maximumRetryAfterNetworkError
-              then
-                echo "Network Error Detected - Retry Process"
-                continue
-              else # 117
-                echo "Network Error Detected - Exit Process"
-                let t1+=1
-                exit $t1
-              fi # 117
-            else # 115
-              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-              then
-                let t1+=1
-              else # 125
-                echo Package has already been published.
-                local_f="${f}_local"
-                mv "$f" "$local_f"
-                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                npm pack $package_name
-                if cmp -s "$f" "$local_f"
+                if grep -q "network read ECONNRESET" "publish_log"
                 then
-                  echo Continuing as published package matches the current one that was attempting to be released.
-                else # 134
-                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                  let t1+=1
-                fi # 134
-                rm "$f"
-                mv "$local_f" "$f"
-              fi # 125
-            fi # 115
-
-          else # 113
-            break
-          fi # 113
-          rm publish_log
-        fi # 108
+                  if ! $i -eq $maximumRetryIfNetworkError
+                  then
+                    echo "Network Error Detected"
+                    continue
+                  else
+                    echo "Final Network Error"
+                    exit $t1
+                  fi
+                else
+                  if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+                  then
+                    let t1+=1
+                  else
+                    echo Package has already been published.
+                    local_f="${f}_local"
+                    mv "$f" "$local_f"
+                    package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                    npm pack $package_name
+                    if cmp -s "$f" "$local_f"
+                    then
+                      echo Continuing as published package matches the current one that was attempting to be released.
+                    else
+                      echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                      let t1+=1
+                    fi
+                    rm "$f"
+                    mv "$local_f" "$f"
+                    exit $t1
+                  fi
+                fi
+            else
+              break
+            fi
+            rm publish_log
+          done
+        fi
       done
       rm ~/.npmrc
       exit $t1
-
-
-

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -107,7 +107,6 @@ steps:
         fi
         if [[ $f != "" ]]; then
           for i in $( seq 0 $maximumRetryIfNetworkError )
-            echo "i :" $i
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -27,6 +27,10 @@ parameters:
   type: string
   default:
 
+- name: maximumRetryIfNetworkError
+  type: number
+  default: 3
+
 steps:
 - task: Bash@3
   displayName: Generate .npmrc for ${{ parameters.artifactPath }}
@@ -53,7 +57,6 @@ steps:
           echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
-
           echo Deleting @fluid-internal packages
           rm -f fluid-internal-*
           echo Deleting @fluid-msinternal packages
@@ -72,7 +75,6 @@ steps:
     workingFile: $(Pipeline.Workspace)/pack//${{ parameters.artifactPath }}/.npmrc
     customEndPoint: ${{ parameters.customEndPoint }}
 - task: Bash@3
-  retryCountOnTaskFailure: 3
   displayName: Publish Packages for ${{ parameters.artifactPath }}
   inputs:
     targetType: 'inline'
@@ -104,44 +106,40 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          checkVersion=${f##/*}
-          checkVersion=${checkVersion:2:-4}
-
-          if [[ $checkVersion == *"fluidframework"* ]]; then
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
-          else
-            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
-          fi
-
-          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
-          checkError=$(npm view $checkVersion)
-
-          if [[ "$checkError" == "" || "$checkError" =~ "npm ERR!" ]]; then
+          for i in {1..$maxIter}
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then
-                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-                then
-                  let t1+=1
+                if [ [grep -q "network read ECONNRESET" "publish_log"] && [! $i -eq $maximumRetryIfNetworkError] ]; then
+                  echo "Network Error"
+                  continue
                 else
-                  echo Package has already been published.
-                  local_f="${f}_local"
-                  mv "$f" "$local_f"
-                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                  npm pack $package_name
-                  if cmp -s "$f" "$local_f"
+                  if ! grep -q "You cannot publish over the previously published versions" "publish_log"
                   then
-                    echo Continuing as published package matches the current one that was attempting to be released.
-                  else
-                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
                     let t1+=1
+                  else
+                    echo Package has already been published.
+                    local_f="${f}_local"
+                    mv "$f" "$local_f"
+                    package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                    npm pack $package_name
+                    if cmp -s "$f" "$local_f"
+                    then
+                      echo Continuing as published package matches the current one that was attempting to be released.
+                    else
+                      echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                      let t1+=1
+                    fi
+                    rm "$f"
+                    mv "$local_f" "$f"
+                    exit $t1
                   fi
-                  rm "$f"
-                  mv "$local_f" "$f"
                 fi
+            else
+              break
             fi
-          fi
-          rm publish_log
+            rm publish_log
+          done
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -141,6 +141,14 @@ steps:
             fi
           fi
           rm publish_log
+
+          checkIfPublished=$(npm view $checkVersion)
+          if [[ $checkIfPublished != "" ]]; then
+            echo "Published"
+          else
+            echo "Not Published"
+          fi
+
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -107,6 +107,7 @@ steps:
         fi
         if [[ $f != "" ]]; then
           for i in $( seq 0 $maximumRetryIfNetworkError )
+            echo "i : " $i
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -72,6 +72,7 @@ steps:
     workingFile: $(Pipeline.Workspace)/pack//${{ parameters.artifactPath }}/.npmrc
     customEndPoint: ${{ parameters.customEndPoint }}
 - task: Bash@3
+  retryCountOnTaskFailure: 3
   displayName: Publish Packages for ${{ parameters.artifactPath }}
   inputs:
     targetType: 'inline'

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -98,6 +98,12 @@ steps:
         packages=*.tgz
         sorted=false
       fi
+
+      for testIdx in $( seq 1 $maximumRetryIfNetworkError )
+      do
+        echo "TESTIDX :" $testIdx
+      done
+
       for packageName in $packages
       do
         if [[ $sorted == true ]]; then
@@ -113,7 +119,7 @@ steps:
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then
-                if grep -q "network read ECONNRESET" "publish_log"
+                if grep -q "code ENOTFOUND" "publish_log"
                 then
                   if ! $i -eq $maximumRetryIfNetworkError
                   then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -106,7 +106,9 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          for i in $( seq 0 $maximumRetryIfNetworkError )
+          echo "Max : " $maximumRetryIfNetworkError
+          for i in $( seq 1 $maximumRetryIfNetworkError )
+          do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -115,7 +115,7 @@ steps:
           checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
           checkError=$(npm view $checkVersion)
 
-          if [[ "$checkError" = "" || "$checkError" =~ "npm ERR!" ]]; then
+          if [[ "$checkError" == "" || "$checkError" =~ "npm ERR!" ]]; then
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -116,6 +116,7 @@ steps:
                 if grep -q "network read ECONNRESET" "publish_log"
                 then
                   if ! $i -eq $maximumRetryIfNetworkError
+                  then
                     echo "Network Error Detected"
                     continue
                   else

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -103,28 +103,42 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-          if grep -q "npm ERR!" "publish_log"
-          then
-              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-              then
-                let t1+=1
-              else
-                echo Package has already been published.
-                local_f="${f}_local"
-                mv "$f" "$local_f"
-                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                npm pack $package_name
-                if cmp -s "$f" "$local_f"
+          checkVersion=${f##/*}
+          checkVersion=${checkVersion:2:-4}
+
+          if [[ $checkVersion == *"fluidframework"* ]]; then
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/1')
+          else
+            checkVersion=$(echo $checkVersion | sed 's/-/\/''/2')
+          fi
+
+          checkVersion=@$(echo $checkVersion | sed -E 's/-([0-9])/@\1/')
+          checkError=$(npm view $checkVersion)
+
+          if [[ "$checkError" = "" || "$checkError" =~ "npm ERR!" ]]; then
+            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+            if grep -q "npm ERR!" "publish_log"
+            then
+                if ! grep -q "You cannot publish over the previously published versions" "publish_log"
                 then
-                  echo Continuing as published package matches the current one that was attempting to be released.
-                else
-                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
                   let t1+=1
+                else
+                  echo Package has already been published.
+                  local_f="${f}_local"
+                  mv "$f" "$local_f"
+                  package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                  npm pack $package_name
+                  if cmp -s "$f" "$local_f"
+                  then
+                    echo Continuing as published package matches the current one that was attempting to be released.
+                  else
+                    echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                    let t1+=1
+                  fi
+                  rm "$f"
+                  mv "$local_f" "$f"
                 fi
-                rm "$f"
-                mv "$local_f" "$f"
-              fi
+            fi
           fi
           rm publish_log
         fi

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -107,7 +107,7 @@ steps:
         fi
         if [[ $f != "" ]]; then
           for i in $( seq 0 $maximumRetryIfNetworkError )
-            echo "i : " $i
+            echo "i :" $i
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -116,6 +116,8 @@ steps:
                   if ! $i -eq $maximumRetryIfNetworkError
                     echo "Network Error Detected"
                     continue
+                  else
+                    exit $t1
                   fi
                 else
                   if ! grep -q "You cannot publish over the previously published versions" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -141,14 +141,6 @@ steps:
             fi
           fi
           rm publish_log
-
-          checkIfPublished=$(npm view $checkVersion)
-          if [[ $checkIfPublished != "" ]]; then
-            echo "Published"
-          else
-            echo "Not Published"
-          fi
-
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -116,7 +116,6 @@ steps:
                 if grep -q "network read ECONNRESET" "publish_log"
                 then
                   if ! $i -eq $maximumRetryIfNetworkError
-                  then
                     echo "Network Error Detected"
                     continue
                   else

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -109,6 +109,7 @@ steps:
           echo "Max : " $maximumRetryIfNetworkError
           for i in $( seq 1 $maximumRetryIfNetworkError )
           do
+            echo "i :" $i
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then
@@ -118,6 +119,7 @@ steps:
                     echo "Network Error Detected"
                     continue
                   else
+                    echo "Final Network Error"
                     exit $t1
                   fi
                 else

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -27,10 +27,6 @@ parameters:
   type: string
   default:
 
-- name: maximumRetryIfNetworkError
-  type: number
-  default: 3
-
 steps:
 - task: Bash@3
   displayName: Generate .npmrc for ${{ parameters.artifactPath }}
@@ -91,6 +87,7 @@ steps:
       echo Tag: $tag
       cp .npmrc ~/.npmrc
       t1=0
+      maximumRetryIfNetworkError=3
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
         sorted=true

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,9 +111,12 @@ steps:
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then
-                if [ [grep -q "network read ECONNRESET" "publish_log"] && [! $i -eq $maximumRetryIfNetworkError] ]; then
-                  echo "Network Error Detected"
-                  continue
+                if grep -q "network read ECONNRESET" "publish_log"
+                then
+                  if ! $i -eq $maximumRetryIfNetworkError
+                    echo "Network Error Detected"
+                    continue
+                  fi
                 else
                   if ! grep -q "You cannot publish over the previously published versions" "publish_log"
                   then


### PR DESCRIPTION
### Description

665: Ability to Rerun Publish Step If There Are Any Network Error https://dev.azure.com/fluidframework/internal/_workitems/edit/665/

### Approach

1. `include-publish-npm-package-steps.yml` in `tools/pipelines/templates` directory publishes the package in topological order using the `lerna` library.
2. `packagePublishOrder.txt` is generated inside the `Pipeline.Workspace` and the list of the topologically sorted packages are iterated for publish
3. When iterating through the loop, string variable `checkVersion` extracts the name of the `.tgz` file and goes through conversions listed below  
- `***` are masked within the pipeline
- remove the first two characters `./` using string slicing 
- if `fluidframework`, then change the first `-` to `/`, otherwise change the second `-` to `/`
- change the last `-` before the first digit to `@`
- add `@` at the beginning and remove the extension `.tgz`
- e.g.: 
- `***framework-tinylicious-client-0.0.0-96564-test.tgz` -> `@fluidframework-tinylicious/client@0.0.0-96564-test`
- `***-tools-***app-odsp-urlresolver-0.0.0-96564-test.tgz` -> `@fluid-tools-fluidapp-odsp-urlresolver-0.0.0-96564-test`

4. Use `npm view $checkVersion` to check whether the package with the specified version number exists in the npm registry
5. If error is detected or empty result is returned after the command, package is subject to publish, otherwise does not need to go through the remaining steps

### Test

- The code below checks if the package was successfully published after the `npm publish`, and it consoles the expected output `Published`

```
checkIfPublished=$(npm view $checkVersion)
if [[ $checkIfPublished != "" ]]; then
  echo "Published"
else
  echo "Not Published"
fi
```

