### PR TITLE
Fix r11s lock file missing node-rdkafka

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -13449,6 +13449,1208 @@
 				"process-on-spawn": "^1.0.0"
 			}
 		},
+		"node-rdkafka": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.14.0.tgz",
+			"integrity": "sha512-g/I6e1/07uuy3Tjeka7JKZDhbeKeDsX0P9Lj2gsZqsfqWXnwbEfLs3AaKs2/QPts62RWiXLoBhxI7W4cREZXyw==",
+			"dev": true,
+			"requires": {
+				"bindings": "^1.3.1",
+				"nan": "^2.14.0"
+			},
+			"dependencies": {
+				"@babel/parser": {
+					"version": "7.19.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
+					"integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA=="
+				},
+				"@gar/promisify": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+					"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
+				},
+				"@npmcli/fs": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+					"integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+					"requires": {
+						"@gar/promisify": "^1.0.1",
+						"semver": "^7.3.5"
+					}
+				},
+				"@npmcli/move-file": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+					"integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+					"requires": {
+						"mkdirp": "^1.0.4",
+						"rimraf": "^3.0.2"
+					}
+				},
+				"@tootallnate/once": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+					"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+				},
+				"@types/linkify-it": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+					"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
+				},
+				"@types/markdown-it": {
+					"version": "12.2.3",
+					"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+					"integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+					"requires": {
+						"@types/linkify-it": "*",
+						"@types/mdurl": "*"
+					}
+				},
+				"@types/mdurl": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+					"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+				},
+				"abbrev": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+				},
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"requires": {
+						"debug": "4"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.4",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+							"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+						}
+					}
+				},
+				"agentkeepalive": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+					"integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+					"requires": {
+						"debug": "^4.1.0",
+						"depd": "^1.1.2",
+						"humanize-ms": "^1.2.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.4",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+							"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+						}
+					}
+				},
+				"aggregate-error": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+					"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+					"requires": {
+						"clean-stack": "^2.0.0",
+						"indent-string": "^4.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+				},
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+				},
+				"are-we-there-yet": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+					"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^3.6.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "3.6.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+							"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+							"requires": {
+								"inherits": "^2.0.3",
+								"string_decoder": "^1.1.1",
+								"util-deprecate": "^1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+							"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+							"requires": {
+								"safe-buffer": "~5.2.0"
+							}
+						}
+					}
+				},
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+				},
+				"balanced-match": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+				},
+				"bindings": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+					"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+					"dev": true,
+					"requires": {
+						"file-uri-to-path": "1.0.0"
+					}
+				},
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"browser-stdout": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+					"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+				},
+				"cacache": {
+					"version": "15.3.0",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+					"integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+					"requires": {
+						"@npmcli/fs": "^1.0.0",
+						"@npmcli/move-file": "^1.0.1",
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"glob": "^7.1.4",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^6.0.0",
+						"minipass": "^3.1.1",
+						"minipass-collect": "^1.0.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.2",
+						"mkdirp": "^1.0.3",
+						"p-map": "^4.0.0",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^3.0.2",
+						"ssri": "^8.0.1",
+						"tar": "^6.0.2",
+						"unique-filename": "^1.1.1"
+					}
+				},
+				"catharsis": {
+					"version": "0.9.0",
+					"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+					"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+					"requires": {
+						"lodash": "^4.17.15"
+					}
+				},
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+				},
+				"clean-stack": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+					"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+				},
+				"cli": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+					"integrity": "sha512-41U72MB56TfUMGndAKK8vJ78eooOD4Z5NOL4xEfjc0c23s+6EYKXlXsmACBVclLP1yOfWCgEganVzddVrSNoTg==",
+					"requires": {
+						"exit": "0.1.2",
+						"glob": "^7.1.1"
+					}
+				},
+				"color-support": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+					"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+				},
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+				},
+				"console-browserify": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+					"integrity": "sha512-duS7VP5pvfsNLDvL1O4VOEbw37AI3A4ZUQYemvDlnpGrNu9tprR7BYWpDYwC0Xia0Zxz5ZupdiIrUp0GH1aXfg==",
+					"requires": {
+						"date-now": "^0.1.4"
+					}
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+				},
+				"core-util-is": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+					"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+				},
+				"date-now": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+					"integrity": "sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+				},
+				"depd": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+					"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+				},
+				"dom-serializer": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+					"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"entities": "^2.0.0"
+					},
+					"dependencies": {
+						"domelementtype": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+							"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+						},
+						"entities": {
+							"version": "2.2.0",
+							"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+							"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+						}
+					}
+				},
+				"domelementtype": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+					"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+				},
+				"domhandler": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+					"integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
+					"requires": {
+						"domelementtype": "1"
+					}
+				},
+				"domutils": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+					"integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
+					"requires": {
+						"dom-serializer": "0",
+						"domelementtype": "1"
+					}
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"encoding": {
+					"version": "0.1.13",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+					"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+					"optional": true,
+					"requires": {
+						"iconv-lite": "^0.6.2"
+					}
+				},
+				"entities": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+					"integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ=="
+				},
+				"env-paths": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+					"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+				},
+				"err-code": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+					"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+				},
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+				},
+				"exit": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+					"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="
+				},
+				"file-uri-to-path": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+					"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+					"dev": true
+				},
+				"fs-minipass": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+				},
+				"gauge": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+					"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+					"requires": {
+						"aproba": "^1.0.3 || ^2.0.0",
+						"color-support": "^1.1.3",
+						"console-control-strings": "^1.1.0",
+						"has-unicode": "^2.0.1",
+						"signal-exit": "^3.0.7",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"wide-align": "^1.1.5"
+					}
+				},
+				"glob": {
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.1.1",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					},
+					"dependencies": {
+						"minimatch": {
+							"version": "3.1.2",
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+							"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.10",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+					"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+				},
+				"growl": {
+					"version": "1.10.5",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+					"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+				},
+				"he": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+					"integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA=="
+				},
+				"htmlparser2": {
+					"version": "3.8.3",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+					"integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
+					"requires": {
+						"domelementtype": "1",
+						"domhandler": "2.3",
+						"domutils": "1.5",
+						"entities": "1.0",
+						"readable-stream": "1.1"
+					}
+				},
+				"http-cache-semantics": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+				},
+				"http-proxy-agent": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+					"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+					"requires": {
+						"@tootallnate/once": "1",
+						"agent-base": "6",
+						"debug": "4"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.4",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+							"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+						}
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+					"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.4",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+							"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+						}
+					}
+				},
+				"humanize-ms": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+					"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+					"requires": {
+						"ms": "^2.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+					"optional": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+				},
+				"infer-owner": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+					"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+				},
+				"ip": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+					"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"is-lambda": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+					"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+				},
+				"js2xmlparser": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+					"integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+					"requires": {
+						"xmlcreate": "^2.0.4"
+					}
+				},
+				"jsdoc": {
+					"version": "3.6.11",
+					"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+					"integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+					"requires": {
+						"@babel/parser": "^7.9.4",
+						"@types/markdown-it": "^12.2.3",
+						"bluebird": "^3.7.2",
+						"catharsis": "^0.9.0",
+						"escape-string-regexp": "^2.0.0",
+						"js2xmlparser": "^4.0.2",
+						"klaw": "^3.0.0",
+						"markdown-it": "^12.3.2",
+						"markdown-it-anchor": "^8.4.1",
+						"marked": "^4.0.10",
+						"mkdirp": "^1.0.4",
+						"requizzle": "^0.2.3",
+						"strip-json-comments": "^3.1.0",
+						"taffydb": "2.6.2",
+						"underscore": "~1.13.2"
+					}
+				},
+				"jshint": {
+					"version": "2.13.5",
+					"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.5.tgz",
+					"integrity": "sha512-dB2n1w3OaQ35PLcBGIWXlszjbPZwsgZoxsg6G8PtNf2cFMC1l0fObkYLUuXqTTdi6tKw4sAjfUseTdmDMHQRcg==",
+					"requires": {
+						"cli": "~1.0.0",
+						"console-browserify": "1.1.x",
+						"exit": "0.1.x",
+						"htmlparser2": "3.8.x",
+						"lodash": "~4.17.21",
+						"minimatch": "~3.0.2",
+						"strip-json-comments": "1.0.x"
+					},
+					"dependencies": {
+						"strip-json-comments": {
+							"version": "1.0.4",
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+							"integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg=="
+						}
+					}
+				},
+				"klaw": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+					"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+					"requires": {
+						"graceful-fs": "^4.1.9"
+					}
+				},
+				"linkify-it": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+					"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+					"requires": {
+						"uc.micro": "^1.0.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"make-fetch-happen": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+					"integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+					"requires": {
+						"agentkeepalive": "^4.1.3",
+						"cacache": "^15.2.0",
+						"http-cache-semantics": "^4.1.0",
+						"http-proxy-agent": "^4.0.1",
+						"https-proxy-agent": "^5.0.0",
+						"is-lambda": "^1.0.1",
+						"lru-cache": "^6.0.0",
+						"minipass": "^3.1.3",
+						"minipass-collect": "^1.0.2",
+						"minipass-fetch": "^1.3.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"negotiator": "^0.6.2",
+						"promise-retry": "^2.0.1",
+						"socks-proxy-agent": "^6.0.0",
+						"ssri": "^8.0.0"
+					}
+				},
+				"markdown-it": {
+					"version": "12.3.2",
+					"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+					"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+					"requires": {
+						"argparse": "^2.0.1",
+						"entities": "~2.1.0",
+						"linkify-it": "^3.0.1",
+						"mdurl": "^1.0.1",
+						"uc.micro": "^1.0.5"
+					},
+					"dependencies": {
+						"entities": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+							"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+						}
+					}
+				},
+				"markdown-it-anchor": {
+					"version": "8.6.5",
+					"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+					"integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ=="
+				},
+				"marked": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+					"integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw=="
+				},
+				"mdurl": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+					"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+				},
+				"minimatch": {
+					"version": "3.0.8",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+					"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
+				},
+				"minipass": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+					"integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"minipass-collect": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+					"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"minipass-fetch": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+					"integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+					"requires": {
+						"encoding": "^0.1.12",
+						"minipass": "^3.1.0",
+						"minipass-sized": "^1.0.3",
+						"minizlib": "^2.0.0"
+					}
+				},
+				"minipass-flush": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+					"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"minipass-pipeline": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+					"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"minipass-sized": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+					"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"mocha": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+					"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+					"requires": {
+						"browser-stdout": "1.3.1",
+						"commander": "2.15.1",
+						"debug": "3.1.0",
+						"diff": "3.5.0",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.5",
+						"he": "1.1.1",
+						"minimatch": "3.0.4",
+						"mkdirp": "0.5.1",
+						"supports-color": "5.4.0"
+					},
+					"dependencies": {
+						"escape-string-regexp": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+							"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+						},
+						"glob": {
+							"version": "7.1.2",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+							"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						}
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+				},
+				"nan": {
+					"version": "2.17.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+					"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+					"dev": true
+				},
+				"negotiator": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+					"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+				},
+				"node-gyp": {
+					"version": "8.4.1",
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+					"integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+					"requires": {
+						"env-paths": "^2.2.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.6",
+						"make-fetch-happen": "^9.1.0",
+						"nopt": "^5.0.0",
+						"npmlog": "^6.0.0",
+						"rimraf": "^3.0.2",
+						"semver": "^7.3.5",
+						"tar": "^6.1.2",
+						"which": "^2.0.2"
+					}
+				},
+				"nopt": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+					"requires": {
+						"abbrev": "1"
+					}
+				},
+				"npmlog": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+					"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+					"requires": {
+						"are-we-there-yet": "^3.0.0",
+						"console-control-strings": "^1.1.0",
+						"gauge": "^4.0.3",
+						"set-blocking": "^2.0.0"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+				},
+				"promise-inflight": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+					"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="
+				},
+				"promise-retry": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+					"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+					"requires": {
+						"err-code": "^2.0.2",
+						"retry": "^0.12.0"
+					}
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"requizzle": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+					"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+					"requires": {
+						"lodash": "^4.17.14"
+					}
+				},
+				"retry": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+					"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+					"optional": true
+				},
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+				},
+				"signal-exit": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+				},
+				"smart-buffer": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+					"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+				},
+				"socks": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+					"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+					"requires": {
+						"ip": "^2.0.0",
+						"smart-buffer": "^4.2.0"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+					"integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+					"requires": {
+						"agent-base": "^6.0.2",
+						"debug": "^4.3.3",
+						"socks": "^2.6.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.4",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+							"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+						}
+					}
+				},
+				"ssri": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+					"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+					"requires": {
+						"minipass": "^3.1.1"
+					}
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"taffydb": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+					"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
+				},
+				"tar": {
+					"version": "6.1.11",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+					"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					}
+				},
+				"toolkit-jsdoc": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/toolkit-jsdoc/-/toolkit-jsdoc-1.0.0.tgz",
+					"integrity": "sha512-57bpRaZgZ8M2FUblW3OJVWDfbING/rBvCda/mxXEth6fCp3M1m6/tX+pvXSJyqq24tVzdTYaGM+ZduPlwcDFHw=="
+				},
+				"uc.micro": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+					"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+				},
+				"underscore": {
+					"version": "1.13.6",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+					"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+				},
+				"unique-filename": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+					"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+					"requires": {
+						"unique-slug": "^2.0.0"
+					}
+				},
+				"unique-slug": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+					"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+					"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+					"requires": {
+						"string-width": "^1.0.2 || 2 || 3 || 4"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+				},
+				"xmlcreate": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+					"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
 		"node-releases": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -83,6 +83,7 @@
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",
     "lerna": "^4.0.0",
+    "node-rdkafka": "^2.14.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "run-script-os": "^1.1.5",


### PR DESCRIPTION
Likely due to a bug in npm v6, node-rdkafka didn't get included in the lock file.
However, if I preinstall it in the outer root package, the npm install in the lerna phase would pick it up.

Use that as a workaround.   I will confirm if this issue still exists for newer version of npm.