### PR TITLE
Change all `export *` in `packages/loader` and `packages/runtime` to named exports

### DIFF
--- a/packages/loader/container-utils/src/index.ts
+++ b/packages/loader/container-utils/src/index.ts
@@ -3,4 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export * from "./error";
+export {
+	ClientSessionExpiredError,
+	DataCorruptionError,
+	DataProcessingError,
+	extractSafePropertiesFromMessage,
+	GenericError,
+	ThrottlingWarning,
+	UsageError,
+} from "./error";

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -3,24 +3,59 @@
  * Licensed under the MIT License.
  */
 
-export * from "./blobCacheStorageService";
-export * from "./blobAggregationStorage";
-export * from "./buildSnapshotTree";
-export * from "./documentStorageServiceProxy";
-export * from "./insecureUrlResolver";
-export * from "./multiDocumentServiceFactory";
-export * from "./multiUrlResolver";
-export * from "./network";
-export * from "./readAndParse";
-export * from "./fluidResolvedUrl";
-export * from "./summaryForCreateNew";
-export * from "./parallelRequests";
-export * from "./prefetchDocumentStorageService";
-export * from "./networkUtils";
-export * from "./rateLimiter";
-export * from "./runWithRetry";
-export * from "./treeConversions";
-export * from "./treeUtils";
-export * from "./messageRecognition";
-export * from "./error";
-export * from "./emptyDocumentDeltaStorageService";
+export { BlobAggregationStorage, SnapshotExtractor } from "./blobAggregationStorage";
+export { BlobCacheStorageService } from "./blobCacheStorageService";
+export { buildSnapshotTree } from "./buildSnapshotTree";
+export { DocumentStorageServiceProxy } from "./documentStorageServiceProxy";
+export { EmptyDocumentDeltaStorageService } from "./emptyDocumentDeltaStorageService";
+export { UsageError } from "./error";
+export { ensureFluidResolvedUrl, isFluidResolvedUrl } from "./fluidResolvedUrl";
+export { InsecureUrlResolver } from "./insecureUrlResolver";
+export {
+	canBeCoalescedByService,
+	isRuntimeMessage,
+	isUnpackedRuntimeMessage,
+	MessageType2,
+} from "./messageRecognition";
+export { MultiDocumentServiceFactory } from "./multiDocumentServiceFactory";
+export { configurableUrlResolver, MultiUrlResolver } from "./multiUrlResolver";
+export {
+	AuthorizationError,
+	canRetryOnError,
+	createGenericNetworkError,
+	createWriteError,
+	DeltaStreamConnectionForbiddenError,
+	DriverErrorTelemetryProps,
+	FluidInvalidSchemaError,
+	GenericNetworkError,
+	getRetryDelayFromError,
+	getRetryDelaySecondsFromError,
+	IAnyDriverError,
+	isOnline,
+	LocationRedirectionError,
+	NetworkErrorBasic,
+	NonRetryableError,
+	OnlineStatus,
+	RetryableError,
+	ThrottlingError,
+} from "./network";
+export { logNetworkFailure, waitForConnectedState } from "./networkUtils";
+export {
+	emptyMessageStream,
+	ParallelRequests,
+	Queue,
+	requestOps,
+	streamFromMessages,
+	streamObserver,
+} from "./parallelRequests";
+export { PrefetchDocumentStorageService } from "./prefetchDocumentStorageService";
+export { RateLimiter } from "./rateLimiter";
+export { readAndParse } from "./readAndParse";
+export { IProgress, runWithRetry } from "./runWithRetry";
+export {
+	combineAppAndProtocolSummary,
+	getDocAttributesFromProtocolSummary,
+	getQuorumValuesFromProtocolSummary,
+} from "./summaryForCreateNew";
+export { convertSummaryTreeToSnapshotITree } from "./treeConversions";
+export { convertSnapshotAndBlobsToSummaryTree, ISummaryTreeAssemblerProps, SummaryTreeAssembler } from "./treeUtils";

--- a/packages/loader/location-redirection-utils/src/index.ts
+++ b/packages/loader/location-redirection-utils/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./resolveWithLocationRedirection";
+export { isLocationRedirectionError, resolveWithLocationRedirectionHandling } from "./resolveWithLocationRedirection";

--- a/packages/loader/test-loader-utils/src/index.ts
+++ b/packages/loader/test-loader-utils/src/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./mockDocumentService";
-export * from "./mockDeltaStorage";
-export * from "./mockDocumentDeltaConnection";
+export { MockDocumentDeltaStorageService } from "./mockDeltaStorage";
+export { MockDocumentService } from "./mockDocumentService";
+export { MockDocumentDeltaConnection } from "./mockDocumentDeltaConnection";

--- a/packages/loader/web-code-loader/src/index.ts
+++ b/packages/loader/web-code-loader/src/index.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-export * from "./semVerCdnCodeResolver";
-export * from "./utils";
-export * from "./webLoader";
-export * from "./allowList";
+
+export { AllowList } from "./allowList";
+export { SemVerCdnCodeResolver } from "./semVerCdnCodeResolver";
+export { extractPackageIdentifierDetails, IPackageIdentifierDetails, resolveFluidPackageEnvironment } from "./utils";
+export { WebCodeLoader } from "./webLoader";

--- a/packages/runtime/container-runtime-definitions/src/index.ts
+++ b/packages/runtime/container-runtime-definitions/src/index.ts
@@ -3,4 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export * from "./containerRuntime";
+export {
+	IContainerRuntime,
+	IContainerRuntimeBaseWithCombinedEvents,
+	IContainerRuntimeEvents,
+	IDataStoreWithBindToContext_Deprecated,
+	IProvideContainerRuntime,
+} from "./containerRuntime";

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -10,8 +10,15 @@
 * @packageDocumentation
 */
 
-export * from "./channel";
-export * from "./dataStoreRuntime";
-export * from "./jsonable";
-export * from "./serializable";
-export * from "./storage";
+export {
+	IChannel,
+	IChannelFactory,
+	IChannelServices,
+	IChannelStorageService,
+	IDeltaConnection,
+	IDeltaHandler,
+} from "./channel";
+export { IFluidDataStoreRuntime, IFluidDataStoreRuntimeEvents } from "./dataStoreRuntime";
+export { Jsonable } from "./jsonable";
+export { Serializable } from "./serializable";
+export { IChannelAttributes } from "./storage";

--- a/packages/runtime/datastore/src/index.ts
+++ b/packages/runtime/datastore/src/index.ts
@@ -3,5 +3,11 @@
  * Licensed under the MIT License.
  */
 
-export * from "./dataStoreRuntime";
-export * from "./fluidHandle";
+export { FluidObjectHandle } from "./fluidHandle";
+export {
+	DataStoreMessageType,
+	FluidDataStoreRuntime,
+	ISharedObjectRegistry,
+	mixinRequestHandler,
+	mixinSummaryHandler,
+} from "./dataStoreRuntime";

--- a/packages/runtime/garbage-collector/src/index.ts
+++ b/packages/runtime/garbage-collector/src/index.ts
@@ -2,6 +2,17 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-export * from "./garbageCollector";
-export * from "./utils";
-export * from "./interfaces";
+export { runGarbageCollection } from "./garbageCollector";
+export { IGCResult } from "./interfaces";
+export {
+	cloneGCData,
+	concatGarbageCollectionData,
+	concatGarbageCollectionStates,
+	GCDataBuilder,
+	removeRouteFromAllNodes,
+	trimLeadingAndTrailingSlashes,
+	trimLeadingSlashes,
+	trimTrailingSlashes,
+	unpackChildNodesGCDetails,
+	unpackChildNodesUsedRoutes,
+} from "./utils";

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -3,9 +3,46 @@
  * Licensed under the MIT License.
  */
 
-export * from "./dataStoreFactory";
-export * from "./dataStoreRegistry";
-export * from "./dataStoreContext";
-export * from "./garbageCollection";
-export * from "./protocol";
-export * from "./summary";
+export {
+	AliasResult,
+	BindState,
+	CreateChildSummarizerNodeFn,
+	FlushMode,
+	IContainerRuntimeBase,
+	IContainerRuntimeBaseEvents,
+	IDataStore,
+	IFluidDataStoreChannel,
+	IFluidDataStoreContext,
+	IFluidDataStoreContextDetached,
+	IFluidDataStoreContextEvents,
+	VisibilityState,
+} from "./dataStoreContext";
+export { IFluidDataStoreFactory, IProvideFluidDataStoreFactory } from "./dataStoreFactory";
+export {
+	FluidDataStoreRegistryEntry,
+	IFluidDataStoreRegistry,
+	IProvideFluidDataStoreRegistry,
+	NamedFluidDataStoreRegistryEntries,
+	NamedFluidDataStoreRegistryEntry,
+} from "./dataStoreRegistry";
+export { gcBlobKey, IGarbageCollectionData, IGarbageCollectionDetailsBase } from "./garbageCollection";
+export { IAttachMessage, IEnvelope, IInboundSignalMessage, InboundAttachMessage, ISignalEnvelope } from "./protocol";
+export {
+	blobCountPropertyName,
+	channelsTreeName,
+	CreateChildSummarizerNodeParam,
+	CreateSummarizerNodeSource,
+	IGarbageCollectionNodeData,
+	IGarbageCollectionState,
+	ISummarizeInternalResult,
+	ISummarizeResult,
+	ISummarizerNode,
+	ISummarizerNodeConfig,
+	ISummarizerNodeConfigWithGC,
+	ISummarizerNodeWithGC,
+	ISummaryStats,
+	ISummaryTreeWithStats,
+	ITelemetryContext,
+	SummarizeInternalFn,
+	totalBlobSizePropertyName,
+} from "./summary";

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -3,12 +3,41 @@
  * Licensed under the MIT License.
  */
 
-export * from "./dataStoreHandleContextUtils";
-export * from "./dataStoreHelpers";
-export * from "./objectstoragepartition";
-export * from "./objectstorageutils";
-export * from "./requestParser";
-export * from "./runtimeFactoryHelper";
-export * from "./summarizerNode";
-export * from "./summaryUtils";
-export * from "./utils";
+export { generateHandleContextPath } from "./dataStoreHandleContextUtils";
+export {
+	create404Response,
+	createDataStoreFactory,
+	createResponseError,
+	exceptionToResponse,
+	Factory,
+	requestFluidObject,
+	responseToException,
+} from "./dataStoreHelpers";
+export { ObjectStoragePartition } from "./objectstoragepartition";
+export { getNormalizedObjectStoragePathParts, listBlobsAtTreePath } from "./objectstorageutils";
+export { RequestParser } from "./requestParser";
+export { RuntimeFactoryHelper } from "./runtimeFactoryHelper";
+export {
+	createRootSummarizerNode,
+	createRootSummarizerNodeWithGC,
+	IRootSummarizerNode,
+	IRootSummarizerNodeWithGC,
+	ISummarizerNodeRootContract,
+	RefreshSummaryResult,
+} from "./summarizerNode";
+export {
+	addBlobToSummary,
+	addSummarizeResultToSummary,
+	addTreeToSummary,
+	calculateStats,
+	convertSnapshotTreeToSummaryTree,
+	convertSummaryTreeToITree,
+	convertToSummaryTree,
+	convertToSummaryTreeWithStats,
+	getBlobSize,
+	mergeStats,
+	SummaryTreeBuilder,
+	TelemetryContext,
+	utf8ByteLength,
+} from "./summaryUtils";
+export { ReadAndParseBlob, seqFromTree } from "./utils";

--- a/packages/runtime/test-runtime-utils/src/index.ts
+++ b/packages/runtime/test-runtime-utils/src/index.ts
@@ -3,11 +3,24 @@
  * Licensed under the MIT License.
  */
 
-export * from "./insecureTokenProvider";
-export * from "./mocksDataStoreContext";
-export * from "./mockDeltas";
-export * from "./mockHandle";
-export * from "./mocks";
-export * from "./mocksForReconnection";
-export * from "./mockStorage";
-export * from "./validateAssertionError";
+export { InsecureTokenProvider } from "./insecureTokenProvider";
+export { MockFluidDataStoreContext } from "./mocksDataStoreContext";
+export { MockDeltaManager, MockDeltaQueue } from "./mockDeltas";
+export { MockHandle } from "./mockHandle";
+export {
+	IMockContainerRuntimePendingMessage,
+	MockContainerRuntime,
+	MockContainerRuntimeFactory,
+	MockDeltaConnection,
+	MockEmptyDeltaConnection,
+	MockFluidDataStoreRuntime,
+	MockObjectStorageService,
+	MockQuorumClients,
+	MockSharedObjectServices,
+} from "./mocks";
+export {
+	MockContainerRuntimeFactoryForReconnection,
+	MockContainerRuntimeForReconnection,
+} from "./mocksForReconnection";
+export { MockStorage } from "./mockStorage";
+export { validateAssertionError } from "./validateAssertionError";


### PR DESCRIPTION
This PR converts all `export *` in `packages/loader` and `packages/runtime` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.