### PR TITLE
refactor(build-cli): remove -r from global --root flag

### DIFF
--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -20,7 +20,6 @@ import { isReleaseGroup } from "./releaseGroups";
  * A re-usable CLI flag to parse the root directory of the Fluid repo.
  */
 export const rootPathFlag = Flags.build({
-    char: "r",
     description: "Root directory of the Fluid repo (default: env _FLUID_ROOT_).",
     env: "_FLUID_ROOT_",
     hidden: true,


### PR DESCRIPTION
The --root argument is rarely used directly and doesn't warrant a "shortcut" flag. The flag is also hidden and typically set via an env variable or automatically deduced -- even more reason to remove it.