### PR TITLE
Bump protocol-definitions typetests to 1.0.0 baseline

### DIFF
--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -285,9 +285,9 @@
             }
         },
         "@fluidframework/protocol-definitions-previous": {
-            "version": "npm:@fluidframework/protocol-definitions@0.1028.1000",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000.tgz",
-            "integrity": "sha512-Gqw9ji/QJsgRu0Bv7hRNxmbGWEQjrGezscTmnEf2S1PEfgdXNd2OFSB2YYsnHOe8/+yz2teqs4U41+V5D6MaEA==",
+            "version": "npm:@fluidframework/protocol-definitions@1.0.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.0.0.tgz",
+            "integrity": "sha512-ulowxU/6yVLQ2A+bJ2BD2yomKjRkGYwj91jdvmEtb7dWICnQpvgwxdcGnbxd2F6g3FnP9BmtZYRB2IQNMovk3A==",
             "dev": true,
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1"

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
     "@fluidframework/eslint-config-fluid": "^1.0.0",
-    "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@0.1028.1000",
+    "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -62,14 +62,8 @@
   "typeValidation": {
     "version": "0.1029.1000",
     "broken": {
-      "InterfaceDeclaration_IConnected": {
-        "backCompat": false
-      },
       "RemovedInterfaceDeclaration_ISummaryConfiguration": {
         "forwardCompat": false,
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IClientConfiguration": {
         "backCompat": false
       },
       "RemovedInterfaceDeclaration_ISummaryAuthor": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -60,7 +60,7 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.1029.1000",
+    "version": "1.1.0",
     "broken": {
       "RemovedInterfaceDeclaration_ISummaryConfiguration": {
         "forwardCompat": false,

--- a/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.ts
+++ b/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.ts
@@ -251,7 +251,6 @@ declare function get_current_InterfaceDeclaration_IClientConfiguration():
 declare function use_old_InterfaceDeclaration_IClientConfiguration(
     use: TypeOnly<old.IClientConfiguration>);
 use_old_InterfaceDeclaration_IClientConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IClientConfiguration());
 
 /*
@@ -372,7 +371,6 @@ declare function get_current_InterfaceDeclaration_IConnected():
 declare function use_old_InterfaceDeclaration_IConnected(
     use: TypeOnly<old.IConnected>);
 use_old_InterfaceDeclaration_IConnected(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnected());
 
 /*
@@ -1026,6 +1024,30 @@ use_old_InterfaceDeclaration_ISnapshotTreeEx(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_IsoDate": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_IsoDate():
+    TypeOnly<old.IsoDate>;
+declare function use_current_TypeAliasDeclaration_IsoDate(
+    use: TypeOnly<current.IsoDate>);
+use_current_TypeAliasDeclaration_IsoDate(
+    get_old_TypeAliasDeclaration_IsoDate());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_IsoDate": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_IsoDate():
+    TypeOnly<current.IsoDate>;
+declare function use_old_TypeAliasDeclaration_IsoDate(
+    use: TypeOnly<old.IsoDate>);
+use_old_TypeAliasDeclaration_IsoDate(
+    get_current_TypeAliasDeclaration_IsoDate());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ISummaryAck": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISummaryAck():
@@ -1074,18 +1096,6 @@ use_old_InterfaceDeclaration_ISummaryAttachment(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryAuthor": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryAuthor": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ISummaryBlob": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISummaryBlob():
@@ -1106,30 +1116,6 @@ declare function use_old_InterfaceDeclaration_ISummaryBlob(
     use: TypeOnly<old.ISummaryBlob>);
 use_old_InterfaceDeclaration_ISummaryBlob(
     get_current_InterfaceDeclaration_ISummaryBlob());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryCommitter": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryCommitter": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryConfiguration": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryConfiguration": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
Since protocol-defs has released 1.0.0, that should be the previous version used in the typetests.