### PR TITLE
build(client): bump deps on eslint config to next version

### DIFF
--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
     "@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@0.20.1",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
     "@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@0.20.1",
-    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
+    "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -91,7 +91,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
     "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
+    "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/base64-js": "^1.3.0",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -91,7 +91,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
     "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/base64-js": "^1.3.0",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
-    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
+    "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^17.0.1",
     "concurrently": "^6.2.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/presence-tracker/package.json
+++ b/examples/data-objects/presence-tracker/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/orderedmap": "^1.0.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/marked": "^2.0.2",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^17.0.1",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/test-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -92,7 +92,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/schema-upgrade/package.json
+++ b/examples/hosts/app-integration/schema-upgrade/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^17.0.1",
     "@types/semver": "^7.3.6",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -41,7 +41,7 @@
     "@cerner/duplicate-package-checker-webpack-plugin": "^2.3.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/bundle-size-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -57,7 +57,7 @@
     "@fluid-experimental/property-common": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "babel-loader": "^8.0.5",
     "concurrently": "^6.2.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -70,7 +70,7 @@
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4023,9 +4023,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.0.0.tgz",
-			"integrity": "sha512-qbgxQ1//bt9k9VQyCyiBVM5mYxg7juvR6nI6Oeskdn2pSAMwIgtjza4FNBA6gRRD19/pAnZbt63zTzEMI0dFBw==",
+			"version": "1.1.0-101804",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.1.0-101804.tgz",
+			"integrity": "sha512-Y6UzvHLOv/wURulrWvEnkrYuk2iLnQSGwhdvxTAnJbqeOGN67G6YC8sOQBxV5fD+epwbOwBLTQPAO0Q4d1l9ag==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",
@@ -28222,9 +28222,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -28367,9 +28367,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/cell-previous": "npm:@fluidframework/cell@^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/counter-previous": "npm:@fluidframework/counter@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/ink-previous": "npm:@fluidframework/ink@^1.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -79,7 +79,7 @@
     "@fluid-tools/benchmark": "^0.43.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/map-previous": "npm:@fluidframework/map@^1.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -80,7 +80,7 @@
     "@fluid-tools/benchmark": "^0.43.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@^1.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -77,7 +77,7 @@
     "@fluid-internal/stochastic-test-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@^1.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -73,7 +73,7 @@
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@^1.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/quorum/package.json
+++ b/packages/dds/quorum/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -72,7 +72,7 @@
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@^1.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -85,7 +85,7 @@
     "@fluid-tools/benchmark": "^0.43.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/gitresources": "^0.1038.2000",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@^1.0.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -78,7 +78,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@^1.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@^1.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -76,7 +76,7 @@
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -86,7 +86,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-drivers": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jest": "22.2.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
     "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@1.1.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@^1.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@^1.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@^1.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@^1.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@^1.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@^1.1.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@^1.1.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@^1.0.0",
     "@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -64,7 +64,7 @@
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@^1.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@^1.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -81,7 +81,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-loader-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@^1.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@^1.2.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@^1.2.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
     "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@^1.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/ink": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@fluid-tools/benchmark": "^0.43.0",
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -117,7 +117,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nock": "^9.3.0",

--- a/packages/test/test-gc-sweep-tests/package.json
+++ b/packages/test/test-gc-sweep-tests/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@^1.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@^1.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/json-stable-stringify": "^1.0.32",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -94,7 +94,7 @@
     "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@^1.1.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@^1.0.0",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.6000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
+    "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@fluidframework/mocha-test-setup": "^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": "^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": "^1.2.5",
     "@fluidframework/test-utils": "^1.2.5",
     "@microsoft/api-extractor": "^7.22.2",

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.4.4000",
-    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
+    "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@fluidframework/mocha-test-setup": "^1.2.5",
     "@fluidframework/test-utils": "^1.2.5",
     "@microsoft/api-extractor": "^7.22.2",

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@fluidframework/mocha-test-setup": "^0.41.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
+    "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@fluidframework/mocha-test-setup": "^0.41.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^1.0.0",
+    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^1.1.0-101804",
+    "@fluidframework/eslint-config-fluid": "^1.0.0",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",


### PR DESCRIPTION
Updated the following:

  client (release group)

Dependencies on @fluidframework/eslint-config-fluid updated:

  @fluidframework/eslint-config-fluid: ^1.1.0-101804
