### PR TITLE
Fix back compat for idleTime

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -594,7 +594,7 @@ export interface ISummaryConfigurationDisableSummarizer {
 // @public (undocumented)
 export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
     // @deprecated (undocumented)
-    idleTime: number;
+    idleTime?: number;
     maxIdleTime: number;
     maxOps: number;
     maxTime: number;

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -108,13 +108,16 @@
     "version": "2.0.0",
     "broken": {
       "VariableDeclaration_DefaultSummaryConfiguration": {
-        "forwardCompat": false
+        "forwardCompat": false,
+        "backCompat": false
       },
       "TypeAliasDeclaration_ISummaryConfiguration": {
-        "forwardCompat": false
+        "forwardCompat": false,
+        "backCompat": false
       },
       "InterfaceDeclaration_ISummaryConfigurationHeuristics": {
-        "forwardCompat": false
+        "forwardCompat": false,
+        "backCompat": false
       },
       "InterfaceDeclaration_IGeneratedSummaryStats": {
         "backCompat": false

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -233,7 +233,7 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
      * @deprecated Please move all implementations to {@link ISummaryConfigurationHeuristics.minIdleTime} and
      * {@link ISummaryConfigurationHeuristics.maxIdleTime} instead.
      */
-    idleTime: number;
+    idleTime?: number;
     /**
      * Defines the maximum allowed time, since the last received Ack, before running the summary
      * with reason maxTime.
@@ -296,8 +296,6 @@ export type ISummaryConfiguration =
 
 export const DefaultSummaryConfiguration: ISummaryConfiguration = {
     state: "enabled",
-
-    idleTime: 15 * 1000, // 15 secs.
 
     minIdleTime: 0,
 

--- a/packages/runtime/container-runtime/src/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summarizerHeuristics.ts
@@ -119,6 +119,9 @@ export class SummarizeHeuristicRunner implements ISummarizeHeuristicRunner {
     }
 
     public get idleTime(): number {
+        if (this.configuration.idleTime !== undefined) {
+            return this.configuration.idleTime;
+        }
         const maxIdleTime = this.configuration.maxIdleTime;
         const minIdleTime = this.configuration.minIdleTime;
         const weightedNumOfOps = getWeightedNumberOfOps(

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -58,7 +58,6 @@ describe("Runtime", () => {
             };
             const summaryConfig: ISummaryConfiguration = {
                 state: "enabled",
-                idleTime: 5000, // 5 sec (idle)
                 maxTime: 5000 * 12, // 1 min (active)
                 maxOps: 1000, // 1k ops (active)
                 minOpsForLastSummaryAttempt: 50,

--- a/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
@@ -23,7 +23,6 @@ describe("Runtime", () => {
 
             const defaultSummaryConfig: ISummaryConfigurationHeuristics = {
                 state: "enabled",
-                idleTime: 5000, // 5 sec (idle)
                 maxTime: 5000 * 12, // 1 min (active)
                 maxOps: 1000, // 1k ops (active)
                 minOpsForLastSummaryAttempt: 50,
@@ -314,6 +313,18 @@ describe("Runtime", () => {
                 runner.run();
                 assertAttemptCount(1, "should run");
                 assert(getLastAttempt() === "maxOps");
+            });
+
+            it("idleTime should take precedence", () => {
+                const idleTime = 100;
+                const minIdleTime = 0;
+                const maxIdleTime = 200;
+                initialize({ idleTime, minIdleTime, maxIdleTime });
+
+                assert.strictEqual(runner.idleTime, 100, "expect idleTime to take precedence when provided");
+
+                initialize({ minIdleTime, maxIdleTime });
+                assert.strictEqual(runner.idleTime, 200, "expect maxIdleTime when idleTime is not provided");
             });
         });
     });

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -133,6 +133,7 @@ declare function get_current_VariableDeclaration_DefaultSummaryConfiguration():
 declare function use_old_VariableDeclaration_DefaultSummaryConfiguration(
     use: TypeOnly<typeof old.DefaultSummaryConfiguration>);
 use_old_VariableDeclaration_DefaultSummaryConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_current_VariableDeclaration_DefaultSummaryConfiguration());
 
 /*
@@ -1279,6 +1280,7 @@ declare function get_current_TypeAliasDeclaration_ISummaryConfiguration():
 declare function use_old_TypeAliasDeclaration_ISummaryConfiguration(
     use: TypeOnly<old.ISummaryConfiguration>);
 use_old_TypeAliasDeclaration_ISummaryConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_ISummaryConfiguration());
 
 /*
@@ -1352,6 +1354,7 @@ declare function get_current_InterfaceDeclaration_ISummaryConfigurationHeuristic
 declare function use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
     use: TypeOnly<old.ISummaryConfigurationHeuristics>);
 use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummaryConfigurationHeuristics());
 
 /*


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

## Description

[PR#10179](https://github.com/microsoft/FluidFramework/pull/10179) introduced back-compat issue with the `idleTime` property in summary heuristics. The property was deprecated, but no functionality was added to continue temporary support for the property before it was officially removed.