### PR TITLE
Add IRootDataObject interface

### DIFF
--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -40,7 +40,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
-    constructor(container: IContainer, rootDataObject: RootDataObject);
+    constructor(container: IContainer, rootDataObject: IRootDataObject);
     attach(): Promise<string>;
     get attachState(): AttachState;
     connect(): Promise<void>;
@@ -87,6 +87,12 @@ export interface IMember {
 }
 
 // @public
+export interface IRootDataObject {
+    create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
+    readonly initialObjects: LoadableObjectRecord;
+}
+
+// @public
 export interface IServiceAudience<M extends IMember> extends IEventProvider<IServiceAudienceEvents<M>> {
     getMembers(): Map<string, M>;
     getMyself(): M | undefined;
@@ -120,7 +126,7 @@ export type MemberChangedListener<M extends IMember> = (clientId: string, member
 // @public
 export class RootDataObject extends DataObject<{
     InitialState: RootDataObjectProps;
-}> {
+}> implements IRootDataObject {
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
     protected hasInitialized(): Promise<void>;
     protected initializingFirstTime(props: RootDataObjectProps): Promise<void>;

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -11,8 +11,7 @@ import {
     ICriticalContainerError,
     ConnectionState,
 } from "@fluidframework/container-definitions";
-import { LoadableObjectClass, LoadableObjectRecord } from "./types";
-import { RootDataObject } from "./rootDataObject";
+import type { IRootDataObject, LoadableObjectClass, LoadableObjectRecord } from "./types";
 
 /**
  * Events emitted from {@link IFluidContainer}.
@@ -223,7 +222,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
 
     public constructor(
         private readonly container: IContainer,
-        private readonly rootDataObject: RootDataObject,
+        private readonly rootDataObject: IRootDataObject,
     ) {
         super();
         container.on("connected", this.connectedHandler);

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -15,6 +15,7 @@ import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ContainerSchema,
     DataObjectClass,
+    IRootDataObject,
     LoadableObjectClass,
     LoadableObjectClassRecord,
     LoadableObjectRecord,
@@ -38,7 +39,7 @@ export interface RootDataObjectProps {
  * The entry-point/root collaborative object of the {@link IFluidContainer | Fluid Container}.
  * Abstracts the dynamic code required to build a Fluid Container into a static representation for end customers.
  */
-export class RootDataObject extends DataObject<{ InitialState: RootDataObjectProps; }> {
+export class RootDataObject extends DataObject<{ InitialState: RootDataObjectProps; }> implements IRootDataObject {
     private readonly initialObjectsDirKey = "initial-objects-key";
     private readonly _initialObjects: LoadableObjectRecord = {};
 
@@ -93,9 +94,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
     }
 
     /**
-     * Provides a record of the initial objects defined on creation.
-     *
-     * @see {@link RootDataObject.initializingFirstTime}
+     * {@inheritDoc IRootDataObject.initialObjects}
      */
     public get initialObjects(): LoadableObjectRecord {
         if (Object.keys(this._initialObjects).length === 0) {
@@ -105,11 +104,7 @@ export class RootDataObject extends DataObject<{ InitialState: RootDataObjectPro
     }
 
     /**
-     * Dynamically creates a new detached collaborative object (DDS/DataObject).
-     *
-     * @param objectClass - Type of the collaborative object to be created.
-     *
-     * @typeParam T - The class of the `DataObject` or `SharedObject`.
+     * {@inheritDoc IRootDataObject.create}
      */
     public async create<T extends IFluidLoadable>(
         objectClass: LoadableObjectClass<T>,

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -94,6 +94,26 @@ export interface ContainerSchema {
 }
 
 /**
+ * Holds the collection of objects that the container was initially created with, as well as provides the ability
+ * to dynamically create further objects during usage.
+ */
+export interface IRootDataObject {
+    /**
+     * Provides a record of the initial objects defined on creation.
+     */
+    readonly initialObjects: LoadableObjectRecord;
+
+    /**
+     * Dynamically creates a new detached collaborative object (DDS/DataObject).
+     *
+     * @param objectClass - Type of the collaborative object to be created.
+     *
+     * @typeParam T - The class of the `DataObject` or `SharedObject`.
+     */
+    create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
+}
+
+/**
  * Signature for {@link IMember} change events.
  *
  * @param clientId - A unique identifier for the client.

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -25,7 +25,7 @@ import {
     DOProviderContainerRuntimeFactory,
     FluidContainer,
     IFluidContainer,
-    RootDataObject,
+    IRootDataObject,
 } from "@fluidframework/fluid-static";
 import {
     TinyliciousClientProps,
@@ -75,7 +75,7 @@ export class TinyliciousClient {
             config: {},
         });
 
-        const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
+        const rootDataObject = await requestFluidObject<IRootDataObject>(container, "/");
 
         /**
          * See {@link FluidContainer.attach}
@@ -110,7 +110,7 @@ export class TinyliciousClient {
     ): Promise<{ container: IFluidContainer; services: TinyliciousContainerServices; }> {
         const loader = this.createLoader(containerSchema);
         const container = await loader.resolve({ url: id });
-        const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
+        const rootDataObject = await requestFluidObject<IRootDataObject>(container, "/");
         const fluidContainer = new FluidContainer(container, rootDataObject);
         const services = this.getContainerServices(container);
         return { container: fluidContainer, services };


### PR DESCRIPTION
Small change to put an interface on the RootDataObject.  As a result, FluidContainer and TinyliciousClient can just reference the interface rather than the class directly.