### PR TITLE
Exclude @fluidframework/eslint-config-fluid from fluid-build npm script checks

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -32,6 +32,7 @@ const uncheckedPackages = [
     "@fluid-tools/build-cli",
     "@fluid-tools/version-tools",
     "@fluidframework/build-tools",
+    "@fluidframework/eslint-config-fluid",
 ];
 
 export class FluidRepoBuild extends FluidRepo {


### PR DESCRIPTION
## Description

The [recent addition](https://github.com/microsoft/FluidFramework/pull/12559) of a `build` script to `@fluidframework/eslint-config-fluid` caused it to be checked for several other scripts for which it's not compliant during `npm run build:fast`. Excluding it to fix the warnings.

I first thought of making it compliant but starting with `build` it's already doing something of its own, so...

## Any relevant logs or outputs

Without this change:

<img width="880" alt="image" src="https://user-images.githubusercontent.com/716334/196566756-7d099e14-160a-49ac-b231-6017e6b25eb7.png">

With this change:

<img width="885" alt="image" src="https://user-images.githubusercontent.com/716334/196566237-8fb6ce1f-44cd-42cd-9ead-49427934d313.png">
