### PR TITLE
Bump common-utils typetests to 1.0.0 baseline

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -633,14 +633,15 @@
             "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
         },
         "@fluidframework/common-utils-previous": {
-            "version": "npm:@fluidframework/common-utils@0.32.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
-            "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+            "version": "npm:@fluidframework/common-utils@1.0.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.0.0.tgz",
+            "integrity": "sha512-O3UoZ2dQR/ZWMXTSbDcTH93WMqHmEKoYhYMn6cybESswmMOA2E9UF3B2TkJ+aofBLOLllDKXXGtuhPmu/9rTqQ==",
             "dev": true,
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
                 "@types/events": "^3.0.0",
                 "base64-js": "^1.5.1",
+                "buffer": "^6.0.3",
                 "events": "^3.1.0",
                 "lodash": "^4.17.21",
                 "sha.js": "^2.4.11"

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -90,7 +90,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
-    "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@^0.32.0",
+    "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@1.0.0",
     "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -126,16 +126,7 @@
     "outputName": "jest-junit-report.xml"
   },
   "typeValidation": {
-    "version": "0.33.1000",
-    "broken": {
-      "RemovedFunctionDeclaration_extractLogSafeErrorProperties": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedClassDeclaration_BatchManager": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
-    }
+    "version": "1.1.0",
+    "broken": {}
   }
 }

--- a/common/lib/common-utils/src/test/types/validateCommonUtilsPrevious.ts
+++ b/common/lib/common-utils/src/test/types/validateCommonUtilsPrevious.ts
@@ -64,18 +64,6 @@ use_old_ClassDeclaration_BaseTelemetryNullLogger(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BatchManager": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BatchManager": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_Buffer": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_Buffer():
@@ -240,18 +228,6 @@ declare function use_old_ClassDeclaration_EventForwarder(
     use: TypeOnly<old.EventForwarder>);
 use_old_ClassDeclaration_EventForwarder(
     get_current_ClassDeclaration_EventForwarder());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_extractLogSafeErrorProperties": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_extractLogSafeErrorProperties": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -900,6 +876,30 @@ declare function use_old_FunctionDeclaration_safelyParseJSON(
     use: TypeOnly<typeof old.safelyParseJSON>);
 use_old_FunctionDeclaration_safelyParseJSON(
     get_current_FunctionDeclaration_safelyParseJSON());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_setLongTimeout": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_setLongTimeout():
+    TypeOnly<typeof old.setLongTimeout>;
+declare function use_current_FunctionDeclaration_setLongTimeout(
+    use: TypeOnly<typeof current.setLongTimeout>);
+use_current_FunctionDeclaration_setLongTimeout(
+    get_old_FunctionDeclaration_setLongTimeout());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_setLongTimeout": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_setLongTimeout():
+    TypeOnly<typeof current.setLongTimeout>;
+declare function use_old_FunctionDeclaration_setLongTimeout(
+    use: TypeOnly<typeof old.setLongTimeout>);
+use_old_FunctionDeclaration_setLongTimeout(
+    get_current_FunctionDeclaration_setLongTimeout());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
Since common-utils has released 1.0.0, that should be the previous version used in the typetests.