### PR TITLE
tools: Add build script to reduce confusion

### DIFF
--- a/common/build/eslint-config-fluid/README.md
+++ b/common/build/eslint-config-fluid/README.md
@@ -16,7 +16,7 @@ If you want to change the shared lint config (that is, this package), you need t
 2. Publish a pre-release package.
 3. Update the core packages to use the pre-release lint config.
 
-When updating the lint config (step 1), run `npm run print-config` and commit any resulting changes.
+When updating the lint config (step 1), run `npm run build` and commit any resulting changes.
 
 ### Tracking lint config changes over time
 
@@ -33,6 +33,7 @@ a diff to review as part of a PR -- just like we do with API reports for code ch
 
 | Script                     | Description                                                                                                   |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `build`                    | `npm run print-config`                                                                                        |
 | `cleanup-printed-configs`  | Clean up the printed configs. Removes the `parser` property and sorts the JSON.                               |
 | `format`                   | `npm run prettier:fix`                                                                                        |
 | `lint`                     | `npm run prettier`                                                                                            |

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -12,6 +12,7 @@
   "author": "Microsoft and contributors",
   "main": "index.js",
   "scripts": {
+    "build": "npm run print-config",
     "cleanup-printed-configs": "node ./scripts/cleanup-printed-configs.js ./printed-configs",
     "format": "npm run prettier:fix",
     "lint": "npm run prettier",

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -69,7 +69,7 @@ extends:
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/build/eslint-config-fluid
     tagName: eslint-config-fluid
-    taskBuild: print-config
+    taskBuild: build
     taskBuildDocs: false
     taskLint: false
     taskTest: [] # no tests


### PR DESCRIPTION
Adds a script called "build" to the eslint config package to make the package workflow more similar to other packages.