### PR TITLE
Change all `export *` in `server/routerlicious/packages` to named exports 

### DIFF
--- a/server/routerlicious/packages/gitresources/src/index.ts
+++ b/server/routerlicious/packages/gitresources/src/index.ts
@@ -3,5 +3,26 @@
  * Licensed under the MIT License.
  */
 
-export * from "./resources";
-export * from "./services";
+export {
+	IAuthor,
+	IBlob,
+	ICommit,
+	ICommitDetails,
+	ICommitHash,
+	ICommitter,
+	ICreateBlobParams,
+	ICreateBlobResponse,
+	ICreateCommitParams,
+	ICreateRefParams,
+	ICreateRepoParams,
+	ICreateTagParams,
+	ICreateTreeEntry,
+	ICreateTreeParams,
+	IPatchRefParams,
+	IRef,
+	ITag,
+	ITagger,
+	ITree,
+	ITreeEntry,
+} from "./resources";
+export { IHeader } from "./services";

--- a/server/routerlicious/packages/kafka-orderer/src/index.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./kafkaOrderer";
+export { KafkaOrderer, KafkaOrdererConnection, KafkaOrdererFactory } from "./kafkaOrderer";

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/index.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./lambdaFactory";
-export * from "./documentContext";
+export { DocumentContext } from "./documentContext";
+export { DocumentLambdaFactory } from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas-driver/src/index.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./document-router";
-export * from "./kafka-service";
+export { DocumentContext, DocumentLambdaFactory } from "./document-router";
+export { IKafkaResources, KafkaRunner, KafkaRunnerFactory, PartitionManager } from "./kafka-service";

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/index.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./partitionManager";
-export * from "./runner";
-export * from "./runnerFactory";
+export { PartitionManager } from "./partitionManager";
+export { KafkaRunner } from "./runner";
+export { IKafkaResources, KafkaRunnerFactory } from "./runnerFactory";

--- a/server/routerlicious/packages/lambdas/src/broadcaster/index.ts
+++ b/server/routerlicious/packages/lambdas/src/broadcaster/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./lambda";
-export * from "./lambdaFactory";
+export { BroadcasterLambda } from "./lambda";
+export { BroadcasterLambdaFactory } from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas/src/copier/index.ts
+++ b/server/routerlicious/packages/lambdas/src/copier/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./lambda";
-export * from "./lambdaFactory";
+export { CopierLambda } from "./lambda";
+export { CopierLambdaFactory } from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas/src/deli/index.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/index.ts
@@ -3,6 +3,11 @@
  * Licensed under the MIT License.
  */
 
-export * from "./checkpointManager";
-export * from "./lambda";
-export * from "./lambdaFactory";
+export {
+	createDeliCheckpointManagerFromCollection,
+	DeliCheckpointReason,
+	ICheckpointParams,
+	IDeliCheckpointManager,
+} from "./checkpointManager";
+export { DeliLambda, IDeliLambdaEvents, OpEventType } from "./lambda";
+export { DeliLambdaFactory } from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas/src/foreman/index.ts
+++ b/server/routerlicious/packages/lambdas/src/foreman/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./lambda";
-export * from "./lambdaFactory";
+export { ForemanLambda } from "./lambda";
+export { ForemanLambdaFactory } from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas/src/index.ts
+++ b/server/routerlicious/packages/lambdas/src/index.ts
@@ -3,12 +3,44 @@
  * Licensed under the MIT License.
  */
 
-export * from "./alfred";
-export * from "./broadcaster";
-export * from "./copier";
-export * from "./deli";
-export * from "./foreman";
-export * from "./scribe";
-export * from "./moira";
-export * from "./scriptorium";
-export * from "./utils";
+export { configureWebSocketServices } from "./alfred";
+export { BroadcasterLambda, BroadcasterLambdaFactory } from "./broadcaster";
+export { CopierLambda, CopierLambdaFactory } from "./copier";
+export {
+	createDeliCheckpointManagerFromCollection,
+	DeliCheckpointReason,
+	DeliLambda,
+	DeliLambdaFactory,
+	ICheckpointParams,
+	IDeliCheckpointManager,
+	IDeliLambdaEvents,
+	OpEventType,
+} from "./deli";
+export { ForemanLambda, ForemanLambdaFactory } from "./foreman";
+export { MoiraLambda, MoiraLambdaFactory } from "./moira";
+export {
+	CheckpointManager,
+	ICheckpointManager,
+	ILatestSummaryState,
+	IPendingMessageReader,
+	ISummaryReader,
+	ISummaryWriter,
+	ISummaryWriteResponse,
+	ScribeLambda,
+	ScribeLambdaFactory,
+	SummaryReader,
+	SummaryWriter,
+} from "./scribe";
+export { ScriptoriumLambda, ScriptoriumLambdaFactory } from "./scriptorium";
+export {
+	createNackMessage,
+	createRoomJoinMessage,
+	createRoomLeaveMessage,
+	createSessionMetric,
+	generateClientId,
+	getRandomInt,
+	isDocumentSessionValid,
+	isDocumentValid,
+	logCommonSessionEndMetrics,
+	NoOpLambda,
+} from "./utils";

--- a/server/routerlicious/packages/lambdas/src/moira/index.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./lambda";
-export * from "./lambdaFactory";
+export { MoiraLambda } from "./lambda";
+export { MoiraLambdaFactory } from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas/src/scribe/index.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/index.ts
@@ -3,9 +3,16 @@
  * Licensed under the MIT License.
  */
 
-export * from "./checkpointManager";
-export * from "./interfaces";
-export * from "./lambda";
-export * from "./lambdaFactory";
-export * from "./summaryReader";
-export * from "./summaryWriter";
+export { CheckpointManager } from "./checkpointManager";
+export {
+	ICheckpointManager,
+	ILatestSummaryState,
+	IPendingMessageReader,
+	ISummaryReader,
+	ISummaryWriter,
+	ISummaryWriteResponse,
+} from "./interfaces";
+export { ScribeLambda } from "./lambda";
+export { ScribeLambdaFactory } from "./lambdaFactory";
+export { SummaryReader } from "./summaryReader";
+export { SummaryWriter } from "./summaryWriter";

--- a/server/routerlicious/packages/lambdas/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./lambda";
-export * from "./lambdaFactory";
+export { ScriptoriumLambda } from "./lambda";
+export { ScriptoriumLambdaFactory } from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas/src/utils/index.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/index.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-export * from "./clientIdGenerator";
-export * from "./messageGenerator";
-export * from "./noOpLambda";
-export * from "./random";
-export * from "./telemetryHelper";
-export * from "./validateDocument";
+export { generateClientId } from "./clientIdGenerator";
+export { createNackMessage, createRoomJoinMessage, createRoomLeaveMessage } from "./messageGenerator";
+export { NoOpLambda } from "./noOpLambda";
+export { getRandomInt } from "./random";
+export { createSessionMetric, logCommonSessionEndMetrics } from "./telemetryHelper";
+export { isDocumentSessionValid, isDocumentValid } from "./validateDocument";

--- a/server/routerlicious/packages/local-server/src/index.ts
+++ b/server/routerlicious/packages/local-server/src/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./localDeltaConnectionServer";
-export * from "./localOrdererManager";
-export * from "./localWebSocketServer";
+export { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "./localDeltaConnectionServer";
+export { LocalOrdererManager } from "./localOrdererManager";
+export { LocalWebSocket, LocalWebSocketServer } from "./localWebSocketServer";

--- a/server/routerlicious/packages/memory-orderer/src/index.ts
+++ b/server/routerlicious/packages/memory-orderer/src/index.ts
@@ -3,13 +3,23 @@
  * Licensed under the MIT License.
  */
 
-export * from "./interfaces";
-export * from "./localContext";
-export * from "./localKafka";
-export * from "./localLambdaController";
-export * from "./localNodeFactory";
-export * from "./localOrderer";
-export * from "./localOrderManager";
-export * from "./nodeManager";
-export * from "./pubsub";
-export * from "./reservationManager";
+export {
+	IConcreteNode,
+	IConcreteNodeFactory,
+	IConnectedMessage,
+	IConnectMessage,
+	IKafkaSubscriber,
+	ILocalOrdererSetup,
+	INodeMessage,
+	IOpMessage,
+	IReservationManager,
+} from "./interfaces";
+export { LocalContext } from "./localContext";
+export { LocalKafka } from "./localKafka";
+export { LocalLambdaController, LocalLambdaControllerState } from "./localLambdaController";
+export { LocalNodeFactory } from "./localNodeFactory";
+export { LocalOrderer } from "./localOrderer";
+export { LocalOrderManager } from "./localOrderManager";
+export { NodeManager } from "./nodeManager";
+export { IPubSub, ISubscriber, PubSub, WebSocketSubscriber } from "./pubsub";
+export { IReservation, ReservationManager } from "./reservationManager";

--- a/server/routerlicious/packages/protocol-base/src/index.ts
+++ b/server/routerlicious/packages/protocol-base/src/index.ts
@@ -3,8 +3,29 @@
  * Licensed under the MIT License.
  */
 
-export * from "./blobs";
-export * from "./protocol";
-export * from "./quorum";
-export * from "./utils";
-export * from "./scribeHelper";
+export {
+	addBlobToTree,
+	AttachmentTreeEntry,
+	BlobTreeEntry,
+	buildHierarchy,
+	getGitMode,
+	getGitType,
+	TreeTreeEntry,
+} from "./blobs";
+export {
+	ILocalSequencedClient,
+	IProtocolHandler,
+	IScribeProtocolState,
+	isSystemMessage,
+	ProtocolOpHandler,
+} from "./protocol";
+export {
+	IQuorumSnapshot,
+	Quorum,
+	QuorumClients,
+	QuorumClientsSnapshot,
+	QuorumProposals,
+	QuorumProposalsSnapshot,
+} from "./quorum";
+export { generateServiceProtocolEntries, getQuorumTreeEntries, mergeAppAndProtocolTree } from "./scribeHelper";
+export { isServiceMessageType } from "./utils";

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./runnerFactory";
-export * from "./runner";
-export * from "./services";
+export { AlfredRunner } from "./runner";
+export { AlfredResources, AlfredResourcesFactory, AlfredRunnerFactory, OrdererManager } from "./runnerFactory";
+export { DeltaService } from "./services";

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/services/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/services/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./deltaService";
+export { DeltaService } from "./deltaService";

--- a/server/routerlicious/packages/routerlicious-base/src/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/index.ts
@@ -3,7 +3,30 @@
  * Licensed under the MIT License.
  */
 
-export * from "./alfred";
-export * from "./ordering";
-export * from "./riddler";
-export * from "./utils";
+export {
+	AlfredResources,
+	AlfredResourcesFactory,
+	AlfredRunner,
+	AlfredRunnerFactory,
+	DeltaService,
+	OrdererManager,
+} from "./alfred";
+export { OrderingResourcesFactory } from "./ordering";
+export {
+	ITenantDocument,
+	RiddlerResources,
+	RiddlerResourcesFactory,
+	RiddlerRunner,
+	RiddlerRunnerFactory,
+	TenantManager,
+} from "./riddler";
+export {
+	catch404,
+	Constants,
+	createDocumentRouter,
+	getIdFromRequest,
+	getSession,
+	getTenantIdFromRequest,
+	handleError,
+	IPlugin,
+} from "./utils";

--- a/server/routerlicious/packages/routerlicious-base/src/ordering/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/ordering/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./resourcesFactory";
+export { OrderingResourcesFactory } from "./resourcesFactory";

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./runnerFactory";
-export * from "./runner";
-export * from "./tenantManager";
+export { RiddlerRunner } from "./runner";
+export { RiddlerResources, RiddlerResourcesFactory, RiddlerRunnerFactory } from "./runnerFactory";
+export { ITenantDocument, TenantManager } from "./tenantManager";

--- a/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export * from "./constants";
-export * from "./documentRouter";
-export * from "./middleware";
-export * from "./params";
-export * from "./sessionHelper";
+export { Constants } from "./constants";
+export { createDocumentRouter, IPlugin } from "./documentRouter";
+export { catch404, handleError } from "./middleware";
+export { getIdFromRequest, getTenantIdFromRequest } from "./params";
+export { getSession } from "./sessionHelper";

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -3,21 +3,61 @@
  * Licensed under the MIT License.
  */
 
-export * from "./auth";
-export * from "./constants";
-export * from "./error";
-export * from "./generateNames";
-export * from "./gitManager";
-export * from "./historian";
-export * from "./interfaces";
-export * from "./promiseTimeout";
-export * from "./restLessClient";
-export * from "./restWrapper";
-export * from "./rollingHash";
-export * from "./scopes";
-export * from "./storage";
-export * from "./storageContracts";
-export * from "./storageUtils";
-export * from "./summaryTreeUploadManager";
-export * from "./utils";
-export * from "./wholeSummaryUploadManager";
+export { generateToken, generateUser, validateTokenClaims, validateTokenClaimsExpiration } from "./auth";
+export { CorrelationIdHeaderName, DriverVersionHeaderName, LatestSummaryId } from "./constants";
+export {
+	createFluidServiceNetworkError,
+	INetworkErrorDetails,
+	isNetworkError,
+	NetworkError,
+	throwFluidServiceNetworkError,
+} from "./error";
+export { choose, getRandomName } from "./generateNames";
+export { GitManager } from "./gitManager";
+export { getAuthorizationTokenFromCredentials, Historian, ICredentials } from "./historian";
+export { IAlfredTenant, ISession } from "./interfaces";
+export { promiseTimeout } from "./promiseTimeout";
+export { RestLessClient, RestLessFieldNames } from "./restLessClient";
+export { BasicRestWrapper, RestWrapper } from "./restWrapper";
+export { defaultHash, getNextHash } from "./rollingHash";
+export { canRead, canSummarize, canWrite } from "./scopes";
+export {
+	ICreateRefParamsExternal,
+	IGetRefParamsExternal,
+	IGitCache,
+	IGitManager,
+	IGitService,
+	IHistorian,
+	IPatchRefParamsExternal,
+	ISummaryUploadManager,
+} from "./storage";
+export {
+	ExtendedSummaryObject,
+	IEmbeddedSummaryHandle,
+	INormalizedWholeSummary,
+	ISummaryTree,
+	IWholeFlatSummary,
+	IWholeFlatSummaryBlob,
+	IWholeFlatSummaryTree,
+	IWholeFlatSummaryTreeEntry,
+	IWholeFlatSummaryTreeEntryBlob,
+	IWholeFlatSummaryTreeEntryTree,
+	IWholeSummaryBlob,
+	IWholeSummaryPayload,
+	IWholeSummaryPayloadType,
+	IWholeSummaryTree,
+	IWholeSummaryTreeBaseEntry,
+	IWholeSummaryTreeHandleEntry,
+	IWholeSummaryTreeValueEntry,
+	IWriteSummaryResponse,
+	WholeSummaryTreeEntry,
+	WholeSummaryTreeValue,
+} from "./storageContracts";
+export {
+	buildTreePath,
+	convertSummaryTreeToWholeSummaryTree,
+	convertWholeFlatSummaryToSnapshotTreeAndBlobs,
+} from "./storageUtils";
+export { SummaryTreeUploadManager } from "./summaryTreeUploadManager";
+export { getOrCreateRepository } from "./utils";
+export { WholeSummaryUploadManager } from "./wholeSummaryUploadManager";

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -3,33 +3,114 @@
  * Licensed under the MIT License.
  */
 
-export * from "./cache";
-export * from "./celaNames";
-export * from "./clientManager";
-export * from "./combinedContext";
-export * from "./combinedLambda";
-export * from "./combinedProducer";
-export * from "./configuration";
-export * from "./database";
-export * from "./delta";
-export * from "./document";
-export * from "./emptyTaskMessageSender";
-export * from "./http";
-export * from "./lambdas";
-export * from "./messages";
-export * from "./metricClient";
-export * from "./mongo";
-export * from "./mongoDatabaseManager";
-export * from "./orderer";
-export * from "./pendingBoxcar";
-export * from "./publisher";
-export * from "./queue";
-export * from "./runner";
-export * from "./runWithRetry";
-export * from "./secretManager";
-export * from "./taskMessages";
-export * from "./tenant";
-export * from "./throttler";
-export * from "./token";
-export * from "./usageData";
-export * from "./zookeeper";
+export { ICache } from "./cache";
+export { chooseCelaName } from "./celaNames";
+export { IClientManager, ISequencedSignalClient } from "./clientManager";
+export { CombinedContext } from "./combinedContext";
+export { CombinedLambda } from "./combinedLambda";
+export { CombinedProducer } from "./combinedProducer";
+export {
+	DefaultServiceConfiguration,
+	IBroadcasterServerConfiguration,
+	IDeliCheckpointHeuristicsServerConfiguration,
+	IDeliOpEventServerConfiguration,
+	IDeliServerConfiguration,
+	IDeliSummaryNackMessagesServerConfiguration,
+	IDocumentLambdaServerConfiguration,
+	IMoiraServerConfiguration,
+	IScribeServerConfiguration,
+	IServerConfiguration,
+	IServiceConfiguration,
+} from "./configuration";
+export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory } from "./database";
+export { IDeltaService } from "./delta";
+export { IClientSequenceNumber, IDeliState, IDocument, IDocumentDetails, IDocumentStorage, IScribe } from "./document";
+export { EmptyTaskMessageSender } from "./emptyTaskMessageSender";
+export { IHttpServer, IWebServer, IWebServerFactory, IWebSocket, IWebSocketServer, RequestListener } from "./http";
+export {
+	extractBoxcar,
+	IContext,
+	IContextErrorData,
+	ILogger,
+	IPartitionConfig,
+	IPartitionLambda,
+	IPartitionLambdaConfig,
+	IPartitionLambdaFactory,
+	IPartitionLambdaPlugin,
+	LambdaCloseType,
+	LambdaName,
+} from "./lambdas";
+export {
+	BoxcarType,
+	ControlMessageType,
+	IBoxcarMessage,
+	IControlMessage,
+	IDisableNackMessagesControlMessageContents,
+	IExtendClientControlMessageContents,
+	ILambdaStartControlMessageContents,
+	IMessage,
+	INackMessage,
+	INackMessagesControlMessageContents,
+	IObjectMessage,
+	IRawOperationMessage,
+	IRawOperationMessageBatch,
+	IRoutingKey,
+	ISequencedOperationMessage,
+	ISystemMessage,
+	ITicketedMessage,
+	ITicketedSignalMessage,
+	IUpdateDSNControlMessageContents,
+	IUpdateReferenceSequenceNumberMessage,
+	NackMessagesType,
+	NackOperationType,
+	RawOperationType,
+	SequencedOperationType,
+	SignalOperationType,
+	SystemOperations,
+	SystemType,
+} from "./messages";
+export { DefaultMetricClient, IMetricClient } from "./metricClient";
+export { MongoManager } from "./mongo";
+export { MongoDatabaseManager } from "./mongoDatabaseManager";
+export { INode, IOrderer, IOrdererConnection, IOrdererManager, IOrdererSocket } from "./orderer";
+export { MaxBatchSize, PendingBoxcar } from "./pendingBoxcar";
+export { IMessageBatch, IPublisher, ITopic } from "./publisher";
+export {
+	IConsumer,
+	IPartition,
+	IPartitionWithEpoch,
+	IPendingBoxcar,
+	IPendingMessage,
+	IProducer,
+	IQueuedMessage,
+} from "./queue";
+export { IResources, IResourcesFactory, IRunner, IRunnerFactory } from "./runner";
+export {
+	calculateRetryIntervalForNetworkError,
+	requestWithRetry,
+	runWithRetry,
+	shouldRetryNetworkError,
+} from "./runWithRetry";
+export { ISecretManager } from "./secretManager";
+export { IAgent, IAgentUploader, ITaskMessage, ITaskMessageReceiver, ITaskMessageSender } from "./taskMessages";
+export {
+	ITenant,
+	ITenantConfig,
+	ITenantCustomData,
+	ITenantKeys,
+	ITenantManager,
+	ITenantOrderer,
+	ITenantStorage,
+	KeyName,
+} from "./tenant";
+export {
+	IThrottleAndUsageStorageManager,
+	IThrottler,
+	IThrottlerHelper,
+	IThrottlerResponse,
+	IThrottlingMetrics,
+	ThrottlingError,
+} from "./throttler";
+export { TokenGenerator } from "./token";
+export { clientConnectivityStorageId, IUsageData, signalUsageStorageId } from "./usageData";
+export { IZookeeperClient, ZookeeperClientConstructor } from "./zookeeper";

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/index.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./kafkaNodeConsumer";
-export * from "./kafkaNodeProducer";
-export * from "./resourcesFactory";
+export { KafkaNodeConsumer } from "./kafkaNodeConsumer";
+export { KafkaNodeProducer } from "./kafkaNodeProducer";
+export { IKafkaResources, KafkaResources, KafkaResourcesFactory } from "./resourcesFactory";

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/index.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./rdkafkaConsumer";
-export * from "./rdkafkaProducer";
-export * from "./resourcesFactory";
+export { IKafkaConsumerOptions, RdkafkaConsumer } from "./rdkafkaConsumer";
+export { IKafkaProducerOptions, RdkafkaProducer } from "./rdkafkaProducer";
+export { IRdkafkaResources, RdkafkaResources, RdkafkaResourcesFactory } from "./resourcesFactory";

--- a/server/routerlicious/packages/services-ordering-zookeeper/src/index.ts
+++ b/server/routerlicious/packages/services-ordering-zookeeper/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./zookeeperClient";
+export { ZookeeperClient } from "./zookeeperClient";

--- a/server/routerlicious/packages/services-shared/src/index.ts
+++ b/server/routerlicious/packages/services-shared/src/index.ts
@@ -3,11 +3,23 @@
  * Licensed under the MIT License.
  */
 
-export * from "./http";
-export * from "./redisSocketIoAdapter";
-export * from "./restLessServer";
-export * from "./runner";
-export * from "./storage";
-export * from "./webServer";
-export * from "./wholeSummaryReadGitManager";
-export * from "./wholeSummaryWriteGitManager";
+export { containsPathTraversal, defaultErrorMessage, handleResponse, validateRequestParams } from "./http";
+export {
+	ISocketIoRedisConnection,
+	ISocketIoRedisOptions,
+	ISocketIoRedisSubscriptionConnection,
+	RedisSocketIoAdapter,
+} from "./redisSocketIoAdapter";
+export { decodeHeader, RestLessServer } from "./restLessServer";
+export { run, runService } from "./runner";
+export { DocumentStorage } from "./storage";
+export {
+	BasicWebServerFactory,
+	HttpServer,
+	IHttpServerConfig,
+	RequestListener,
+	SocketIoWebServerFactory,
+	WebServer,
+} from "./webServer";
+export { WholeSummaryReadGitManager } from "./wholeSummaryReadGitManager";
+export { WholeSummaryWriteGitManager } from "./wholeSummaryWriteGitManager";

--- a/server/routerlicious/packages/services-telemetry/src/index.ts
+++ b/server/routerlicious/packages/services-telemetry/src/index.ts
@@ -3,9 +3,23 @@
  * Licensed under the MIT License.
  */
 
-export * from "./lumber";
-export * from "./lumberEventNames";
-export * from "./lumberjack";
-export * from "./resources";
-export * from "./schema";
-export * from "./lumberjackCommonTestUtils";
+export { Lumber } from "./lumber";
+export { LumberEventName } from "./lumberEventNames";
+export { Lumberjack } from "./lumberjack";
+export { TestEngine1, TestEngine2, TestLumberjack, TestSchemaValidator } from "./lumberjackCommonTestUtils";
+export {
+	BaseTelemetryProperties,
+	CommonProperties,
+	getLumberBaseProperties,
+	handleError,
+	HttpProperties,
+	ILumberjackEngine,
+	ILumberjackSchemaValidationResult,
+	ILumberjackSchemaValidator,
+	LogLevel,
+	LumberType,
+	QueuedMessageProperties,
+	SessionState,
+	ThrottlingTelemetryProperties,
+} from "./resources";
+export { BaseLumberjackSchemaValidator, BasePropertiesValidator, LambdaSchemaValidator } from "./schema";

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -3,17 +3,29 @@
  * Licensed under the MIT License.
  */
 
-export * from "./asyncLocalStorage";
-export * from "./auth";
-export * from "./conversion";
-export * from "./deleteSummarizedOps";
-export * from "./dns";
-export * from "./errorUtils";
-export * from "./executeOnInterval";
-export * from "./generateNames";
-export * from "./logger";
-export * from "./morganLoggerMiddleware";
-export * from "./port";
-export * from "./redisUtils";
-export * from "./throttlerMiddleware";
-export * from "./winstonLumberjackEngine";
+export { bindCorrelationId, getCorrelationId, getCorrelationIdWithHttpFallback } from "./asyncLocalStorage";
+export {
+	generateToken,
+	generateUser,
+	getCreationToken,
+	getParam,
+	respondWithNetworkError,
+	validateTokenClaims,
+	verifyStorageToken,
+} from "./auth";
+export { parseBoolean } from "./conversion";
+export { deleteSummarizedOps } from "./deleteSummarizedOps";
+export { getHostIp } from "./dns";
+export { FluidServiceError, FluidServiceErrorCode } from "./errorUtils";
+export { executeOnInterval, ScheduledJob } from "./executeOnInterval";
+export { choose, getRandomName } from "./generateNames";
+export { configureLogging, IWinstonConfig } from "./logger";
+export { alternativeMorganLoggerMiddleware, jsonMorganLoggerMiddleware } from "./morganLoggerMiddleware";
+export { normalizePort } from "./port";
+export {
+	executeRedisMultiWithHmsetExpire,
+	executeRedisMultiWithHmsetExpireAndLpush,
+	IRedisParameters,
+} from "./redisUtils";
+export { IThrottleMiddlewareOptions, throttle } from "./throttlerMiddleware";
+export { WinstonLumberjackEngine } from "./winstonLumberjackEngine";

--- a/server/routerlicious/packages/services/src/index.ts
+++ b/server/routerlicious/packages/services/src/index.ts
@@ -3,19 +3,41 @@
  * Licensed under the MIT License.
  */
 
-export * from "./dbFactory";
-export * from "./kafkaProducerFactory";
-export * from "./messageReceiver";
-export * from "./messageSender";
-export * from "./metricClient";
-export * from "./mongodb";
-export * from "./nodeCodeLoader";
-export * from "./redis";
-export * from "./redisClientManager";
-export * from "./redisThrottleAndUsageStorageManager";
-export * from "./secretManager";
-export * from "./socketIoRedisPublisher";
-export * from "./tenant";
-export * from "./throttler";
-export * from "./throttlerHelper";
-export * from "@fluidframework/server-services-shared";
+export { getDbFactory } from "./dbFactory";
+export { createProducer } from "./kafkaProducerFactory";
+export { createMessageReceiver } from "./messageReceiver";
+export { createMessageSender } from "./messageSender";
+export { createMetricClient } from "./metricClient";
+export { MongoCollection, MongoDb, MongoDbFactory } from "./mongodb";
+export { NodeAllowList, NodeCodeLoader } from "./nodeCodeLoader";
+export { RedisCache } from "./redis";
+export { ClientManager } from "./redisClientManager";
+export { RedisThrottleAndUsageStorageManager } from "./redisThrottleAndUsageStorageManager";
+export { SecretManager } from "./secretManager";
+export { SocketIoRedisPublisher, SocketIoRedisTopic } from "./socketIoRedisPublisher";
+export { Tenant, TenantManager } from "./tenant";
+export { Throttler } from "./throttler";
+export { ThrottlerHelper } from "./throttlerHelper";
+export {
+	BasicWebServerFactory,
+	containsPathTraversal,
+	decodeHeader,
+	defaultErrorMessage,
+	DocumentStorage,
+	handleResponse,
+	HttpServer,
+	IHttpServerConfig,
+	ISocketIoRedisConnection,
+	ISocketIoRedisOptions,
+	ISocketIoRedisSubscriptionConnection,
+	RedisSocketIoAdapter,
+	RequestListener,
+	RestLessServer,
+	run,
+	runService,
+	SocketIoWebServerFactory,
+	validateRequestParams,
+	WebServer,
+	WholeSummaryReadGitManager,
+	WholeSummaryWriteGitManager,
+} from "@fluidframework/server-services-shared";

--- a/server/routerlicious/packages/test-utils/src/index.ts
+++ b/server/routerlicious/packages/test-utils/src/index.ts
@@ -3,17 +3,17 @@
  * Licensed under the MIT License.
  */
 
-export * from "./logger";
-export * from "./messageFactory";
-export * from "./testCache";
-export * from "./testClientManager";
-export * from "./testCollection";
-export * from "./testContext";
-export * from "./testDocumentStorage";
-export * from "./testHistorian";
-export * from "./testKafka";
-export * from "./testPublisher";
-export * from "./testTenantManager";
-export * from "./testThrottleAndUsageStorageManager";
-export * from "./testThrottlerHelper";
-export * from "./testThrottler";
+export { DebugLogger } from "./logger";
+export { KafkaMessageFactory, MessageFactory } from "./messageFactory";
+export { TestCache } from "./testCache";
+export { TestClientManager } from "./testClientManager";
+export { ITestDbFactory, TestCollection, TestDb, TestDbFactory } from "./testCollection";
+export { TestContext } from "./testContext";
+export { TestDocumentStorage, writeSummaryTree } from "./testDocumentStorage";
+export { TestHistorian } from "./testHistorian";
+export { TestConsumer, TestKafka, TestProducer } from "./testKafka";
+export { IEvent, TestPublisher, TestTopic } from "./testPublisher";
+export { TestTenant, TestTenantManager } from "./testTenantManager";
+export { TestThrottleAndUsageStorageManager } from "./testThrottleAndUsageStorageManager";
+export { TestThrottler } from "./testThrottler";
+export { TestThrottlerHelper } from "./testThrottlerHelper";


### PR DESCRIPTION
This PR converts all `export *` in `server/routerlicious/packages` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.