### PR TITLE
Moving ElectedClientNotSummarized from sendErrorEvent to sendTelemetryEvent

### DIFF
--- a/packages/runtime/container-runtime/src/summarizerClientElection.ts
+++ b/packages/runtime/container-runtime/src/summarizerClientElection.ts
@@ -77,7 +77,7 @@ export class SummarizerClientElection
                 // Log and elect a new summarizer client.
                 const opsSinceLastReport = sequenceNumber - this.lastReportedSeq;
                 if (opsSinceLastReport > this.maxOpsSinceLastSummary) {
-                    this.logger.sendErrorEvent({
+                    this.logger.sendTelemetryEvent({
                         eventName: "ElectedClientNotSummarizing",
                         electedClientId,
                         lastSummaryAckSeqForClient: this.lastSummaryAckSeqForClient,


### PR DESCRIPTION
Today, the ElectedClientNotSummarized event is treated as an error and as the number of hits is dependent to the number of running clients, a running stress test with 100+ clients will end up generating 100+ errors. This is not necessarily a bug and ends up creating unnecessary incidents (Ex. [Bug 2241](https://dev.azure.com/fluidframework/internal/_workitems/edit/2241)). 
After talking to the OCEs (Navin, Si) and Jatin, we've decided to move it from an error to a generic telemetry event to reduce the noise from the system.

