### PR TITLE
[GC-stress] Updated the test to send ops as per opRatePerMin config

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -24,7 +24,7 @@ import { LeaderElection } from "./leaderElection";
 import {
     rootDataObjectFactory,
     IGCDataStore,
-} from "./gcDataStore";
+} from "./gcDataStores";
 
 export interface IRunConfig {
     runId: number;

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -113,7 +113,7 @@ async function orchestratorProcess(
         // In case testId is provided, name of the file to be created is taken as the testId provided
         : initialize(testDriver, seed, profile, args.verbose === true, args.testId));
 
-    const estRunningTimeMin = Math.floor(profile.totalSendCount / (profile.opRatePerMin * profile.numClients));
+    const estRunningTimeMin = Math.floor(profile.totalSendCount / profile.opRatePerMin);
     console.log(`Connecting to ${args.testId !== undefined ? "existing" : "new"}`);
     console.log(`Selected test profile: ${profile.name}`);
     console.log(`Estimated run time: ${estRunningTimeMin} minutes\n`);

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -1,10 +1,10 @@
 {
     "profiles": {
         "gc": {
-            "opRatePerMin": 120,
+            "opRatePerMin": 600,
             "progressIntervalMs": 5000,
-            "numClients": 10,
-            "totalSendCount": 1000,
+            "numClients": 5,
+            "totalSendCount": 1200,
             "inactiveTimeoutMs": [10000],
             "optionOverrides":{
                 "tinylicious":{
@@ -20,10 +20,10 @@
             }
         },
         "gc_ci": {
-            "opRatePerMin": 120,
+            "opRatePerMin": 800,
             "progressIntervalMs": 5000,
             "numClients": 10,
-            "totalSendCount": 7200,
+            "totalSendCount": 48000,
             "inactiveTimeoutMs": [60000],
             "optionOverrides":{
                 "tinylicious":{
@@ -39,7 +39,7 @@
             }
         },
         "gc_fault": {
-            "opRatePerMin": 120,
+            "opRatePerMin": 600,
             "progressIntervalMs": 5000,
             "numClients": 10,
             "totalSendCount": 1000,


### PR DESCRIPTION
Note: This change is in a test branch not in main.

- Updated the tests to send ops as per the opRatePerMin config.
- The root data store does not send ops but just loads the child data stores.
- Basically, there can be maximum of 8 data stores (excluding root) that are referenced and sending ops. So, they each send opRatePerMin / 8 ops per minute. The only disadvantage is that we may end up sending less than opRatePerMin every minute since the actual number of data stores can be < 8.
- This simplifies the calculation of how long the test will run. It will also help us adjust the op rate as per the throttling limits.