### PR TITLE
Change default exports in `common/lib` to named exports

### DIFF
--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -9,23 +9,39 @@
  * @packageDocumentation
  */
 
-export * from "./assert";
-export * from "./indexNode";
-export * from "./base64Encoding";
-export * from "./disposal";
-export * from "./eventForwarder";
-export * from "./heap";
-export * from "./logger";
-export * from "./promiseCache";
-export * from "./promises";
-export * from "./rangeTracker";
-export * from "./rateLimiter";
-export * from "./safeParser";
-export * from "./timer";
-export * from "./trace";
-export * from "./typedEventEmitter";
-export * from "./unreachable";
-export * from "./lazy";
-export * from "./performanceIsomorphic";
-export * from "./delay";
-export * from "./bufferShared";
+export { assert } from "./assert";
+export {
+    Buffer,
+    bufferToString,
+    gitHashFile,
+    hashFile,
+    IsoBuffer,
+    performance,
+    stringToBuffer,
+    Uint8ArrayToString,
+} from "./indexNode";
+export { fromBase64ToUtf8, fromUtf8ToBase64, toUtf8 } from "./base64Encoding";
+export { doIfNotDisposed } from "./disposal";
+export { EventForwarder } from "./eventForwarder";
+export { Heap, IComparer, IHeapNode, NumberComparer } from "./heap";
+export { BaseTelemetryNullLogger, TelemetryNullLogger } from "./logger";
+export { PromiseCache, PromiseCacheExpiry, PromiseCacheOptions } from "./promiseCache";
+export { Deferred, LazyPromise } from "./promises";
+export { IRange, IRangeTrackerSnapshot, RangeTracker } from "./rangeTracker";
+export { RateLimiter } from "./rateLimiter";
+export { safelyParseJSON } from "./safeParser";
+export {
+    IPromiseTimer,
+    IPromiseTimerResult,
+    ITimer,
+    PromiseTimer,
+    setLongTimeout,
+    Timer,
+} from "./timer";
+export { ITraceEvent, Trace } from "./trace";
+export { EventEmitterEventType, TypedEventEmitter, TypedEventTransform } from "./typedEventEmitter";
+export { unreachableCase } from "./unreachable";
+export { Lazy } from "./lazy";
+export { IsomorphicPerformance } from "./performanceIsomorphic";
+export { delay } from "./delay";
+export { Uint8ArrayToArrayBuffer } from "./bufferShared";

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -10,6 +10,12 @@
  */
 
 export { assert } from "./assert";
+export { fromBase64ToUtf8, fromUtf8ToBase64, toUtf8 } from "./base64Encoding";
+export { Uint8ArrayToArrayBuffer } from "./bufferShared";
+export { delay } from "./delay";
+export { doIfNotDisposed } from "./disposal";
+export { EventForwarder } from "./eventForwarder";
+export { Heap, IComparer, IHeapNode, NumberComparer } from "./heap";
 export {
     Buffer,
     bufferToString,
@@ -20,11 +26,9 @@ export {
     stringToBuffer,
     Uint8ArrayToString,
 } from "./indexNode";
-export { fromBase64ToUtf8, fromUtf8ToBase64, toUtf8 } from "./base64Encoding";
-export { doIfNotDisposed } from "./disposal";
-export { EventForwarder } from "./eventForwarder";
-export { Heap, IComparer, IHeapNode, NumberComparer } from "./heap";
+export { Lazy } from "./lazy";
 export { BaseTelemetryNullLogger, TelemetryNullLogger } from "./logger";
+export { IsomorphicPerformance } from "./performanceIsomorphic";
 export { PromiseCache, PromiseCacheExpiry, PromiseCacheOptions } from "./promiseCache";
 export { Deferred, LazyPromise } from "./promises";
 export { IRange, IRangeTrackerSnapshot, RangeTracker } from "./rangeTracker";
@@ -41,7 +45,3 @@ export {
 export { ITraceEvent, Trace } from "./trace";
 export { EventEmitterEventType, TypedEventEmitter, TypedEventTransform } from "./typedEventEmitter";
 export { unreachableCase } from "./unreachable";
-export { Lazy } from "./lazy";
-export { IsomorphicPerformance } from "./performanceIsomorphic";
-export { delay } from "./delay";
-export { Uint8ArrayToArrayBuffer } from "./bufferShared";

--- a/common/lib/common-utils/src/indexBrowser.ts
+++ b/common/lib/common-utils/src/indexBrowser.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export * from "./bufferBrowser";
-export * from "./hashFileBrowser";
-export * from "./performanceBrowser";
+export {
+    bufferToString,
+    isArrayBuffer,
+    IsoBuffer,
+    stringToBuffer,
+    Uint8ArrayToString,
+} from "./bufferBrowser";
+export { gitHashFile, hashFile } from "./hashFileBrowser";
+export { performance } from "./performanceBrowser";

--- a/common/lib/common-utils/src/indexNode.ts
+++ b/common/lib/common-utils/src/indexNode.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export * from "./bufferNode";
-export * from "./hashFileNode";
-export * from "./performanceNode";
+export {
+    Buffer,
+    bufferToString,
+    IsoBuffer,
+    stringToBuffer,
+    Uint8ArrayToString,
+} from "./bufferNode";
+export { gitHashFile, hashFile } from "./hashFileNode";
+export { performance } from "./performanceNode";

--- a/common/lib/protocol-definitions/src/index.ts
+++ b/common/lib/protocol-definitions/src/index.ts
@@ -19,6 +19,7 @@ export {
     ISequencedClient,
     ISignalClient,
 } from "./clients";
+export { IClientConfiguration } from "./config";
 export {
     IApprovedProposal,
     ICommittedProposal,
@@ -33,7 +34,6 @@ export {
     IQuorumProposalsEvents,
     ISequencedProposal,
 } from "./consensus";
-export { IClientConfiguration } from "./config";
 export { IsoDate } from "./date";
 export {
     IBranchOrigin,
@@ -58,6 +58,8 @@ export {
     NackErrorType,
     SignalType,
 } from "./protocol";
+export { ScopeType } from "./scopes";
+export { IConnect, IConnected } from "./sockets";
 export {
     FileMode,
     IAttachment,
@@ -81,7 +83,6 @@ export {
     SummaryType,
     SummaryTypeNoHandle,
 } from "./summary";
-export { IUser } from "./users";
 export {
     IActorClient,
     ISummaryTokenClaims,
@@ -89,5 +90,4 @@ export {
     ITokenProvider,
     ITokenService,
 } from "./tokens";
-export { ScopeType } from "./scopes";
-export { IConnect, IConnected } from "./sockets";
+export { IUser } from "./users";

--- a/common/lib/protocol-definitions/src/index.ts
+++ b/common/lib/protocol-definitions/src/index.ts
@@ -10,14 +10,84 @@
  * @packageDocumentation
  */
 
-export * from "./clients";
-export * from "./consensus";
-export * from "./config";
-export * from "./date";
-export * from "./protocol";
-export * from "./storage";
-export * from "./summary";
-export * from "./users";
-export * from "./tokens";
-export * from "./scopes";
-export * from "./sockets";
+export {
+    ConnectionMode,
+    ICapabilities,
+    IClient,
+    IClientDetails,
+    IClientJoin,
+    ISequencedClient,
+    ISignalClient,
+} from "./clients";
+export {
+    IApprovedProposal,
+    ICommittedProposal,
+    IProcessMessageResult,
+    IProposal,
+    IProtocolState,
+    IQuorum,
+    IQuorumClients,
+    IQuorumClientsEvents,
+    IQuorumEvents,
+    IQuorumProposals,
+    IQuorumProposalsEvents,
+    ISequencedProposal,
+} from "./consensus";
+export { IClientConfiguration } from "./config";
+export { IsoDate } from "./date";
+export {
+    IBranchOrigin,
+    IDocumentMessage,
+    IDocumentSystemMessage,
+    IHelpMessage,
+    INack,
+    INackContent,
+    IQueueMessage,
+    ISequencedDocumentAugmentedMessage,
+    ISequencedDocumentMessage,
+    ISequencedDocumentSystemMessage,
+    IServerError,
+    ISignalMessage,
+    ISummaryAck,
+    ISummaryContent,
+    ISummaryNack,
+    ISummaryProposal,
+    ITrace,
+    IUploadedSummaryDetails,
+    MessageType,
+    NackErrorType,
+    SignalType,
+} from "./protocol";
+export {
+    FileMode,
+    IAttachment,
+    IBlob,
+    ICreateBlobResponse,
+    IDocumentAttributes,
+    ISnapshotTree,
+    ISnapshotTreeEx,
+    ITree,
+    ITreeEntry,
+    IVersion,
+    TreeEntry,
+} from "./storage";
+export {
+    ISummaryAttachment,
+    ISummaryBlob,
+    ISummaryHandle,
+    ISummaryTree,
+    SummaryObject,
+    SummaryTree,
+    SummaryType,
+    SummaryTypeNoHandle,
+} from "./summary";
+export { IUser } from "./users";
+export {
+    IActorClient,
+    ISummaryTokenClaims,
+    ITokenClaims,
+    ITokenProvider,
+    ITokenService,
+} from "./tokens";
+export { ScopeType } from "./scopes";
+export { IConnect, IConnected } from "./sockets";


### PR DESCRIPTION
This PR converts default exports in `/common` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.