### PR TITLE
Bumped peer deps for azure client and tinylicious client.

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -85,7 +85,7 @@
     "typescript": "~4.5.5"
   },
   "peerDependencies": {
-    "fluid-framework": "^1.0.1"
+    "fluid-framework": "^1.2.7"
   },
   "typeValidation": {
     "version": "1.1.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -73,7 +73,7 @@
     "typescript": "~4.5.5"
   },
   "peerDependencies": {
-    "fluid-framework": "^2.0.0"
+    "fluid-framework": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
   },
   "typeValidation": {
     "version": "2.0.0",


### PR DESCRIPTION
Bumped peer deps for azure client and tinylicious client. Looks like bump tools may have missed this.