### PR TITLE
Cancel join session refresh timer once container is closed

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -503,6 +503,7 @@ export class OdspDocumentService implements IDocumentService {
             this._opsCache?.flushOps();
         }
         this._opsCache?.dispose();
+        this.clearJoinSessionTimer();
     }
 
     protected get opsCache() {


### PR DESCRIPTION
## Description

Fix for: https://dev.azure.com/fluidframework/internal/_workitems/edit/2179?src=WorkItemMention&src-action=artifact_link
So we refresh the join session after every few mins. Now when the container is closed, we have a refresh scheduled. I have code to clear this referesh on "disconnect" event which seems to be not triggering. Seems like I have to clear the refresh in dispose() method so that we don't refresh the join session once the container is closed.