### PR TITLE
Increase 'Conversion test binary format' test timeout for coverage

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -84,7 +84,7 @@ export interface BlockUpdateActions {
     child: (block: IMergeBlock, index: number) => void;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "Client" is marked as @public, but its signature references "IClientEvents" which is marked as @internal
+// Warning: (ae-forgotten-export) The symbol "IClientEvents" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export class Client extends TypedEventEmitter<IClientEvents> {
@@ -305,11 +305,6 @@ export function extend<T>(base: MapLike<T>, extension: MapLike<T> | undefined, c
 
 // @public (undocumented)
 export function extendIfUndefined<T>(base: MapLike<T>, extension: MapLike<T> | undefined): MapLike<T>;
-
-// Warning: (ae-internal-missing-underscore) The name "IClientEvents" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export type IClientEvents = (event: "normalize", listener: (target: IEventThisPlaceHolder) => void) => void;
 
 // @public (undocumented)
 export interface ICombiningOp {

--- a/packages/drivers/odsp-driver/src/test/test.ts
+++ b/packages/drivers/odsp-driver/src/test/test.ts
@@ -12,7 +12,7 @@ import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "../odspSnapshotParser
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser";
 
 describe("Binary WireFormat perf", () => {
-    it("Conversion test json", async () => {
+    it("Conversion test json", () => {
         const jsonSnapshot = fs.readFileSync(
             `${__dirname}/../../src/test/SamplePerfFilesforFluid/mediumJson.fluid.json`,
             { encoding: "utf8" },
@@ -26,7 +26,7 @@ describe("Binary WireFormat perf", () => {
         assert(result.blobs !== undefined, "snapshot blobs should exist");
     });
 
-    it("Conversion test binary format", async () => {
+    it("Conversion test binary format", () => {
         const binarySnapshot = fs.readFileSync(
             `${__dirname}/../../src/test/SamplePerfFilesforFluid/medium.fluid.wireformat`,
         );
@@ -40,5 +40,5 @@ describe("Binary WireFormat perf", () => {
 
         const parseTime = performance.now() - start;
         console.log("Binary Format medium snapshot parse time ", parseTime);
-    }).timeout(3000); // This can take more time if running in parallel
+    }).timeout(4000); // This can take more time if running mocha tests in parallel. Set it to 4s for coverage runs as well.
 });


### PR DESCRIPTION
Conversion test binary format takes longer than 2s for non-coverage runs sometimes when running in parallel, so need to set an explicit timeout. But it also takes longer then 3s for coverage runs.  Set the timeout to 4s.