### PR TITLE
Update AgentScheduler to implement IFluidLoadable

### DIFF
--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -16,7 +16,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "concurrently npm:build:compile npm:lint",
-    "build:compile": "npm run tsc && npm run build:test && npm run build:esnext",
+    "build:compile": "npm run tsc && npm run typetests:gen && npm run build:test && npm run build:esnext",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
@@ -29,7 +29,8 @@
     "lint:fix": "npm run eslint:fix",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
-    "tsfmt:fix": "tsfmt --replace"
+    "tsfmt:fix": "tsfmt --replace",
+    "typetests:gen": "fluid-type-validator -g -d ."
   },
   "nyc": {
     "all": true,
@@ -90,6 +91,9 @@
   },
   "typeValidation": {
     "version": "2.0.0",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_IAgentScheduler": {"forwardCompat": false},
+      "InterfaceDeclaration_IProvideAgentScheduler": {"forwardCompat": false}
+    }
   }
 }

--- a/packages/framework/agent-scheduler/src/agent.ts
+++ b/packages/framework/agent-scheduler/src/agent.ts
@@ -4,6 +4,7 @@
  */
 
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { IFluidLoadable } from "@fluidframework/core-interfaces";
 
 export const IAgentScheduler: keyof IProvideAgentScheduler = "IAgentScheduler";
 
@@ -35,7 +36,7 @@ export interface IAgentSchedulerEvents extends IEvent {
 /**
  * Agent scheduler distributes a set of tasks/variables across connected clients.
  */
-export interface IAgentScheduler extends IProvideAgentScheduler, IEventProvider<IAgentSchedulerEvents> {
+export interface IAgentScheduler extends IProvideAgentScheduler, IEventProvider<IAgentSchedulerEvents>, IFluidLoadable {
     /**
      * Registers a set of new tasks to distribute amongst connected clients. Only use this if a client wants
      * a new agent to run but does not have the capability to run the agent inside the host.

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -6,7 +6,6 @@
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
     IFluidHandle,
-    IFluidLoadable,
     IRequest,
 } from "@fluidframework/core-interfaces";
 import {
@@ -53,7 +52,7 @@ const mapWait = async <T = any>(map: ISharedMap, key: string): Promise<T> => {
 
 const schedulerId = "scheduler";
 
-export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements IAgentScheduler, IFluidLoadable {
+export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements IAgentScheduler {
     public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext, existing: boolean) {
         let root: ISharedMap;
         let consensusRegisterCollection: ConsensusRegisterCollection<string | null>;

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -6,6 +6,7 @@
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
     IFluidHandle,
+    IFluidLoadable,
     IRequest,
 } from "@fluidframework/core-interfaces";
 import {
@@ -52,7 +53,7 @@ const mapWait = async <T = any>(map: ISharedMap, key: string): Promise<T> => {
 
 const schedulerId = "scheduler";
 
-export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements IAgentScheduler {
+export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements IAgentScheduler, IFluidLoadable {
     public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext, existing: boolean) {
         let root: ISharedMap;
         let consensusRegisterCollection: ConsensusRegisterCollection<string | null>;
@@ -75,6 +76,7 @@ export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> imp
     }
 
     public get IAgentScheduler() { return this; }
+    public get IFluidLoadable() { return this; }
 
     private get clientId(): string {
         if (this.runtime.attachState === AttachState.Detached) {

--- a/packages/framework/agent-scheduler/src/test/types/validateAgentSchedulerPrevious.ts
+++ b/packages/framework/agent-scheduler/src/test/types/validateAgentSchedulerPrevious.ts
@@ -71,6 +71,7 @@ declare function get_old_InterfaceDeclaration_IAgentScheduler():
 declare function use_current_InterfaceDeclaration_IAgentScheduler(
     use: TypeOnly<current.IAgentScheduler>);
 use_current_InterfaceDeclaration_IAgentScheduler(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IAgentScheduler());
 
 /*
@@ -119,6 +120,7 @@ declare function get_old_InterfaceDeclaration_IProvideAgentScheduler():
 declare function use_current_InterfaceDeclaration_IProvideAgentScheduler(
     use: TypeOnly<current.IProvideAgentScheduler>);
 use_current_InterfaceDeclaration_IProvideAgentScheduler(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideAgentScheduler());
 
 /*


### PR DESCRIPTION
AgentScheduler exposes handle but not via IFluidLoadable which makes it hard to access in general.

Fixes [AB#2251](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2251) (which links to an internal discussion in Loop codebase that exposed this gap)