### PR TITLE
build(build-tools): Run clean:manifest before build:compile

### DIFF
--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -22,7 +22,7 @@
     "/oclif.manifest.json"
   ],
   "scripts": {
-    "build": "npm run build:genver && concurrently npm:clean:manifest npm:build:compile npm:lint && npm run build:docs",
+    "build": "npm run build:genver && npm run clean:manifest && concurrently npm:build:compile npm:lint && npm run build:docs",
     "build:compile": "npm run tsc && npm run build:copy",
     "build:copy": "copyfiles -u 1 \"src/**/*.fsl\" lib",
     "build:diagrams": "jssm-viz -i \"./src/machines/*.fsl\"",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -22,7 +22,7 @@
     "/oclif.manifest.json"
   ],
   "scripts": {
-    "build": "npm run build:genver && concurrently npm:clean:manifest npm:build:compile npm:lint && npm run build:docs",
+    "build": "npm run build:genver && npm run clean:manifest && concurrently npm:build:compile npm:lint && npm run build:docs",
     "build:commonjs": "npm run tsc && npm run build:test",
     "build:compile": "npm run build:commonjs",
     "build:docs": "api-extractor run --local",


### PR DESCRIPTION
The manifest file was previously removed in parallel with the build. This sometimes causes the build to pick up an old manifest file when building.

This change makes the manifest file removal serial.