### PR TITLE
Add shorter duration for stale PR

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1564,6 +1564,10 @@
             "parameters": {}
           },
           {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
             "name": "noActivitySince",
             "parameters": {
               "days": 180
@@ -1616,63 +1620,139 @@
             "weekDay": 0,
             "hours": [
               0,
-              6,
-              12,
-              18
+              12
             ]
           },
           {
             "weekDay": 1,
             "hours": [
               0,
-              6,
-              12,
-              18
+              12
             ]
           },
           {
             "weekDay": 2,
             "hours": [
               0,
-              6,
-              12,
-              18
+              12
             ]
           },
           {
             "weekDay": 3,
             "hours": [
               0,
-              6,
-              12,
-              18
+              12
             ]
           },
           {
             "weekDay": 4,
             "hours": [
               0,
-              6,
-              12,
-              18
+              12
             ]
           },
           {
             "weekDay": 5,
             "hours": [
               0,
-              6,
-              12,
-              18
+              12
             ]
           },
           {
             "weekDay": 6,
             "hours": [
               0,
-              6,
-              12,
-              18
+              12
+            ]
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 60
+            }
+          }
+        ],
+        "taskName": "Mark old PR as stale",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "status: stale"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This PR has been automatically marked as stale because it has had no activity for 60 days. It will be closed if no further activity occurs **within 8 days of this comment**. Thank you for your contributions to Fluid Framework!"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              12
+            ]
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              12
+            ]
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              12
+            ]
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              12
+            ]
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              12
+            ]
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              12
+            ]
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              12
             ]
           }
         ],
@@ -1694,11 +1774,99 @@
             }
           }
         ],
-        "taskName": "Close stale issues after 8 days ",
+        "taskName": "Close stale issues or PR after 8 days ",
         "actions": [
           {
             "name": "closeIssue",
             "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "status: stale"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "status: stale"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remove stale label from PR when PR is updated",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "status: stale"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "status: stale"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Remove stale label from PR when PR is commented on",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "status: stale"
+            }
           }
         ]
       }


### PR DESCRIPTION
Duplicate Fabricbot rule for marking stale issue to mark PR as stale after 60 days of inactivities.

[AB#2260](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2260)