### PR TITLE
Tree: fix sequence field format imports

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -4,7 +4,15 @@
  */
 
 import { clone, fail, StackyIterator } from "../../util";
-import * as F from "./format";
+import {
+    Changeset,
+    Mark,
+    MarkList,
+    Modify,
+    ModifyInsert,
+    ModifyReattach,
+    SizedMark,
+} from "./format";
 import { MarkListFactory } from "./markListFactory";
 import {
     getInputLength,
@@ -33,13 +41,13 @@ export type NodeChangeComposer<TNodeChange> = (changes: TNodeChange[]) => TNodeC
  * - Support for slices is not implemented.
  */
 export function compose<TNodeChange>(
-    changes: F.Changeset<TNodeChange>[],
+    changes: Changeset<TNodeChange>[],
     composeChild: NodeChangeComposer<TNodeChange>,
-): F.Changeset<TNodeChange> {
+): Changeset<TNodeChange> {
     if (changes.length === 1) {
         return changes[0];
     }
-    let composed: F.Changeset<TNodeChange> = [];
+    let composed: Changeset<TNodeChange> = [];
     for (const change of changes) {
         composed = composeMarkLists(composed, change, composeChild);
     }
@@ -47,15 +55,15 @@ export function compose<TNodeChange>(
 }
 
 function composeMarkLists<TNodeChange>(
-    baseMarkList: F.MarkList<TNodeChange>,
-    newMarkList: F.MarkList<TNodeChange>,
+    baseMarkList: MarkList<TNodeChange>,
+    newMarkList: MarkList<TNodeChange>,
     composeChild: NodeChangeComposer<TNodeChange>,
-): F.MarkList<TNodeChange> {
+): MarkList<TNodeChange> {
     const factory = new MarkListFactory<TNodeChange>();
     const baseIter = new StackyIterator(baseMarkList);
     const newIter = new StackyIterator(newMarkList);
     for (let newMark of newIter) {
-        let baseMark: F.Mark<TNodeChange> | undefined = baseIter.pop();
+        let baseMark: Mark<TNodeChange> | undefined = baseIter.pop();
         if (baseMark === undefined) {
             // We have reached a region of the field that the base change does not affect.
             // We therefore adopt the new mark as is.
@@ -129,10 +137,10 @@ function composeMarkLists<TNodeChange>(
  * @returns A mark that is equivalent to applying both `baseMark` and `newMark` successively.
  */
 function composeMarks<TNodeChange>(
-    baseMark: F.Mark<TNodeChange>,
-    newMark: F.SizedMark<TNodeChange>,
+    baseMark: Mark<TNodeChange>,
+    newMark: SizedMark<TNodeChange>,
     composeChild: NodeChangeComposer<TNodeChange>,
-): F.Mark<TNodeChange> {
+): Mark<TNodeChange> {
     if (isSkipMark(baseMark)) {
         return clone(newMark);
     }
@@ -198,7 +206,7 @@ function composeMarks<TNodeChange>(
         case "Revive": {
             switch (newType) {
                 case "Modify": {
-                    const modRevive: F.ModifyReattach<TNodeChange> = {
+                    const modRevive: ModifyReattach<TNodeChange> = {
                         type: "MRevive",
                         id: baseMark.id,
                         tomb: baseMark.tomb,
@@ -220,8 +228,8 @@ function composeMarks<TNodeChange>(
 }
 
 function updateModifyLike<TNodeChange>(
-    curr: F.Modify<TNodeChange>,
-    base: F.ModifyInsert<TNodeChange> | F.Modify<TNodeChange> | F.ModifyReattach<TNodeChange>,
+    curr: Modify<TNodeChange>,
+    base: ModifyInsert<TNodeChange> | Modify<TNodeChange> | ModifyReattach<TNodeChange>,
     composeChild: NodeChangeComposer<TNodeChange>,
 ) {
     base.changes = composeChild([base.changes, curr.changes]);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -4,14 +4,14 @@
  */
 
 import { fail } from "../../util";
-import * as F from "./format";
+import { Changeset, ChangesetTag, Mark, MarkList, OpId } from "./format";
 import { isSkipMark } from "./utils";
 
 /**
  * Dummy value used in place of the actual tag.
  * TODO: give `invert` access real tag data.
  */
-export const DUMMY_INVERT_TAG: F.ChangesetTag = "Dummy Invert Changeset Tag";
+export const DUMMY_INVERT_TAG: ChangesetTag = "Dummy Invert Changeset Tag";
 
 export type NodeChangeInverter<TNodeChange> = (change: TNodeChange) => TNodeChange;
 
@@ -27,24 +27,24 @@ export type NodeChangeInverter<TNodeChange> = (change: TNodeChange) => TNodeChan
  * - Support for slices is not implemented.
  */
 export function invert<TNodeChange>(
-    change: F.Changeset<TNodeChange>,
+    change: Changeset<TNodeChange>,
     invertChild: NodeChangeInverter<TNodeChange>,
-): F.Changeset<TNodeChange> {
+): Changeset<TNodeChange> {
     // TODO: support the input change being a squash
-    const opIdToTag = (id: F.OpId): F.ChangesetTag => {
+    const opIdToTag = (id: OpId): ChangesetTag => {
         return DUMMY_INVERT_TAG;
     };
     return invertMarkList(change, opIdToTag, invertChild);
 }
 
-type IdToTagLookup = (id: F.OpId) => F.ChangesetTag;
+type IdToTagLookup = (id: OpId) => ChangesetTag;
 
 function invertMarkList<TNodeChange>(
-    markList: F.MarkList<TNodeChange>,
+    markList: MarkList<TNodeChange>,
     opIdToTag: IdToTagLookup,
     invertChild: NodeChangeInverter<TNodeChange>,
-): F.MarkList<TNodeChange> {
-    const inverseMarkList: F.MarkList<TNodeChange> = [];
+): MarkList<TNodeChange> {
+    const inverseMarkList: MarkList<TNodeChange> = [];
     for (const mark of markList) {
         const inverseMarks = invertMark(mark, opIdToTag, invertChild);
         inverseMarkList.push(...inverseMarks);
@@ -53,10 +53,10 @@ function invertMarkList<TNodeChange>(
 }
 
 function invertMark<TNodeChange>(
-    mark: F.Mark<TNodeChange>,
+    mark: Mark<TNodeChange>,
     opIdToTag: IdToTagLookup,
     invertChild: NodeChangeInverter<TNodeChange>,
-): F.Mark<TNodeChange>[] {
+): Mark<TNodeChange>[] {
     if (isSkipMark(mark)) {
         return [mark];
     } else {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/markListFactory.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/markListFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as F from "./format";
+import { Mark, MarkList, ObjectMark, Skip } from "./format";
 import { isObjMark, isSkipMark, tryExtendMark } from "./utils";
 
 /**
@@ -15,9 +15,9 @@ import { isObjMark, isSkipMark, tryExtendMark } from "./utils";
  */
 export class MarkListFactory<TNodeChange> {
     private offset = 0;
-    public readonly list: F.MarkList<TNodeChange> = [];
+    public readonly list: MarkList<TNodeChange> = [];
 
-    public push(...marks: F.Mark<TNodeChange>[]): void {
+    public push(...marks: Mark<TNodeChange>[]): void {
         for (const item of marks) {
             if (isSkipMark(item)) {
                 this.pushOffset(item);
@@ -27,11 +27,11 @@ export class MarkListFactory<TNodeChange> {
         }
     }
 
-    public pushOffset(offset: F.Skip): void {
+    public pushOffset(offset: Skip): void {
         this.offset += offset;
     }
 
-    public pushContent(mark: F.ObjectMark<TNodeChange>): void {
+    public pushContent(mark: ObjectMark<TNodeChange>): void {
         if (this.offset > 0) {
             this.list.push(this.offset);
             this.offset = 0;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -13,7 +13,7 @@ import {
     isSkipMark,
     splitMarkOnInput,
 } from "./utils";
-import * as F from "./format";
+import { Changeset, Mark, MarkList, SizedMark } from "./format";
 import { MarkListFactory } from "./markListFactory";
 
 /**
@@ -32,10 +32,10 @@ import { MarkListFactory } from "./markListFactory";
  * - Support for slices is not implemented.
  */
 export function rebase<TNodeChange>(
-    change: F.Changeset<TNodeChange>,
-    base: F.Changeset<TNodeChange>,
+    change: Changeset<TNodeChange>,
+    base: Changeset<TNodeChange>,
     rebaseChild: NodeChangeRebaser<TNodeChange>,
-): F.Changeset<TNodeChange> {
+): Changeset<TNodeChange> {
     return rebaseMarkList(change, base, rebaseChild);
 }
 
@@ -45,15 +45,15 @@ export type NodeChangeRebaser<TNodeChange> = (
 ) => TNodeChange;
 
 function rebaseMarkList<TNodeChange>(
-    currMarkList: F.MarkList<TNodeChange>,
-    baseMarkList: F.MarkList<TNodeChange>,
+    currMarkList: MarkList<TNodeChange>,
+    baseMarkList: MarkList<TNodeChange>,
     rebaseChild: NodeChangeRebaser<TNodeChange>,
-): F.MarkList<TNodeChange> {
+): MarkList<TNodeChange> {
     const factory = new MarkListFactory<TNodeChange>();
     const baseIter = new StackyIterator(baseMarkList);
     const currIter = new StackyIterator(currMarkList);
     for (let baseMark of baseIter) {
-        let currMark: F.Mark<TNodeChange> | undefined = currIter.pop();
+        let currMark: Mark<TNodeChange> | undefined = currIter.pop();
         if (currMark === undefined) {
             break;
         }
@@ -123,10 +123,10 @@ function rebaseMarkList<TNodeChange>(
 }
 
 function rebaseMark<TNodeChange>(
-    currMark: F.SizedMark<TNodeChange>,
-    baseMark: F.SizedMark<TNodeChange>,
+    currMark: SizedMark<TNodeChange>,
+    baseMark: SizedMark<TNodeChange>,
     rebaseChild: NodeChangeRebaser<TNodeChange>,
-): F.SizedMark<TNodeChange> {
+): SizedMark<TNodeChange> {
     if (isSkipMark(baseMark)) {
         return clone(currMark);
     }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -6,17 +6,17 @@
 import { ITreeCursor } from "../../forest";
 import { FieldEditor } from "../modular-schema";
 import { jsonableTreeFromCursor } from "../treeTextCursorLegacy";
-import * as F from "./format";
+import { Changeset, Mark, NodeChangeType } from "./format";
 
-export interface SequenceFieldEditor extends FieldEditor<F.Changeset> {
-    insert(index: number, cursor: ITreeCursor | ITreeCursor[]): F.Changeset;
-    delete(index: number, count: number): F.Changeset;
+export interface SequenceFieldEditor extends FieldEditor<Changeset> {
+    insert(index: number, cursor: ITreeCursor | ITreeCursor[]): Changeset;
+    delete(index: number, count: number): Changeset;
 }
 
 export const sequenceFieldEditor: SequenceFieldEditor = {
-    buildChildChange: (index: number, change: F.NodeChangeType): F.Changeset =>
+    buildChildChange: (index: number, change: NodeChangeType): Changeset =>
         markAtIndex(index, { type: "Modify", changes: change }),
-    insert: (index: number, cursors: ITreeCursor | ITreeCursor[]): F.Changeset =>
+    insert: (index: number, cursors: ITreeCursor | ITreeCursor[]): Changeset =>
         markAtIndex(index, {
             type: "Insert",
             id: 0,
@@ -24,10 +24,10 @@ export const sequenceFieldEditor: SequenceFieldEditor = {
                 ? cursors.map(jsonableTreeFromCursor)
                 : [jsonableTreeFromCursor(cursors)],
         }),
-    delete: (index: number, count: number): F.Changeset =>
+    delete: (index: number, count: number): Changeset =>
         markAtIndex(index, { type: "Delete", id: 0, count }),
 };
 
-function markAtIndex(index: number, mark: F.Mark): F.Changeset {
+function markAtIndex(index: number, mark: Mark): Changeset {
     return index === 0 ? [mark] : [index, mark];
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -9,13 +9,13 @@ import { Delta } from "../../tree";
 import { applyModifyToTree } from "../deltaUtils";
 import { mapTreeFromCursor, singleMapTreeCursor } from "../mapTreeCursor";
 import { singleTextCursor } from "../treeTextCursor";
-import * as F from "./format";
+import { MarkList, ModifyInsert } from "./format";
 import { isSkipMark } from "./utils";
 
 export type ToDelta<TNodeChange> = (child: TNodeChange) => Delta.Modify;
 
 export function sequenceFieldToDelta<TNodeChange>(
-    marks: F.MarkList<TNodeChange>,
+    marks: MarkList<TNodeChange>,
     deltaFromChild: ToDelta<TNodeChange>,
 ): Delta.MarkList {
     const out = new OffsetListFactory<Delta.Mark>();
@@ -131,7 +131,7 @@ export function sequenceFieldToDelta<TNodeChange>(
  * The returned `fields` map may be empty if all modifications are applied by the function.
  */
 function cloneAndModify<TNodeChange>(
-    insert: F.ModifyInsert<TNodeChange>,
+    insert: ModifyInsert<TNodeChange>,
     deltaFromChild: ToDelta<TNodeChange>,
 ): DeltaInsertModification {
     // TODO: consider processing modifications at the same time as cloning to avoid unnecessary cloning


### PR DESCRIPTION
Replaces usage of `import * as F from "./format";` with "vanilla" imports of the actually used code.

This is necessary because API Extractor doesn't handle the above import style and complains about "F" needing to be exported. Note that these definitions are not yet exported (they will be in a future PR, this PR aims to make that later PR easier to review.)