### PR TITLE
Tree: fix changeset encoding

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -931,7 +931,7 @@ export type NodeChangeRebaser = (change: NodeChangeset, baseChange: NodeChangese
 // @public (undocumented)
 type NodeChangeRebaser_2<TNodeChange> = (change: TNodeChange, baseChange: TNodeChange) => TNodeChange;
 
-// @public (undocumented)
+// @public
 export interface NodeChangeset {
     // (undocumented)
     fieldChanges?: FieldChangeMap;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -81,6 +81,9 @@ export type NodeChangeComposer = (changes: NodeChangeset[]) => NodeChangeset;
 export type NodeChangeEncoder = (change: NodeChangeset) => JsonCompatibleReadOnly;
 export type NodeChangeDecoder = (change: JsonCompatibleReadOnly) => NodeChangeset;
 
+/**
+ * Changeset for a subtree rooted at a specific node.
+ */
 export interface NodeChangeset {
     fieldChanges?: FieldChangeMap;
     valueChange?: ValueChange;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -22,7 +22,7 @@ import { FieldKind, Multiplicity } from "./fieldKind";
  */
 export interface GenericChange {
     /**
-     * Index withing the field of the changed node.
+     * Index within the field of the changed node.
      */
     index: number;
     /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -18,10 +18,16 @@ import {
 import { FieldKind, Multiplicity } from "./fieldKind";
 
 /**
- * A field-agnostic change to a single element of a field.
+ * A field-kind-agnostic change to a single node within a field.
  */
 export interface GenericChange {
+    /**
+     * Index withing the field of the changed node.
+     */
     index: number;
+    /**
+     * Change to the node.
+     */
     nodeChange: NodeChangeset;
 }
 
@@ -30,6 +36,7 @@ export interface GenericChange {
  */
 export interface EncodedGenericChange {
     index: number;
+    // TODO: this format needs more documentation (ideally in the form of more specific types).
     nodeChange: JsonCompatibleReadOnly;
 }
 
@@ -120,11 +127,9 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
             change: GenericChangeset,
             encodeChild: NodeChangeEncoder,
         ): JsonCompatibleReadOnly {
-            // Would use `change.map(...)` but the type system doesn't accept it
-            const encoded: JsonCompatibleReadOnly[] & EncodedGenericChangeset = [];
-            for (const { index, nodeChange } of change) {
-                encoded.push({ index, nodeChange: encodeChild(nodeChange) });
-            }
+            const encoded: JsonCompatibleReadOnly[] & EncodedGenericChangeset = change.map(
+                ({ index, nodeChange }) => ({ index, nodeChange: encodeChild(nodeChange) }),
+            );
             return encoded;
         },
         decodeJson: (

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeEncoding.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeEncoding.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FieldKindIdentifier } from "../../core";
+import { brand, JsonCompatibleReadOnly } from "../../util";
+import { FieldChangeMap, NodeChangeset, ValueChange } from "./fieldChangeHandler";
+import { FieldKind } from "./fieldKind";
+import { getChangeHandler } from "./modularChangeFamily";
+
+interface EncodedNodeChangeset {
+    valueChange?: ValueChange;
+    fieldChanges?: EncodedFieldChangeMap;
+}
+
+type EncodedFieldChangeMap = Record<string, EncodedFieldChange> & JsonCompatibleReadOnly;
+
+interface EncodedFieldChange {
+    fieldKind: FieldKindIdentifier;
+    /**
+     * Encoded in format selected by `fieldKind`
+     */
+    change: JsonCompatibleReadOnly;
+}
+
+export function encodeForJsonFormat0(
+    fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>,
+    change: FieldChangeMap,
+): JsonCompatibleReadOnly {
+    const encodedFields: EncodedFieldChangeMap = {};
+    for (const [field, fieldChange] of change.entries()) {
+        const encodedChange = getChangeHandler(
+            fieldKinds,
+            fieldChange.fieldKind,
+        ).encoder.encodeForJson(0, fieldChange.change, (childChange) =>
+            encodeNodeChangesForJson(fieldKinds, childChange),
+        );
+
+        const encodedField: EncodedFieldChange & JsonCompatibleReadOnly = {
+            fieldKind: fieldChange.fieldKind,
+            change: encodedChange,
+        };
+
+        encodedFields[field as string] = encodedField;
+    }
+
+    return encodedFields;
+}
+
+function encodeNodeChangesForJson(
+    fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>,
+    change: NodeChangeset,
+): JsonCompatibleReadOnly {
+    const encodedChange: EncodedNodeChangeset = {};
+    if (change.valueChange !== undefined) {
+        encodedChange.valueChange = change.valueChange;
+    }
+
+    if (change.fieldChanges !== undefined) {
+        const encodedFieldChanges = encodeForJsonFormat0(fieldKinds, change.fieldChanges);
+        encodedChange.fieldChanges = encodedFieldChanges as unknown as EncodedFieldChangeMap;
+    }
+
+    return encodedChange as JsonCompatibleReadOnly;
+}
+
+export function decodeJsonFormat0(
+    fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>,
+    change: JsonCompatibleReadOnly,
+): FieldChangeMap {
+    const encodedChange = change as unknown as EncodedFieldChangeMap;
+    const decodedFields: FieldChangeMap = new Map();
+    for (const field of Object.keys(encodedChange)) {
+        const fieldChange = encodedChange[field];
+        const fieldChangeset = getChangeHandler(
+            fieldKinds,
+            fieldChange.fieldKind,
+        ).encoder.decodeJson(0, fieldChange.change, (encodedChild) =>
+            decodeNodeChangesetFromJson(fieldKinds, encodedChild),
+        );
+
+        decodedFields.set(brand(field), {
+            fieldKind: fieldChange.fieldKind,
+            change: brand(fieldChangeset),
+        });
+    }
+
+    return decodedFields;
+}
+
+function decodeNodeChangesetFromJson(
+    fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>,
+    change: JsonCompatibleReadOnly,
+): NodeChangeset {
+    const encodedChange = change as EncodedNodeChangeset;
+    const decodedChange: NodeChangeset = {};
+    if (encodedChange.valueChange !== undefined) {
+        decodedChange.valueChange = encodedChange.valueChange;
+    }
+
+    if (encodedChange.fieldChanges !== undefined) {
+        decodedChange.fieldChanges = decodeJsonFormat0(fieldKinds, encodedChange.fieldChanges);
+    }
+
+    return decodedChange;
+}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeEncoding.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeEncoding.ts
@@ -37,7 +37,7 @@ type EncodedFieldChangeMap = EncodedFieldChange[];
 
 interface EncodedFieldChange {
     fieldKey: LocalFieldKey | GlobalFieldKey;
-    global: boolean;
+    keyIsGlobal: boolean;
     fieldKind: FieldKindIdentifier;
     /**
      * Encoded in format selected by `fieldKind`
@@ -62,7 +62,7 @@ export function encodeForJsonFormat0(
         const fieldKey: LocalFieldKey | GlobalFieldKey = global ? keyFromSymbol(field) : field;
         const encodedField: EncodedFieldChange = {
             fieldKey,
-            global,
+            keyIsGlobal: global,
             fieldKind: fieldChange.fieldKind,
             change: encodedChange,
         };
@@ -103,7 +103,7 @@ export function decodeJsonFormat0(
             (encodedChild) => decodeNodeChangesetFromJson(fieldKinds, encodedChild),
         );
 
-        const fieldKey: FieldKey = field.global
+        const fieldKey: FieldKey = field.keyIsGlobal
             ? symbolFromKey(brand<GlobalFieldKey>(field.fieldKey))
             : brand<LocalFieldKey>(field.fieldKey);
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -28,6 +28,7 @@ import {
 } from "./fieldChangeHandler";
 import { FieldKind } from "./fieldKind";
 import { convertGenericChange, GenericChangeset, genericFieldKind } from "./genericFieldKind";
+import { decodeJsonFormat0, encodeForJsonFormat0 } from "./modularChangeEncoding";
 
 /**
  * Implementation of ChangeFamily which delegates work in a given field to the appropriate FieldKind
@@ -94,16 +95,13 @@ export class ModularChangeFamily
 
         const fieldChanges = new Map<FieldKey, FieldChange[]>();
         for (const change of changes) {
-            for (const [key, fieldChange] of change.entries()) {
+            for (const [key, fieldChange] of change) {
                 getOrAddEmptyToMap(fieldChanges, key).push(fieldChange);
             }
         }
 
         const composedFields: FieldChangeMap = new Map();
-        for (const field of fieldChanges.keys()) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const changesForField = fieldChanges.get(field)!;
-
+        for (const [field, changesForField] of fieldChanges) {
             const { fieldKind, changesets } = this.normalizeFieldChanges(changesForField);
             const composedField = fieldKind.changeHandler.rebaser.compose(
                 changesets,
@@ -176,7 +174,7 @@ export class ModularChangeFamily
     rebase(change: FieldChangeMap, over: FieldChangeMap): FieldChangeMap {
         const rebasedFields: FieldChangeMap = new Map();
 
-        for (const [field, fieldChange] of change.entries()) {
+        for (const [field, fieldChange] of change) {
             const baseChanges = over.get(field);
             if (baseChanges === undefined) {
                 rebasedFields.set(field, fieldChange);
@@ -253,7 +251,7 @@ export class ModularChangeFamily
     }
 }
 
-function getFieldKind(
+export function getFieldKind(
     fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>,
     kind: FieldKindIdentifier,
 ): FieldKind {
@@ -265,7 +263,7 @@ function getFieldKind(
     return fieldKind;
 }
 
-function getChangeHandler(
+export function getChangeHandler(
     fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>,
     kind: FieldKindIdentifier,
 ): FieldChangeHandler<unknown> {
@@ -278,91 +276,12 @@ class ModularChangeEncoder extends ChangeEncoder<FieldChangeMap> {
     }
 
     encodeForJson(formatVersion: number, change: FieldChangeMap): JsonCompatibleReadOnly {
-        const encodedFields: EncodedFieldChangeMap = {};
-        for (const [field, fieldChange] of change.entries()) {
-            const encodedChange = getChangeHandler(
-                this.fieldKinds,
-                fieldChange.fieldKind,
-            ).encoder.encodeForJson(formatVersion, fieldChange.change, (childChange) =>
-                this.encodeNodeChangesForJson(formatVersion, childChange),
-            );
-
-            const encodedField: EncodedFieldChange & JsonCompatibleReadOnly = {
-                fieldKind: fieldChange.fieldKind,
-                change: encodedChange,
-            };
-
-            encodedFields[field as string] = encodedField;
-        }
-
-        return encodedFields;
-    }
-
-    private encodeNodeChangesForJson(
-        formatVersion: number,
-        change: NodeChangeset,
-    ): JsonCompatibleReadOnly {
-        const encodedChange: EncodedNodeChangeset = {};
-        if (change.valueChange !== undefined) {
-            encodedChange.valueChange = change.valueChange;
-        }
-
-        if (change.fieldChanges !== undefined) {
-            const encodedFieldChanges = this.encodeForJson(formatVersion, change.fieldChanges);
-            encodedChange.fieldChanges = encodedFieldChanges as unknown as EncodedFieldChangeMap;
-        }
-
-        return encodedChange as JsonCompatibleReadOnly;
+        return encodeForJsonFormat0(this.fieldKinds, change);
     }
 
     decodeJson(formatVersion: number, change: JsonCompatibleReadOnly): FieldChangeMap {
-        const encodedChange = change as unknown as EncodedFieldChangeMap;
-        const decodedFields: FieldChangeMap = new Map();
-        for (const field of Object.keys(encodedChange)) {
-            const fieldChange = encodedChange[field];
-            const fieldChangeset = getChangeHandler(
-                this.fieldKinds,
-                fieldChange.fieldKind,
-            ).encoder.decodeJson(formatVersion, fieldChange.change, (encodedChild) =>
-                this.decodeNodeChangesetFromJson(formatVersion, encodedChild),
-            );
-
-            decodedFields.set(brand(field), {
-                fieldKind: fieldChange.fieldKind,
-                change: brand(fieldChangeset),
-            });
-        }
-
-        return decodedFields;
+        return decodeJsonFormat0(this.fieldKinds, change);
     }
-
-    private decodeNodeChangesetFromJson(
-        formatVersion: number,
-        change: JsonCompatibleReadOnly,
-    ): NodeChangeset {
-        const encodedChange = change as EncodedNodeChangeset;
-        const decodedChange: NodeChangeset = {};
-        if (encodedChange.valueChange !== undefined) {
-            decodedChange.valueChange = encodedChange.valueChange;
-        }
-
-        if (encodedChange.fieldChanges !== undefined) {
-            decodedChange.fieldChanges = this.decodeJson(formatVersion, encodedChange.fieldChanges);
-        }
-
-        return decodedChange;
-    }
-}
-interface EncodedNodeChangeset {
-    valueChange?: ValueChange;
-    fieldChanges?: EncodedFieldChangeMap;
-}
-
-type EncodedFieldChangeMap = Record<string, EncodedFieldChange> & JsonCompatibleReadOnly;
-
-interface EncodedFieldChange {
-    fieldKind: FieldKindIdentifier;
-    change: JsonCompatibleReadOnly;
 }
 
 /**

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -220,8 +220,7 @@ describe("SharedTree", () => {
             assert.equal(getTestValue(tree2), undefined);
         });
 
-        // TODO: Add global field representation in changesets and delta
-        it.skip("can edit a global field", async () => {
+        it("can edit a global field", async () => {
             const provider = await TestTreeProvider.create(2);
             const [tree1, tree2] = provider.trees;
 


### PR DESCRIPTION
## Description

The new format handles global field keys, and since it avoids using FieldKeys and object keys, it avoids potential issues with special field key names (like __proto__ or hasOwnKey etc.) which could collide with JS members from the prototype.

This change also factors the encoding logic into its own file, which will help with compatibility and versioning in the future.

## Reviewer Guidance

I split this up into two commits:
- a refactor to isolate the encoding code
- an update to the encoded format

## Does this introduce a breaking change?

Yes: the persisted changeset format is updated: Existing documents with trailing ops will be broken, and collab between before and after versions will not work.
