### PR TITLE
fix(build-cli): policy-check should only run on main by default

### DIFF
--- a/build-tools/packages/build-cli/.eslintrc.cjs
+++ b/build-tools/packages/build-cli/.eslintrc.cjs
@@ -20,10 +20,15 @@ module.exports = {
         "import/no-default-export": "off",
 
         // This package uses interfaces and types that are not exposed directly by oclif and npm-check-updates.
+        // We also call commands' run method directly in some cases, so these are all excluded.
         "import/no-internal-modules": [
             "error",
             {
-                allow: ["@oclif/core/lib/interfaces", "npm-check-updates/build/src/types/**"],
+                allow: [
+                    "@oclif/core/lib/interfaces",
+                    "npm-check-updates/build/src/types/**",
+                    "**/commands/**",
+                ],
             },
         ],
 

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -17,7 +17,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version|-V)
-@fluid-tools/build-cli/0.4.8000
+@fluid-tools/build-cli/0.4.9000
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND

--- a/build-tools/packages/build-cli/src/commands/generate/readme.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/readme.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 import { Interfaces } from "@oclif/core";
-// eslint-disable-next-line import/no-internal-modules
 import { default as BaseReadme } from "oclif/lib/commands/readme";
 
 export default class Readme extends BaseReadme {

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -166,7 +166,7 @@ export const checkFlags = {
     }),
     policyCheck: Flags.boolean({
         allowNo: true,
-        default: true,
+        default: false,
         description: "Check that the local repo complies with all policy.",
     }),
 };

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -166,7 +166,7 @@ export const checkFlags = {
     }),
     policyCheck: Flags.boolean({
         allowNo: true,
-        default: false,
+        default: true, // This value isn't used directly; the default is based on the branch. See comment in run method.
         description: "Check that the local repo complies with all policy.",
     }),
 };

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -409,6 +409,9 @@ export const checkPolicy: StateHandlerFunction = async (
             );
         }
 
+        // oclif docs suggest using proper function calls into underlying APIs rather than calling a command directly
+        // but it's very convenient in this case. check policy is a command where the CLI is the "best" interface; it doesn't
+        // expose a better programmatic API and making one just to make it cleaner to call here seems unnecessary.
         await CheckPolicy.run([
             "--fix",
             "--exclusions",

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -26,6 +26,7 @@ import {
 import { CommandLogger } from "../logging";
 import { MachineState } from "../machines";
 import { isReleaseGroup } from "../releaseGroups";
+import { branchesRunDefaultPolicy } from "../repoConfig";
 import { FluidReleaseStateHandlerData } from "./fluidReleaseStateHandler";
 import { BaseStateHandler, StateHandlerFunction } from "./stateHandlers";
 
@@ -402,9 +403,9 @@ export const checkPolicy: StateHandlerFunction = async (
     assert(context !== undefined, "Context is undefined.");
 
     if (shouldCheckPolicy === true) {
-        if (context.originalBranchName !== "main") {
+        if (!branchesRunDefaultPolicy.includes(context.originalBranchName)) {
             log.warning(
-                "WARNING: Policy check fixes are not expected outside of main branch!  Make sure you know what you are doing.",
+                `Policy check fixes are not expected on the ${context.originalBranchName} branch! Make sure you know what you are doing.`,
             );
         }
 
@@ -430,6 +431,11 @@ export const checkPolicy: StateHandlerFunction = async (
             );
             BaseStateHandler.signalFailure(machine, state);
         }
+        // eslint-disable-next-line no-negated-condition
+    } else if (!branchesRunDefaultPolicy.includes(context.originalBranchName)) {
+        log.verbose(
+            `Skipping policy check because it does not run on the ${context.originalBranchName} branch by default. Pass --policyCheck to force it to run.`,
+        );
     } else {
         log.warning("Skipping policy check.");
     }

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -28,6 +28,8 @@ import { MachineState } from "../machines";
 import { isReleaseGroup } from "../releaseGroups";
 import { FluidReleaseStateHandlerData } from "./fluidReleaseStateHandler";
 import { BaseStateHandler, StateHandlerFunction } from "./stateHandlers";
+// eslint-disable-next-line import/no-internal-modules
+import { CheckPolicy } from "../commands/check/policy";
 
 /**
  * Checks that the current branch matches the expected branch for a release.

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -11,7 +11,6 @@ import { MonoRepoKind } from "@fluidframework/build-tools";
 
 import { bumpVersionScheme } from "@fluid-tools/version-tools";
 
-// eslint-disable-next-line import/no-internal-modules
 import { CheckPolicy } from "../commands/check/policy";
 import {
     generateBumpDepsBranchName,

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -28,8 +28,6 @@ import { MachineState } from "../machines";
 import { isReleaseGroup } from "../releaseGroups";
 import { FluidReleaseStateHandlerData } from "./fluidReleaseStateHandler";
 import { BaseStateHandler, StateHandlerFunction } from "./stateHandlers";
-// eslint-disable-next-line import/no-internal-modules
-import { CheckPolicy } from "../commands/check/policy";
 
 /**
  * Checks that the current branch matches the expected branch for a release.

--- a/build-tools/packages/build-cli/src/repoConfig.ts
+++ b/build-tools/packages/build-cli/src/repoConfig.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * The branches in this list should run policy check by default during release-related activities.
+ */
+export const branchesRunDefaultPolicy = ["main"];

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -74,7 +74,7 @@ $ npm install -g @fluid-tools/version-tools
 $ fluv COMMAND
 running command...
 $ fluv (--version|-V)
-@fluid-tools/version-tools/0.4.8000
+@fluid-tools/version-tools/0.4.9000
 $ fluv --help [COMMAND]
 USAGE
   $ fluv COMMAND


### PR DESCRIPTION
Updates the release command to run policy-check by default for the main branch, but not on other branches. This can be overridden by passing `--policyCheck` or `--no-policyCheck`.

Fixes [AB#1962](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1962)