### PR TITLE
[main > v2int/2.0] build: Pass build-tools version correctly

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -218,6 +218,7 @@ stages:
         parameters:
           buildDirectory: ${{ parameters.buildDirectory }}
           buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+          buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
           tagName: ${{ parameters.tagName }}
     - ${{ if eq(parameters.setVersion, false) }}:
       - task: Bash@3

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -207,6 +207,7 @@ stages:
           parameters:
             buildDirectory: ${{ parameters.buildDirectory }}
             buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+            buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
             tagName: ${{ parameters.tagName }}
 
         # Build

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -50,6 +50,7 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
+        echo "${{ parameters.buildToolsVersionToInstall }}"
         npm install --global "@fluid-tools/build-cli@${{ parameters.buildToolsVersionToInstall }}"
 
 - task: Bash@3

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -46,6 +46,10 @@ parameters:
   type: string
   default: client
 
+- name: buildToolsVersionToInstall
+  type: string
+  default: repo
+
 variables:
   # We use 'chalk' to colorize output, which auto-detects color support in the
   # running terminal.  The log output shown in Azure DevOps job runs only has
@@ -107,6 +111,7 @@ stages:
           parameters:
             buildDirectory: ${{ variables.buildDirectory }}
             buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+            buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
             tagName: ${{ parameters.tagName }}
 
         # Build


### PR DESCRIPTION
Cherry-pick of #12485 to the v2int/2.0 release branch.