### PR TITLE
Change default exports in `experimental/examples` to named exports

### DIFF
--- a/experimental/examples/bubblebench/common/src/index.ts
+++ b/experimental/examples/bubblebench/common/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export * from "./view";
-export * from "./types";
-export * from "./rnd";
-export * from "./stats";
+export { AppView } from "./view";
+export { IAppState, IArrayish, IBubble, IClient, makeBubble, makeClient } from "./types";
+export { normal, randomColor, rnd } from "./rnd";
+export { Stats } from "./stats";

--- a/experimental/examples/bubblebench/ot/src/proxy/index.ts
+++ b/experimental/examples/bubblebench/ot/src/proxy/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./tree";
+export { observe } from "./tree";

--- a/experimental/examples/bubblebench/sharedtree/src/proxy/index.ts
+++ b/experimental/examples/bubblebench/sharedtree/src/proxy/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./tree";
+export { TreeArrayProxy, TreeObjectProxy } from "./tree";
 export { fromJson } from "./treeutils";


### PR DESCRIPTION
This PR converts default exports in `experimental/examples` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.