### PR TITLE
Remove batch size config test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -109,17 +109,6 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
         assert(limit < maxMessageSizeInBytes * 2);
     });
 
-    it("A large batch (smaller than 1MB) will not close the container if there is no batch size limit", async () => {
-        await setupContainers({ ...testContainerConfig, runtimeOptions: { maxBatchSizeInBytes: Infinity } }, {});
-        // 950 * 1024 is the default max batch size limit
-        const largeString = generateStringOfSize(950 * 1024 / 2);
-        const messageCount = 2;
-        setMapKeys(dataObject1map, messageCount, largeString);
-        await provider.ensureSynchronized();
-
-        assertMapValues(dataObject2map, messageCount, largeString);
-    });
-
     it("Small ops will pass", async () => {
         const maxMessageSizeInBytes = 800 * 1024; // slightly below 1Mb
         await setupContainers(testContainerConfig, {});


### PR DESCRIPTION
**ADO:2318**

Adding this test wasn't a great idea in the first place. The intent here is to validate that if `maxBatchSizeInBytes` is set to `infinity`, the runtime will allow batches of any size to be sent, while the default size being 972k. But the de facto batch size limit (from socket.io) is 1 MB, therefore this test was exploiting this difference in thresholds by attempting to create a payload of 972k, however this approach is vulnerable to changes in the metadata/encodings that may change the size of the overall payload. We do have coverage for the behavior change in the batch manager for this config.