### PR TITLE
Removed unnecessary export IGarbageCollectionRuntime

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -74,6 +74,8 @@ export enum ContainerMessageType {
     Rejoin = "rejoin"
 }
 
+// Warning: (ae-forgotten-export) The symbol "IGarbageCollectionRuntime" needs to be exported by the entry point index.d.ts
+//
 // @public
 export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements IContainerRuntime, IGarbageCollectionRuntime, IRuntime, ISummarizerRuntime, ISummarizerInternalsProvider {
     addedGCOutboundReference(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
@@ -334,17 +336,6 @@ export interface IContainerRuntimeOptions {
 export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
     readonly afterSequenceNumber?: number;
     readonly override?: boolean;
-}
-
-// @public
-export interface IGarbageCollectionRuntime {
-    closeFn: (error?: ICriticalContainerError) => void;
-    deleteUnusedRoutes(unusedRoutes: string[]): void;
-    getCurrentReferenceTimestampMs(): number | undefined;
-    getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    getNodeType(nodePath: string): GCNodeType;
-    updateStateBeforeGC(): Promise<void>;
-    updateUsedRoutes(usedRoutes: string[]): void;
 }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -105,6 +105,11 @@
   },
   "typeValidation": {
     "version": "2.0.0-internal.2.1.0",
-    "broken": {}
+    "broken": {
+      "RemovedInterfaceDeclaration_IGarbageCollectionRuntime": {
+        "forwardCompat": false,
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -29,7 +29,6 @@ export { FluidDataStoreRegistry } from "./dataStoreRegistry";
 export {
     gcBlobPrefix,
     gcTreeKey,
-    IGarbageCollectionRuntime,
     IGCStats,
 } from "./garbageCollection";
 export {

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -520,26 +520,14 @@ use_old_InterfaceDeclaration_IEnqueueSummarizeOptions(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IGarbageCollectionRuntime": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IGarbageCollectionRuntime": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IGarbageCollectionRuntime():
-    TypeOnly<old.IGarbageCollectionRuntime>;
-declare function use_current_InterfaceDeclaration_IGarbageCollectionRuntime(
-    use: TypeOnly<current.IGarbageCollectionRuntime>);
-use_current_InterfaceDeclaration_IGarbageCollectionRuntime(
-    get_old_InterfaceDeclaration_IGarbageCollectionRuntime());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IGarbageCollectionRuntime": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IGarbageCollectionRuntime": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IGarbageCollectionRuntime():
-    TypeOnly<current.IGarbageCollectionRuntime>;
-declare function use_old_InterfaceDeclaration_IGarbageCollectionRuntime(
-    use: TypeOnly<old.IGarbageCollectionRuntime>);
-use_old_InterfaceDeclaration_IGarbageCollectionRuntime(
-    get_current_InterfaceDeclaration_IGarbageCollectionRuntime());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
## Description
IGarbageCollectionRuntime was exported from the "container-runtime" package but it should not. It is an internal interface used only by the ContainerRuntime and GarbageCollector classes.

## Does this introduce a breaking change?
Techically, yes. But this is an internal interface and should not be used by anyone.