### PR TITLE
Turn SummaryStatus:Behind into a regular event and summarizerClientElection to be false in the stress tests.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1194,7 +1194,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 // if summaries are enabled and we are not the summarizer client.
                 const defaultAction = () => {
                     if (this.summaryCollection.opsSinceLastAck > this.maxOpsSinceLastSummary) {
-                        this.logger.sendErrorEvent({ eventName: "SummaryStatus:Behind" });
+                        this.logger.sendTelemetryEvent({ eventName: "SummaryStatus:Behind" });
                         // unregister default to no log on every op after falling behind
                         // and register summary ack handler to re-register this handler
                         // after successful summary

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -61,7 +61,7 @@ const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
     initialSummarizerDelayMs: numberCases,
     summaryConfigOverrides: [undefined],
     maxOpsSinceLastSummary: numberCases,
-    summarizerClientElection: booleanCases,
+    summarizerClientElection: [false],
     summarizerOptions: [undefined],
 };
 


### PR DESCRIPTION
The SummaryStatus:Behind event is dependent on the number of clients in the quorum, which is currently up to 120 clients during the stress test runs. Taking in consideration we create incidents based on number of errors (currently > 50), a single second in which the clients get behind will trigger up to 120 errors during the stress test runs. Even in production it might skew out our telemetry data.   After talking to the OCEs ( Navin, Si) and Jatin, we ve decided to move it to a regular telemetry event for now. 

Also, we are taking the chance to enforce summarizerClientElection to be always false during the stress test runs. 

Sample incidents: 

https://portal.microsofticm.com/imp/v3/incidents/details/340813540/home

https://portal.microsofticm.com/imp/v3/incidents/details/341118841/home