### PR TITLE
Install self signed cert for R11s cluster in test pipelines

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -48,6 +48,12 @@ parameters:
   type: boolean
   default: false
 
+# Name of the Secure File that contains the self-signed cert for the R11s deployment.
+# If not blank, the pipeline will try to install it to the local cert store.
+- name: r11sSelfSignedCertSecureFile
+  type: string
+  default: ""
+
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -85,6 +91,27 @@ jobs:
       # Setup
       - checkout: none
         clean: true
+
+      # Install self-signed cert for R11s deployment in local cert store
+      - ${{ if ne(parameters.r11sSelfSignedCertSecureFile, '') }}:
+        - task: DownloadSecureFile@1
+          displayName: 'Download r11s self-signed cert'
+          name: downloadCertTask
+          inputs:
+            secureFile: ${{ parameters.r11sSelfSignedCertSecureFile }}
+            retryCount: '2'
+
+        - task: Bash@3
+          displayName: 'Install r11s self-signed cert in local cert store'
+          inputs:
+            targetType: 'inline'
+            script: |
+
+              # Extract public part from cert
+              openssl x509 -in $(downloadCertTask.secureFilePath) -out cert.crt
+              # Install cert
+              sudo cp cert.crt /usr/local/share/ca-certificates/
+              sudo update-ca-certificates
 
       # Print parameters/Vars
       - task: Bash@3

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -113,10 +113,6 @@ jobs:
               sudo cp cert.crt /usr/local/share/ca-certificates/
               sudo update-ca-certificates
 
-              # Make sure it worked
-              echo 'CURL after cert install'
-              curl -v https://historian.r11s-wu2-ppe.prague.office-int.com
-
       # Print parameters/Vars
       - task: Bash@3
         displayName: Print Parameters and Variables

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -113,6 +113,10 @@ jobs:
               sudo cp cert.crt /usr/local/share/ca-certificates/
               sudo update-ca-certificates
 
+              # Make sure it worked
+              echo 'CURL after cert install'
+              curl -v https://historian.r11s-wu2-ppe.prague.office-int.com
+
       # Print parameters/Vars
       - task: Bash@3
         displayName: Print Parameters and Variables

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -65,7 +65,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:routerlicious:report
         continueOnError: true
-        r11sSelfSignedCertSecureFile: wu2-ppe=tls-certificate.pem
+        r11sSelfSignedCertSecureFile: wu2-ppe-tls-certificate.pem
         splitTestVariants:
           - name: Non-compat
             flags: --compatVersion=0

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -65,7 +65,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:routerlicious:report
         continueOnError: true
-        r11sSelfSignedCertSecureFile: wu2-ppe-tls-certificate.pem
+        r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
         splitTestVariants:
           - name: Non-compat
             flags: --compatVersion=0

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -65,7 +65,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:routerlicious:report
         continueOnError: true
-        r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
+        r11sSelfSignedCertSecureFile: wu2-ppe=tls-certificate.pem
         splitTestVariants:
           - name: Non-compat
             flags: --compatVersion=0

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -65,6 +65,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:routerlicious:report
         continueOnError: true
+        r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
         splitTestVariants:
           - name: Non-compat
             flags: --compatVersion=0


### PR DESCRIPTION
## Description

This is part of the move from public certs to self-signed certs for the R11s deployment targeted by our e2e tests pipeline.

The certs for both environments in the AKS cluster are already set up in our ADO project so the new pipeline steps in this PR will be able to download them and install them in the build agent's local cert store. The r11s environment targeted by the e2e tests pipeline is still using a public cert. I plan to replace that one with the self-signed cert that is getting installed here only after this change is merged, synced up to the next branch, and possibly ported to lts/release branches, so we don't end up with executions of the e2e tests pipeline that fail because they didn't install the self-signed cert.

## Any relevant logs or outputs

[Here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=99643&view=logs&j=5d40b943-5a8e-529c-ed4b-95198832abfc&t=7dff1b5e-7559-5262-178c-9a365be2a487)'s a test pipeline run that executed the new steps from this PR with a slight change so a) it used the cert of the second environment (which is already deployed there) and b) it made a request to the URL of that second environment to fully validate that the cert installation worked and the cert was trusted when presented by the server.

## Additional information

[Related PR in our internal infrastructure](https://dev.azure.com/fluidframework/internal/_git/ff_internal/pullrequest/487).

Ports of this PR to other branches that need it:
- https://github.com/microsoft/FluidFramework/pull/12497
- https://github.com/microsoft/FluidFramework/pull/12499
- https://github.com/microsoft/FluidFramework/pull/12500
- https://github.com/microsoft/FluidFramework/pull/12501
- https://github.com/microsoft/FluidFramework/pull/12504