### PR TITLE
Change all `export *` in `examples/hosts` to named exports

### DIFF
--- a/examples/hosts/app-integration/container-views/src/index.ts
+++ b/examples/hosts/app-integration/container-views/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./containerCode";
-export * from "./model";
+export { DiceRollerContainerRuntimeFactory } from "./containerCode";
+export { DiceRoller, DiceRollerInstantiationFactory } from "./model";

--- a/examples/hosts/app-integration/schema-upgrade/src/migrationInterfaces/index.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/migrationInterfaces/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./migratableModel";
-export * from "./migrationTool";
-export * from "./migrator";
+export { IImportExportModel, IMigratableModel, IMigratableModelEvents, IVersionedModel } from "./migratableModel";
+export { IMigrationTool, IMigrationToolEvents, MigrationState } from "./migrationTool";
+export { DataTransformationCallback, IMigrator, IMigratorEvents } from "./migrator";

--- a/examples/hosts/app-integration/schema-upgrade/src/migrationTool/index.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/migrationTool/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./migrationTool";
+export { MigrationTool, MigrationToolInstantiationFactory } from "./migrationTool";

--- a/examples/hosts/app-integration/schema-upgrade/src/migrator/index.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/migrator/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./migrator";
+export { Migrator } from "./migrator";

--- a/examples/hosts/app-integration/schema-upgrade/src/modelVersion1/index.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/modelVersion1/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./containerCode";
-export * from "./inventoryList";
+export { InventoryListContainerRuntimeFactory, inventoryListId, migrationToolId } from "./containerCode";
+export { InventoryList, InventoryListInstantiationFactory } from "./inventoryList";

--- a/examples/hosts/app-integration/schema-upgrade/src/modelVersion2/index.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/modelVersion2/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./containerCode";
-export * from "./inventoryList";
+export { InventoryListContainerRuntimeFactory, inventoryListId, migrationToolId } from "./containerCode";
+export { InventoryList, InventoryListInstantiationFactory } from "./inventoryList";

--- a/examples/hosts/app-integration/schema-upgrade/src/view/index.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/view/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./debugView";
-export * from "./appView";
+export { IDebugViewProps, DebugView } from "./debugView";
+export { IInventoryListAppViewProps, InventoryListAppView } from "./appView";


### PR DESCRIPTION
This PR converts `export *` in `examples/hosts` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.