### PR TITLE
Fix testObjectProvider handling of allowedErrors

### DIFF
--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -180,7 +180,11 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
             }
         }
         if (event.category === "error") {
-            this.unexpectedErrors.push(event);
+            if (this.allowedErrors.includes(event.eventName)) {
+                event.category = "generic";
+            } else {
+                this.unexpectedErrors.push(event);
+            }
         }
 
         this.baseLogger.send(event);
@@ -191,7 +195,7 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
         const unexpectedErrors = this.unexpectedErrors.splice(0, this.unexpectedErrors.length);
         return {
             expectedNotFound,
-            unexpectedErrors: unexpectedErrors.filter((event) => !this.allowedErrors.includes(event.eventName)),
+            unexpectedErrors,
         };
     }
 }


### PR DESCRIPTION
In addition to excluding them from "unexpectedErrors", also downgrade category to "generic".  This should fix the noise these errors are generating in our CI pipeline.

See this internal IcM ticket: https://portal.microsofticm.com/imp/v3/incidents/details/341857025/home