### PR TITLE
Rerun Publish Steps after Network Error

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -87,6 +87,7 @@ steps:
       echo Tag: $tag
       cp .npmrc ~/.npmrc
       maximumRetryIfNetworkError=3
+      cnt=0
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
         sorted=true
@@ -95,6 +96,7 @@ steps:
         sorted=false
       fi
       for packageName in $packages
+      let cnt+=1
       do
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
@@ -104,6 +106,12 @@ steps:
         if [[ $f != "" ]]; then
           for i in $( seq 1 $maximumRetryIfNetworkError )
           do
+            if [ `expr $cnt % 10` == 0 ]
+            then
+              echo "Raise Network Error" $cnt
+              nmcli networking off
+            fi
+
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then
@@ -141,6 +149,8 @@ steps:
               rm publish_log
               break
             fi
+            echo "Success"
+            nmcli networking on
             rm publish_log
           done
         fi

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -108,6 +108,7 @@ steps:
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
 
             if [[ $errorFlag == true ]]; then
+              echo "Check ERROR MSG!"
               npx npm-return-error-msg
               $errorFlag=false
             fi

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -87,7 +87,6 @@ steps:
       echo Tag: $tag
       cp .npmrc ~/.npmrc
       maximumRetryIfNetworkError=3
-      cnt=0
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
         sorted=true
@@ -104,14 +103,6 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          for i in $( seq 1 $maximumRetryIfNetworkError )
-          do
-            if [ `expr $cnt % 10` == 0 ]
-            then
-              echo "Raise Network Error" $cnt
-              nmcli networking off
-            fi
-
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then
@@ -149,8 +140,6 @@ steps:
               rm publish_log
               break
             fi
-            echo "Success"
-            nmcli networking on
             rm publish_log
           done
         fi

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -86,7 +86,6 @@ steps:
       fi
       echo Tag: $tag
       cp .npmrc ~/.npmrc
-      t1=0
       maximumRetryIfNetworkError=3
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
@@ -116,14 +115,11 @@ steps:
                     continue
                   else
                     echo "Final Network Error"
-                    let t1+=1
-                    exit $t1
+                    exit 1
                   fi
                 else
-                  if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+                  if grep -q "You cannot publish over the previously published versions" "publish_log"
                   then
-                    let t1+=1
-                  else
                     echo Package has already been published.
                     local_f="${f}_local"
                     mv "$f" "$local_f"
@@ -132,14 +128,14 @@ steps:
                     if cmp -s "$f" "$local_f"
                     then
                       echo Continuing as published package matches the current one that was attempting to be released.
+                      continue
                     else
                       echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                      let t1+=1
                     fi
                   fi
                   rm "$f"
                   mv "$local_f" "$f"
-                  exit $t1
+                  exit 1
                 fi
             else
               rm publish_log
@@ -150,4 +146,4 @@ steps:
         fi
       done
       rm ~/.npmrc
-      exit $t1
+      exit 1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -86,6 +86,7 @@ steps:
       fi
       echo Tag: $tag
       cp .npmrc ~/.npmrc
+      errorFlag=true
       maximumRetryIfNetworkError=3
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
@@ -105,6 +106,12 @@ steps:
           for i in $( seq 1 $maximumRetryIfNetworkError )
           do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+
+            if [[ $errorFlag == true ]]; then
+              npx npm-return-error-msg
+              $errorFlag=false
+            fi
+
             if grep -q "npm ERR!" "publish_log"
             then
                 if grep -q "code ENOTFOUND" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -53,7 +53,6 @@ steps:
           echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
-
           echo Deleting @fluid-internal packages
           rm -f fluid-internal-*
           echo Deleting @fluid-msinternal packages
@@ -88,6 +87,7 @@ steps:
       echo Tag: $tag
       cp .npmrc ~/.npmrc
       t1=0
+      maximumRetryIfNetworkError=3
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
         sorted=true
@@ -103,30 +103,49 @@ steps:
           f=$packageName
         fi
         if [[ $f != "" ]]; then
-          npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
-          if grep -q "npm ERR!" "publish_log"
-          then
-              if ! grep -q "You cannot publish over the previously published versions" "publish_log"
-              then
-                let t1+=1
-              else
-                echo Package has already been published.
-                local_f="${f}_local"
-                mv "$f" "$local_f"
-                package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                npm pack $package_name
-                if cmp -s "$f" "$local_f"
+          for i in $( seq 1 $maximumRetryIfNetworkError )
+          do
+            echo "i :" $i
+            npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
+            if grep -q "npm ERR!" "publish_log"
+            then
+                if grep -q "code ENOTFOUND" "publish_log"
                 then
-                  echo Continuing as published package matches the current one that was attempting to be released.
+                  if ! $i -eq $maximumRetryIfNetworkError
+                  then
+                    echo "Network Error Detected"
+                    continue
+                  else
+                    echo "Final Network Error"
+                    exit $t1
+                  fi
                 else
-                  echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                  let t1+=1
+                  if ! grep -q "You cannot publish over the previously published versions" "publish_log"
+                  then
+                    let t1+=1
+                  else
+                    echo Package has already been published.
+                    local_f="${f}_local"
+                    mv "$f" "$local_f"
+                    package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                    npm pack $package_name
+                    if cmp -s "$f" "$local_f"
+                    then
+                      echo Continuing as published package matches the current one that was attempting to be released.
+                    else
+                      echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                      let t1+=1
+                    fi
+                    rm "$f"
+                    mv "$local_f" "$f"
+                    exit $t1
+                  fi
                 fi
-                rm "$f"
-                mv "$local_f" "$f"
-              fi
-          fi
-          rm publish_log
+            else
+              break
+            fi
+            rm publish_log
+          done
         fi
       done
       rm ~/.npmrc

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -96,13 +96,14 @@ steps:
       fi
       for packageName in $packages
       do
-        let cnt+=1
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
         else
           f=$packageName
         fi
         if [[ $f != "" ]]; then
+          for i in $( seq 1 $maximumRetryIfNetworkError )
+          do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -117,6 +117,7 @@ steps:
                     continue
                   else
                     echo "Final Network Error"
+                    let t1+=1
                     exit $t1
                   fi
                 else
@@ -136,12 +137,13 @@ steps:
                       echo ERROR: Published package does not match the current one attempting to be released for the same version.
                       let t1+=1
                     fi
-                    rm "$f"
-                    mv "$local_f" "$f"
-                    exit $t1
                   fi
+                  rm "$f"
+                  mv "$local_f" "$f"
+                  exit $t1
                 fi
             else
+              rm publish_log
               break
             fi
             rm publish_log

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -96,8 +96,8 @@ steps:
         sorted=false
       fi
       for packageName in $packages
-      let cnt+=1
       do
+        let cnt+=1
         if [[ $sorted == true ]]; then
           f=$(find -name "${packageName}-[0-9]*.tgz")
         else

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -105,7 +105,6 @@ steps:
         if [[ $f != "" ]]; then
           for i in $( seq 1 $maximumRetryIfNetworkError )
           do
-            echo "i :" $i
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
             if grep -q "npm ERR!" "publish_log"
             then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -147,4 +147,4 @@ steps:
         fi
       done
       rm ~/.npmrc
-      exit 1
+      exit 0

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,18 +111,18 @@ steps:
 
             echo "CHECK ERROR : " $checkError
 
-            if [[ "$checkError" =~ "NPM ERR! code ENOTFOUND"]]
-            then
-              echo "Check ERROR MSG! AFTER"
-              if ! $i -eq $maximumRetryIfNetworkError
-              then
-                echo "Network Error Detected"
-                continue
-              else
-                echo "Final Network Error"
-                exit 1
-              fi
-            fi
+            # if [[ "$checkError" =~ "NPM ERR! code ENOTFOUND"]]
+            # then
+            #   echo "Check ERROR MSG! AFTER"
+            #   if ! $i -eq $maximumRetryIfNetworkError
+            #   then
+            #     echo "Network Error Detected"
+            #     continue
+            #   else
+            #     echo "Final Network Error"
+            #     exit 1
+            #   fi
+            # fi
 
             # if grep -q "npm ERR!" "publish_log"
             # then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -107,15 +107,12 @@ steps:
           do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
 
-            if [ $errorFlag == 0 ];
-            then
-              echo "Check ERROR MSG!"
-              npx npm-return-error-msg
-              errorFlag=1
-            fi
+            echo "Check ERROR MSG! BEFORE"
+            npx npm-return-error-msg
 
             if grep -q "npm ERR!" "publish_log"
             then
+                echo "Check ERROR MSG! AFTER"
                 if grep -q "code ENOTFOUND" "publish_log"
                 then
                   if ! $i -eq $maximumRetryIfNetworkError

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -107,50 +107,59 @@ steps:
           do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
 
-            if [ $errorFlag == 0 ];
+            checkError=$(npx npm-return-error-msg)
+
+            if [[ $checkError =~ "NPM ERR! code ENOTFOUND"]]
             then
-              echo "Check ERROR MSG! BEFORE"
-              npx npm-return-error-msg
+              echo "Check ERROR MSG! AFTER"
+              if ! $i -eq $maximumRetryIfNetworkError
+              then
+                echo "Network Error Detected"
+                continue
+              else
+                echo "Final Network Error"
+                exit 1
+              fi
             fi
 
-            if grep -q "npm ERR!" "publish_log"
-            then
-                echo "Check ERROR MSG! AFTER"
-                if grep -q "code ENOTFOUND" "publish_log"
-                then
-                  if ! $i -eq $maximumRetryIfNetworkError
-                  then
-                    echo "Network Error Detected"
-                    continue
-                  else
-                    echo "Final Network Error"
-                    exit 1
-                  fi
-                else
-                  if grep -q "You cannot publish over the previously published versions" "publish_log"
-                  then
-                    echo Package has already been published.
-                    local_f="${f}_local"
-                    mv "$f" "$local_f"
-                    package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-                    npm pack $package_name
-                    if cmp -s "$f" "$local_f"
-                    then
-                      echo Continuing as published package matches the current one that was attempting to be released.
-                      continue
-                    else
-                      echo ERROR: Published package does not match the current one attempting to be released for the same version.
-                    fi
-                  fi
-                  rm "$f"
-                  mv "$local_f" "$f"
-                  exit 1
-                fi
-            else
-              rm publish_log
-              break
-            fi
-            rm publish_log
+            # if grep -q "npm ERR!" "publish_log"
+            # then
+            #     echo "Check ERROR MSG! AFTER"
+            #     if grep -q "code ENOTFOUND" "publish_log"
+            #     then
+            #       if ! $i -eq $maximumRetryIfNetworkError
+            #       then
+            #         echo "Network Error Detected"
+            #         continue
+            #       else
+            #         echo "Final Network Error"
+            #         exit 1
+            #       fi
+            #     else
+            #       if grep -q "You cannot publish over the previously published versions" "publish_log"
+            #       then
+            #         echo Package has already been published.
+            #         local_f="${f}_local"
+            #         mv "$f" "$local_f"
+            #         package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+            #         npm pack $package_name
+            #         if cmp -s "$f" "$local_f"
+            #         then
+            #           echo Continuing as published package matches the current one that was attempting to be released.
+            #           continue
+            #         else
+            #           echo ERROR: Published package does not match the current one attempting to be released for the same version.
+            #         fi
+            #       fi
+            #       rm "$f"
+            #       mv "$local_f" "$f"
+            #       exit 1
+            #     fi
+            # else
+            #   rm publish_log
+            #   break
+            # fi
+            # rm publish_log
           done
         fi
         let errorFlag+=1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -86,7 +86,7 @@ steps:
       fi
       echo Tag: $tag
       cp .npmrc ~/.npmrc
-      errorFlag=true
+      errorFlag=0
       maximumRetryIfNetworkError=3
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
@@ -107,10 +107,11 @@ steps:
           do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
 
-            if [[ $errorFlag == true ]]; then
+            if [ $errorFlag == 0 ];
+            then
               echo "Check ERROR MSG!"
               npx npm-return-error-msg
-              $errorFlag=false
+              errorFlag=1
             fi
 
             if grep -q "npm ERR!" "publish_log"

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,7 +111,8 @@ steps:
 
             echo "CHECK ERROR : " $checkError
 
-            if [ "$checkError" =~ "npm ERR! code ENOTFOUND" ]; then
+            if [ "$checkError" == "npm ERR! code ENOTFOUND" ];
+            then
               echo "Check Error! After!"
               if ! $i -eq $maximumRetryIfNetworkError
               then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -107,8 +107,11 @@ steps:
           do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
 
-            echo "Check ERROR MSG! BEFORE"
-            npx npm-return-error-msg
+            if [ $errorFlag == 0 ];
+            then
+              echo "Check ERROR MSG! BEFORE"
+              npx npm-return-error-msg
+            fi
 
             if grep -q "npm ERR!" "publish_log"
             then
@@ -150,6 +153,7 @@ steps:
             rm publish_log
           done
         fi
+        let errorFlag+=1
       done
       rm ~/.npmrc
       exit 1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,18 +111,17 @@ steps:
 
             echo "CHECK ERROR : " $checkError
 
-            # if [[ "$checkError" =~ "NPM ERR! code ENOTFOUND"]]
-            # then
-            #   echo "Check ERROR MSG! AFTER"
-            #   if ! $i -eq $maximumRetryIfNetworkError
-            #   then
-            #     echo "Network Error Detected"
-            #     continue
-            #   else
-            #     echo "Final Network Error"
-            #     exit 1
-            #   fi
-            # fi
+            if [ "$checkError" = "NPM ERR! code ENOTFOUND" ]; then
+              echo "Check Error! After!"
+              if ! $i -eq $maximumRetryIfNetworkError
+              then
+                echo "Network Error Detected"
+                continue
+              else
+                echo "Final Network Error"
+                exit 1
+              fi
+            fi
 
             # if grep -q "npm ERR!" "publish_log"
             # then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -109,7 +109,7 @@ steps:
 
             checkError=$(npx npm-return-error-msg)
 
-            if [[ $checkError =~ "NPM ERR! code ENOTFOUND"]]
+            if [[ $checkError =~ "NPM ERR! code ENOTFOUND"]];
             then
               echo "Check ERROR MSG! AFTER"
               if ! $i -eq $maximumRetryIfNetworkError

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -109,7 +109,9 @@ steps:
 
             checkError=$(npx npm-return-error-msg)
 
-            if [[ $checkError =~ "NPM ERR! code ENOTFOUND"]];
+            echo "CHECK ERROR : " $checkError
+
+            if [[ "$checkError" =~ "NPM ERR! code ENOTFOUND"]];
             then
               echo "Check ERROR MSG! AFTER"
               if ! $i -eq $maximumRetryIfNetworkError

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -86,7 +86,6 @@ steps:
       fi
       echo Tag: $tag
       cp .npmrc ~/.npmrc
-      errorFlag=0
       maximumRetryIfNetworkError=3
       if [[ -f $(Pipeline.Workspace)/pack/packagePublishOrder.txt ]]; then
         packages=$(cat $(Pipeline.Workspace)/pack/packagePublishOrder.txt)
@@ -107,64 +106,45 @@ steps:
           do
             npm publish $f $tag ${{ parameters.publishFlags }} 2>&1 | tee publish_log
 
-            checkError=$(npx npm-return-error-msg)
-
-            echo "CHECK ERROR : " $checkError
-
-            if [ "$checkError" == "npm ERR! code ENOTFOUND" ];
+            if grep -q "npm ERR!" "publish_log"
             then
-              echo "Check Error! After!"
-              if ! $i -eq $maximumRetryIfNetworkError
-              then
-                echo "Network Error Detected"
-                continue
-              else
-                echo "Final Network Error"
-                exit 1
-              fi
+                if grep -q "code ENOTFOUND" "publish_log"
+                then
+                  if ! $i -eq $maximumRetryIfNetworkError
+                  then
+                    echo "Network Error Detected"
+                    continue
+                  else
+                    echo "Final Network Error"
+                    exit 1
+                  fi
+                else
+                  if grep -q "You cannot publish over the previously published versions" "publish_log"
+                  then
+                    echo Package has already been published.
+                    local_f="${f}_local"
+                    mv "$f" "$local_f"
+                    package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
+                    npm pack $package_name
+                    if cmp -s "$f" "$local_f"
+                    then
+                      echo Continuing as published package matches the current one that was attempting to be released.
+                      continue
+                    else
+                      echo ERROR: Published package does not match the current one attempting to be released for the same version.
+                    fi
+                  fi
+                  rm "$f"
+                  mv "$local_f" "$f"
+                  exit 1
+                fi
+            else
+              rm publish_log
+              break
             fi
-
-            # if grep -q "npm ERR!" "publish_log"
-            # then
-            #     echo "Check ERROR MSG! AFTER"
-            #     if grep -q "code ENOTFOUND" "publish_log"
-            #     then
-            #       if ! $i -eq $maximumRetryIfNetworkError
-            #       then
-            #         echo "Network Error Detected"
-            #         continue
-            #       else
-            #         echo "Final Network Error"
-            #         exit 1
-            #       fi
-            #     else
-            #       if grep -q "You cannot publish over the previously published versions" "publish_log"
-            #       then
-            #         echo Package has already been published.
-            #         local_f="${f}_local"
-            #         mv "$f" "$local_f"
-            #         package_name=$(grep -oP 'npm notice package: \K.*' "publish_log")
-            #         npm pack $package_name
-            #         if cmp -s "$f" "$local_f"
-            #         then
-            #           echo Continuing as published package matches the current one that was attempting to be released.
-            #           continue
-            #         else
-            #           echo ERROR: Published package does not match the current one attempting to be released for the same version.
-            #         fi
-            #       fi
-            #       rm "$f"
-            #       mv "$local_f" "$f"
-            #       exit 1
-            #     fi
-            # else
-            #   rm publish_log
-            #   break
-            # fi
-            # rm publish_log
+            rm publish_log
           done
         fi
-        let errorFlag+=1
       done
       rm ~/.npmrc
       exit 1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,7 +111,7 @@ steps:
 
             echo "CHECK ERROR : " $checkError
 
-            if [ "$checkError" = "NPM ERR! code ENOTFOUND" ]; then
+            if [ "$checkError" =~ "npm ERR! code ENOTFOUND" ]; then
               echo "Check Error! After!"
               if ! $i -eq $maximumRetryIfNetworkError
               then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -129,7 +129,9 @@ steps:
                     if cmp -s "$f" "$local_f"
                     then
                       echo Continuing as published package matches the current one that was attempting to be released.
-                      continue
+                      rm "$f"
+                      mv "$local_f" "$f"
+                      break
                     else
                       echo ERROR: Published package does not match the current one attempting to be released for the same version.
                     fi

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -111,7 +111,7 @@ steps:
 
             echo "CHECK ERROR : " $checkError
 
-            if [[ "$checkError" =~ "NPM ERR! code ENOTFOUND"]];
+            if [[ "$checkError" =~ "NPM ERR! code ENOTFOUND"]]
             then
               echo "Check ERROR MSG! AFTER"
               if ! $i -eq $maximumRetryIfNetworkError


### PR DESCRIPTION
### Description
665: Ability to Rerun Publish Step If There Are Any Network Error https://dev.azure.com/fluidframework/internal/_workitems/edit/665/

### Cases
1. If Publish Package does not encounter an error continue with the remaining packages

2. If Publish Package encounters an error
- Network Error: retry for `$maximumRetryIfNetworkError`-amount of time. If network error is persisted during the entire loop, exit the task in the pipeline
- Non-Network Error: Such as the current package is already published in the registry, fail the pipeline and not continue 