### PR TITLE
Cache ops only on first snapshot fetch

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -325,9 +325,9 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
                 },
             );
 
-            // Successful call, make network calls only
+            // Don't override ops which were fetched during initial load, since we could still need them.
+            const id = this.initializeFromSnapshot(odspSnapshotCacheValue, this.firstVersionCall);
             this.firstVersionCall = false;
-            const id = this.initializeFromSnapshot(odspSnapshotCacheValue);
 
             return id ? [{ id, treeId: undefined! }] : [];
         }

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -265,7 +265,7 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
         return summarySnapshotTree;
     }
 
-    protected initializeFromSnapshot(odspSnapshotCacheValue: ISnapshotContents): string | undefined {
+    protected initializeFromSnapshot(odspSnapshotCacheValue: ISnapshotContents, cacheOps: boolean = true): string | undefined {
         this._snapshotSequenceNumber = odspSnapshotCacheValue.sequenceNumber;
         const { snapshotTree, blobs, ops } = odspSnapshotCacheValue;
 
@@ -281,7 +281,9 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
             this.initBlobsCache(blobs);
         }
 
-        this.ops = ops;
+        if (cacheOps) {
+            this.ops = ops;
+        }
         return id;
     }
 }


### PR DESCRIPTION
## Description

Cache ops only on first snapshot fetch when the container loads as they could always be required. We don't want to override them with ops from later snapshot fetches/refreshes by summarizer.

Above change got reverted in this PR when we reverted whole change instead of just adding back blobs fetch:
[Add back fetching of blobs in fetch snapshot tree call by jatgarg · Pull Request #12405 · microsoft/FluidFramework (github.com)](https://github.com/microsoft/FluidFramework/pull/12405)
