### PR TITLE
Change all `export *` in `examples/utils` to named exports

### DIFF
--- a/examples/utils/example-utils/src/index.ts
+++ b/examples/utils/example-utils/src/index.ts
@@ -3,5 +3,15 @@
  * Licensed under the MIT License.
  */
 
-export * from "./containerViewRuntimeFactory";
-export * from "./modelLoader";
+export { ContainerViewRuntimeFactory, ViewCallback } from "./containerViewRuntimeFactory";
+export {
+	IDetachedModel,
+	IModelLoader,
+	makeModelRequestHandler,
+	ModelContainerRuntimeFactory,
+	ModelLoader,
+	ModelMakerCallback,
+	SessionStorageModelLoader,
+	StaticCodeLoader,
+	TinyliciousModelLoader,
+} from "./modelLoader";

--- a/examples/utils/example-utils/src/modelLoader/index.ts
+++ b/examples/utils/example-utils/src/modelLoader/index.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-export * from "./interfaces";
-export * from "./modelContainerRuntimeFactory";
-export * from "./modelLoader";
-export * from "./sessionStorageModelLoader";
-export * from "./staticCodeLoader";
-export * from "./tinyliciousModelLoader";
+export { IDetachedModel, IModelLoader, ModelMakerCallback } from "./interfaces";
+export { ModelContainerRuntimeFactory } from "./modelContainerRuntimeFactory";
+export { makeModelRequestHandler, ModelLoader } from "./modelLoader";
+export { SessionStorageModelLoader } from "./sessionStorageModelLoader";
+export { StaticCodeLoader } from "./staticCodeLoader";
+export { TinyliciousModelLoader } from "./tinyliciousModelLoader";


### PR DESCRIPTION
This PR converts default exports in `examples/utils` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.