### PR TITLE
bot overrides merge strategy

### DIFF
--- a/.github/workflows/merge-commits.yml
+++ b/.github/workflows/merge-commits.yml
@@ -42,7 +42,7 @@ jobs:
       EXISTS: ${{ steps.check-pr-exists.outputs.result }}
   dequeue:
     runs-on: ubuntu-latest
-    needs: [ check-pr ]
+    needs: [check-pr]
     if: needs.check-pr.outputs.EXISTS == 'false'
     steps:
       - run: npm install @azure/storage-queue
@@ -81,7 +81,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    needs: [ dequeue ]
+    needs: [dequeue]
     if: (needs.dequeue.result) == 'success'
     steps:
       - name: Git checkout
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           token: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
-          fetch-depth: '0'
+          fetch-depth: "0"
       - name: Create branch
         if: ${{needs.dequeue.outputs.LABEL}} == 'queued'
         run: |
@@ -106,7 +106,7 @@ jobs:
     concurrency:
       group: group-pr
       cancel-in-progress: false
-    needs: [ create-branch, dequeue ]
+    needs: [create-branch, dequeue]
     if: needs.create-branch.result == 'success'
     steps:
       - run: npm install @octokit/core
@@ -161,7 +161,8 @@ jobs:
               issue_number: newPr.data.number,
               labels: [
                 'main-next-integrate',
-                'do-not-squash-merge'
+                'do-not-squash-merge',
+                'msftbot:merge-next'
               ]
             })
   remove-from-queue:
@@ -169,7 +170,7 @@ jobs:
     concurrency:
       group: group-pr
       cancel-in-progress: false
-    needs: [ pull-request ]
+    needs: [pull-request]
     if: needs.pull-request.result == 'success'
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
@@ -203,13 +204,13 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    needs: [ create-branch, dequeue ]
+    needs: [create-branch, dequeue]
     steps:
       - name: Git checkout
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           token: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
-          fetch-depth: '0'
+          fetch-depth: "0"
       - name: Merge next
         run: |
           git config user.name $USERNAME
@@ -227,14 +228,14 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    needs: [ merge-dry-run, dequeue ]
+    needs: [merge-dry-run, dequeue]
     if: needs.merge-dry-run.result == 'success'
     steps:
       - name: Git checkout
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           token: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
-          fetch-depth: '0'
+          fetch-depth: "0"
       - name: Push next merge
         run: |
           git config user.name $USERNAME


### PR DESCRIPTION
The default merge strategy is `squash-merge` when `msftbot:merge-next` label is added to prs. But the bot will override the merge startegy to `merge` when `do-not-squash-merge`/ `main-next-integrate` labels are added on the prs. 

Here is a test pr: https://github.com/microsoft/FluidFramework/pull/12552

![image](https://user-images.githubusercontent.com/46719950/196527955-2ab70015-6f39-4de6-9f66-82413f7019d4.png)
