### PR TITLE
Change default exports in azure to named exports 

### DIFF
--- a/azure/packages/azure-client/src/index.ts
+++ b/azure/packages/azure-client/src/index.ts
@@ -9,10 +9,24 @@
  * @packageDocumentation
  */
 
-export * from "./AzureAudience";
-export * from "./AzureClient";
-export * from "./AzureFunctionTokenProvider";
-export * from "./interfaces";
+export { AzureAudience } from "./AzureAudience";
+export { AzureClient } from "./AzureClient";
+export { AzureFunctionTokenProvider } from "./AzureFunctionTokenProvider";
+export {
+	AzureClientProps,
+	AzureConnectionConfig,
+	AzureConnectionConfigType,
+	AzureContainerServices,
+	AzureContainerVersion,
+	AzureGetVersionsOptions,
+	AzureLocalConnectionConfig,
+	AzureMember,
+	AzureRemoteConnectionConfig,
+	AzureUser,
+	IAzureAudience,
+	ITelemetryBaseEvent,
+	ITelemetryBaseLogger,
+} from "./interfaces";
 
 export { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
-export { ScopeType, ITokenClaims, IUser } from "@fluidframework/protocol-definitions";
+export { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";

--- a/azure/packages/azure-client/src/index.ts
+++ b/azure/packages/azure-client/src/index.ts
@@ -13,19 +13,19 @@ export { AzureAudience } from "./AzureAudience";
 export { AzureClient } from "./AzureClient";
 export { AzureFunctionTokenProvider } from "./AzureFunctionTokenProvider";
 export {
-	AzureClientProps,
-	AzureConnectionConfig,
-	AzureConnectionConfigType,
-	AzureContainerServices,
-	AzureContainerVersion,
-	AzureGetVersionsOptions,
-	AzureLocalConnectionConfig,
-	AzureMember,
-	AzureRemoteConnectionConfig,
-	AzureUser,
-	IAzureAudience,
-	ITelemetryBaseEvent,
-	ITelemetryBaseLogger,
+    AzureClientProps,
+    AzureConnectionConfig,
+    AzureConnectionConfigType,
+    AzureContainerServices,
+    AzureContainerVersion,
+    AzureGetVersionsOptions,
+    AzureLocalConnectionConfig,
+    AzureMember,
+    AzureRemoteConnectionConfig,
+    AzureUser,
+    IAzureAudience,
+    ITelemetryBaseEvent,
+    ITelemetryBaseLogger,
 } from "./interfaces";
 
 export { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";


### PR DESCRIPTION
This PR converts default exports in `azure` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.