### PR TITLE
Change default exports in examples/apps to named exports 

### DIFF
--- a/examples/apps/collaborative-textarea/src/index.ts
+++ b/examples/apps/collaborative-textarea/src/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { CollaborativeText } from "./fluid-object";
-export * from "./view";
+export { CollaborativeTextView } from "./view";

--- a/examples/apps/collaborative-textarea/src/index.ts
+++ b/examples/apps/collaborative-textarea/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./fluid-object";
+export { CollaborativeText } from "./fluid-object";
 export * from "./view";

--- a/examples/apps/spaces/src/fluid-object/index.ts
+++ b/examples/apps/spaces/src/fluid-object/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export * from "./spaces";
-export * from "./spacesItemMap";
-export * from "./spacesView";
-export * from "./storage";
+export { ISpacesItem, Spaces } from "./spaces";
+export { ISpacesItemEntry, spacesItemMap, spacesRegistryEntries, templateDefinitions } from "./spacesItemMap";
+export { SpacesView } from "./spacesView";
+export { ISpacesStorage, ISpacesStoredItem, SpacesStorage, SpacesStorageView } from "./storage";

--- a/examples/apps/spaces/src/fluid-object/storage/index.ts
+++ b/examples/apps/spaces/src/fluid-object/storage/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./spacesStorage";
-export * from "./spacesStorageView";
+export { ISpacesStorage, ISpacesStoredItem, SpacesStorage } from "./spacesStorage";
+export { SpacesStorageView } from "./spacesStorageView";

--- a/examples/apps/spaces/src/index.ts
+++ b/examples/apps/spaces/src/index.ts
@@ -3,4 +3,15 @@
  * Licensed under the MIT License.
  */
 
-export * from "./fluid-object";
+export {
+    ISpacesItem,
+    ISpacesItemEntry,
+    ISpacesStorage,
+    ISpacesStoredItem,
+    Spaces,
+    spacesItemMap,
+    spacesRegistryEntries,
+    SpacesStorage,
+    SpacesView,
+    templateDefinitions,
+} from "./fluid-object";

--- a/examples/apps/view-framework-sampler/src/views/index.ts
+++ b/examples/apps/view-framework-sampler/src/views/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./jsView";
-export * from "./reactView";
-export * from "./vueView";
+export { jsRenderDiceRoller } from "./jsView";
+export { DiceRollerView, reactRenderDiceRoller } from "./reactView";
+export { vueRenderDiceRoller } from "./vueView";


### PR DESCRIPTION
This PR converts default exports in `examples/apps` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.