### PR TITLE
Change all `export *` in `packages/drivers` to named exports

### DIFF
--- a/packages/drivers/debugger/src/index.ts
+++ b/packages/drivers/debugger/src/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./fluidDebuggerController";
-export * from "./fluidDebuggerUi";
-export * from "./fluidDebugger";
+export { FluidDebugger } from "./fluidDebugger";
+export { debuggerUIFactory, DebugReplayController } from "./fluidDebuggerController";
+export { DebuggerUI, IDebuggerController, IDebuggerUI } from "./fluidDebuggerUi";

--- a/packages/drivers/driver-base/src/index.ts
+++ b/packages/drivers/driver-base/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./documentDeltaConnection";
+export { DocumentDeltaConnection } from "./documentDeltaConnection";

--- a/packages/drivers/driver-web-cache/src/index.ts
+++ b/packages/drivers/driver-web-cache/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./FluidCache";
+export { FluidCache, FluidCacheConfig } from "./FluidCache";
 export { deleteFluidCacheIndexDbInstance } from "./FluidCacheIndexedDb";

--- a/packages/drivers/file-driver/src/index.ts
+++ b/packages/drivers/file-driver/src/index.ts
@@ -3,8 +3,15 @@
  * Licensed under the MIT License.
  */
 
-export * from "./fileDeltaStorageService";
-export * from "./fileDocumentService";
-export * from "./fileDocumentServiceFactory";
-export * from "./fileDocumentDeltaConnection";
-export * from "./fileDocumentStorageService";
+export { FileDeltaStorageService } from "./fileDeltaStorageService";
+export { FileDocumentService } from "./fileDocumentService";
+export { FileDocumentServiceFactory } from "./fileDocumentServiceFactory";
+export { Replayer, ReplayFileDeltaConnection } from "./fileDocumentDeltaConnection";
+export {
+	FileSnapshotWriterClassFactory,
+	FileStorageDocumentName,
+	FluidFetchReader,
+	FluidFetchReaderFileSnapshotWriter,
+	ISnapshotWriterStorage,
+	ReaderConstructor,
+} from "./fileDocumentStorageService";

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/index.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./urlResolver";
+export { FluidAppOdspUrlResolver } from "./urlResolver";

--- a/packages/drivers/iframe-driver/src/index.ts
+++ b/packages/drivers/iframe-driver/src/index.ts
@@ -3,9 +3,14 @@
  * Licensed under the MIT License.
  */
 
-export * from "./innerDocumentDeltaConnection";
-export * from "./innerDocumentService";
-export * from "./innerDocumentServiceFactory";
-export * from "./outerDocumentServiceFactory";
-export * from "./innerUrlResolver";
-export * from "./outerUrlResolver";
+export { InnerDocumentDeltaConnection, IOuterDocumentDeltaConnectionProxy } from "./innerDocumentDeltaConnection";
+export { InnerDocumentService } from "./innerDocumentService";
+export { InnerDocumentServiceFactory } from "./innerDocumentServiceFactory";
+export { InnerUrlResolver } from "./innerUrlResolver";
+export {
+	DocumentServiceFactoryProxy,
+	ICombinedDriver,
+	IDocumentServiceFactoryProxy,
+	IDocumentServiceFactoryProxyKey,
+} from "./outerDocumentServiceFactory";
+export { IUrlResolverProxy, IUrlResolverProxyKey, OuterUrlResolver } from "./outerUrlResolver";

--- a/packages/drivers/local-driver/src/index.ts
+++ b/packages/drivers/local-driver/src/index.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export * from "./localDeltaStorageService";
-export * from "./localDocumentDeltaConnection";
-export * from "./localDocumentService";
-export * from "./localDocumentServiceFactory";
-export * from "./localDocumentStorageService";
-export * from "./localResolver";
-export * from "./localSessionStorageDb";
+export { LocalDeltaStorageService } from "./localDeltaStorageService";
+export { LocalDocumentDeltaConnection } from "./localDocumentDeltaConnection";
+export { createLocalDocumentService, LocalDocumentService } from "./localDocumentService";
+export { LocalDocumentServiceFactory } from "./localDocumentServiceFactory";
+export { LocalDocumentStorageService } from "./localDocumentStorageService";
+export { createLocalResolverCreateNewRequest, LocalResolver } from "./localResolver";
+export { LocalSessionStorageDbFactory } from "./localSessionStorageDb";

--- a/packages/drivers/odsp-driver-definitions/src/index.ts
+++ b/packages/drivers/odsp-driver-definitions/src/index.ts
@@ -3,8 +3,26 @@
  * Licensed under the MIT License.
  */
 
-export * from "./resolvedUrl";
-export * from "./tokenFetch";
-export * from "./odspCache";
-export * from "./factory";
-export * from "./errors";
+export { IOdspError, IOdspErrorAugmentations, OdspError, OdspErrorType } from "./errors";
+export { HostStoragePolicy, ICollabSessionOptions, IOpsCachingPolicy, ISnapshotOptions } from "./factory";
+export { CacheContentType, ICacheEntry, IEntry, IFileEntry, IPersistedCache, snapshotKey } from "./odspCache";
+export {
+	IOdspResolvedUrl,
+	IOdspUrlParts,
+	ISharingLink,
+	ISharingLinkKind,
+	ShareLinkInfoType,
+	ShareLinkTypes,
+	SharingLinkRole,
+	SharingLinkScope,
+} from "./resolvedUrl";
+export {
+	IdentityType,
+	InstrumentedStorageTokenFetcher,
+	isTokenFromCache,
+	OdspResourceTokenFetchOptions,
+	TokenFetcher,
+	TokenFetchOptions,
+	tokenFromResponse,
+	TokenResponse,
+} from "./tokenFetch";

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -4,32 +4,43 @@
  */
 
 // Constants
-export * from "./constants";
+export { OdcApiSiteOrigin, OdcFileSiteOrigin } from "./constants";
 
-export * from "./contractsPublic";
+export {
+	ClpCompliantAppHeader,
+	IClpCompliantAppHeader,
+	ISharingLinkHeader,
+	OdspFluidDataStoreLocator,
+	SharingLinkHeader,
+} from "./contractsPublic";
 
 // public utils
-export * from "./odspPublicUtils";
-export * from "./odspUrlHelper";
-export * from "./createOdspUrl";
-export * from "./checkUrl";
+export { checkUrl } from "./checkUrl";
+export { createOdspUrl } from "./createOdspUrl";
+export { getHashedDocumentId, ISnapshotContents } from "./odspPublicUtils";
+export { getApiRoot, getOdspUrlParts, isOdcOrigin, isOdcUrl, isSpoUrl } from "./odspUrlHelper";
 
 // prefetch latest snapshot before container load
-export * from "./prefetchLatestSnapshot";
+export { prefetchLatestSnapshot } from "./prefetchLatestSnapshot";
 
 // Factory
-export * from "./odspDocumentServiceFactoryCore";
-export * from "./odspDocumentServiceFactory";
-export * from "./odspDocumentServiceFactoryWithCodeSplit";
+export { createLocalOdspDocumentServiceFactory, OdspDocumentServiceFactory } from "./odspDocumentServiceFactory";
+export { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
+export { OdspDocumentServiceFactoryWithCodeSplit } from "./odspDocumentServiceFactoryWithCodeSplit";
 
 // File creation
-export * from "./createOdspCreateContainerRequest";
+export { createOdspCreateContainerRequest } from "./createOdspCreateContainerRequest";
 
 // URI Resolver functionality, URI management
-export * from "./odspDriverUrlResolverForShareLink";
-export * from "./odspDriverUrlResolver";
+export { OdspDriverUrlResolver } from "./odspDriverUrlResolver";
+export { OdspDriverUrlResolverForShareLink, ShareLinkFetcherProps } from "./odspDriverUrlResolverForShareLink";
 
 // It's used by URL resolve code, but also has some public functions
-export * from "./odspFluidFileLink";
+export {
+	encodeOdspFluidDataStoreLocator,
+	getLocatorFromOdspUrl,
+	locatorQueryParamName,
+	storeLocatorInOdspUrl,
+} from "./odspFluidFileLink";
 
 export { parseCompactSnapshotResponse } from "./compactSnapshotParser";

--- a/packages/drivers/odsp-urlResolver/src/index.ts
+++ b/packages/drivers/odsp-urlResolver/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./urlResolver";
+export { isOdspUrl, OdspUrlResolver } from "./urlResolver";

--- a/packages/drivers/replay-driver/src/index.ts
+++ b/packages/drivers/replay-driver/src/index.ts
@@ -3,7 +3,14 @@
  * Licensed under the MIT License.
  */
 
-export * from "./replayController";
-export * from "./replayDocumentService";
-export * from "./replayDocumentServiceFactory";
-export * from "./storageImplementations";
+export { ReadDocumentStorageServiceBase, ReplayController } from "./replayController";
+export { ReplayDocumentService } from "./replayDocumentService";
+export { ReplayDocumentServiceFactory } from "./replayDocumentServiceFactory";
+export {
+	FileSnapshotReader,
+	IFileSnapshot,
+	OpStorage,
+	SnapshotStorage,
+	StaticStorageDocumentService,
+	StaticStorageDocumentServiceFactory,
+} from "./storageImplementations";

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -4,11 +4,11 @@
  */
 
 // Tokens
-export * from "./defaultTokenProvider";
-export * from "./tokens";
+export { DefaultTokenProvider } from "./defaultTokenProvider";
+export { ITokenProvider, ITokenResponse, ITokenService } from "./tokens";
 
 // Factory
-export * from "./documentServiceFactory";
+export { DocumentPostCreateError, RouterliciousDocumentServiceFactory } from "./documentServiceFactory";
 
 // Configuration
-export * from "./policies";
+export { IRouterliciousDriverPolicies } from "./policies";

--- a/packages/drivers/routerlicious-urlResolver/src/index.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./urlResolver";
+export { IAlfredUser, IConfig, RouterliciousUrlResolver } from "./urlResolver";

--- a/packages/drivers/tinylicious-driver/src/index.ts
+++ b/packages/drivers/tinylicious-driver/src/index.ts
@@ -3,5 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export * from "./insecureTinyliciousUrlResolver";
-export * from "./insecureTinyliciousTokenProvider";
+export { InsecureTinyliciousTokenProvider } from "./insecureTinyliciousTokenProvider";
+export {
+	createTinyliciousCreateNewRequest,
+	defaultTinyliciousEndpoint,
+	defaultTinyliciousPort,
+	InsecureTinyliciousUrlResolver,
+} from "./insecureTinyliciousUrlResolver";


### PR DESCRIPTION
This PR converts all `export *` in `packages/drivers` to named exports.

Related issue: https://github.com/microsoft/FluidFramework/issues/10062

See for the fact that bundle size does not change when the entire repo is converted: https://github.com/microsoft/FluidFramework/pull/12321#issue-1400290954.