### PR TITLE
Update and clean shared API-Extractor configs

### DIFF
--- a/common/build/build-common/api-extractor-common-report.json
+++ b/common/build/build-common/api-extractor-common-report.json
@@ -1,3 +1,5 @@
+// Non-strict API-Extractor configuration.
+// Enforces minimal invariants.
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "./api-extractor-common.json",

--- a/common/build/build-common/api-extractor-common-strict.json
+++ b/common/build/build-common/api-extractor-common-strict.json
@@ -1,3 +1,5 @@
+// Strict API-Extractor configuration.
+// Enforces more-strict API-wise and documentation invariants by failing at build-time.
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "./api-extractor-common-report.json",
@@ -15,11 +17,6 @@
         "logLevel": "error",
         "addToApiReportFile": false
       },
-      // Prevent cyclic `@inheritDoc` comments
-      "ae-cyclic-inherit-doc": {
-        "logLevel": "error",
-        "addToApiReportFile": false
-      },
       // A documentation comment should contain at most one release tag.
       "ae-extra-release-tag": {
         "logLevel": "error",
@@ -33,11 +30,6 @@
       // A type signature should not reference another types whose release tag is less visible.
       "ae-incompatible-release-tags": {
         "logLevel": "error",
-        "addToApiReportFile": true
-      },
-      // Disabled. We don't require that internal members be prefixed with an underscore.
-      "ae-internal-missing-underscore": {
-        "logLevel": "none",
         "addToApiReportFile": false
       },
       // Multiple function overloads should not have @internal tags with other tags.

--- a/common/build/build-common/api-extractor-common-strict.json
+++ b/common/build/build-common/api-extractor-common-strict.json
@@ -50,6 +50,7 @@
       // Disabled. We don't require that all exported members have an explicit release tag. While being explicit
       // is preferred and is a best practice, enabling this requires that we have explicit release tags all the
       // way down, which makes it very tough to adopt this config for most of our packages.
+      // Packages may override this if they wish to enforce the presence of release tags.
       "ae-missing-release-tag": {
         "logLevel": "none",
         "addToApiReportFile": false

--- a/common/build/build-common/api-extractor-common-strict.json
+++ b/common/build/build-common/api-extractor-common-strict.json
@@ -17,6 +17,11 @@
         "logLevel": "error",
         "addToApiReportFile": false
       },
+      // Prevent cyclic `@inheritDoc` comments
+      "ae-cyclic-inherit-doc": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
       // A documentation comment should contain at most one release tag.
       "ae-extra-release-tag": {
         "logLevel": "error",

--- a/common/build/build-common/api-extractor-common.json
+++ b/common/build/build-common/api-extractor-common.json
@@ -92,13 +92,6 @@
          */
         // "addToApiReviewFile": false
       }
-
-      // "TS2551": {
-      //   "logLevel": "warning",
-      //   "addToApiReviewFile": true
-      // },
-      //
-      // . . .
     },
 
     /**
@@ -111,17 +104,26 @@
     "extractorMessageReporting": {
       "default": {
         "logLevel": "error"
-        // "addToApiReviewFile": false
       },
-      "ae-forgotten-export": {
-        "logLevel": "error"
-      },
+      // A documentation comment should contain at most one release tag.
       "ae-extra-release-tag": {
         "logLevel": "warning"
       },
-      "ae-missing-release-tag": {
-        "logLevel": "none"
+      // Reported when an exported API refers to another declaration that is not exported.
+      "ae-forgotten-export": {
+        "logLevel": "error"
       },
+      // Disabled. We don't require that internal members be prefixed with an underscore.
+      "ae-internal-missing-underscore": {
+        "logLevel": "none",
+        "addToApiReportFile": false
+      },
+      // A type signature should not reference another types whose release tag is less visible.
+      "ae-missing-release-tag": {
+        "logLevel": "none",
+        "addToApiReportFile": false
+      },
+      // The @inheritDoc tag needs a TSDoc declaration reference.
       "ae-unresolved-inheritdoc-reference": {
         "logLevel": "error"
       }
@@ -138,13 +140,6 @@
       "default": {
         "logLevel": "error"
       }
-
-      // "tsdoc-link-tag-unescaped-text": {
-      //   "logLevel": "warning",
-      //   "addToApiReviewFile": true
-      // },
-      //
-      // . . .
     }
   }
 }

--- a/common/build/build-common/api-extractor-common.json
+++ b/common/build/build-common/api-extractor-common.json
@@ -106,28 +106,27 @@
       "default": {
         "logLevel": "error"
       },
+      // Prevent cyclic `@inheritDoc` comments
+      "ae-cyclic-inherit-doc": {
+        "logLevel": "error"
+      },
+      // A documentation comment should contain at most one release tag.
+      "ae-extra-release-tag": {
+        "logLevel": "error"
+      },
       "ae-forgotten-export": {
         "logLevel": "error"
       },
-      "ae-extra-release-tag": {
-        "logLevel": "error"
+      // Disabled. We don't require that internal members be prefixed with an underscore.
+      "ae-internal-missing-underscore": {
+        "logLevel": "none"
       },
       "ae-missing-release-tag": {
         "logLevel": "none"
       },
       "ae-unresolved-inheritdoc-reference": {
         "logLevel": "error"
-      },
-      // Disabled. We don't require that internal members be prefixed with an underscore.
-      "ae-internal-missing-underscore": {
-        "logLevel": "none",
-        "addToApiReportFile": false
-      },
-      // Prevent cyclic `@inheritDoc` comments
-      "ae-cyclic-inherit-doc": {
-        "logLevel": "error",
-        "addToApiReportFile": false
-      },
+      }
     },
 
     /**

--- a/common/build/build-common/api-extractor-common.json
+++ b/common/build/build-common/api-extractor-common.json
@@ -116,7 +116,7 @@
         "logLevel": "error"
       },
       "ae-forgotten-export": {
-        "logLevel": "warning"
+        "logLevel": "error"
       },
       // Disabled. We don't require that internal members be prefixed with an underscore.
       "ae-internal-missing-underscore": {

--- a/common/build/build-common/api-extractor-common.json
+++ b/common/build/build-common/api-extractor-common.json
@@ -1,3 +1,4 @@
+// Common base API-Extractor configuration.
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
@@ -63,7 +64,7 @@
      *
      * TypeScript message identifiers start with "TS" followed by an integer.  For example: "TS2551"
      *
-     * DEFAULT VALUE:  A single "default" entry with logLevel=warning.
+     * DEFAULT VALUE: A single "default" entry with logLevel=warning.
      */
     "compilerMessageReporting": {
       /**
@@ -82,7 +83,7 @@
          *
          * DEFAULT VALUE: "warning"
          */
-        "logLevel": "error"
+        "logLevel": "error",
         /**
          * When addToApiReviewFile is true:  If API Extractor is configured to write an API report file (.api.md),
          * then the message will be written inside that file; otherwise, the message is instead logged according to
@@ -90,15 +91,8 @@
          *
          * DEFAULT VALUE: false
          */
-        // "addToApiReviewFile": false
+        "addToApiReviewFile": true
       }
-
-      // "TS2551": {
-      //   "logLevel": "warning",
-      //   "addToApiReviewFile": true
-      // },
-      //
-      // . . .
     },
 
     /**
@@ -111,20 +105,29 @@
     "extractorMessageReporting": {
       "default": {
         "logLevel": "error"
-        // "addToApiReviewFile": false
       },
       "ae-forgotten-export": {
         "logLevel": "error"
       },
       "ae-extra-release-tag": {
-        "logLevel": "warning"
+        "logLevel": "error"
       },
       "ae-missing-release-tag": {
         "logLevel": "none"
       },
       "ae-unresolved-inheritdoc-reference": {
         "logLevel": "error"
-      }
+      },
+      // Disabled. We don't require that internal members be prefixed with an underscore.
+      "ae-internal-missing-underscore": {
+        "logLevel": "none",
+        "addToApiReportFile": false
+      },
+      // Prevent cyclic `@inheritDoc` comments
+      "ae-cyclic-inherit-doc": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
     },
 
     /**
@@ -138,13 +141,6 @@
       "default": {
         "logLevel": "error"
       }
-
-      // "tsdoc-link-tag-unescaped-text": {
-      //   "logLevel": "warning",
-      //   "addToApiReviewFile": true
-      // },
-      //
-      // . . .
     }
   }
 }

--- a/common/build/build-common/api-extractor-common.json
+++ b/common/build/build-common/api-extractor-common.json
@@ -91,7 +91,7 @@
          *
          * DEFAULT VALUE: false
          */
-        "addToApiReviewFile": true
+        // "addToApiReviewFile": false
       }
     },
 
@@ -104,7 +104,8 @@
      */
     "extractorMessageReporting": {
       "default": {
-        "logLevel": "error"
+        "logLevel": "error",
+        "addToApiReportFile": true
       },
       // Prevent cyclic `@inheritDoc` comments
       "ae-cyclic-inherit-doc": {
@@ -115,7 +116,7 @@
         "logLevel": "error"
       },
       "ae-forgotten-export": {
-        "logLevel": "error"
+        "logLevel": "warning"
       },
       // Disabled. We don't require that internal members be prefixed with an underscore.
       "ae-internal-missing-underscore": {
@@ -124,7 +125,19 @@
       "ae-missing-release-tag": {
         "logLevel": "none"
       },
+      // Require packages to include `@packageDocumentation` comment
+      "ae-misplaced-package-tag": {
+        "logLevel": "error"
+      },
+      // The @inheritDoc tag needs a TSDoc declaration reference.
+      "ae-unresolved-inheritdoc-base": {
+        "logLevel": "error"
+      },
       "ae-unresolved-inheritdoc-reference": {
+        "logLevel": "error"
+      },
+      // The @link tag needs a TSDoc declaration reference.
+      "ae-unresolved-link": {
         "logLevel": "error"
       }
     },


### PR DESCRIPTION
Namely:

- Adds top level comments to each config.
- Adds the following rules to the report config (but only adds warnings / errors to report, does not add build-time enforcement):
  - ae-cyclic-inherit-doc
  - ae-misplaced-package-tag
  - ae-unresolved-inheritdoc-base
  - ae-unresolved-inheritdoc-reference
  - ae-unresolved-link
- Correctly omits rule "ae-internal-missing-underscore" from `report` config variant to match strict config.