### PR TITLE
Avoid double `get`

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -87,7 +87,7 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
             return undefined;
         }
 
-        return this._contexts.get(id) as LocalFluidDataStoreContext;
+        return context as LocalFluidDataStoreContext;
     }
 
     /**


### PR DESCRIPTION
## Description

Small fix to avoid calling `get()` twice on a `Map<>`.
