### PR TITLE
Updated CI config to run for ~60 mins

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -23,7 +23,7 @@
             "opRatePerMin": 120,
             "progressIntervalMs": 5000,
             "numClients": 10,
-            "totalSendCount": 10800,
+            "totalSendCount": 7200,
             "inactiveTimeoutMs": [60000],
             "optionOverrides":{
                 "tinylicious":{


### PR DESCRIPTION
90 minutes was really close to 120 mins since there is overhead that adds to the test time. 