### PR TITLE
Add option to legacy SharedTree to allow reverting parts of edits

### DIFF
--- a/api-report/experimental-tree.api.md
+++ b/api-report/experimental-tree.api.md
@@ -891,6 +891,11 @@ export type SharedTreeArgs<WF extends WriteFormat = WriteFormat> = [writeFormat:
 export const sharedTreeAssertionErrorType = "SharedTreeAssertion";
 
 // @public
+export interface SharedTreeBaseOptions {
+    revertPartialTransactions?: boolean;
+}
+
+// @public
 export enum SharedTreeDiagnosticEvent {
     AppliedEdit = "appliedEdit",
     CatchUpBlobUploaded = "uploadedCatchUpBlob",
@@ -937,7 +942,7 @@ export class SharedTreeMergeHealthTelemetryHeartbeat {
 }
 
 // @public
-export type SharedTreeOptions<WF extends WriteFormat, HistoryCompatibility extends 'Forwards' | 'None' = 'Forwards'> = Omit<WF extends WriteFormat.v0_0_2 ? SharedTreeOptions_0_0_2 : WF extends WriteFormat.v0_1_1 ? SharedTreeOptions_0_1_1 : never, HistoryCompatibility extends 'Forwards' ? 'summarizeHistory' : never>;
+export type SharedTreeOptions<WF extends WriteFormat, HistoryCompatibility extends 'Forwards' | 'None' = 'Forwards'> = SharedTreeBaseOptions & Omit<WF extends WriteFormat.v0_0_2 ? SharedTreeOptions_0_0_2 : WF extends WriteFormat.v0_1_1 ? SharedTreeOptions_0_1_1 : never, HistoryCompatibility extends 'Forwards' ? 'summarizeHistory' : never>;
 
 // @public
 export interface SharedTreeOptions_0_0_2 {

--- a/experimental/dds/tree/src/index.ts
+++ b/experimental/dds/tree/src/index.ts
@@ -123,6 +123,7 @@ export { getTraitLocationOfRange, placeFromStablePlace, rangeFromStableRange } f
 export {
 	SharedTreeArgs,
 	SharedTreeOptions,
+	SharedTreeBaseOptions,
 	SharedTreeOptions_0_0_2,
 	SharedTreeOptions_0_1_1,
 	SharedTreeFactory,

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -128,7 +128,7 @@ describe('revert', () => {
 		expect(result).to.have.lengthOf(0);
 	});
 
-	it.only('can revert part of a transaction when the rest cannot be reverted', () => {
+	it('can revert part of a transaction when the rest cannot be reverted', () => {
 		// Build and insert a node to set
 		const node = testTree.buildLeafInternal();
 		const insertedNodeId = 1 as DetachedSequenceId;

--- a/experimental/dds/tree/src/test/utilities/UndoRedoTests.ts
+++ b/experimental/dds/tree/src/test/utilities/UndoRedoTests.ts
@@ -286,85 +286,86 @@ export function runSharedTreeUndoRedoTestSuite(options: SharedTreeUndoRedoOption
 			expect(traitAfterUndo.length).equals(1);
 		});
 
-		// if (!localMode) {
-		// 	it.only('can revert part of a transaction when the rest cannot be reverted', () => {
-		// 		// Set up the trees with revertPartialTransactions turned on
-		// 		const setupResult = setUpTestSharedTree({ revertPartialTransactions: true, ...treeOptions });
-		// 		sharedTree = setupResult.tree;
-		// 		testTree = setUpTestTree(sharedTree);
-		// 		containerRuntimeFactory = setupResult.containerRuntimeFactory;
-		// 		const secondTree = localMode
-		// 			? undefined
-		// 			: setUpTestSharedTree({
-		// 					containerRuntimeFactory,
-		// 					revertPartialTransactions: true,
-		// 					...secondTreeOptions,
-		// 			  }).tree;
-		// 		undoSharedTree = secondTree ?? sharedTree;
+		if (!localMode) {
+            // TODO: unskip or delete once a regression scenario has been identified
+			it.skip('can revert part of a transaction when the rest cannot be reverted', () => {
+				// Set up the trees with revertPartialTransactions turned on
+				const setupResult = setUpTestSharedTree({ revertPartialTransactions: true, ...treeOptions });
+				sharedTree = setupResult.tree;
+				testTree = setUpTestTree(sharedTree);
+				containerRuntimeFactory = setupResult.containerRuntimeFactory;
+				const secondTree = localMode
+					? undefined
+					: setUpTestSharedTree({
+							containerRuntimeFactory,
+							revertPartialTransactions: true,
+							...secondTreeOptions,
+					  }).tree;
+				undoSharedTree = secondTree ?? sharedTree;
 
-		// 		if (additionalSetup !== undefined) {
-		// 			if (secondTree !== undefined) {
-		// 				additionalSetup([sharedTree, undoSharedTree]);
-		// 			} else {
-		// 				additionalSetup([sharedTree]);
-		// 			}
-		// 		}
+				if (additionalSetup !== undefined) {
+					if (secondTree !== undefined) {
+						additionalSetup([sharedTree, undoSharedTree]);
+					} else {
+						additionalSetup([sharedTree]);
+					}
+				}
 
-		// 		// Build and insert two nodes, one to set and the other to detach
-		// 		const newNode = buildLeaf(sharedTree.generateNodeId());
-		// 		sharedTree.applyEdit(...Change.insertTree(newNode, StablePlace.atStartOf(testTree.left.traitLocation)));
-		// 		expect(sharedTree.edits.length).to.equal(2);
-		// 		afterEdit();
+				// Build and insert two nodes, one to set and the other to detach
+				const newNode = buildLeaf(sharedTree.generateNodeId());
+				sharedTree.applyEdit(...Change.insertTree(newNode, StablePlace.atStartOf(testTree.left.traitLocation)));
+				expect(sharedTree.edits.length).to.equal(2);
+				afterEdit();
 
-		// 		const set = Change.setPayload(newNode.identifier, '42');
-		// 		const detachedNodeId = sharedTree.generateNodeId();
-		// 		const detachedNode = buildLeaf(detachedNodeId);
-		// 		const insert = Change.insertTree(detachedNode, StablePlace.atStartOf(testTree.left.traitLocation));
-		// 		const { id } = sharedTree.applyEdit(set, ...insert);
-		// 		expect(sharedTree.edits.length).to.equal(3);
-		// 		afterEdit();
+				const set = Change.setPayload(newNode.identifier, '42');
+				const detachedNodeId = sharedTree.generateNodeId();
+				const detachedNode = buildLeaf(detachedNodeId);
+				const insert = Change.insertTree(detachedNode, StablePlace.atStartOf(testTree.left.traitLocation));
+				const { id } = sharedTree.applyEdit(set, ...insert);
+				expect(sharedTree.edits.length).to.equal(3);
+				afterEdit();
 
-		// 		containerRuntimeFactory.processAllMessages();
+				containerRuntimeFactory.processAllMessages();
 
-		// 		// Check the size of the trait before detaching
-		// 		const traitBeforeDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-		// 		expect(traitBeforeDetach.length).equals(3);
-		// 		const nodeBeforeDetach = sharedTree.currentView.getViewNode(traitBeforeDetach[1]);
-		// 		expect(nodeBeforeDetach.payload).to.equal('42');
+				// Check the size of the trait before detaching
+				const traitBeforeDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+				expect(traitBeforeDetach.length).equals(3);
+				const nodeBeforeDetach = sharedTree.currentView.getViewNode(traitBeforeDetach[1]);
+				expect(nodeBeforeDetach.payload).to.equal('42');
 
-		// 		// Detach the second node
-		// 		const translatedNodeId = translateId(detachedNodeId, sharedTree, undoSharedTree);
-		// 		undoSharedTree.applyEdit(Change.detach(StableRange.only(translatedNodeId)));
-		// 		afterEdit();
+				// Detach the second node
+				const translatedNodeId = translateId(detachedNodeId, sharedTree, undoSharedTree);
+				undoSharedTree.applyEdit(Change.detach(StableRange.only(translatedNodeId)));
+				afterEdit();
 
-		// 		containerRuntimeFactory.processAllMessages();
+				containerRuntimeFactory.processAllMessages();
 
-		// 		// Check that the second node has been detached
-		// 		const traitAfterDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-		// 		expect(traitAfterDetach.length).equals(2);
+				// Check that the second node has been detached
+				const traitAfterDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+				expect(traitAfterDetach.length).equals(2);
 
-		// 		// The undo should succeed and the set should be reverted
-		// 		const undoId = expectDefined(undo(sharedTree, id));
+				// The undo should succeed and the set should be reverted
+				const undoId = expectDefined(undo(sharedTree, id));
 
-		// 		containerRuntimeFactory.processAllMessages();
+				containerRuntimeFactory.processAllMessages();
 
-		// 		// Check that undoing the second insert has no effect and the node whose value was set now has an empty payload
-		// 		const traitAfterUndo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-		// 		expect(traitAfterUndo.length).equals(2);
-		// 		const nodeAfterUndo = sharedTree.currentView.getViewNode(traitAfterUndo[0]);
-		// 		expect(nodeAfterUndo.payload).to.be.undefined;
+				// Check that undoing the second insert has no effect and the node whose value was set now has an empty payload
+				const traitAfterUndo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+				expect(traitAfterUndo.length).equals(2);
+				const nodeAfterUndo = sharedTree.currentView.getViewNode(traitAfterUndo[0]);
+				expect(nodeAfterUndo.payload).to.be.undefined;
 
-		// 		redo(sharedTree, undoId);
+				redo(sharedTree, undoId);
 
-		// 		containerRuntimeFactory.processAllMessages();
+				containerRuntimeFactory.processAllMessages();
 
-		// 		// Check that redoing only includes a set to 42
-		// 		const traitAfterRedo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-		// 		expect(traitAfterRedo.length).equals(2);
-		// 		const nodeAfterRedo = sharedTree.currentView.getViewNode(traitAfterRedo[0]);
-		// 		expect(nodeAfterRedo.payload).to.equal('42');
-		// 	});
-		// }
+				// Check that redoing only includes a set to 42
+				const traitAfterRedo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+				expect(traitAfterRedo.length).equals(2);
+				const nodeAfterRedo = sharedTree.currentView.getViewNode(traitAfterRedo[0]);
+				expect(nodeAfterRedo.payload).to.equal('42');
+			});
+		}
 
 		if (testOutOfOrderRevert === true) {
 			it('works for out-of-order Insert', () => {

--- a/experimental/dds/tree/src/test/utilities/UndoRedoTests.ts
+++ b/experimental/dds/tree/src/test/utilities/UndoRedoTests.ts
@@ -286,89 +286,85 @@ export function runSharedTreeUndoRedoTestSuite(options: SharedTreeUndoRedoOption
 			expect(traitAfterUndo.length).equals(1);
 		});
 
-		it.only('can revert part of a transaction when the rest cannot be reverted', () => {
-			// Set up the trees with revertPartialTransactions turned on
-			const setupResult = setUpTestSharedTree({ revertPartialTransactions: true, ...treeOptions });
-			sharedTree = setupResult.tree;
-			testTree = setUpTestTree(sharedTree);
-			containerRuntimeFactory = setupResult.containerRuntimeFactory;
-			const secondTree = localMode
-				? undefined
-				: setUpTestSharedTree({
-						containerRuntimeFactory,
-						revertPartialTransactions: true,
-						...secondTreeOptions,
-				  }).tree;
-			undoSharedTree = secondTree ?? sharedTree;
+		// if (!localMode) {
+		// 	it.only('can revert part of a transaction when the rest cannot be reverted', () => {
+		// 		// Set up the trees with revertPartialTransactions turned on
+		// 		const setupResult = setUpTestSharedTree({ revertPartialTransactions: true, ...treeOptions });
+		// 		sharedTree = setupResult.tree;
+		// 		testTree = setUpTestTree(sharedTree);
+		// 		containerRuntimeFactory = setupResult.containerRuntimeFactory;
+		// 		const secondTree = localMode
+		// 			? undefined
+		// 			: setUpTestSharedTree({
+		// 					containerRuntimeFactory,
+		// 					revertPartialTransactions: true,
+		// 					...secondTreeOptions,
+		// 			  }).tree;
+		// 		undoSharedTree = secondTree ?? sharedTree;
 
-			if (additionalSetup !== undefined) {
-				if (secondTree !== undefined) {
-					additionalSetup([sharedTree, undoSharedTree]);
-				} else {
-					additionalSetup([sharedTree]);
-				}
-			}
+		// 		if (additionalSetup !== undefined) {
+		// 			if (secondTree !== undefined) {
+		// 				additionalSetup([sharedTree, undoSharedTree]);
+		// 			} else {
+		// 				additionalSetup([sharedTree]);
+		// 			}
+		// 		}
 
-			// Build and insert two nodes, one to set and the other to detach
-			const newNode = buildLeaf(sharedTree.generateNodeId());
-			sharedTree.applyEdit(...Change.insertTree(newNode, StablePlace.atStartOf(testTree.left.traitLocation)));
-			expect(sharedTree.edits.length).to.equal(2);
-			afterEdit();
+		// 		// Build and insert two nodes, one to set and the other to detach
+		// 		const newNode = buildLeaf(sharedTree.generateNodeId());
+		// 		sharedTree.applyEdit(...Change.insertTree(newNode, StablePlace.atStartOf(testTree.left.traitLocation)));
+		// 		expect(sharedTree.edits.length).to.equal(2);
+		// 		afterEdit();
 
-			const set = Change.setPayload(newNode.identifier, '42');
-			const detachedNode = buildLeaf(sharedTree.generateNodeId());
-			const insert = Change.insertTree(detachedNode, StablePlace.atStartOf(testTree.left.traitLocation));
-			const { id } = sharedTree.applyEdit(set, ...insert);
-			expect(sharedTree.edits.length).to.equal(3);
-			afterEdit();
+		// 		const set = Change.setPayload(newNode.identifier, '42');
+		// 		const detachedNodeId = sharedTree.generateNodeId();
+		// 		const detachedNode = buildLeaf(detachedNodeId);
+		// 		const insert = Change.insertTree(detachedNode, StablePlace.atStartOf(testTree.left.traitLocation));
+		// 		const { id } = sharedTree.applyEdit(set, ...insert);
+		// 		expect(sharedTree.edits.length).to.equal(3);
+		// 		afterEdit();
 
-			if (!localMode) {
-				containerRuntimeFactory.processAllMessages();
-			}
+		// 		containerRuntimeFactory.processAllMessages();
 
-			// Check the size of the trait before detaching
-			const traitBeforeDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-			expect(traitBeforeDetach.length).equals(3);
-			const nodeBeforeDetach = sharedTree.currentView.getViewNode(traitBeforeDetach[1]);
-			expect(nodeBeforeDetach.payload).to.equal('42');
+		// 		// Check the size of the trait before detaching
+		// 		const traitBeforeDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+		// 		expect(traitBeforeDetach.length).equals(3);
+		// 		const nodeBeforeDetach = sharedTree.currentView.getViewNode(traitBeforeDetach[1]);
+		// 		expect(nodeBeforeDetach.payload).to.equal('42');
 
-			// Detach the second node
-			sharedTree.applyEdit(Change.detach(StableRange.only(detachedNode)));
-			afterEdit();
+		// 		// Detach the second node
+		// 		const translatedNodeId = translateId(detachedNodeId, sharedTree, undoSharedTree);
+		// 		undoSharedTree.applyEdit(Change.detach(StableRange.only(translatedNodeId)));
+		// 		afterEdit();
 
-			if (!localMode) {
-				containerRuntimeFactory.processAllMessages();
-			}
+		// 		containerRuntimeFactory.processAllMessages();
 
-			// Check that the second node has been detached
-			const traitAfterDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-			expect(traitAfterDetach.length).equals(2);
+		// 		// Check that the second node has been detached
+		// 		const traitAfterDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+		// 		expect(traitAfterDetach.length).equals(2);
 
-			// The undo should succeed and the set should be reverted
-			const undoId = expectDefined(undo(undoSharedTree, id));
+		// 		// The undo should succeed and the set should be reverted
+		// 		const undoId = expectDefined(undo(sharedTree, id));
 
-			if (!localMode) {
-				containerRuntimeFactory.processAllMessages();
-			}
+		// 		containerRuntimeFactory.processAllMessages();
 
-			// Check that undoing the second insert has no effect and the node whose value was set now has an empty payload
-			const traitAfterUndo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-			expect(traitAfterUndo.length).equals(2);
-			const nodeAfterUndo = sharedTree.currentView.getViewNode(traitAfterUndo[0]);
-			expect(nodeAfterUndo.payload).to.be.undefined;
+		// 		// Check that undoing the second insert has no effect and the node whose value was set now has an empty payload
+		// 		const traitAfterUndo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+		// 		expect(traitAfterUndo.length).equals(2);
+		// 		const nodeAfterUndo = sharedTree.currentView.getViewNode(traitAfterUndo[0]);
+		// 		expect(nodeAfterUndo.payload).to.be.undefined;
 
-			redo(undoSharedTree, undoId);
+		// 		redo(sharedTree, undoId);
 
-			if (!localMode) {
-				containerRuntimeFactory.processAllMessages();
-			}
+		// 		containerRuntimeFactory.processAllMessages();
 
-			// Check that redoing only includes a set to 42
-			const traitAfterRedo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
-			expect(traitAfterRedo.length).equals(2);
-			const nodeAfterRedo = sharedTree.currentView.getViewNode(traitAfterRedo[0]);
-			expect(nodeAfterRedo.payload).to.equal('42');
-		});
+		// 		// Check that redoing only includes a set to 42
+		// 		const traitAfterRedo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+		// 		expect(traitAfterRedo.length).equals(2);
+		// 		const nodeAfterRedo = sharedTree.currentView.getViewNode(traitAfterRedo[0]);
+		// 		expect(nodeAfterRedo.payload).to.equal('42');
+		// 	});
+		// }
 
 		if (testOutOfOrderRevert === true) {
 			it('works for out-of-order Insert', () => {

--- a/experimental/dds/tree/src/test/utilities/UndoRedoTests.ts
+++ b/experimental/dds/tree/src/test/utilities/UndoRedoTests.ts
@@ -286,6 +286,90 @@ export function runSharedTreeUndoRedoTestSuite(options: SharedTreeUndoRedoOption
 			expect(traitAfterUndo.length).equals(1);
 		});
 
+		it.only('can revert part of a transaction when the rest cannot be reverted', () => {
+			// Set up the trees with revertPartialTransactions turned on
+			const setupResult = setUpTestSharedTree({ revertPartialTransactions: true, ...treeOptions });
+			sharedTree = setupResult.tree;
+			testTree = setUpTestTree(sharedTree);
+			containerRuntimeFactory = setupResult.containerRuntimeFactory;
+			const secondTree = localMode
+				? undefined
+				: setUpTestSharedTree({
+						containerRuntimeFactory,
+						revertPartialTransactions: true,
+						...secondTreeOptions,
+				  }).tree;
+			undoSharedTree = secondTree ?? sharedTree;
+
+			if (additionalSetup !== undefined) {
+				if (secondTree !== undefined) {
+					additionalSetup([sharedTree, undoSharedTree]);
+				} else {
+					additionalSetup([sharedTree]);
+				}
+			}
+
+			// Build and insert two nodes, one to set and the other to detach
+			const newNode = buildLeaf(sharedTree.generateNodeId());
+			sharedTree.applyEdit(...Change.insertTree(newNode, StablePlace.atStartOf(testTree.left.traitLocation)));
+			expect(sharedTree.edits.length).to.equal(2);
+			afterEdit();
+
+			const set = Change.setPayload(newNode.identifier, '42');
+			const detachedNode = buildLeaf(sharedTree.generateNodeId());
+			const insert = Change.insertTree(detachedNode, StablePlace.atStartOf(testTree.left.traitLocation));
+			const { id } = sharedTree.applyEdit(set, ...insert);
+			expect(sharedTree.edits.length).to.equal(3);
+			afterEdit();
+
+			if (!localMode) {
+				containerRuntimeFactory.processAllMessages();
+			}
+
+			// Check the size of the trait before detaching
+			const traitBeforeDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+			expect(traitBeforeDetach.length).equals(3);
+			const nodeBeforeDetach = sharedTree.currentView.getViewNode(traitBeforeDetach[1]);
+			expect(nodeBeforeDetach.payload).to.equal('42');
+
+			// Detach the second node
+			sharedTree.applyEdit(Change.detach(StableRange.only(detachedNode)));
+			afterEdit();
+
+			if (!localMode) {
+				containerRuntimeFactory.processAllMessages();
+			}
+
+			// Check that the second node has been detached
+			const traitAfterDetach = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+			expect(traitAfterDetach.length).equals(2);
+
+			// The undo should succeed and the set should be reverted
+			const undoId = expectDefined(undo(undoSharedTree, id));
+
+			if (!localMode) {
+				containerRuntimeFactory.processAllMessages();
+			}
+
+			// Check that undoing the second insert has no effect and the node whose value was set now has an empty payload
+			const traitAfterUndo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+			expect(traitAfterUndo.length).equals(2);
+			const nodeAfterUndo = sharedTree.currentView.getViewNode(traitAfterUndo[0]);
+			expect(nodeAfterUndo.payload).to.be.undefined;
+
+			redo(undoSharedTree, undoId);
+
+			if (!localMode) {
+				containerRuntimeFactory.processAllMessages();
+			}
+
+			// Check that redoing only includes a set to 42
+			const traitAfterRedo = sharedTree.currentView.getTrait(testTree.left.traitLocation);
+			expect(traitAfterRedo.length).equals(2);
+			const nodeAfterRedo = sharedTree.currentView.getViewNode(traitAfterRedo[0]);
+			expect(nodeAfterRedo.payload).to.equal('42');
+		});
+
 		if (testOutOfOrderRevert === true) {
 			it('works for out-of-order Insert', () => {
 				const firstNode = testTree.buildLeaf();


### PR DESCRIPTION
- Adds `SharedTreeBaseOptions` that includes flag for toggling partial revert to current options
- Add test to HistoryEditFactory tests to make sure edits can be partially reverted
- Add skipped regression test for testing the scenario we were given. This test isn't behaving as expected because the entire undo fails to apply and the set from '42' to undefined is not reflected in the view. 