### PR TITLE
Skip CG scan injection since we have manual task

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -75,6 +75,9 @@ variables:
       value: "$(FLUID_WEBSITE_TORUS_API_TOKEN)"
     ${{ if eq( parameters['deployEnvironment'], 'old') }}:
       value: "$(AZURE_STATIC_WEB_APPS_API_TOKEN)"
+  # skip injected CG detection as we manually trigger it in a parallel job
+  - name: skipComponentGovernanceDetection
+    value: true
 
 # no PR triggers
 trigger:


### PR DESCRIPTION
Avoid injected CG scan doing duplicated work on the whole repo, instead of a targeted directory.