### PR TITLE
fix(policy-check): Make check policy continue after errors

### DIFF
--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -12,7 +12,7 @@ import { policyHandlers, readJsonAsync } from "@fluidframework/build-tools";
 
 import { BaseCommand } from "../../base";
 
-async function readStdin(): Promise<string | undefined> {
+const readStdin: () => Promise<string | undefined> = async () => {
     return new Promise((resolve) => {
         const stdin = process.openStdin();
         stdin.setEncoding("utf-8");

--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -202,7 +202,7 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
                         process.exitCode = 1;
                     }
 
-                    if(process.exitCode === 1) {
+                    if (process.exitCode === 1) {
                         this.warning(output);
                     } else {
                         this.info(output);
@@ -213,7 +213,8 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
 
     logStats() {
         this.log(
-            `Statistics: ${CheckPolicy.processed} processed, ${CheckPolicy.count - CheckPolicy.processed
+            `Statistics: ${CheckPolicy.processed} processed, ${
+                CheckPolicy.count - CheckPolicy.processed
             } excluded, ${CheckPolicy.count} total`,
         );
         for (const [action, handlerPerf] of CheckPolicy.handlerActionPerf.entries()) {

--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -12,7 +12,7 @@ import { policyHandlers, readJsonAsync } from "@fluidframework/build-tools";
 
 import { BaseCommand } from "../../base";
 
-const readStdin: () => Promise<string | undefined> = async () => {
+async function readStdin(): Promise<string | undefined> {
     return new Promise((resolve) => {
         const stdin = process.openStdin();
         stdin.setEncoding("utf-8");
@@ -94,19 +94,19 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
                 : new RegExp(this.processedFlags.path, "i");
 
         if (this.processedFlags.handler !== undefined) {
-            this.log(`Filtering handlers by regex: ${handlerRegex}`);
+            this.info(`Filtering handlers by regex: ${handlerRegex}`);
         }
 
         if (this.processedFlags.path !== undefined) {
-            this.log(`Filtering file paths by regex: ${pathRegex}`);
+            this.info(`Filtering file paths by regex: ${pathRegex}`);
         }
 
         if (this.processedFlags.fix) {
-            this.log("Resolving errors if possible.");
+            this.info("Resolving errors if possible.");
         }
 
         if (this.processedFlags.exclusions === undefined) {
-            this.error("ERROR: No exclusions file provided.");
+            this.error("No exclusions file provided.");
         }
 
         let exclusionsFile: string[];
@@ -174,49 +174,46 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
 
     // route files to their handlers by regex testing their full paths
     // synchronize output, exit code, and resolve decision for all handlers
-    routeToHandlers(file: string, handlerRegex: RegExp) {
-        const filteredHandlers = policyHandlers.filter(
-            (handler) => handler.match.test(file) && handlerRegex.test(handler.name),
-        );
+    routeToHandlers(file: string, handlerRegex: RegExp): void {
+        policyHandlers
+            .filter((handler) => handler.match.test(file) && handlerRegex.test(handler.name))
+            // eslint-disable-next-line unicorn/no-array-for-each
+            .forEach((handler) => {
+                const result = runWithPerf(handler.name, "handle", () =>
+                    handler.handler(file, CheckPolicy.pathToGitRoot),
+                );
+                if (result !== undefined && result !== "") {
+                    let output = `${newline}file failed policy check: ${file}${newline}${result}`;
+                    const resolver = handler.resolver;
+                    if (this.processedFlags.fix && resolver) {
+                        output += `${newline}attempting to resolve: ${file}`;
+                        const resolveResult = runWithPerf(handler.name, "resolve", () =>
+                            resolver(file, CheckPolicy.pathToGitRoot),
+                        );
 
-        for (const handler of filteredHandlers) {
-            const result = runWithPerf(handler.name, "handle", () =>
-                handler.handler(file, CheckPolicy.pathToGitRoot),
-            );
-            const resolver = handler.resolver;
+                        if (resolveResult?.message !== undefined) {
+                            output += newline + resolveResult.message;
+                        }
 
-            if (result === undefined) {
-                return;
-            }
+                        if (!resolveResult.resolved) {
+                            process.exitCode = 1;
+                        }
+                    } else {
+                        process.exitCode = 1;
+                    }
 
-            if (!this.processedFlags.fix || resolver === undefined) {
-                return this.exit(1);
-            }
-
-            let output = `${newline}file failed policy check: ${file}${newline}${result}`;
-
-            output += `${newline}attempting to resolve: ${file}`;
-            const resolveResult = runWithPerf(handler.name, "resolve", () =>
-                resolver(file, CheckPolicy.pathToGitRoot),
-            );
-
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            if (resolveResult.message) {
-                output += newline + resolveResult.message;
-            }
-
-            if (!resolveResult.resolved) {
-                return this.exit(1);
-            }
-
-            this.log(output);
-        }
+                    if(process.exitCode === 1) {
+                        this.warning(output);
+                    } else {
+                        this.info(output);
+                    }
+                }
+            });
     }
 
     logStats() {
         this.log(
-            `Statistics: ${CheckPolicy.processed} processed, ${
-                CheckPolicy.count - CheckPolicy.processed
+            `Statistics: ${CheckPolicy.processed} processed, ${CheckPolicy.count - CheckPolicy.processed
             } excluded, ${CheckPolicy.count} total`,
         );
         for (const [action, handlerPerf] of CheckPolicy.handlerActionPerf.entries()) {
@@ -236,7 +233,7 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
 
         CheckPolicy.count++;
         if (!exclusions.every((value) => !value.test(line))) {
-            this.log(`Excluded: ${line}`);
+            this.verbose(`Excluded: ${line}`);
             return;
         }
 


### PR DESCRIPTION
The `check policy` command was not working properly. I think the primary problem was calls to `this.exit(1)` inside routeToHandlers, which made the process exit instead of continuing to process other handlers.

This change fixes the problem.