### PR TITLE
fix(build-cli): Require versionConstraint flag in generate:typetests

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -114,16 +114,16 @@ Generates type tests based on the individual package settings in package.json.
 ```
 USAGE
   $ flub generate typetests [-d <value> | --packages | -g client|server|azure|build-tools] [--prepare | --generate]
-    [--exact <value> |  | [-s
-    ^previousMajor|^previousMinor|~previousMajor|~previousMinor|previousMajor|previousMinor|baseMinor|baseMajor | ]]
+    (--exact <value> |  | -s
+    ^previousMajor|^previousMinor|~previousMajor|~previousMinor|previousMajor|previousMinor|baseMinor|baseMajor)
     [--reset | ] [-v]
 
 FLAGS
   -d, --dir=<value>                 Run on the package in this directory.
   -g, --releaseGroup=<option>       Run on all packages within this release group.
                                     <options: client|server|azure|build-tools>
-  -s, --versionConstraint=<option>  [default: baseMinor] The type of version constraint to use for previous versions.
-                                    Only applies to the prepare phase.
+  -s, --versionConstraint=<option>  (required) The type of version constraint to use for previous versions. Only applies
+                                    to the prepare phase.
                                     <options: ^previousMajor|^previousMinor|~previousMajor|~previousMinor|previousMajor|
                                     previousMinor|baseMinor|baseMajor>
   -v, --verbose                     Verbose logging.

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -52,7 +52,6 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
             char: "s",
             description:
                 "The type of version constraint to use for previous versions. Only applies to the prepare phase.",
-            exclusive: ["generate"],
             options: [
                 "^previousMajor",
                 "^previousMinor",
@@ -63,7 +62,7 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
                 "baseMinor",
                 "baseMajor",
             ],
-            default: "baseMinor",
+            required: true,
         }),
         exact: Flags.string({
             description:

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -143,7 +143,7 @@ export type PreviousVersionStyle =
 export async function getAndUpdatePackageDetails(
     packageDir: string,
     writeUpdates: boolean | undefined,
-    previousVersionStyle: PreviousVersionStyle = "baseMinor",
+    previousVersionStyle: PreviousVersionStyle,
     exactPreviousVersionString?: string,
     resetBroken?: boolean,
 ): Promise<(PackageDetails & { skipReason?: undefined }) | { skipReason: string }> {

--- a/build-tools/packages/build-tools/src/typeValidator/typeValidator.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/typeValidator.ts
@@ -67,6 +67,7 @@ async function run(): Promise<boolean> {
                     const packageData = await getAndUpdatePackageDetails(
                         packageDir,
                         program.generateOnly === true,
+                        "baseMinor",
                     ).finally(() => output.push(`Loaded(${Date.now() - start}ms)`));
                     if (packageData.skipReason !== undefined) {
                         output.push(packageData.skipReason);


### PR DESCRIPTION
The generate:typetests command was incorrectly calculating the previous version when running in generate only mode. There was also not a way to indicate what version style to use, since the flag was exclusive with the `--generate` flag.

This change makes the `-s` flag required, so the user has to choose a style explicitly.