### PR TITLE
Use leaner OdspDocumentServiceFactoryWithCodeSplit factory to measure bundle size  for odsp driver.

### DIFF
--- a/examples/utils/bundle-size-tests/src/odspDriver.ts
+++ b/examples/utils/bundle-size-tests/src/odspDriver.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
+import { OdspDocumentServiceFactoryWithCodeSplit } from "@fluidframework/odsp-driver";
 
 export function apisToBundle() {
      // Pass through dummy parameters, this file is only used for bundle analysis
-    new OdspDocumentServiceFactory(undefined as any, undefined as any);
+    new OdspDocumentServiceFactoryWithCodeSplit(undefined as any, undefined as any);
 }


### PR DESCRIPTION
## Description

Use leaner OdspDocumentServiceFactoryWithCodeSplit factory to measure bundle size.