### PR TITLE
Revert Remove initial set of deprecated properties from ISummaryRuntimeOptions

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -21,18 +21,10 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 - [Remove iframe-driver](#remove-iframe-driver)
-- [Remove Deprecated Fields from ISummaryRuntimeOptions](#Remove-Deprecated-Fields-from-ISummaryRuntimeOptions)
 
 ### Remove iframe-driver
 The iframe-driver package was deprecated in 2.0.0-internal.1.3.0 and has now been removed.
 
-### Remove Deprecated Fields from ISummaryRuntimeOptions
-The following fields are being removed from `ISummaryRuntimeOptions` as they became properties from `ISummaryConfiguration`:
-
-`ISummaryRuntimeOptions.disableSummaries`
-`ISummaryRuntimeOptions.maxOpsSinceLastSummary`
-`ISummaryRuntimeOptions.summarizerClientElection`
-`ISummaryRuntimeOptions.summarizerOptions`
 # 2.0.0-internal.2.0.0
 
 ## 2.0.0-internal.2.0.0 Upcoming changes

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -614,7 +614,17 @@ export interface ISummaryOpMessage extends ISequencedDocumentMessage {
 // @public (undocumented)
 export interface ISummaryRuntimeOptions {
     // @deprecated
+    disableSummaries?: boolean;
+    // @deprecated
     initialSummarizerDelayMs?: number;
+    // @deprecated (undocumented)
+    maxOpsSinceLastSummary?: number;
+    // @deprecated
+    summarizerClientElection?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "ISummarizerOptions" needs to be exported by the entry point index.d.ts
+    //
+    // @deprecated
+    summarizerOptions?: Readonly<Partial<ISummarizerOptions>>;
     summaryConfigOverrides?: ISummaryConfiguration;
 }
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -244,7 +244,7 @@ describe("Runtime", () => {
                             undefined, // requestHandler
                             {
                                 summaryOptions: {
-                                    summaryConfigOverrides: { state: "disabled" },
+                                    disableSummaries: true,
                                 },
                                 flushMode,
                             },

--- a/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
@@ -33,7 +33,7 @@ describe("Hardware Stats", () => {
         undefined, // requestHandler
         {
             summaryOptions: {
-                summaryConfigOverrides: { state: "disabled" },
+                disableSummaries: true,
             },
         },
     );

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
@@ -38,6 +38,7 @@ interface SearchContent extends ProvideSearchContent {
 // Note GC needs to be disabled.
 const runtimeOptions: IContainerRuntimeOptions = {
     summaryOptions: {
+        disableSummaries: true,
         summaryConfigOverrides: { state: "disabled" },
     },
     gcOptions: { gcAllowed: false },

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -223,9 +223,7 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
         createDataStoreRuntime(),
     );
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: {
-            summaryConfigOverrides: { state: "disabled" },
-        },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: false },
     };
     const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>

--- a/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
@@ -39,9 +39,7 @@ describeFullCompat("Audience correctness", (getTestObjectProvider) => {
         undefined,
         [innerRequestHandler],
         // Disable summaries so the summarizer client doesn't interfere with the audience
-        { summaryOptions: {
-            summaryConfigOverrides: { state: "disabled" },
-        } },
+        { summaryOptions: { disableSummaries: true } },
     );
 
     const createContainer = async (): Promise<Container> => await provider.createContainer(runtimeFactory) as Container;

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -95,8 +95,7 @@ async function runAndValidateBatch(
         const loader = provider.createLoader(
             [[
                 provider.defaultCodeDetails,
-                provider.createFluidEntryPoint({ runtimeOptions: { summaryOptions: {
-                    summaryConfigOverrides: { state: "disabled" } } } }),
+                provider.createFluidEntryPoint({ runtimeOptions: { summaryOptions: { disableSummaries: true } } }),
             ]],
             {
                 documentServiceFactory: proxyDsf,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -42,6 +42,7 @@ describeFullCompat.skip("GC summary compatibility tests", (getTestObjectProvider
     async function createContainer(): Promise<IContainer> {
         const runtimeOptions: IContainerRuntimeOptions = {
             summaryOptions: {
+                disableSummaries: true,
                 summaryConfigOverrides: {
                     state: "disabled",
                 },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
@@ -80,7 +80,8 @@ describeFullCompat("GC reference updates in local summary", (getTestObjectProvid
 
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: {
-           summaryConfigOverrides: {
+            disableSummaries: true,
+            summaryConfigOverrides: {
                 state: "disabled",
             },
          },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
@@ -89,6 +89,7 @@ describeNoCompat("GC reference updates in summarizer", (getTestObjectProvider) =
 
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: {
+            disableSummaries: true,
             summaryConfigOverrides: { state: "disabled" },
         },
         gcOptions: { gcAllowed: true },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTestConfigs.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTestConfigs.ts
@@ -11,6 +11,7 @@ import { ITestContainerConfig, mockConfigProvider } from "@fluidframework/test-u
 export const defaultGCConfig: ITestContainerConfig = {
     runtimeOptions: {
         summaryOptions: {
+            disableSummaries: true,
             summaryConfigOverrides: { state: "disabled" },
         },
         gcOptions: { gcAllowed: true },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -171,7 +171,7 @@ describeNoCompat("GC Tree stored as a handle in summaries", (getTestObjectProvid
     let provider: ITestObjectProvider;
     const dataObjectFactory = new TestFluidObjectFactory([]);
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: true },
     };
     const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
@@ -53,6 +53,7 @@ describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
     const dataObjectFactory = new TestFluidObjectFactory([]);
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: {
+            disableSummaries: true,
             summaryConfigOverrides: {
                 state: "disabled",
             },

--- a/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
@@ -117,6 +117,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
                             ...testContainerConfig.runtimeOptions,
                             summaryOptions: {
                                 ...testContainerConfig.runtimeOptions?.summaryOptions,
+                                disableSummaries: false,
                             },
                         },
                     })]],

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -47,6 +47,7 @@ const testContainerConfig: ITestContainerConfig = {
     runtimeOptions: {
         enableOfflineLoad: true,
         summaryOptions: {
+            initialSummarizerDelayMs: 20, // Previous Containers had this property under SummaryOptions.
             summaryConfigOverrides: {
                 ...DefaultSummaryConfiguration,
                 ...{

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -31,6 +31,7 @@ const flushPromises = async () => new Promise((resolve) => process.nextTick(reso
 const testContainerConfig: ITestContainerConfig = {
     runtimeOptions: {
         summaryOptions: {
+            initialSummarizerDelayMs: 0, // back-compat - Old runtime takes 5 seconds to start summarizer without this.
             summaryConfigOverrides: {
                 ...DefaultSummaryConfiguration,
                 ...{ maxOps: 10, initialSummarizerDelayMs: 0, minIdleTime: 10, maxIdleTime: 10 },

--- a/packages/test/test-end-to-end-tests/src/test/t9sregressiontest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/t9sregressiontest.spec.ts
@@ -22,7 +22,8 @@ const testContainerConfig: ITestContainerConfig = {
     registry,
     runtimeOptions: {
         summaryOptions: {
-            summaryConfigOverrides: { state: "disabled" },
+            // currently these tests will break if we load from a summary that was too recent
+            disableSummaries: true,
         },
     },
 };

--- a/packages/test/test-gc-sweep-tests/src/test/autoRunTest.spec.ts
+++ b/packages/test/test-gc-sweep-tests/src/test/autoRunTest.spec.ts
@@ -32,7 +32,7 @@ describeNoCompat("GC InactiveObjectX tests", (getTestObjectProvider) => {
     summaryOptions.summarizerClientElection = true;
     // Summaries should run automatically
     const runtimeOptions: IContainerRuntimeOptions = {
-        ...summaryOptions,
+        summaryOptions,
         gcOptions: {
             gcAllowed: true,
         },

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -6,7 +6,7 @@
 import {
     IContainerRuntimeOptions,
     IGCRuntimeOptions,
-    ISummaryConfigurationHeuristics,
+    ISummaryRuntimeOptions,
 } from "@fluidframework/container-runtime";
 import {
     booleanCases,
@@ -56,36 +56,25 @@ const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
     sessionExpiryTimeoutMs: [undefined], // Don't want coverage here
 };
 
-const summaryConfigurationMatrix: OptionsMatrix<ISummaryConfigurationHeuristics> = {
-    state: ["enabled"],
-    minIdleTime: [0],
-    maxIdleTime: [30 * 1000], // 30 secs.
-    maxTime: [60 * 1000], // 1 min.
-    maxOps: [100], // Summarize if 100 weighted ops received since last snapshot.
-    minOpsForLastSummaryAttempt: [10],
-    maxAckWaitTime: [10 * 60 * 1000], // 10 mins.
-    maxOpsSinceLastSummary: [400, 800, 2000],
-    initialSummarizerDelayMs: [2, 2500, 6000],
+const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
+    disableSummaries: [false],
+    initialSummarizerDelayMs: numberCases,
+    summaryConfigOverrides: [undefined],
+    maxOpsSinceLastSummary: numberCases,
     summarizerClientElection: booleanCases,
-    nonRuntimeOpWeight: [0.1],
-    runtimeOpWeight: [1.0],
+    summarizerOptions: [undefined],
 };
 
 export function generateRuntimeOptions(
     seed: number, overrides: Partial<OptionsMatrix<IContainerRuntimeOptions>> | undefined) {
     const gcOptions =
         generatePairwiseOptions(applyOverrides(gcOptionsMatrix, overrides?.gcOptions as any), seed);
-
-    const summaryOptionsMatrixOptions =
-        generatePairwiseOptions(summaryConfigurationMatrix, seed);
-
-    const newSummaryOptions = summaryOptionsMatrixOptions.map((option) => {
-            return { summaryConfigOverrides: option };
-    });
+    const summaryOptions =
+        generatePairwiseOptions(applyOverrides(summaryOptionsMatrix, overrides?.summaryOptions as any), seed);
 
     const runtimeOptionsMatrix: OptionsMatrix<IContainerRuntimeOptions> = {
         gcOptions: [undefined, ...gcOptions],
-        summaryOptions: [undefined, ...newSummaryOptions],
+        summaryOptions: [undefined, ...summaryOptions],
         loadSequenceNumberVerification: [undefined],
         enableOfflineLoad: [undefined],
         flushMode: [undefined],


### PR DESCRIPTION
Due to some stress test regression, reverting the commit that added more flexibility to the ISummaryRuntimeOptions matrix override.
Commit that is being reverted:
https://github.com/microsoft/FluidFramework/commit/ef97ca9cc195eadd3a0d808b83a7a98f18c689fb