### PR TITLE
[main > v2int/2.0]: Rename single commit summary flag (#12521)

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -617,7 +617,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.mc = loggerToMonitoringContext(ChildLogger.create(this.subLogger, "Container"));
 
         const summarizeProtocolTree =
-            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree")
+            this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree2")
             ?? this.loader.services.options.summarizeProtocolTree;
 
         this.options = {

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -15,13 +15,13 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Container.summarizeProtocolTree": [true, false]
+                        "Fluid.Container.summarizeProtocolTree2": [true, false]
                     }
                 },
                 "odsp-odsp-df":{
                     "configurations":{
                         "Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
-                        "Fluid.Container.summarizeProtocolTree": [true, false]
+                        "Fluid.Container.summarizeProtocolTree2": [true, false]
                     }
                 }
             }
@@ -55,7 +55,7 @@
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
-                        "Fluid.Container.summarizeProtocolTree": [true, false]
+                        "Fluid.Container.summarizeProtocolTree2": [true, false]
                     }
                 }
             }


### PR DESCRIPTION
## Description

Rename single commit summary flag due to a bug in 0.59 branch. So, we cannot reenable previous flag until hosts are off 0.59. So renaming it so that we can start enabling the new flag.

