### PR TITLE
Change all `export *` in `server/gitrest` to named exports

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/index.ts
@@ -3,9 +3,48 @@
  * Licensed under the MIT License.
  */
 
-export * from "./externalStorageManager";
-export * from "./logger";
-export * from "./routes";
-export * from "./runner";
-export * from "./runnerFactory";
-export * from "./utils";
+export { ExternalStorageManager, IExternalStorageManager } from "./externalStorageManager";
+export { configureGitRestLogging } from "./logger";
+export { create, IRoutes } from "./routes";
+export { GitrestRunner } from "./runner";
+export { GitrestResources, GitrestResourcesFactory, GitrestRunnerFactory } from "./runnerFactory";
+export {
+	BaseGitRestTelemetryProperties,
+	checkSoftDeleted,
+	Constants,
+	exists,
+	getExternalWriterParams,
+	getGitDirectory,
+	getLumberjackBasePropertiesFromRepoManagerParams,
+	getRepoManagerFromWriteAPI,
+	getRepoManagerParamsFromRequest,
+	getRepoPath,
+	getRequestPathCategory,
+	getSoftDeletedMarkerPath,
+	GitObjectType,
+	GitWholeSummaryManager,
+	IExternalWriterConfig,
+	IFileSystemManager,
+	IFileSystemManagerFactory,
+	IFileSystemManagerParams,
+	IFileSystemPromises,
+	IRepoManagerParams,
+	IRepositoryManager,
+	IRepositoryManagerFactory,
+	isChannelSummary,
+	isContainerSummary,
+	IsomorphicGitManagerFactory,
+	IsomorphicGitRepositoryManager,
+	IStorageDirectoryConfig,
+	IStorageRoutingId,
+	latestSummarySha,
+	logAndThrowApiError,
+	NodeFsManagerFactory,
+	NodegitRepositoryManager,
+	NodegitRepositoryManagerFactory,
+	parseStorageRoutingId,
+	persistLatestFullSummaryInStorage,
+	retrieveLatestFullSummaryFromStorage,
+	validateBlobContent,
+	validateBlobEncoding,
+} from "./utils";

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -3,9 +3,45 @@
  * Licensed under the MIT License.
  */
 
-export * from "./definitions";
-export * from "./gitWholeSummaryManager";
-export * from "./helpers";
-export * from "./isomorphicgitManager";
-export * from "./nodeFsManagerFactory";
-export * from "./nodegitManager";
+export {
+	BaseGitRestTelemetryProperties,
+	Constants,
+	GitObjectType,
+	IExternalWriterConfig,
+	IFileSystemManager,
+	IFileSystemManagerFactory,
+	IFileSystemManagerParams,
+	IFileSystemPromises,
+	IRepoManagerParams,
+	IRepositoryManager,
+	IRepositoryManagerFactory,
+	IStorageDirectoryConfig,
+	IStorageRoutingId,
+} from "./definitions";
+export {
+	GitWholeSummaryManager,
+	isChannelSummary,
+	isContainerSummary,
+	latestSummarySha,
+} from "./gitWholeSummaryManager";
+export {
+	checkSoftDeleted,
+	exists,
+	getExternalWriterParams,
+	getGitDirectory,
+	getLumberjackBasePropertiesFromRepoManagerParams,
+	getRepoManagerFromWriteAPI,
+	getRepoManagerParamsFromRequest,
+	getRepoPath,
+	getRequestPathCategory,
+	getSoftDeletedMarkerPath,
+	logAndThrowApiError,
+	parseStorageRoutingId,
+	persistLatestFullSummaryInStorage,
+	retrieveLatestFullSummaryFromStorage,
+	validateBlobContent,
+	validateBlobEncoding,
+} from "./helpers";
+export { IsomorphicGitManagerFactory, IsomorphicGitRepositoryManager } from "./isomorphicgitManager";
+export { NodeFsManagerFactory } from "./nodeFsManagerFactory";
+export { NodegitRepositoryManager, NodegitRepositoryManagerFactory } from "./nodegitManager";


### PR DESCRIPTION
This PR converts all `export *` in `server/gitrest` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954. I could not merge that PR because it is too large for one change and would make main-next integration a nightmare.