### PR TITLE
[TaskManager] Cleanup TSDoc comments

### DIFF
--- a/api-report/task-manager.api.md
+++ b/api-report/task-manager.api.md
@@ -26,7 +26,7 @@ export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     volunteerForTask(taskId: string): Promise<boolean>;
 }
 
-// @public (undocumented)
+// @public
 export interface ITaskManagerEvents extends ISharedObjectEvents {
     (event: "assigned" | "completed" | "lost", listener: (taskId: string) => void): any;
 }

--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -30,7 +30,7 @@ export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
 
     /**
      * Continuously volunteer for the task. Watch the "assigned" event to determine if the task is assigned.
-     * The local client will automatically re-enter the queue if the local client disconnects.
+     * The local client will automatically re-enter the queue if it disconnects.
      * @param taskId - Identifier for the task
      */
     subscribeToTask(taskId: string): void;

--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -5,6 +5,9 @@
 
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 
+/**
+ * Events emitted by {@link TaskManager}.
+ */
 export interface ITaskManagerEvents extends ISharedObjectEvents {
     /**
      * Notifies when the local client has reached the front of the queue, left the queue, or a task was completed.
@@ -16,45 +19,44 @@ export interface ITaskManagerEvents extends ISharedObjectEvents {
 /**
  * Task manager interface
  */
-
 export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     /**
-     * Volunteer for the task.  Promise resolves true when the task is assigned to the local client. It rejects if the
-     * local client is removed from the queue without being assigned the task for any reason, such as disconnecting or
-     * abandoning the task while in queue.
+     * Volunteer for the task. Returns a promise that resolves `true` if the task is assigned to the local client and
+     * `false` if the task was completed by another client. It rejects if the local client abandoned the task or
+     * disconnected while in queue.
      * @param taskId - Identifier for the task
      */
     volunteerForTask(taskId: string): Promise<boolean>;
 
     /**
-     * Continuously volunteer to lock the task.  Watch the "assigned" event to determine if the task lock is assigned.
-     * We automatically re-enter the queue if the task lock is lost for any reason.
+     * Continuously volunteer for the task. Watch the "assigned" event to determine if the task is assigned.
+     * The local client will automatically re-enter the queue if the local client disconnects.
      * @param taskId - Identifier for the task
      */
     subscribeToTask(taskId: string): void;
 
     /**
-     * Exit the queue, releasing the task if currently locked.
+     * Exit the queue, releasing the task if currently assigned.
      * @param taskId - Identifier for the task
      */
     abandon(taskId: string): void;
 
     /**
      * Check whether this client is the current assignee for the task and there is no outstanding abandon op that
-     * would release the lock.
+     * would abandon the assignment.
      * @param taskId - Identifier for the task
      */
     assigned(taskId: string): boolean;
 
     /**
-     * Check whether this client is either the current assignee for the task or is waiting in line or we expect they
-     * will be in line after outstanding ops have been ack'd.
+     * Check whether this client is either the current assignee, in queue, or we expect they will be in queue after
+     * outstanding ops have been ack'd.
      * @param taskId - Identifier for the task
      */
     queued(taskId: string): boolean;
 
     /**
-     * Check whether this client is subscribed for the task.
+     * Check whether this client is currently subscribed to the task.
      * @param taskId - Identifier for the task
      */
     subscribed(taskId: string): boolean;

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -84,6 +84,13 @@ const snapshotFileName = "header";
  * taskManager.subscribeToTask("NameOfTask");
  * ```
  *
+ * To check if the local client is currently subscribed to a task, use the `subscribed()` method.
+ * ```typescript
+ * if (taskManager.subscribed("NameOfTask")) {
+ *     console.log("This client is currently subscribed to the task.");
+ * }
+ * ```
+ *
  * To release the rights to the task, use the `abandon()` method.  The next client in the queue will then get the
  * rights to run the task.
  *
@@ -101,6 +108,13 @@ const snapshotFileName = "header";
  * if (taskManager.assigned("NameOfTask")) {
  *     console.log("This client currently has the rights to run the task");
  * }
+ * ```
+ *
+ * To signal to other connected clients that a task is completed, use the `complete()` method. This will release all
+ * clients from the queue and emit the "completed" event.
+ *
+ * ```typescript
+ * taskManager.complete("NameOfTask");
  * ```
  *
  * ### Eventing

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -52,9 +52,10 @@ const snapshotFileName = "header";
 /**
  * The TaskManager distributed data structure tracks queues of clients that want to exclusively run a task.
  *
- * It is still experimental and under development.  Please do try it out, but expect breaking changes in the future.
- *
  * @remarks
+ *
+ * For an in-depth overview, see [TaskManager](https://fluidframework.com/docs/data-structures/taskmanager/).
+ *
  * ### Creation
  *
  * To create a `TaskManager`, call the static create method:
@@ -75,6 +76,14 @@ const snapshotFileName = "header";
  *     .catch((err) => { console.error(err); });
  * ```
  *
+ * Alternatively, you can indefinitely volunteer for a task with the synchronous `subscribeToTask()` method. This
+ * method does not return a value, therefore you need to rely on eventing to know when you have acquired the rights
+ * to run the task (see below).
+ *
+ * ```typescript
+ * taskManager.subscribeToTask("NameOfTask");
+ * ```
+ *
  * To release the rights to the task, use the `abandon()` method.  The next client in the queue will then get the
  * rights to run the task.
  *
@@ -82,21 +91,22 @@ const snapshotFileName = "header";
  * taskManager.abandon("NameOfTask");
  * ```
  *
- * To inspect your state in the queue, you can use the `queued()` and `assignedTask()` methods.
+ * To inspect your state in the queue, you can use the `queued()` and `assigned()` methods.
  *
  * ```typescript
  * if (taskManager.queued("NameOfTask")) {
- *     console.log("This client is somewhere in the queue, potentially even having the lock");
+ *     console.log("This client is somewhere in the queue, potentially even having the task assignment.");
  * }
  *
- * if (taskManager.queued("NameOfTask")) {
+ * if (taskManager.assigned("NameOfTask")) {
  *     console.log("This client currently has the rights to run the task");
  * }
  * ```
  *
  * ### Eventing
  *
- * `TaskManager` is an `EventEmitter`, and will emit events when a task is assigned to the client or released.
+ * `TaskManager` is an `EventEmitter`, and will emit events when a task is assigned to the client, when the task
+ * assignment is lost, and when a task was completed by another client.
  *
  * ```typescript
  * taskManager.on("assigned", (taskId: string) => {
@@ -106,10 +116,14 @@ const snapshotFileName = "header";
  * taskManager.on("lost", (taskId: string) => {
  *     console.log(`Client released task: ${taskId}`);
  * });
+ *
+ * taskManager.on("completed", (taskId: string) => {
+ *     console.log(`Another client completed task: ${taskId}`);
+ * });
  * ```
  *
- * These can be useful if the logic to volunteer for a task is separated from the logic to perform the task and it's
- * not convenient to pass the Promise around.
+ * These can be useful if the logic to volunteer for a task is separated from the logic to perform the task, such as
+ * when using the `subscribeToTask()` method.
  */
 export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITaskManager {
     /**
@@ -336,7 +350,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
         }
 
         if (!this.connected) {
-            throw new Error(`Attempted to lock in disconnected state: ${taskId}`);
+            throw new Error(`Attempted to volunteer in disconnected state: ${taskId}`);
         }
 
         // This promise works even if we already have an outstanding volunteer op.
@@ -367,7 +381,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
                 this.abandonWatcher.off("abandon", checkIfAbandoned);
                 this.connectionWatcher.off("disconnect", rejectOnDisconnect);
                 this.completedWatcher.off("completed", checkIfCompleted);
-                reject(new Error(`Abandoned before acquiring lock: ${taskId}`));
+                reject(new Error(`Abandoned before acquiring task assignment: ${taskId}`));
             };
 
             const rejectOnDisconnect = () => {
@@ -375,7 +389,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
                 this.abandonWatcher.off("abandon", checkIfAbandoned);
                 this.connectionWatcher.off("disconnect", rejectOnDisconnect);
                 this.completedWatcher.off("completed", checkIfCompleted);
-                reject(new Error(`Disconnected before acquiring lock: ${taskId}`));
+                reject(new Error(`Disconnected before acquiring task assignment: ${taskId}`));
             };
 
             const checkIfCompleted = (eventTaskId: string) => {

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -54,7 +54,7 @@ const snapshotFileName = "header";
  *
  * @remarks
  *
- * For an in-depth overview, see [TaskManager](https://fluidframework.com/docs/data-structures/taskmanager/).
+ * For an in-depth overview, see [TaskManager](https://fluidframework.com/docs/data-structures/task-manager/).
  *
  * ### Creation
  *


### PR DESCRIPTION
## Description

This PR cleans up TSDoc comments to better represent the current state of TaskManager.

## Reviewer Guidance

- General thoughts on the state of TaskManager TSDoc comments.
- Double check that the wording makes sense and is easy to read/understand.
- Thoughts on linking to the [ff.com TaskManager doc](https://fluidframework.com/docs/data-structures/task-manager/) in the `TaskManager` class TSDoc `@remarks` section.

## Other information or known dependencies

[AB#2247](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2247)
