### PR TITLE
Change `build-tools` to named exports

### DIFF
--- a/build-tools/packages/build-cli/src/commands/merge/branches.ts
+++ b/build-tools/packages/build-cli/src/commands/merge/branches.ts
@@ -5,7 +5,7 @@
 import { Flags } from "@oclif/core";
 
 import { BaseCommand } from "../../base";
-import { createPullRequest, getUserAccess, pullRequestExists, pullRequestInfo } from "../../lib";
+import { github } from "../../lib";
 
 /**
  * This command class is used to merge two branches based on the batch size provided.
@@ -49,7 +49,7 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
 
         const context = await this.getContext();
         const gitRepo = context.gitRepo;
-        const prExists: boolean = await pullRequestExists(flags.auth, this.logger);
+        const prExists: boolean = await github.pullRequestExists(flags.auth, this.logger);
 
         if (prExists) {
             this.exit(-1);
@@ -136,13 +136,17 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
             await gitRepo.setUpstream(`${flags.source}-${flags.target}-${unmergedCommitList[0]}`);
             await gitRepo.resetBranch(unmergedCommitList[0]);
             // fetch name of owner associated to the pull request
-            const prInfo = await pullRequestInfo(flags.auth, unmergedCommitList[0], this.logger);
+            const prInfo = await github.pullRequestInfo(
+                flags.auth,
+                unmergedCommitList[0],
+                this.logger,
+            );
             this.info(
                 `Fetch pull request info for single commit id ${unmergedCommitList[0]} and assignee ${prInfo.data[0].assignee.login}`,
             );
-            const user = await getUserAccess(flags.auth, this.logger);
+            const user = await github.getUserAccess(flags.auth, this.logger);
             this.info(`List users with push access to main branch ${user}`);
-            prNumber = await createPullRequest(
+            prNumber = await github.createPullRequest(
                 flags.auth,
                 `${flags.source}-${flags.target}-${unmergedCommitList[0]}`,
                 flags.target,
@@ -154,7 +158,7 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
             );
         } else {
             // fetch name of owner associated to the pull request
-            const prInfo = await pullRequestInfo(
+            const prInfo = await github.pullRequestInfo(
                 flags.auth,
                 unmergedCommitList[commit],
                 this.logger,
@@ -162,9 +166,9 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
             this.info(
                 `Fetch pull request info for bulk commit ids till ${unmergedCommitList[commit]} and assignee ${prInfo.data[0].assignee.login}`,
             );
-            const user = await getUserAccess(flags.auth, this.logger);
+            const user = await github.getUserAccess(flags.auth, this.logger);
             this.info(`List users with push access to main branch ${user}`);
-            prNumber = await createPullRequest(
+            prNumber = await github.createPullRequest(
                 flags.auth,
                 branchName,
                 flags.target,

--- a/build-tools/packages/build-cli/src/commands/merge/branches.ts
+++ b/build-tools/packages/build-cli/src/commands/merge/branches.ts
@@ -5,7 +5,7 @@
 import { Flags } from "@oclif/core";
 
 import { BaseCommand } from "../../base";
-import { github } from "../../lib";
+import { createPullRequest, getUserAccess, pullRequestExists, pullRequestInfo } from "../../lib";
 
 /**
  * This command class is used to merge two branches based on the batch size provided.
@@ -49,7 +49,7 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
 
         const context = await this.getContext();
         const gitRepo = context.gitRepo;
-        const prExists: boolean = await github.pullRequestExists(flags.auth, this.logger);
+        const prExists: boolean = await pullRequestExists(flags.auth, this.logger);
 
         if (prExists) {
             this.exit(-1);
@@ -136,17 +136,13 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
             await gitRepo.setUpstream(`${flags.source}-${flags.target}-${unmergedCommitList[0]}`);
             await gitRepo.resetBranch(unmergedCommitList[0]);
             // fetch name of owner associated to the pull request
-            const prInfo = await github.pullRequestInfo(
-                flags.auth,
-                unmergedCommitList[0],
-                this.logger,
-            );
+            const prInfo = await pullRequestInfo(flags.auth, unmergedCommitList[0], this.logger);
             this.info(
                 `Fetch pull request info for single commit id ${unmergedCommitList[0]} and assignee ${prInfo.data[0].assignee.login}`,
             );
-            const user = await github.getUserAccess(flags.auth, this.logger);
+            const user = await getUserAccess(flags.auth, this.logger);
             this.info(`List users with push access to main branch ${user}`);
-            prNumber = await github.createPullRequest(
+            prNumber = await createPullRequest(
                 flags.auth,
                 `${flags.source}-${flags.target}-${unmergedCommitList[0]}`,
                 flags.target,
@@ -158,7 +154,7 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
             );
         } else {
             // fetch name of owner associated to the pull request
-            const prInfo = await github.pullRequestInfo(
+            const prInfo = await pullRequestInfo(
                 flags.auth,
                 unmergedCommitList[commit],
                 this.logger,
@@ -166,9 +162,9 @@ export default class MergeBranch extends BaseCommand<typeof MergeBranch.flags> {
             this.info(
                 `Fetch pull request info for bulk commit ids till ${unmergedCommitList[commit]} and assignee ${prInfo.data[0].assignee.login}`,
             );
-            const user = await github.getUserAccess(flags.auth, this.logger);
+            const user = await getUserAccess(flags.auth, this.logger);
             this.info(`List users with push access to main branch ${user}`);
-            prNumber = await github.createPullRequest(
+            prNumber = await createPullRequest(
                 flags.auth,
                 branchName,
                 flags.target,

--- a/build-tools/packages/build-cli/src/lib/index.ts
+++ b/build-tools/packages/build-cli/src/lib/index.ts
@@ -35,4 +35,4 @@ export {
 } from "./package";
 export { difference } from "./sets";
 export { getIndent, indentString } from "./text";
-export * as github from "./github";
+export { createPullRequest, getUserAccess, pullRequestExists, pullRequestInfo } from "./github";

--- a/build-tools/packages/build-cli/src/lib/index.ts
+++ b/build-tools/packages/build-cli/src/lib/index.ts
@@ -35,4 +35,4 @@ export {
 } from "./package";
 export { difference } from "./sets";
 export { getIndent, indentString } from "./text";
-export { createPullRequest, getUserAccess, pullRequestExists, pullRequestInfo } from "./github";
+export * as github from "./github";

--- a/build-tools/packages/bundle-size-tools/src/ADO/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/index.ts
@@ -3,15 +3,24 @@
  * Licensed under the MIT License.
  */
 
-export * from "./AdoArtifactFileProvider";
-export * from "./AdoSizeComparator";
-export * from "./Constants";
-export * from "./DefaultStatsProcessors";
-export * from "./FileSystemBundleFileProvider";
-export * from "./getAzureDevopsApi";
-export * from "./getBuildTagForCommit";
-export * from "./getBundleBuddyConfigMap";
-export * from "./getBundleFilePathsFromFolder";
-export * from "./getBundleSummaries";
-export * from "./getCommentForBundleDiff";
-export * from "./PrCommentsUtils";
+export {
+    getBundleBuddyConfigFileFromZip,
+    getBundlePathsFromZipObject,
+    getStatsFileFromZip,
+    getZipObjectFromArtifact,
+} from "./AdoArtifactFileProvider";
+export { ADOSizeComparator } from "./AdoSizeComparator";
+export { IADOConstants, totalSizeMetricName } from "./Constants";
+export { DefaultStatsProcessors } from "./DefaultStatsProcessors";
+export {
+    getBundleBuddyConfigFromFileSystem,
+    getBundlePathsFromFileSystem,
+    getStatsFileFromFileSystem,
+} from "./FileSystemBundleFileProvider";
+export { getAzureDevopsApi } from "./getAzureDevopsApi";
+export { getBuildTagForCommit } from "./getBuildTagForCommit";
+export { getBundleBuddyConfigMap, GetBundleBuddyConfigMapArgs } from "./getBundleBuddyConfigMap";
+export { BundleFileData, getBundleFilePathsFromFolder } from "./getBundleFilePathsFromFolder";
+export { getBundleSummaries, GetBundleSummariesArgs } from "./getBundleSummaries";
+export { getCommentForBundleDiff, getSimpleComment } from "./getCommentForBundleDiff";
+export { prCommentsUtils } from "./PrCommentsUtils";

--- a/build-tools/packages/bundle-size-tools/src/ADO/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/index.ts
@@ -3,15 +3,24 @@
  * Licensed under the MIT License.
  */
 
-export * from "./AdoArtifactFileProvider";
-export * from "./AdoSizeComparator";
-export * from "./Constants";
-export * from "./DefaultStatsProcessors";
-export * from "./FileSystemBundleFileProvider";
-export * from "./getAzureDevopsApi";
-export * from "./getBuildTagForCommit";
-export * from "./getBundleBuddyConfigMap";
-export * from "./getBundleFilePathsFromFolder";
-export * from "./getBundleSummaries";
-export * from "./getCommentForBundleDiff";
-export * from "./PrCommentsUtils";
+export {
+    getBundleBuddyConfigFileFromZip,
+    getBundlePathsFromZipObject,
+    getStatsFileFromZip,
+    getZipObjectFromArtifact,
+} from "./AdoArtifactFileProvider";
+export { ADOSizeComparator } from "./AdoSizeComparator";
+export { IADOConstants, totalSizeMetricName } from "./Constants";
+export { DefaultStatsProcessors } from "./DefaultStatsProcessors";
+export {
+    getBundleBuddyConfigFromFileSystem,
+    getBundlePathsFromFileSystem,
+    getStatsFileFromFileSystem,
+} from "./FileSystemBundleFileProvider";
+export { getAzureDevopsApi } from "./getAzureDevopsApi";
+export { getBuildTagForCommit } from "./getBuildTagForCommit";
+export { GetBundleBuddyConfigMapArgs, getBundleBuddyConfigMap } from "./getBundleBuddyConfigMap";
+export { BundleFileData, getBundleFilePathsFromFolder } from "./getBundleFilePathsFromFolder";
+export { GetBundleSummariesArgs, getBundleSummaries } from "./getBundleSummaries";
+export { getCommentForBundleDiff, getSimpleComment } from "./getCommentForBundleDiff";
+export { prCommentsUtils } from "./PrCommentsUtils";

--- a/build-tools/packages/bundle-size-tools/src/ADO/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/index.ts
@@ -3,24 +3,15 @@
  * Licensed under the MIT License.
  */
 
-export {
-    getBundleBuddyConfigFileFromZip,
-    getBundlePathsFromZipObject,
-    getStatsFileFromZip,
-    getZipObjectFromArtifact,
-} from "./AdoArtifactFileProvider";
-export { ADOSizeComparator } from "./AdoSizeComparator";
-export { IADOConstants, totalSizeMetricName } from "./Constants";
-export { DefaultStatsProcessors } from "./DefaultStatsProcessors";
-export {
-    getBundleBuddyConfigFromFileSystem,
-    getBundlePathsFromFileSystem,
-    getStatsFileFromFileSystem,
-} from "./FileSystemBundleFileProvider";
-export { getAzureDevopsApi } from "./getAzureDevopsApi";
-export { getBuildTagForCommit } from "./getBuildTagForCommit";
-export { GetBundleBuddyConfigMapArgs, getBundleBuddyConfigMap } from "./getBundleBuddyConfigMap";
-export { BundleFileData, getBundleFilePathsFromFolder } from "./getBundleFilePathsFromFolder";
-export { GetBundleSummariesArgs, getBundleSummaries } from "./getBundleSummaries";
-export { getCommentForBundleDiff, getSimpleComment } from "./getCommentForBundleDiff";
-export { prCommentsUtils } from "./PrCommentsUtils";
+export * from "./AdoArtifactFileProvider";
+export * from "./AdoSizeComparator";
+export * from "./Constants";
+export * from "./DefaultStatsProcessors";
+export * from "./FileSystemBundleFileProvider";
+export * from "./getAzureDevopsApi";
+export * from "./getBuildTagForCommit";
+export * from "./getBundleBuddyConfigMap";
+export * from "./getBundleFilePathsFromFolder";
+export * from "./getBundleSummaries";
+export * from "./getCommentForBundleDiff";
+export * from "./PrCommentsUtils";

--- a/build-tools/packages/bundle-size-tools/src/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/index.ts
@@ -3,69 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export {
-    ADOSizeComparator,
-    BundleFileData,
-    DefaultStatsProcessors,
-    GetBundleBuddyConfigMapArgs,
-    GetBundleSummariesArgs,
-    IADOConstants,
-    getAzureDevopsApi,
-    getBuildTagForCommit,
-    getBundleBuddyConfigFileFromZip,
-    getBundleBuddyConfigFromFileSystem,
-    getBundleBuddyConfigMap,
-    getBundleFilePathsFromFolder,
-    getBundlePathsFromFileSystem,
-    getBundlePathsFromZipObject,
-    getBundleSummaries,
-    getCommentForBundleDiff,
-    getSimpleComment,
-    getStatsFileFromFileSystem,
-    getStatsFileFromZip,
-    getZipObjectFromArtifact,
-    prCommentsUtils,
-    totalSizeMetricName,
-} from "./ADO";
-export {
-    BannedModule,
-    BannedModulesPlugin,
-    BannedModulesPluginOptions,
-} from "./bannedModulesPlugin/bannedModulesPlugin";
-export {
-    BundleBuddyConfig,
-    BundleComparison,
-    BundleComparisonResult,
-    BundleMetric,
-    BundleMetricSet,
-    BundleSummaries,
-    ChunkToAnalyze,
-    WebpackStatsProcessor,
-} from "./BundleBuddyTypes";
-export {
-    BundleBuddyConfigWebpackPlugin,
-    BundleBuddyPluginConfig,
-} from "./BundleBuddyConfigWebpackPlugin";
-export { bundlesContainNoChanges, compareBundles } from "./compareBundles";
-export {
-    BundleBuddyConfigProcessorOptions,
-    EntryStatsProcessorOptions,
-    TotalSizeStatsProcessorOptions,
-    getBundleBuddyConfigProcessor,
-    getEntryStatsProcessor,
-    getTotalSizeStatsProcessor,
-} from "./statsProcessors";
-export {
-    AggregatedChunkAnalysis,
-    ChunkSizeInfo,
-    GetBuildOptions,
-    decompressStatsFile,
-    getAllFilesInDirectory,
-    getBaselineCommit,
-    getBuilds,
-    getChunkAndDependencySizes,
-    getChunkParsedSize,
-    getLastCommitHashFromPR,
-    getPriorCommit,
-    unzipStream,
-} from "./utilities";
+export * from "./ADO";
+export * from "./bannedModulesPlugin/bannedModulesPlugin";
+export * from "./BundleBuddyTypes";
+export * from "./BundleBuddyConfigWebpackPlugin";
+export * from "./compareBundles";
+export * from "./statsProcessors";
+export * from "./utilities";

--- a/build-tools/packages/bundle-size-tools/src/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/index.ts
@@ -3,10 +3,69 @@
  * Licensed under the MIT License.
  */
 
-export * from "./ADO";
-export * from "./bannedModulesPlugin/bannedModulesPlugin";
-export * from "./BundleBuddyTypes";
-export * from "./BundleBuddyConfigWebpackPlugin";
-export * from "./compareBundles";
-export * from "./statsProcessors";
-export * from "./utilities";
+export {
+    ADOSizeComparator,
+    BundleFileData,
+    DefaultStatsProcessors,
+    GetBundleBuddyConfigMapArgs,
+    GetBundleSummariesArgs,
+    IADOConstants,
+    getAzureDevopsApi,
+    getBuildTagForCommit,
+    getBundleBuddyConfigFileFromZip,
+    getBundleBuddyConfigFromFileSystem,
+    getBundleBuddyConfigMap,
+    getBundleFilePathsFromFolder,
+    getBundlePathsFromFileSystem,
+    getBundlePathsFromZipObject,
+    getBundleSummaries,
+    getCommentForBundleDiff,
+    getSimpleComment,
+    getStatsFileFromFileSystem,
+    getStatsFileFromZip,
+    getZipObjectFromArtifact,
+    prCommentsUtils,
+    totalSizeMetricName,
+} from "./ADO";
+export {
+    BannedModule,
+    BannedModulesPlugin,
+    BannedModulesPluginOptions,
+} from "./bannedModulesPlugin/bannedModulesPlugin";
+export {
+    BundleBuddyConfig,
+    BundleComparison,
+    BundleComparisonResult,
+    BundleMetric,
+    BundleMetricSet,
+    BundleSummaries,
+    ChunkToAnalyze,
+    WebpackStatsProcessor,
+} from "./BundleBuddyTypes";
+export {
+    BundleBuddyConfigWebpackPlugin,
+    BundleBuddyPluginConfig,
+} from "./BundleBuddyConfigWebpackPlugin";
+export { bundlesContainNoChanges, compareBundles } from "./compareBundles";
+export {
+    BundleBuddyConfigProcessorOptions,
+    EntryStatsProcessorOptions,
+    TotalSizeStatsProcessorOptions,
+    getBundleBuddyConfigProcessor,
+    getEntryStatsProcessor,
+    getTotalSizeStatsProcessor,
+} from "./statsProcessors";
+export {
+    AggregatedChunkAnalysis,
+    ChunkSizeInfo,
+    GetBuildOptions,
+    decompressStatsFile,
+    getAllFilesInDirectory,
+    getBaselineCommit,
+    getBuilds,
+    getChunkAndDependencySizes,
+    getChunkParsedSize,
+    getLastCommitHashFromPR,
+    getPriorCommit,
+    unzipStream,
+} from "./utilities";

--- a/build-tools/packages/bundle-size-tools/src/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/index.ts
@@ -33,6 +33,10 @@ export {
     BannedModulesPluginOptions,
 } from "./bannedModulesPlugin/bannedModulesPlugin";
 export {
+    BundleBuddyConfigWebpackPlugin,
+    BundleBuddyPluginConfig,
+} from "./BundleBuddyConfigWebpackPlugin";
+export {
     BundleBuddyConfig,
     BundleComparison,
     BundleComparisonResult,
@@ -42,10 +46,6 @@ export {
     ChunkToAnalyze,
     WebpackStatsProcessor,
 } from "./BundleBuddyTypes";
-export {
-    BundleBuddyConfigWebpackPlugin,
-    BundleBuddyPluginConfig,
-} from "./BundleBuddyConfigWebpackPlugin";
 export { bundlesContainNoChanges, compareBundles } from "./compareBundles";
 export {
     BundleBuddyConfigProcessorOptions,

--- a/build-tools/packages/bundle-size-tools/src/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/index.ts
@@ -3,10 +3,69 @@
  * Licensed under the MIT License.
  */
 
-export * from "./ADO";
-export * from "./bannedModulesPlugin/bannedModulesPlugin";
-export * from "./BundleBuddyTypes";
-export * from "./BundleBuddyConfigWebpackPlugin";
-export * from "./compareBundles";
-export * from "./statsProcessors";
-export * from "./utilities";
+export {
+    ADOSizeComparator,
+    BundleFileData,
+    DefaultStatsProcessors,
+    getAzureDevopsApi,
+    getBuildTagForCommit,
+    getBundleBuddyConfigFileFromZip,
+    getBundleBuddyConfigFromFileSystem,
+    getBundleBuddyConfigMap,
+    GetBundleBuddyConfigMapArgs,
+    getBundleFilePathsFromFolder,
+    getBundlePathsFromFileSystem,
+    getBundlePathsFromZipObject,
+    getBundleSummaries,
+    GetBundleSummariesArgs,
+    getCommentForBundleDiff,
+    getSimpleComment,
+    getStatsFileFromFileSystem,
+    getStatsFileFromZip,
+    getZipObjectFromArtifact,
+    IADOConstants,
+    prCommentsUtils,
+    totalSizeMetricName,
+} from "./ADO";
+export {
+    BannedModule,
+    BannedModulesPlugin,
+    BannedModulesPluginOptions,
+} from "./bannedModulesPlugin/bannedModulesPlugin";
+export {
+    BundleBuddyConfig,
+    BundleComparison,
+    BundleComparisonResult,
+    BundleMetric,
+    BundleMetricSet,
+    BundleSummaries,
+    ChunkToAnalyze,
+    WebpackStatsProcessor,
+} from "./BundleBuddyTypes";
+export {
+    BundleBuddyConfigWebpackPlugin,
+    BundleBuddyPluginConfig,
+} from "./BundleBuddyConfigWebpackPlugin";
+export { bundlesContainNoChanges, compareBundles } from "./compareBundles";
+export {
+    BundleBuddyConfigProcessorOptions,
+    EntryStatsProcessorOptions,
+    getBundleBuddyConfigProcessor,
+    getEntryStatsProcessor,
+    getTotalSizeStatsProcessor,
+    TotalSizeStatsProcessorOptions,
+} from "./statsProcessors";
+export {
+    AggregatedChunkAnalysis,
+    ChunkSizeInfo,
+    decompressStatsFile,
+    getAllFilesInDirectory,
+    getBaselineCommit,
+    GetBuildOptions,
+    getBuilds,
+    getChunkAndDependencySizes,
+    getChunkParsedSize,
+    getLastCommitHashFromPR,
+    getPriorCommit,
+    unzipStream,
+} from "./utilities";

--- a/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
@@ -3,12 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export {
-    BundleBuddyConfigProcessorOptions,
-    getBundleBuddyConfigProcessor,
-} from "./bundleBuddyConfigProcessor";
+export { BundleBuddyConfigProcessorOptions, getBundleBuddyConfigProcessor } from "./bundleBuddyConfigProcessor";
 export { EntryStatsProcessorOptions, getEntryStatsProcessor } from "./entryStatsProcessor";
-export {
-    getTotalSizeStatsProcessor,
-    TotalSizeStatsProcessorOptions,
-} from "./totalSizeStatsProcessor";
+export { getTotalSizeStatsProcessor, TotalSizeStatsProcessorOptions } from "./totalSizeStatsProcessor";

--- a/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export { BundleBuddyConfigProcessorOptions, getBundleBuddyConfigProcessor } from "./bundleBuddyConfigProcessor";
-export { EntryStatsProcessorOptions, getEntryStatsProcessor } from "./entryStatsProcessor";
-export { getTotalSizeStatsProcessor, TotalSizeStatsProcessorOptions } from "./totalSizeStatsProcessor";
+export * from "./bundleBuddyConfigProcessor";
+export * from "./entryStatsProcessor";
+export * from "./totalSizeStatsProcessor";

--- a/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export * from "./bundleBuddyConfigProcessor";
-export * from "./entryStatsProcessor";
-export * from "./totalSizeStatsProcessor";
+export {
+    BundleBuddyConfigProcessorOptions,
+    getBundleBuddyConfigProcessor,
+} from "./bundleBuddyConfigProcessor";
+export { EntryStatsProcessorOptions, getEntryStatsProcessor } from "./entryStatsProcessor";
+export {
+    getTotalSizeStatsProcessor,
+    TotalSizeStatsProcessorOptions,
+} from "./totalSizeStatsProcessor";

--- a/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export { BundleBuddyConfigProcessorOptions, getBundleBuddyConfigProcessor } from "./bundleBuddyConfigProcessor";
+export {
+    BundleBuddyConfigProcessorOptions,
+    getBundleBuddyConfigProcessor,
+} from "./bundleBuddyConfigProcessor";
 export { EntryStatsProcessorOptions, getEntryStatsProcessor } from "./entryStatsProcessor";
-export { getTotalSizeStatsProcessor, TotalSizeStatsProcessorOptions } from "./totalSizeStatsProcessor";
+export {
+    getTotalSizeStatsProcessor,
+    TotalSizeStatsProcessorOptions,
+} from "./totalSizeStatsProcessor";

--- a/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/statsProcessors/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./bundleBuddyConfigProcessor";
-export * from "./entryStatsProcessor";
-export * from "./totalSizeStatsProcessor";
+export { BundleBuddyConfigProcessorOptions, getBundleBuddyConfigProcessor } from "./bundleBuddyConfigProcessor";
+export { EntryStatsProcessorOptions, getEntryStatsProcessor } from "./entryStatsProcessor";
+export { getTotalSizeStatsProcessor, TotalSizeStatsProcessorOptions } from "./totalSizeStatsProcessor";

--- a/build-tools/packages/bundle-size-tools/src/utilities/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/utilities/index.ts
@@ -6,7 +6,11 @@
 export { decompressStatsFile } from "./decompressStatsFile";
 export { getAllFilesInDirectory } from "./getAllFilesInDirectory";
 export { GetBuildOptions, getBuilds } from "./getBuilds";
-export { AggregatedChunkAnalysis, ChunkSizeInfo, getChunkAndDependencySizes } from "./getChunkAndDependenciesSizes";
+export {
+    AggregatedChunkAnalysis,
+    ChunkSizeInfo,
+    getChunkAndDependencySizes,
+} from "./getChunkAndDependenciesSizes";
 export { getChunkParsedSize } from "./getChunkParsedSize";
 export { getLastCommitHashFromPR } from "./getLastCommitHashFromPR";
 export { getBaselineCommit, getPriorCommit } from "./gitCommands";

--- a/build-tools/packages/bundle-size-tools/src/utilities/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/utilities/index.ts
@@ -3,11 +3,15 @@
  * Licensed under the MIT License.
  */
 
-export * from "./decompressStatsFile";
-export * from "./getAllFilesInDirectory";
-export * from "./getBuilds";
-export * from "./getChunkAndDependenciesSizes";
-export * from "./getChunkParsedSize";
-export * from "./getLastCommitHashFromPR";
-export * from "./gitCommands";
-export * from "./unzipStream";
+export { decompressStatsFile } from "./decompressStatsFile";
+export { getAllFilesInDirectory } from "./getAllFilesInDirectory";
+export { GetBuildOptions, getBuilds } from "./getBuilds";
+export {
+    AggregatedChunkAnalysis,
+    ChunkSizeInfo,
+    getChunkAndDependencySizes,
+} from "./getChunkAndDependenciesSizes";
+export { getChunkParsedSize } from "./getChunkParsedSize";
+export { getLastCommitHashFromPR } from "./getLastCommitHashFromPR";
+export { getBaselineCommit, getPriorCommit } from "./gitCommands";
+export { unzipStream } from "./unzipStream";

--- a/build-tools/packages/bundle-size-tools/src/utilities/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/utilities/index.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-export { decompressStatsFile } from "./decompressStatsFile";
-export { getAllFilesInDirectory } from "./getAllFilesInDirectory";
-export { GetBuildOptions, getBuilds } from "./getBuilds";
-export { AggregatedChunkAnalysis, ChunkSizeInfo, getChunkAndDependencySizes } from "./getChunkAndDependenciesSizes";
-export { getChunkParsedSize } from "./getChunkParsedSize";
-export { getLastCommitHashFromPR } from "./getLastCommitHashFromPR";
-export { getBaselineCommit, getPriorCommit } from "./gitCommands";
-export { unzipStream } from "./unzipStream";
+export * from "./decompressStatsFile";
+export * from "./getAllFilesInDirectory";
+export * from "./getBuilds";
+export * from "./getChunkAndDependenciesSizes";
+export * from "./getChunkParsedSize";
+export * from "./getLastCommitHashFromPR";
+export * from "./gitCommands";
+export * from "./unzipStream";

--- a/build-tools/packages/bundle-size-tools/src/utilities/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/utilities/index.ts
@@ -6,11 +6,7 @@
 export { decompressStatsFile } from "./decompressStatsFile";
 export { getAllFilesInDirectory } from "./getAllFilesInDirectory";
 export { GetBuildOptions, getBuilds } from "./getBuilds";
-export {
-    AggregatedChunkAnalysis,
-    ChunkSizeInfo,
-    getChunkAndDependencySizes,
-} from "./getChunkAndDependenciesSizes";
+export { AggregatedChunkAnalysis, ChunkSizeInfo, getChunkAndDependencySizes } from "./getChunkAndDependenciesSizes";
 export { getChunkParsedSize } from "./getChunkParsedSize";
 export { getLastCommitHashFromPR } from "./getLastCommitHashFromPR";
 export { getBaselineCommit, getPriorCommit } from "./gitCommands";

--- a/build-tools/packages/bundle-size-tools/src/utilities/index.ts
+++ b/build-tools/packages/bundle-size-tools/src/utilities/index.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-export * from "./decompressStatsFile";
-export * from "./getAllFilesInDirectory";
-export * from "./getBuilds";
-export * from "./getChunkAndDependenciesSizes";
-export * from "./getChunkParsedSize";
-export * from "./getLastCommitHashFromPR";
-export * from "./gitCommands";
-export * from "./unzipStream";
+export { decompressStatsFile } from "./decompressStatsFile";
+export { getAllFilesInDirectory } from "./getAllFilesInDirectory";
+export { GetBuildOptions, getBuilds } from "./getBuilds";
+export { AggregatedChunkAnalysis, ChunkSizeInfo, getChunkAndDependencySizes } from "./getChunkAndDependenciesSizes";
+export { getChunkParsedSize } from "./getChunkParsedSize";
+export { getLastCommitHashFromPR } from "./getLastCommitHashFromPR";
+export { getBaselineCommit, getPriorCommit } from "./gitCommands";
+export { unzipStream } from "./unzipStream";

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -3,7 +3,15 @@
  * Licensed under the MIT License.
  */
 
-export * from "./bumpTypes";
+export {
+    isVersionBumpType,
+    isVersionBumpTypeExtended,
+    ReleaseVersion,
+    VersionBumpType,
+    VersionBumpTypeExtended,
+    VersionChangeType,
+    VersionChangeTypeExtended,
+} from "./bumpTypes";
 export {
     changePreReleaseIdentifier,
     getVersionRange,

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -4,13 +4,13 @@
  */
 
 export {
-    isVersionBumpType,
-    isVersionBumpTypeExtended,
-    ReleaseVersion,
-    VersionBumpType,
-    VersionBumpTypeExtended,
-    VersionChangeType,
-    VersionChangeTypeExtended,
+	isVersionBumpType,
+	isVersionBumpTypeExtended,
+	ReleaseVersion,
+	VersionBumpType,
+	VersionBumpTypeExtended,
+	VersionChangeType,
+	VersionChangeTypeExtended,
 } from "./bumpTypes";
 export {
     changePreReleaseIdentifier,

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -3,15 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
-	isVersionBumpType,
-	isVersionBumpTypeExtended,
-	ReleaseVersion,
-	VersionBumpType,
-	VersionBumpTypeExtended,
-	VersionChangeType,
-	VersionChangeTypeExtended,
-} from "./bumpTypes";
+export * from "./bumpTypes";
 export {
     changePreReleaseIdentifier,
     getVersionRange,

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -3,7 +3,15 @@
  * Licensed under the MIT License.
  */
 
-export * from "./bumpTypes";
+export {
+	isVersionBumpType,
+	isVersionBumpTypeExtended,
+	ReleaseVersion,
+	VersionBumpType,
+	VersionBumpTypeExtended,
+	VersionChangeType,
+	VersionChangeTypeExtended,
+} from "./bumpTypes";
 export {
     changePreReleaseIdentifier,
     getVersionRange,

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -4,13 +4,13 @@
  */
 
 export {
-	isVersionBumpType,
-	isVersionBumpTypeExtended,
-	ReleaseVersion,
-	VersionBumpType,
-	VersionBumpTypeExtended,
-	VersionChangeType,
-	VersionChangeTypeExtended,
+    isVersionBumpType,
+    isVersionBumpTypeExtended,
+    ReleaseVersion,
+    VersionBumpType,
+    VersionBumpTypeExtended,
+    VersionChangeType,
+    VersionChangeTypeExtended,
 } from "./bumpTypes";
 export {
     changePreReleaseIdentifier,


### PR DESCRIPTION
This PR converts default exports in `build-tools` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare. 