### PR TITLE
Tree: add "core" library

### DIFF
--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -305,6 +305,7 @@ flowchart
         shared-tree-->feature
         subgraph feature ["feature-libraries"]
             direction TB
+            editable-tree-->defaultFieldKinds
             defaultRebaser
             defaultSchema-->defaultFieldKinds-->modular-schema
             forestIndex-->treeTextCursor

--- a/packages/dds/tree/src/core/README.md
+++ b/packages/dds/tree/src/core/README.md
@@ -4,3 +4,6 @@ Reexports the contents of the "core" libraries.
 This is the set of libraries on which [shared-tree-core](../shared-tree-core/README.md) depends.
 
 This mainly exists to simplify imports (and `fence.json` files) for code like [feature- libraries](../feature-libraries/README.md) and [shared-tree](../shared-tree/README.md).
+
+The core libraries could be nested inside this directory (as is done with [feature- libraries](../feature-libraries/README.md));
+for now this was avoided to keep the nesting levels lower and avoid having to move a lot of code.

--- a/packages/dds/tree/src/core/README.md
+++ b/packages/dds/tree/src/core/README.md
@@ -1,0 +1,6 @@
+# core
+
+Reexports the contents of the "core" libraries.
+This is the set of libraries on which [shared-tree-core](../shared-tree-core/README.md) depends.
+
+This mainly exists to simplify imports (and `fence.json` files) for code like [feature- libraries](../feature-libraries/README.md) and [shared-tree](../shared-tree/README.md).

--- a/packages/dds/tree/src/core/README.md
+++ b/packages/dds/tree/src/core/README.md
@@ -5,5 +5,5 @@ This is the set of libraries on which [shared-tree-core](../shared-tree-core/REA
 
 This mainly exists to simplify imports (and `fence.json` files) for code like [feature- libraries](../feature-libraries/README.md) and [shared-tree](../shared-tree/README.md).
 
-The core libraries could be nested inside this directory (as is done with [feature- libraries](../feature-libraries/README.md));
+The core libraries could be nested inside this directory (as is done with [feature-libraries](../feature-libraries/README.md));
 for now this was avoided to keep the nesting levels lower and avoid having to move a lot of code.

--- a/packages/dds/tree/src/core/README.md
+++ b/packages/dds/tree/src/core/README.md
@@ -3,7 +3,7 @@
 Reexports the contents of the "core" libraries.
 This is the set of libraries on which [shared-tree-core](../shared-tree-core/README.md) depends.
 
-This mainly exists to simplify imports (and `fence.json` files) for code like [feature- libraries](../feature-libraries/README.md) and [shared-tree](../shared-tree/README.md).
+This mainly exists to simplify imports (and `fence.json` files) for code like [feature-libraries](../feature-libraries/README.md) and [shared-tree](../shared-tree/README.md).
 
 The core libraries could be nested inside this directory (as is done with [feature-libraries](../feature-libraries/README.md));
 for now this was avoided to keep the nesting levels lower and avoid having to move a lot of code.

--- a/packages/dds/tree/src/core/fence.json
+++ b/packages/dds/tree/src/core/fence.json
@@ -4,16 +4,17 @@
   // Depending on "shared-tree-core" so implementations of Indexes can be here.
   // Could move the index abstraction elsewhere instead.
   "imports": [
-    "schema-stored",
-    "schema-view",
-    "tree",
-    "util",
-    "rebase",
-    "forest",
-    "dependency-tracking",
-    "shared-tree-core",
     "change-family",
     "checkout",
-    "transaction"
+    "core",
+    "dependency-tracking",
+    "edit-manager",
+    "forest",
+    "rebase",
+    "schema-stored",
+    "schema-view",
+    "shared-tree-core",
+    "transaction",
+    "tree"
   ]
 }

--- a/packages/dds/tree/src/core/fence.json
+++ b/packages/dds/tree/src/core/fence.json
@@ -15,6 +15,7 @@
     "schema-view",
     "shared-tree-core",
     "transaction",
-    "tree"
+    "tree",
+    "util"
   ]
 }

--- a/packages/dds/tree/src/core/fence.json
+++ b/packages/dds/tree/src/core/fence.json
@@ -1,0 +1,19 @@
+{
+  "tags": ["core"],
+  "exports": ["index"],
+  // Depending on "shared-tree-core" so implementations of Indexes can be here.
+  // Could move the index abstraction elsewhere instead.
+  "imports": [
+    "schema-stored",
+    "schema-view",
+    "tree",
+    "util",
+    "rebase",
+    "forest",
+    "dependency-tracking",
+    "shared-tree-core",
+    "change-family",
+    "checkout",
+    "transaction"
+  ]
+}

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -1,0 +1,132 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export {
+    Dependee,
+    Dependent,
+    NamedComputation,
+    ObservingDependent,
+    InvalidationToken,
+    recordDependency,
+    SimpleDependee,
+    cachedValue,
+    ICachedValue,
+    DisposingDependee,
+    SimpleObservingDependent,
+} from "../dependency-tracking";
+
+export {
+    EmptyKey,
+    FieldKey,
+    TreeType,
+    Value,
+    TreeValue,
+    AnchorSet,
+    DetachedField,
+    UpPath,
+    Anchor,
+    RootField,
+    ChildCollection,
+    ChildLocation,
+    FieldMapObject,
+    NodeData,
+    GenericTreeNode,
+    JsonableTree,
+    Delta,
+    rootFieldKey,
+    FieldScope,
+    GlobalFieldKeySymbol,
+    symbolFromKey,
+    keyFromSymbol,
+    ITreeCursorNew,
+    CursorLocationType,
+    ITreeCursorSynchronous,
+    GenericFieldsNode,
+    AnchorLocator,
+    genericTreeKeys,
+    getGenericTreeField,
+    genericTreeDeleteIfEmpty,
+    getDepth,
+    symbolIsFieldKey,
+    mapCursorFieldNew,
+    mapCursorFields,
+    isGlobalFieldKey,
+    getMapTreeField,
+    MapTree,
+    detachedFieldAsKey,
+    keyAsDetachedField,
+    visitDelta,
+    setGenericTreeField,
+} from "../tree";
+
+export {
+    ITreeCursor,
+    TreeNavigationResult,
+    IEditableForest,
+    IForestSubscription,
+    TreeLocation,
+    FieldLocation,
+    ForestLocation,
+    ITreeSubscriptionCursor,
+    ITreeSubscriptionCursorState,
+    SynchronousNavigationResult,
+    mapCursorField,
+    initializeForest,
+} from "../forest";
+
+export {
+    LocalFieldKey,
+    GlobalFieldKey,
+    TreeSchemaIdentifier,
+    NamedTreeSchema,
+    Named,
+    FieldSchema,
+    ValueSchema,
+    TreeSchema,
+    StoredSchemaRepository,
+    FieldKindIdentifier,
+    TreeTypeSet,
+    SchemaData,
+    SchemaPolicy,
+    SchemaDataAndPolicy,
+    InMemoryStoredSchemaRepository,
+    schemaDataIsEmpty,
+    fieldSchema,
+    namedTreeSchema,
+    lookupTreeSchema,
+    lookupGlobalFieldSchema,
+    TreeSchemaBuilder,
+    emptyMap,
+    emptySet,
+} from "../schema-stored";
+
+export {
+    ChangeEncoder,
+    ChangeFamily,
+    ProgressiveEditBuilder,
+    ProgressiveEditBuilderBase,
+} from "../change-family";
+
+export { Rebaser, ChangeRebaser, RevisionTag, ChangesetFromChangeRebaser } from "../rebase";
+
+export { ICheckout, TransactionResult } from "../checkout";
+
+export { Checkout, runSynchronousTransaction } from "../transaction";
+
+export {
+    Index,
+    SharedTreeCore,
+    SummaryElement,
+    SummaryElementParser,
+    SummaryElementStringifier,
+} from "../shared-tree-core";
+
+export {
+    Adapters,
+    ViewSchemaData,
+    AdaptedViewSchema,
+    Compatibility,
+    FieldAdapter,
+} from "../schema-view";

--- a/packages/dds/tree/src/domains/fence.json
+++ b/packages/dds/tree/src/domains/fence.json
@@ -1,5 +1,5 @@
 {
   "tags": ["domains"],
   "exports": ["index"],
-  "imports": ["schema-stored", "util", "forest", "tree", "feature-libraries"]
+  "imports": ["util", "core", "feature-libraries"]
 }

--- a/packages/dds/tree/src/domains/json/fence.json
+++ b/packages/dds/tree/src/domains/json/fence.json
@@ -1,5 +1,5 @@
 {
   "tags": ["tree"],
   "exports": ["index"],
-  "imports": ["schema-stored", "util", "forest", "tree", "feature-libraries"]
+  "imports": ["util", "core", "feature-libraries"]
 }

--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -5,16 +5,16 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { Jsonable } from "@fluidframework/datastore-definitions";
-import { LocalFieldKey } from "../../schema-stored";
-import { JsonCompatible, JsonCompatibleObject } from "../../util";
 import {
+    LocalFieldKey,
     ITreeCursorNew as ITreeCursor,
     EmptyKey,
     FieldKey,
     mapCursorFieldNew,
     mapCursorFields,
     ITreeCursorSynchronous,
-} from "../../tree";
+} from "../../core";
+import { JsonCompatible, JsonCompatibleObject } from "../../util";
 import { CursorAdapter, isPrimitiveValue, singleStackTreeCursor } from "../../feature-libraries";
 import {
     jsonArray,

--- a/packages/dds/tree/src/domains/json/jsonCursorLegacy.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursorLegacy.ts
@@ -5,15 +5,18 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { Jsonable } from "@fluidframework/datastore-definitions";
-import { LocalFieldKey } from "../../schema-stored";
 import { JsonCompatible, JsonCompatibleObject } from "../../util";
 import {
     ITreeCursor,
     mapCursorField,
     TreeNavigationResult,
     SynchronousNavigationResult,
-} from "../../forest";
-import { EmptyKey, FieldKey, TreeType, Value } from "../../tree";
+    LocalFieldKey,
+    EmptyKey,
+    FieldKey,
+    TreeType,
+    Value,
+} from "../../core";
 
 import {
     jsonArray,

--- a/packages/dds/tree/src/domains/json/jsonDomainSchema.ts
+++ b/packages/dds/tree/src/domains/json/jsonDomainSchema.ts
@@ -20,8 +20,8 @@ import {
     fieldSchema,
     namedTreeSchema,
     SchemaData,
-} from "../../schema-stored";
-import { EmptyKey } from "../../tree";
+    EmptyKey,
+} from "../../core";
 import { brand } from "../../util";
 
 const jsonTypeSchema: Map<TreeSchemaIdentifier, NamedTreeSchema> = new Map();

--- a/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
@@ -3,12 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import { ChangeEncoder, ChangeFamily, ProgressiveEditBuilder } from "../change-family";
-import { ITreeCursor } from "../forest";
-import { ChangeRebaser } from "../rebase";
-import { FieldKindIdentifier } from "../schema-stored";
+import {
+    ChangeEncoder,
+    ChangeFamily,
+    ProgressiveEditBuilder,
+    ITreeCursor,
+    ChangeRebaser,
+    FieldKindIdentifier,
+    AnchorSet,
+    Delta,
+    FieldKey,
+    ITreeCursorSynchronous,
+    UpPath,
+    Value,
+} from "../core";
 import { brand } from "../util";
-import { AnchorSet, Delta, FieldKey, ITreeCursorSynchronous, UpPath, Value } from "../tree";
 import {
     FieldKind,
     ModularChangeFamily,

--- a/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
@@ -4,10 +4,14 @@
  */
 
 import { assert, IsoBuffer } from "@fluidframework/common-utils";
-import { ChangeEncoder } from "../change-family";
-import { ITreeCursor } from "../forest";
-import { FieldKindIdentifier } from "../schema-stored";
-import { AnchorSet, Delta, JsonableTree } from "../tree";
+import {
+    ChangeEncoder,
+    ITreeCursor,
+    FieldKindIdentifier,
+    AnchorSet,
+    Delta,
+    JsonableTree,
+} from "../core";
 import { brand, fail, JsonCompatible, JsonCompatibleReadOnly } from "../util";
 import { singleTextCursor } from "./treeTextCursor";
 import {

--- a/packages/dds/tree/src/feature-libraries/defaultSchema.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultSchema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { fieldSchema, emptyMap, emptySet, ValueSchema, TreeSchema } from "../schema-stored";
+import { fieldSchema, emptyMap, emptySet, ValueSchema, TreeSchema } from "../core";
 import { value, forbidden, fieldKinds } from "./defaultFieldKinds";
 import { FullSchemaPolicy } from "./modular-schema";
 

--- a/packages/dds/tree/src/feature-libraries/deltaUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/deltaUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { unreachableCase } from "@fluidframework/common-utils";
-import { Delta, FieldKey, getMapTreeField, MapTree } from "../tree";
+import { Delta, FieldKey, getMapTreeField, MapTree } from "../core";
 import { fail, OffsetListFactory } from "../util";
 import { mapTreeFromCursor } from "./mapTreeCursor";
 

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -4,23 +4,24 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { Value, Anchor, FieldKey, symbolIsFieldKey } from "../../tree";
 import {
+    Value,
+    Anchor,
+    FieldKey,
+    symbolIsFieldKey,
     IEditableForest,
     TreeNavigationResult,
     mapCursorField,
     ITreeSubscriptionCursor,
     ITreeSubscriptionCursorState,
-} from "../../forest";
-import { brand } from "../../util";
-import {
     FieldSchema,
     LocalFieldKey,
     TreeSchemaIdentifier,
     NamedTreeSchema,
     ValueSchema,
     lookupTreeSchema,
-} from "../../schema-stored";
+} from "../../core";
+import { brand } from "../../util";
 import { FieldKind, Multiplicity } from "../modular-schema";
 import {
     AdaptingProxyHandler,

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -4,9 +4,13 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { IEditableForest, TreeNavigationResult } from "../../forest";
-import { lookupGlobalFieldSchema } from "../../schema-stored";
-import { rootFieldKey, symbolFromKey } from "../../tree";
+import {
+    IEditableForest,
+    TreeNavigationResult,
+    lookupGlobalFieldSchema,
+    rootFieldKey,
+    symbolFromKey,
+} from "../../core";
 import { EditableField, proxifyField, ProxyTarget, UnwrappedEditableField } from "./editableTree";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/editable-tree/fence.json
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/fence.json
@@ -2,13 +2,5 @@
   "tags": ["forest-proxy"],
   "exports": ["index"],
   // TODO: "feature-libraries" dependency is for defaultFieldKinds, and should be removed once proper view schema are provided.
-  "imports": [
-    "schema-stored",
-    "tree",
-    "dependency-tracking",
-    "forest",
-    "util",
-    "feature-libraries",
-    "modular-schema"
-  ]
+  "imports": ["util", "core", "feature-libraries", "modular-schema"]
 }

--- a/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
@@ -4,16 +4,20 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { EmptyKey, FieldKey, isGlobalFieldKey, keyFromSymbol, Value } from "../../tree";
 import { fail } from "../../util";
 import {
+    EmptyKey,
+    FieldKey,
+    isGlobalFieldKey,
+    keyFromSymbol,
+    Value,
     TreeSchema,
     ValueSchema,
     FieldSchema,
     LocalFieldKey,
     SchemaDataAndPolicy,
     lookupGlobalFieldSchema,
-} from "../../schema-stored";
+} from "../../core";
 // TODO:
 // This module currently is assuming use of defaultFieldKinds.
 // The field kinds should instead come from a view schema registry thats provided somewhere.

--- a/packages/dds/tree/src/feature-libraries/fence.json
+++ b/packages/dds/tree/src/feature-libraries/fence.json
@@ -1,17 +1,5 @@
 {
   "tags": ["feature-libraries"],
   "exports": ["index"],
-  // Depending on "shared-tree-core" so implementations of Indexes can be here.
-  // Could move the index abstraction elsewhere instead.
-  "imports": [
-    "schema-stored",
-    "schema-view",
-    "tree",
-    "util",
-    "rebase",
-    "forest",
-    "dependency-tracking",
-    "shared-tree-core",
-    "change-family"
-  ]
+  "imports": ["util", "core"]
 }

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -20,15 +20,16 @@ import {
     initializeForest,
     ITreeSubscriptionCursor,
     TreeNavigationResult,
-} from "../forest";
-import {
     Index,
     SummaryElement,
     SummaryElementParser,
     SummaryElementStringifier,
-} from "../shared-tree-core";
-import { cachedValue, ICachedValue, recordDependency } from "../dependency-tracking";
-import { JsonableTree, Delta } from "../tree";
+    cachedValue,
+    ICachedValue,
+    recordDependency,
+    JsonableTree,
+    Delta,
+} from "../core";
 import { jsonableTreeFromCursor } from "./treeTextCursorLegacy";
 import { singleTextCursor } from "./treeTextCursor";
 

--- a/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
@@ -11,7 +11,7 @@ import {
     CursorLocationType,
     mapCursorFieldNew as mapCursorField,
     ITreeCursorSynchronous,
-} from "../tree";
+} from "../core";
 import { CursorAdapter, singleStackTreeCursor } from "./treeCursorUtils";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -4,7 +4,7 @@
  */
 
 import { compareSets, fail } from "../../util";
-import { TreeSchema, ValueSchema, FieldSchema, TreeTypeSet, SchemaData } from "../../schema-stored";
+import { TreeSchema, ValueSchema, FieldSchema, TreeTypeSet, SchemaData } from "../../core";
 import { FullSchemaPolicy, Multiplicity } from "./fieldKind";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fence.json
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fence.json
@@ -1,13 +1,5 @@
 {
   "tags": ["modular-schema"],
   "exports": ["index"],
-  "imports": [
-    "schema-stored",
-    "schema-view",
-    "tree",
-    "util",
-    "rebase",
-    "dependency-tracking",
-    "change-family"
-  ]
+  "imports": ["util", "core"]
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKindIdentifier } from "../../schema-stored";
-import { Delta, FieldKey, Value } from "../../tree";
+import { FieldKindIdentifier, Delta, FieldKey, Value } from "../../core";
 import { Brand, Invariant, JsonCompatibleReadOnly } from "../../util";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldKind.ts
@@ -10,7 +10,7 @@ import {
     SchemaPolicy,
     fieldSchema,
     SchemaData,
-} from "../../schema-stored";
+} from "../../core";
 import { isNeverField } from "./comparison";
 import { FieldChangeHandler, FieldEditor } from "./fieldChangeHandler";
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Delta } from "../../tree";
+import { Delta } from "../../core";
 import { brand, JsonCompatibleReadOnly } from "../../util";
 import {
     FieldChangeHandler,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -9,10 +9,14 @@ import {
     ChangeFamily,
     ProgressiveEditBuilder,
     ProgressiveEditBuilderBase,
-} from "../../change-family";
-import { ChangeRebaser } from "../../rebase";
-import { FieldKindIdentifier } from "../../schema-stored";
-import { AnchorSet, Delta, FieldKey, UpPath, Value } from "../../tree";
+    ChangeRebaser,
+    FieldKindIdentifier,
+    AnchorSet,
+    Delta,
+    FieldKey,
+    UpPath,
+    Value,
+} from "../../core";
 import { brand, getOrAddEmptyToMap, JsonCompatibleReadOnly } from "../../util";
 import {
     FieldChangeHandler,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/typedSchema.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/typedSchema.ts
@@ -13,7 +13,7 @@ import {
     TreeSchemaIdentifier,
     namedTreeSchema,
     NamedTreeSchema,
-} from "../../schema-stored";
+} from "../../core";
 import { FieldKind } from "./fieldKind";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/view.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/view.ts
@@ -13,14 +13,12 @@ import {
     FieldKindIdentifier,
     GlobalFieldKey,
     InMemoryStoredSchemaRepository,
-} from "../../schema-stored";
-import {
     Adapters,
     ViewSchemaData,
     AdaptedViewSchema,
     Compatibility,
     FieldAdapter,
-} from "../../schema-view";
+} from "../../core";
 import { FieldKind, FullSchemaPolicy } from "./fieldKind";
 import { allowsRepoSuperset, isNeverTree } from "./comparison";
 

--- a/packages/dds/tree/src/feature-libraries/object-forest/fence.json
+++ b/packages/dds/tree/src/feature-libraries/object-forest/fence.json
@@ -1,13 +1,5 @@
 {
   "tags": ["object-forest"],
   "exports": ["index"],
-  "imports": [
-    "schema-stored",
-    "tree",
-    "dependency-tracking",
-    "forest",
-    "util",
-    "rebase",
-    "feature-libraries"
-  ]
+  "imports": ["util", "core", "feature-libraries"]
 }

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -11,15 +11,11 @@ import {
     recordDependency,
     SimpleDependee,
     SimpleObservingDependent,
-} from "../../dependency-tracking";
-import {
     ITreeSubscriptionCursor,
     IEditableForest,
     ITreeSubscriptionCursorState,
     TreeNavigationResult,
-} from "../../forest";
-import { StoredSchemaRepository } from "../../schema-stored";
-import {
+    StoredSchemaRepository,
     FieldKey,
     DetachedField,
     AnchorSet,
@@ -33,7 +29,7 @@ import {
     Anchor,
     visitDelta,
     ITreeCursorNew,
-} from "../../tree";
+} from "../../core";
 import { brand, fail } from "../../util";
 import { jsonableTreeFromCursor } from "../treeTextCursor";
 

--- a/packages/dds/tree/src/feature-libraries/schemaIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaIndex.ts
@@ -21,16 +21,12 @@ import {
     SummaryElement,
     SummaryElementParser,
     SummaryElementStringifier,
-} from "../shared-tree-core";
-import {
     cachedValue,
     Dependee,
     Dependent,
     ICachedValue,
     recordDependency,
-} from "../dependency-tracking";
-import { Delta } from "../tree";
-import {
+    Delta,
     FieldKindIdentifier,
     FieldSchema,
     GlobalFieldKey,
@@ -43,7 +39,7 @@ import {
     TreeSchemaIdentifier,
     ValueSchema,
     schemaDataIsEmpty,
-} from "../schema-stored";
+} from "../core";
 import { brand, isJsonObject, JsonCompatibleReadOnly } from "../util";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/format.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { JsonableTree, TreeValue } from "../../../tree";
+import { JsonableTree, TreeValue } from "../../../core";
 
 // TODOs:
 // Clipboard

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -5,15 +5,15 @@
 
 import { unreachableCase } from "@fluidframework/common-utils";
 import { singleTextCursor } from "../../treeTextCursor";
-import { TreeSchemaIdentifier } from "../../../schema-stored";
 import {
+    TreeSchemaIdentifier,
     FieldKey,
     Value,
     Delta,
     genericTreeKeys,
     getGenericTreeField,
     genericTreeDeleteIfEmpty,
-} from "../../../tree";
+} from "../../../core";
 import { brand, brandOpaque, clone, fail, makeArray, OffsetListFactory } from "../../../util";
 import { ProtoNode, Transposed as T } from "./format";
 import { isSkipMark } from "./utils";

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/fence.json
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/fence.json
@@ -1,13 +1,5 @@
 {
   "tags": ["sequence-change-family"],
   "exports": ["index"],
-  "imports": [
-    "change-family",
-    "forest",
-    "rebase",
-    "schema-stored",
-    "tree",
-    "util",
-    "feature-libraries"
-  ]
+  "imports": ["util", "core", "feature-libraries"]
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeFamily.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ChangeFamily } from "../../change-family";
-import { AnchorSet, Delta } from "../../tree";
+import { ChangeFamily, AnchorSet, Delta } from "../../core";
 import { toDelta } from "./changeset";
 import { sequenceChangeRebaser } from "./sequenceChangeRebaser";
 import { sequenceChangeEncoder, SequenceChangeset } from "./sequenceChangeset";

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeRebaser.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeRebaser.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ChangeRebaser } from "../../rebase";
-import { AnchorSet } from "../../tree";
+import { ChangeRebaser, AnchorSet } from "../../core";
 import { toDelta } from "./changeset";
 import { SequenceChangeset } from "./sequenceChangeset";
 import { compose } from "./compose";

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeset.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceChangeset.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ChangeEncoder } from "../../change-family";
+import { ChangeEncoder } from "../../core";
 import { JsonCompatible } from "../../util";
 import { Transposed as T } from "./changeset";
 

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
@@ -3,9 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { ProgressiveEditBuilderBase } from "../../change-family";
-import { ITreeCursor } from "../../forest";
-import { AnchorSet, UpPath, Value, Delta, getDepth } from "../../tree";
+import {
+    ProgressiveEditBuilderBase,
+    ITreeCursor,
+    AnchorSet,
+    UpPath,
+    Value,
+    Delta,
+    getDepth,
+} from "../../core";
 import { fail } from "../../util";
 import { jsonableTreeFromCursor } from "../treeTextCursorLegacy";
 import { Transposed as T } from "./changeset";

--- a/packages/dds/tree/src/feature-libraries/sequence-field/fence.json
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/fence.json
@@ -1,5 +1,5 @@
 {
   "tags": ["sequence-field"],
   "exports": ["index"],
-  "imports": ["forest", "tree", "util", "feature-libraries", "schema-stored"]
+  "imports": ["util", "core", "feature-libraries"]
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { JsonableTree } from "../../tree";
+import { JsonableTree } from "../../core";
 import { NodeChangeset } from "../modular-schema";
 
 export type NodeChangeType = NodeChangeset;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITreeCursor } from "../../forest";
+import { ITreeCursor } from "../../core";
 import { FieldEditor } from "../modular-schema";
 import { jsonableTreeFromCursor } from "../treeTextCursorLegacy";
 import { Changeset, Mark, NodeChangeType } from "./format";

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -5,8 +5,7 @@
 
 import { unreachableCase } from "@fluidframework/common-utils";
 import { brand, brandOpaque, fail, makeArray, OffsetListFactory } from "../../util";
-import { TreeSchemaIdentifier } from "../../schema-stored";
-import { Delta } from "../../tree";
+import { TreeSchemaIdentifier, Delta } from "../../core";
 import { applyModifyToTree } from "../deltaUtils";
 import { mapTreeFromCursor, singleMapTreeCursor } from "../mapTreeCursor";
 import { singleTextCursor } from "../treeTextCursor";

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -11,7 +11,7 @@ import {
     CursorLocationType,
     ITreeCursorSynchronous,
     Value,
-} from "../tree";
+} from "../core";
 import { fail } from "../util";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -13,7 +13,7 @@ import {
     mapCursorFieldNew as mapCursorField,
     ITreeCursorSynchronous,
     setGenericTreeField,
-} from "../tree";
+} from "../core";
 import { CursorAdapter, singleStackTreeCursor } from "./treeCursorUtils";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/treeTextCursorLegacy.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursorLegacy.ts
@@ -9,8 +9,6 @@ import {
     TreeNavigationResult,
     mapCursorField,
     SynchronousNavigationResult,
-} from "../forest";
-import {
     DetachedField,
     detachedFieldAsKey,
     FieldKey,
@@ -21,7 +19,7 @@ import {
     TreeType,
     UpPath,
     Value,
-} from "../tree";
+} from "../core";
 import { fail } from "../util";
 
 /**

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -11,9 +11,6 @@ export {
     InvalidationToken,
     recordDependency,
     SimpleDependee,
-} from "./dependency-tracking";
-
-export {
     EmptyKey,
     FieldKey,
     TreeType,
@@ -41,9 +38,6 @@ export {
     ITreeCursorSynchronous,
     GenericFieldsNode,
     AnchorLocator,
-} from "./tree";
-
-export {
     ITreeCursor,
     TreeNavigationResult,
     IEditableForest,
@@ -54,9 +48,6 @@ export {
     ITreeSubscriptionCursor,
     ITreeSubscriptionCursorState,
     SynchronousNavigationResult,
-} from "./forest";
-
-export {
     LocalFieldKey,
     GlobalFieldKey,
     TreeSchemaIdentifier,
@@ -71,7 +62,17 @@ export {
     SchemaData,
     SchemaPolicy,
     SchemaDataAndPolicy,
-} from "./schema-stored";
+    ChangeEncoder,
+    ChangeFamily,
+    ProgressiveEditBuilder,
+    ProgressiveEditBuilderBase,
+    Rebaser,
+    ChangeRebaser,
+    RevisionTag,
+    ChangesetFromChangeRebaser,
+    ICheckout,
+    TransactionResult,
+} from "./core";
 
 export {
     Brand,
@@ -92,17 +93,6 @@ export {
     JsonCompatible,
     JsonCompatibleObject,
 } from "./util";
-
-export {
-    ChangeEncoder,
-    ChangeFamily,
-    ProgressiveEditBuilder,
-    ProgressiveEditBuilderBase,
-} from "./change-family";
-
-export { Rebaser, ChangeRebaser, RevisionTag, ChangesetFromChangeRebaser } from "./rebase";
-
-export { ICheckout, TransactionResult } from "./checkout";
 
 export {
     cursorToJsonObject,

--- a/packages/dds/tree/src/shared-tree/fence.json
+++ b/packages/dds/tree/src/shared-tree/fence.json
@@ -1,16 +1,5 @@
 {
   "tags": ["shared-tree"],
   "exports": ["index"],
-  "imports": [
-    "schema-stored",
-    "tree",
-    "dependency-tracking",
-    "util",
-    "rebase",
-    "forest",
-    "shared-tree-core",
-    "feature-libraries",
-    "transaction",
-    "checkout"
-  ]
+  "imports": ["util", "core", "feature-libraries"]
 }

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -13,7 +13,21 @@ import {
 } from "@fluidframework/datastore-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ISharedObject } from "@fluidframework/shared-object-base";
-import { ICheckout, TransactionResult } from "../checkout";
+import {
+    ICheckout,
+    TransactionResult,
+    IForestSubscription,
+    StoredSchemaRepository,
+    InMemoryStoredSchemaRepository,
+    Index,
+    SharedTreeCore,
+    Checkout as TransactionCheckout,
+    runSynchronousTransaction,
+    Anchor,
+    AnchorLocator,
+    AnchorSet,
+    UpPath,
+} from "../core";
 import {
     defaultSchemaPolicy,
     EditableTreeContext,
@@ -29,11 +43,6 @@ import {
     SchemaEditor,
     DefaultChangeset,
 } from "../feature-libraries";
-import { IForestSubscription } from "../forest";
-import { StoredSchemaRepository, InMemoryStoredSchemaRepository } from "../schema-stored";
-import { Index, SharedTreeCore } from "../shared-tree-core";
-import { Checkout as TransactionCheckout, runSynchronousTransaction } from "../transaction";
-import { Anchor, AnchorLocator, AnchorSet, UpPath } from "../tree";
 
 /**
  * Collaboratively editable tree distributed data-structure,


### PR DESCRIPTION
## Description

Align dependency diagram in readme with the actual code by:
- add editableTree to the readme
- add "core" to the libraries.

## Reviewer Guidance

Is this a good idea?

It's not clear to me if this is an improvement and I'd like some opinions on if you think this would help with code reviewing fence files, and avoiding undesired dependencies, as well as general understanding of the codebase.

Also consider the cost of having the extra layer of reexports: currently there is little intentional control over what is exported at that layer and what is not: thus that layer of exports may be more of a burden than a feature.