### PR TITLE
Remove op reentrancy checks in `main`

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -25,8 +25,6 @@ import {
     normalizeError,
     logIfFalse,
     safeRaiseEvent,
-    MonitoringContext,
-    loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils";
 import {
     IDocumentDeltaStorageService,
@@ -50,13 +48,12 @@ import {
     DataCorruptionError,
     extractSafePropertiesFromMessage,
     DataProcessingError,
-    UsageError,
 } from "@fluidframework/container-utils";
 import { DeltaQueue } from "./deltaQueue";
 import {
     IConnectionManagerFactoryArgs,
     IConnectionManager,
- } from "./contracts";
+} from "./contracts";
 
 export interface IConnectionArgs {
     mode?: ConnectionMode;
@@ -112,14 +109,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     private pending: ISequencedDocumentMessage[] = [];
     private fetchReason: string | undefined;
 
-    private readonly mc: MonitoringContext;
-
     // A boolean used to assert that ops are not being sent while processing another op.
     private currentlyProcessingOps: boolean = false;
-
-    // Feature gate that closes a container when sending an op if the container is
-    // concurrently processing another op
-    private readonly preventConcurrentOpSend: boolean = true;
 
     // The minimum sequence number and last sequence number received from the server
     private minSequenceNumber: number = 0;
@@ -205,7 +196,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
      * Tells if  current connection has checkpoint information.
      * I.e. we know how far behind the client was at the time of establishing connection
      */
-     public get hasCheckpointSequenceNumber() {
+    public get hasCheckpointSequenceNumber() {
         // Valid to be called only if we have active connection.
         assert(this.connectionManager.connected, 0x0df /* "Missing active connection" */);
         return this._checkpointSequenceNumber !== undefined;
@@ -220,9 +211,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     public get clientDetails() { return this.connectionManager.clientDetails; }
 
     public submit(type: MessageType, contents?: string, batch = false, metadata?: any) {
-        if (this.currentlyProcessingOps && this.preventConcurrentOpSend) {
-            this.close(new UsageError("Making changes to data model is disallowed while processing ops."));
-        }
         const messagePartial: Omit<IDocumentMessage, "clientSequenceNumber"> = {
             contents,
             metadata,
@@ -343,8 +331,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
         };
 
         this.connectionManager = createConnectionManager(props);
-        this.mc = loggerToMonitoringContext(logger);
-        this.preventConcurrentOpSend = this.mc.config.getBoolean("Fluid.Container.ConcurrentOpSend") === true;
         this._inbound = new DeltaQueue<ISequencedDocumentMessage>(
             (op) => {
                 this.processInboundMessage(op);
@@ -412,7 +398,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
             if (checkpointSequenceNumber > this.lastQueuedSequenceNumber) {
                 this.fetchMissingDeltas("AfterConnection");
             }
-        // we do not know the gap, and we will not learn about it if socket is quite - have to ask.
+            // we do not know the gap, and we will not learn about it if socket is quite - have to ask.
         } else if (connection.mode === "read") {
             this.fetchMissingDeltas("AfterReadConnection");
         }
@@ -730,9 +716,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
             // Report if we found some issues
             if (duplicate !== 0 || gap !== 0 && !allowGaps || initialGap > 0 && this.fetchReason === undefined) {
                 eventName = "enqueueMessages";
-            // Also report if we are fetching ops, and same range comes in, thus making this fetch obsolete.
+                // Also report if we are fetching ops, and same range comes in, thus making this fetch obsolete.
             } else if (this.fetchReason !== undefined && this.fetchReason !== reason &&
-                    (from <= this.lastQueuedSequenceNumber + 1 && last > this.lastQueuedSequenceNumber)) {
+                (from <= this.lastQueuedSequenceNumber + 1 && last > this.lastQueuedSequenceNumber)) {
                 eventName = "enqueueMessagesExtraFetch";
             }
 
@@ -893,15 +879,15 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     /**
      * Retrieves the missing deltas between the given sequence numbers
      */
-     private fetchMissingDeltas(reasonArg: string, to?: number) {
-         this.fetchMissingDeltasCore(reasonArg, false /* cacheOnly */, to).catch((error) => {
-             this.logger.sendErrorEvent({ eventName: "fetchMissingDeltasException" }, error);
-         });
-     }
+    private fetchMissingDeltas(reasonArg: string, to?: number) {
+        this.fetchMissingDeltasCore(reasonArg, false /* cacheOnly */, to).catch((error) => {
+            this.logger.sendErrorEvent({ eventName: "fetchMissingDeltasException" }, error);
+        });
+    }
 
-     /**
-     * Retrieves the missing deltas between the given sequence numbers
-     */
+    /**
+    * Retrieves the missing deltas between the given sequence numbers
+    */
     private async fetchMissingDeltasCore(
         reason: string,
         cacheOnly: boolean,

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -17,7 +17,7 @@ import {
     ChannelFactoryRegistry,
     ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { describeFullCompat, describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
+import { describeFullCompat, describeNoCompat } from "@fluidframework/test-version-utils";
 
 const mapId = "mapKey";
 const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
@@ -379,75 +379,6 @@ describeNoCompat("SharedMap orderSequentially", (getTestObjectProvider) => {
         });
         sharedMap.on("clear", (local, target) => {
             clearEventCount++;
-        });
-    });
-    describe("Concurrent op processing", () => {
-        let container2: Container;
-        let dataObject2: ITestFluidObject;
-        let sharedMap2: SharedMap;
-
-        beforeEach(async () => {
-            provider.reset();
-            provider = getTestObjectProvider();
-        });
-
-        const setupContainers = async (
-            containerConfig: ITestContainerConfig,
-            featureGates: Record<string, ConfigTypes> = {},
-        ) => {
-            const configWithFeatureGates = {
-                ...containerConfig,
-                loaderProps: { configProvider: configProvider(featureGates) },
-            };
-            const container1 = await provider.makeTestContainer(configWithFeatureGates) as Container;
-            container2 = await provider.loadTestContainer(configWithFeatureGates) as Container;
-
-            dataObject = await requestFluidObject<ITestFluidObject>(container1, "default");
-            dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
-
-            sharedMap = await dataObject.getSharedObject<SharedMap>(mapId);
-            sharedMap2 = await dataObject2.getSharedObject<SharedMap>(mapId);
-
-            await provider.ensureSynchronized();
-        };
-
-        // ADO #1834 tracks fixing it!
-        // This test case does not work correctly - it used to work before batching changes for the wrong reason.
-        // Please see above ticket for more info
-        itExpects.skip("Should close container when sending an op while processing another op",
-            [{
-                eventName: "fluid:telemetry:Container:ContainerClose",
-                error: "Making changes to data model is disallowed while processing ops.",
-            }], async () => {
-                await setupContainers(testContainerConfig, { "Fluid.Container.ConcurrentOpSend": true });
-
-                sharedMap.on("valueChanged", (changed, local) => {
-                    if (!local) {
-                        assert.equal(changed.key, "key2", "Incorrect value for key1 in container 1");
-                    }
-                    // Avoid re-entrancy by setting a new key
-                    if (changed.key !== "key2") {
-                        sharedMap2.set("key2", "v2");
-                    }
-                });
-                // Set 1st key to trigger above valueChanged
-                sharedMap.set("key1", "v1");
-                await provider.ensureSynchronized();
-            });
-
-        it("Negative test with unset concurrentOpSend feature gate", async () => {
-            await setupContainers(testContainerConfig, { "Fluid.Container.ConcurrentOpSend": false });
-            sharedMap.on("valueChanged", (changed, local) => {
-                // Avoid re-entrancy by setting a new key
-                if (changed.key !== "key2") {
-                    sharedMap2.set("key2", "v2");
-                }
-            });
-            // Set 1st key to trigger above valueChanged
-            sharedMap.set("key1", "v1");
-            await provider.ensureSynchronized();
-            assert.equal(sharedMap.get("key1"), "v1", "The new value is not updated in map 1");
-            assert.equal(sharedMap2.get("key2"), "v2", "The new value is not updated in map 2");
         });
     });
 


### PR DESCRIPTION
**ADO:1834**

[The op reentrancy issue is currently handled in the `next` branch](https://github.com/microsoft/FluidFramework/pull/12326), so this code is no longer needed in `main`. The validation was disabled by default, so there are no regressions in terms of functionality for the current scenarios.