### PR TITLE
refactor(build-tools): Include ".generated" in typetest filenames

### DIFF
--- a/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
@@ -109,7 +109,7 @@ export async function generateTests(packageDetails: PackageDetails) {
             `${testPath}/validate${oldVersionNameForFile
                 .split("-")
                 .map((p) => p[0].toUpperCase() + p.substring(1))
-                .join("")}.ts`,
+                .join("")}.generated.ts`,
             testString.join("\n"),
         );
     }


### PR DESCRIPTION
This PR makes generated files clear from their file name so  reviewers can see the generated file warning when reviewing deltas in PRs. THis change adopts the `.generated.*` convention from <https://github.com/microsoft/TypeScript/wiki/Coding-guidelines#components>.

The fix I chose was dead-simple -- but in looking at the code I'd really like to clean the logic up more. Still, this change is simple and effective as-is.

[AB#2233](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2233)