### PR TITLE
[main > lts]: Accept both json and binary in trees latest stress test (#11443)

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -18,7 +18,7 @@
                 },
                 "odsp-odsp-df":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [0, 1],
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
                         "Fluid.Container.summarizeProtocolTree": [true, false]
                     }
                 }
@@ -102,7 +102,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [1]
+                        "Fluid.Driver.Odsp.snapshotFormatFetchType": [2]
                     }
                 }
             }


### PR DESCRIPTION
## Description

Accept both json and binary in trees latest stress test and let the server decide what to give.
