### PR TITLE
refactor(build-cli): Use new check policy command within release command

### DIFF
--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -11,6 +11,8 @@ import { MonoRepoKind } from "@fluidframework/build-tools";
 
 import { bumpVersionScheme } from "@fluid-tools/version-tools";
 
+// eslint-disable-next-line import/no-internal-modules
+import { CheckPolicy } from "../commands/check/policy";
 import {
     generateBumpDepsBranchName,
     generateBumpDepsCommitMessage,
@@ -26,8 +28,6 @@ import { MachineState } from "../machines";
 import { isReleaseGroup } from "../releaseGroups";
 import { FluidReleaseStateHandlerData } from "./fluidReleaseStateHandler";
 import { BaseStateHandler, StateHandlerFunction } from "./stateHandlers";
-// eslint-disable-next-line import/no-internal-modules
-import { CheckPolicy } from "../commands/check/policy";
 
 /**
  * Checks that the current branch matches the expected branch for a release.
@@ -422,8 +422,8 @@ export const checkPolicy: StateHandlerFunction = async (
                 "packages",
                 "build-tools",
                 "data",
-                "exclusions.json"
-            )
+                "exclusions.json",
+            ),
         ]);
 
         // check for policy check violation

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -7,7 +7,7 @@ import inquirer from "inquirer";
 import { Machine } from "jssm";
 import path from "path";
 
-import { MonoRepoKind, exec } from "@fluidframework/build-tools";
+import { MonoRepoKind } from "@fluidframework/build-tools";
 
 import { bumpVersionScheme } from "@fluid-tools/version-tools";
 
@@ -26,6 +26,8 @@ import { MachineState } from "../machines";
 import { isReleaseGroup } from "../releaseGroups";
 import { FluidReleaseStateHandlerData } from "./fluidReleaseStateHandler";
 import { BaseStateHandler, StateHandlerFunction } from "./stateHandlers";
+// eslint-disable-next-line import/no-internal-modules
+import { CheckPolicy } from "../commands/check/policy";
 
 /**
  * Checks that the current branch matches the expected branch for a release.
@@ -411,32 +413,18 @@ export const checkPolicy: StateHandlerFunction = async (
             );
         }
 
-        // await CheckPolicy.run([
-        //     "--fix",
-        //     "--exclusions",
-        //     path.join(
-        //         context.gitRepo.resolvedRoot,
-        //         "build-tools",
-        //         "packages",
-        //         "build-tools",
-        //         "data",
-        //         "exclusions.json"
-        //     )
-        // ]);
-
-        await exec(
-            `node ${path.join(
+        await CheckPolicy.run([
+            "--fix",
+            "--exclusions",
+            path.join(
                 context.gitRepo.resolvedRoot,
                 "build-tools",
                 "packages",
                 "build-tools",
-                "dist",
-                "repoPolicyCheck",
-                "repoPolicyCheck.js",
-            )} -r`,
-            context.gitRepo.resolvedRoot,
-            "policy-check:fix failed",
-        );
+                "data",
+                "exclusions.json"
+            )
+        ]);
 
         // check for policy check violation
         const afterPolicyCheckStatus = await context.gitRepo.getStatus();


### PR DESCRIPTION
Updates the release command to use the new `check policy` command, which was fixed in an earlier commit.