### PR TITLE
Install self-signed cert during pipeline run - port to release/v2int/1.4

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -48,6 +48,12 @@ parameters:
   type: boolean
   default: false
 
+# Name of the Secure File that contains the self-signed cert for the R11s deployment.
+# If not blank, the pipeline will try to install it to the local cert store.
+- name: r11sSelfSignedCertSecureFile
+  type: string
+  default: ""
+
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -85,6 +91,27 @@ jobs:
       # Setup
       - checkout: none
         clean: true
+
+      # Install self-signed cert for R11s deployment in local cert store
+      - ${{ if ne(parameters.r11sSelfSignedCertSecureFile, '') }}:
+        - task: DownloadSecureFile@1
+          displayName: 'Download r11s self-signed cert'
+          name: downloadCertTask
+          inputs:
+            secureFile: ${{ parameters.r11sSelfSignedCertSecureFile }}
+            retryCount: '2'
+
+        - task: Bash@3
+          displayName: 'Install r11s self-signed cert in local cert store'
+          inputs:
+            targetType: 'inline'
+            script: |
+
+              # Extract public part from cert
+              openssl x509 -in $(downloadCertTask.secureFilePath) -out cert.crt
+              # Install cert
+              sudo cp cert.crt /usr/local/share/ca-certificates/
+              sudo update-ca-certificates
 
       # Print parameters/Vars
       - task: Bash@3

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -65,6 +65,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:routerlicious:report
         continueOnError: true
+        r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
         splitTestVariants:
           - name: Non-compat
             flags: --compatVersion=0


### PR DESCRIPTION
## Description

Port of https://github.com/microsoft/FluidFramework/pull/12431 to release/v2int/1.4 branch.

## Other information or known dependencies

The self-signed SSL cert will only be deployed to the cluster and "become effective" after the main PR and all ports to other branches are merged, and main has synced up to next.