### PR TITLE
Change all `export *` in `server/historian` and `server/tinylicious` to named exports

### DIFF
--- a/server/historian/packages/historian-base/src/index.ts
+++ b/server/historian/packages/historian-base/src/index.ts
@@ -3,8 +3,23 @@
  * Licensed under the MIT License.
  */
 
-export * from "./logger";
-export * from "./routes";
-export * from "./services";
-export * from "./runnerFactory";
-export * from "./runner";
+export { configureHistorianLogging } from "./logger";
+export { create, IRoutes } from "./routes";
+export { HistorianRunner } from "./runner";
+export { HistorianResources, HistorianResourcesFactory, HistorianRunnerFactory } from "./runnerFactory";
+export {
+	ICache,
+	IConnectionString,
+	ICredentials,
+	IDocument,
+	IExternalStorage,
+	IOauthAccessInfo,
+	IStorage,
+	ITenant,
+	ITenantCustomDataExternal,
+	ITenantService,
+	RedisCache,
+	RedisTenantCache,
+	RestGitService,
+	RiddlerService,
+} from "./services";

--- a/server/historian/packages/historian-base/src/services/index.ts
+++ b/server/historian/packages/historian-base/src/services/index.ts
@@ -3,8 +3,18 @@
  * Licensed under the MIT License.
  */
 
-export * from "./definitions";
-export * from "./redisCache";
-export * from "./redisTenantCache";
-export * from "./restGitService";
-export * from "./riddlerService";
+export {
+	ICache,
+	IConnectionString,
+	ICredentials,
+	IExternalStorage,
+	IOauthAccessInfo,
+	IStorage,
+	ITenant,
+	ITenantCustomDataExternal,
+	ITenantService,
+} from "./definitions";
+export { RedisCache } from "./redisCache";
+export { RedisTenantCache } from "./redisTenantCache";
+export { IDocument, RestGitService } from "./restGitService";
+export { RiddlerService } from "./riddlerService";

--- a/server/historian/packages/historian-base/src/test/utils/index.ts
+++ b/server/historian/packages/historian-base/src/test/utils/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./testCache";
-export * from "./testTenantService";
+export { TestCache } from "./testCache";
+export { TestTenantService } from "./testTenantService";

--- a/server/tinylicious/src/services/index.ts
+++ b/server/tinylicious/src/services/index.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export * from "./dbFactory";
-export * from "./pubSubPublisher";
-export * from "./taskMessageSender";
-export * from "./tenantManager";
-export * from "./webServerFactory";
+export { getDbFactory } from "./dbFactory";
+export { PubSubPublisher } from "./pubSubPublisher";
+export { TaskMessageSender } from "./taskMessageSender";
+export { TenantManager, TinyliciousTenant } from "./tenantManager";
+export { WebServerFactory } from "./webServerFactory";


### PR DESCRIPTION
This PR converts all `export *` in `server/historian` and `server/tinylicious` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.