### PR TITLE
Add alternative mechanism for sending ops in load tests

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -473,9 +473,9 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
         const clientSendCount = config.testConfig.totalSendCount / config.testConfig.numClients;
         const opsSendType = (config.testConfig.opsSendType === "undefined") ?
         "staggeredReadWrite" : config.testConfig.opsSendType;
+        const opsPerCycle = config.testConfig.opRatePerMin * cycleMs / 60000;
+        const opsGapMs = cycleMs / opsPerCycle;
         if (opsSendType === "staggeredReadWrite") {
-            const opsPerCycle = config.testConfig.opRatePerMin * cycleMs / 60000;
-            const opsGapMs = cycleMs / opsPerCycle;
             try {
                 while (dataModel.counter.value < clientSendCount && !this.disposed) {
                     // this enables a quick ramp down. due to restart, some clients can lag
@@ -507,8 +507,6 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
             }
         } else if (opsSendType === "allClientsConcurrentReadWrite") {
             try {
-                const opsPerCycle = config.testConfig.opRatePerMin * cycleMs / 60000;
-                const opsGapMs = cycleMs / opsPerCycle;
                 while (dataModel.counter.value < clientSendCount) {
                     dataModel.counter.increment(1);
                     // Random jitter of +- 50% of opWaitMs

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -25,6 +25,7 @@ export interface ILoadTestConfig {
     signalsPerMin?: number;
     faultInjectionMaxMs?: number;
     faultInjectionMinMs?: number;
+    opsSendType?: string;
     /**
      * Number of "attachment" type blobs to upload over the course of the test run.
      */

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -128,6 +128,26 @@
             "readWriteCycleMs":  30000,
             "faultInjectionMinMs":  900000,
             "faultInjectionMaxMs":  1800000
+        },
+        "custom_profile_6":  {
+            "opRatePerMin":  7,
+            "signalsPerMin":  46,
+            "totalSignalsSendCount":  420000,
+            "progressIntervalMs":  20000,
+            "numClients":  10,
+            "totalSendCount":  70000,
+            "readWriteCycleMs":  30000,
+            "faultInjectionMinMs":  900000,
+            "faultInjectionMaxMs":  1800000,
+            "optionOverrides":{
+              "odsp":{
+                  "configurations":{
+                      "Fluid.Container.summarizeProtocolTree": [true]
+                  }
+              }
+
+          },
+            "opsSendType":  "allClientsConcurrentReadWrite"
         }
     }
 }


### PR DESCRIPTION
- Add support for all the clients sending and receiving ops concurrently, in load tests. Previously, we supported only a staggered read-write mechanism where only half the clients would be sending ops at any given time.
- The primary motivation for having this additional mechanism is that the previous mechanism does not allow us to send ops at certain rates.
- For instance, it was not possible to send ops at an effective rate of 6 ops/min/client with the staggered read-write mechanism. Priyam has run some tests to verify this, and documented the effective rates observed in the client metrics - we observe that the effective rate of ops sent does not match 6 ops/min/client.