### PR TITLE
[v2int/1.4] Update AgentScheduler to implement IFluidLoadable 

### DIFF
--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -6,6 +6,7 @@
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
     IFluidHandle,
+    IFluidLoadable,
     IRequest,
 } from "@fluidframework/core-interfaces";
 import {
@@ -52,7 +53,10 @@ const mapWait = async <T = any>(map: ISharedMap, key: string): Promise<T> => {
 
 const schedulerId = "scheduler";
 
-export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements IAgentScheduler {
+export class AgentScheduler
+    extends TypedEventEmitter<IAgentSchedulerEvents>
+    implements IAgentScheduler, IFluidLoadable
+{ // eslint-disable-line @typescript-eslint/brace-style
     public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext, existing: boolean) {
         let root: ISharedMap;
         let consensusRegisterCollection: ConsensusRegisterCollection<string | null>;
@@ -75,6 +79,7 @@ export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> imp
     }
 
     public get IAgentScheduler() { return this; }
+    public get IFluidLoadable() { return this; }
 
     private get clientId(): string {
         if (this.runtime.attachState === AttachState.Detached) {


### PR DESCRIPTION
Reduced port of #12491 to int.1.4 release branch.

This adds `IFluidLoadable` member to `AgentScheduler` but doesn't update the interfaces, since it's not needed for the bug fix and that would not be suitable for a patch.