### PR TITLE
Change all `export `* in `packages/test`, `packages/tools` and `packages/utils` to named exports

### DIFF
--- a/packages/test/mocha-test-setup/src/index.ts
+++ b/packages/test/mocha-test-setup/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./mochaHooks";
+export { mochaHooks } from "./mochaHooks";

--- a/packages/test/stochastic-test-utils/src/index.ts
+++ b/packages/test/stochastic-test-utils/src/index.ts
@@ -3,10 +3,45 @@
  * Licensed under the MIT License.
  */
 
-export * from "./describeFuzz";
-export * from "./generators";
-export * from "./types";
-export * from "./performActions";
-export { makeRandom } from "./random";
-export { XSadd } from "./xsadd";
+export {
+	createFuzzDescribe,
+	defaultOptions,
+	DescribeFuzz,
+	describeFuzz,
+	DescribeFuzzSuite,
+	FuzzDescribeOptions,
+	FuzzSuiteArguments,
+} from "./describeFuzz";
+export {
+	asyncGeneratorFromArray,
+	chain,
+	chainAsync,
+	chainAsyncIterables,
+	chainIterables,
+	createWeightedAsyncGenerator,
+	createWeightedGenerator,
+	generatorFromArray,
+	interleave,
+	interleaveAsync,
+	repeat,
+	repeatAsync,
+	take,
+	takeAsync,
+} from "./generators";
 export { PerformanceWordMarkovChain, SpaceEfficientWordMarkovChain } from "./markovChain";
+export { performFuzzActions, performFuzzActionsAsync } from "./performActions";
+export { makeRandom } from "./random";
+export {
+	AcceptanceCondition,
+	AsyncGenerator,
+	AsyncReducer,
+	AsyncWeights,
+	BaseFuzzTestState,
+	done,
+	Generator,
+	IRandom,
+	Reducer,
+	SaveInfo,
+	Weights,
+} from "./types";
+export { XSadd } from "./xsadd";

--- a/packages/test/test-app-insights-logger/src/index.ts
+++ b/packages/test/test-app-insights-logger/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./appinsightstestlogger";
+export { AppInsightsTestLogger } from "./appinsightstestlogger";

--- a/packages/test/test-driver-definitions/src/index.ts
+++ b/packages/test/test-driver-definitions/src/index.ts
@@ -11,4 +11,11 @@ declare global {
     export const getTestLogger: (() => ITelemetryBufferedLogger) | undefined;
 }
 
-export * from "./interfaces";
+export {
+	DriverEndpoint,
+	ITelemetryBufferedLogger,
+	ITestDriver,
+	OdspEndpoint,
+	RouterliciousEndpoint,
+	TestDriverTypes,
+} from "./interfaces";

--- a/packages/test/test-drivers/src/index.ts
+++ b/packages/test/test-drivers/src/index.ts
@@ -3,12 +3,17 @@
  * Licensed under the MIT License.
  */
 
-export * from "./localServerTestDriver";
-export * from "./odspTestDriver";
-export * from "./tinyliciousTestDriver";
-export * from "./routerliciousTestDriver";
-export * from "./factory";
-
-export * from "./localDriverApi";
-export * from "./odspDriverApi";
-export * from "./routerliciousDriverApi";
+export {
+	createFluidTestDriver,
+	CreateFromEnvConfigParam,
+	DriverApi,
+	DriverApiType,
+	FluidTestDriverConfig,
+} from "./factory";
+export { LocalDriverApi, LocalDriverApiType } from "./localDriverApi";
+export { LocalServerTestDriver } from "./localServerTestDriver";
+export { generateOdspHostStoragePolicy, OdspDriverApi, OdspDriverApiType } from "./odspDriverApi";
+export { assertOdspEndpoint, OdspTestDriver } from "./odspTestDriver";
+export { RouterliciousDriverApi, RouterliciousDriverApiType } from "./routerliciousDriverApi";
+export { assertRouterliciousEndpoint, RouterliciousTestDriver } from "./routerliciousTestDriver";
+export { TinyliciousTestDriver } from "./tinyliciousTestDriver";

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -3,15 +3,36 @@
  * Licensed under the MIT License.
  */
 
-export * from "./interfaces";
-export * from "./testObjectProvider";
-export * from "./loaderContainerTracker";
-export * from "./localLoader";
-export * from "./localCodeLoader";
-export * from "./retry";
-export * from "./testContainerRuntimeFactory";
-export * from "./testFluidObject";
-export * from "./timeoutUtils";
-export * from "./DriverWrappers";
-export * from "./TestSummaryUtils";
-export * from "./TestConfigs";
+export { wrapDocumentService, wrapDocumentServiceFactory, wrapDocumentStorageService } from "./DriverWrappers";
+export { IProvideTestFluidObject, ITestFluidObject } from "./interfaces";
+export { LoaderContainerTracker } from "./loaderContainerTracker";
+export { fluidEntryPoint, LocalCodeLoader, SupportedExportInterfaces } from "./localCodeLoader";
+export { createAndAttachContainer, createLoader } from "./localLoader";
+export { retryWithEventualValue } from "./retry";
+export { mockConfigProvider } from "./TestConfigs";
+export { createTestContainerRuntimeFactory, TestContainerRuntimeFactory } from "./testContainerRuntimeFactory";
+export { ChannelFactoryRegistry, TestFluidObject, TestFluidObjectFactory } from "./testFluidObject";
+export {
+	createDocumentId,
+	DataObjectFactoryType,
+	EventAndErrorTrackingLogger,
+	getUnexpectedLogErrorException,
+	IOpProcessingController,
+	ITestContainerConfig,
+	ITestObjectProvider,
+	TestObjectProvider,
+} from "./testObjectProvider";
+export {
+	createSummarizer,
+	createSummarizerFromFactory,
+	summarizeNow,
+	waitForContainerConnection,
+} from "./TestSummaryUtils";
+export {
+	defaultTimeoutDurationMs,
+	ensureContainerConnected,
+	timeoutAwait,
+	timeoutPromise,
+	TimeoutWithError,
+	TimeoutWithValue,
+} from "./timeoutUtils";

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -3,7 +3,25 @@
  * Licensed under the MIT License.
  */
 export { mochaGlobalSetup } from "./compatConfig";
-export * from "./compatUtils";
-export * from "./testApi";
-export * from "./itExpects";
-export * from "./describeCompat";
+export {
+	getDataStoreFactory,
+	getVersionedTestObjectProvider,
+	ITestDataObject,
+	TestDataObjectType,
+} from "./compatUtils";
+export {
+	DescribeCompat,
+	DescribeCompatSuite,
+	describeFullCompat,
+	describeLoaderCompat,
+	describeNoCompat,
+	ITestObjectProviderOptions,
+} from "./describeCompat";
+export { ExpectedEvents, ExpectsTest, itExpects } from "./itExpects";
+export {
+	ensurePackageInstalled,
+	getContainerRuntimeApi,
+	getDataRuntimeApi,
+	getDriverApi,
+	getLoaderApi,
+} from "./testApi";

--- a/packages/tools/fluid-runner/src/index.ts
+++ b/packages/tools/fluid-runner/src/index.ts
@@ -5,10 +5,10 @@
 
 /* eslint-disable import/no-internal-modules */
 export { ICodeLoaderBundle, IFluidFileConverter } from "./codeLoaderBundle";
-export * from "./exportFile";
+export { createContainerAndExecute, exportFile, IExportFileResponse } from "./exportFile";
 export { fluidRunner } from "./fluidRunner";
 export { OutputFormat } from "./logger/fileLogger";
 export { createLogger, getTelemetryFileValidationError } from "./logger/loggerUtils";
-export * from "./parseBundleAndExportFile";
+export { parseBundleAndExportFile } from "./parseBundleAndExportFile";
 export { getSnapshotFileContent } from "./utils";
 /* eslint-enable import/no-internal-modules */

--- a/packages/tools/replay-tool/src/index.ts
+++ b/packages/tools/replay-tool/src/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./replayArgs";
-export * from "./helpers";
-export * from "./replayMessages";
+export { compareWithReferenceSnapshot, getNormalizedFileSnapshot, loadContainer, uploadSummary } from "./helpers";
+export { ReplayArgs } from "./replayArgs";
+export { ReplayTool } from "./replayMessages";

--- a/packages/tools/webpack-fluid-loader/src/index.ts
+++ b/packages/tools/webpack-fluid-loader/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./routes";
+export { after, before, devServerConfig } from "./routes";

--- a/packages/utils/odsp-doclib-utils/src/index.ts
+++ b/packages/utils/odsp-doclib-utils/src/index.ts
@@ -3,8 +3,50 @@
  * Licensed under the MIT License.
  */
 
-export * from "./odspAuth";
-export * from "./odspDocLibUtils";
-export * from "./odspRequest";
-export * from "./odspDrives";
-export * from "./odspErrorUtils";
+export {
+	authRequestWithRetry,
+	fetchTokens,
+	getFetchTokenUrl,
+	getLoginPageUrl,
+	getOdspRefreshTokenFn,
+	getOdspScope,
+	getPushRefreshTokenFn,
+	getRefreshTokenFn,
+	IClientConfig,
+	IOdspAuthRequestInfo,
+	IOdspTokens,
+	pushScope,
+	refreshTokens,
+	TokenRequestCredentials,
+} from "./odspAuth";
+export {
+	getAadTenant,
+	getAadUrl,
+	getServer,
+	getSiteUrl,
+	isOdspHostname,
+	isPushChannelHostname,
+} from "./odspDocLibUtils";
+export {
+	getChildrenByDriveItem,
+	getDriveId,
+	getDriveItemByRootFileName,
+	getDriveItemByServerRelativePath,
+	getDriveItemFromDriveAndItem,
+	IOdspDriveItem,
+} from "./odspDrives";
+export {
+	createOdspNetworkError,
+	enrichOdspError,
+	fetchIncorrectResponse,
+	getSPOAndGraphRequestIdsFromResponse,
+	hasFacetCodes,
+	OdspErrorResponse,
+	OdspErrorResponseInnerError,
+	OdspRedirectError,
+	OdspServiceReadOnlyErrorCode,
+	parseFacetCodes,
+	throwOdspNetworkError,
+	tryParseErrorResponse,
+} from "./odspErrorUtils";
+export { getAsync, postAsync, putAsync, unauthPostAsync } from "./odspRequest";

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -2,16 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-export * from "./debugLogger";
-export * from "./errorLogging";
-export * from "./eventEmitterWithErrorHandling";
-export * from "./events";
-export * from "./fluidErrorBase";
-export * from "./logger";
-export * from "./mockLogger";
-export * from "./thresholdCounter";
-export * from "./utils";
-export * from "./sampledTelemetryHelper";
 export {
     MonitoringContext,
     IConfigProviderBase,
@@ -21,3 +11,41 @@ export {
     ConfigTypes,
     loggerToMonitoringContext,
 } from "./config";
+export { DebugLogger } from "./debugLogger";
+export {
+	extractLogSafeErrorProperties,
+	generateErrorWithStack,
+	generateStack,
+	getCircularReplacer,
+	IFluidErrorAnnotations,
+	isExternalError,
+	isILoggingError,
+	isTaggedTelemetryPropertyValue,
+	LoggingError,
+	NORMALIZED_ERROR_TYPE,
+	normalizeError,
+	wrapError,
+	wrapErrorAndLog,
+} from "./errorLogging";
+export { EventEmitterWithErrorHandling } from "./eventEmitterWithErrorHandling";
+export { connectedEventName, disconnectedEventName, raiseConnectedEvent, safeRaiseEvent } from "./events";
+export { hasErrorInstanceId, IFluidErrorBase, isFluidError, isValidLegacyError } from "./fluidErrorBase";
+export {
+	BaseTelemetryNullLogger,
+	ChildLogger,
+	IPerformanceEventMarkers,
+	ITelemetryLoggerPropertyBag,
+	ITelemetryLoggerPropertyBags,
+	MultiSinkLogger,
+	PerformanceEvent,
+	TaggedLoggerAdapter,
+	TelemetryDataTag,
+	TelemetryEventPropertyTypes,
+	TelemetryLogger,
+	TelemetryNullLogger,
+	TelemetryUTLogger,
+} from "./logger";
+export { MockLogger } from "./mockLogger";
+export { ThresholdCounter } from "./thresholdCounter";
+export { SampledTelemetryHelper } from "./sampledTelemetryHelper";
+export { logIfFalse } from "./utils";

--- a/packages/utils/tool-utils/src/index.ts
+++ b/packages/utils/tool-utils/src/index.ts
@@ -3,6 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export * from "./fluidToolRC";
-export * from "./odspTokenManager";
-export * from "./snapshotNormalizer";
+export { IAsyncCache, IResources, loadRC, lockRC, saveRC } from "./fluidToolRC";
+export {
+	getMicrosoftConfiguration,
+	IOdspTokenManagerCacheKey,
+	OdspTokenConfig,
+	OdspTokenManager,
+	odspTokensCache,
+} from "./odspTokenManager";
+export { gcBlobPrefix, getNormalizedSnapshot, ISnapshotNormalizerConfig } from "./snapshotNormalizer";


### PR DESCRIPTION
This PR converts all `export `* in `packages/test`, `packages/tools` and `packages/utils` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.