### PR TITLE
Scenario Runner: Added DocLoader stage

### DIFF
--- a/azure/packages/test/scenario-runner/src/DocCreatorRunner.ts
+++ b/azure/packages/test/scenario-runner/src/DocCreatorRunner.ts
@@ -2,10 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
 import child_process from "child_process";
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";

--- a/azure/packages/test/scenario-runner/src/DocLoaderRunner.ts
+++ b/azure/packages/test/scenario-runner/src/DocLoaderRunner.ts
@@ -19,46 +19,46 @@ export interface AzureClientConfig {
     tenantId?: string;
 }
 
-export interface DocSchema {
+export interface DocLoaderSchema {
     initialObjects: { [key: string]: string };
     dynamicObjects?: { [key: string]: string };
 }
 
-export interface DocCreatorRunnerConfig {
+export interface DocLoaderRunnerConfig {
     connectionConfig: AzureClientConfig;
-    schema: DocSchema;
-    numDocs: number;
+    schema: DocLoaderSchema;
+    docIds: string[];
     clientStartDelayMs: number;
 }
 
-export class DocCreatorRunner extends TypedEventEmitter<IRunnerEvents> implements IRunner {
+export class DocLoaderRunner extends TypedEventEmitter<IRunnerEvents> implements IRunner {
     private status: RunnnerStatus = "notStarted";
-    private readonly docIds: string[] = [];
-    constructor(public readonly c: DocCreatorRunnerConfig) {
+    constructor(public readonly c: DocLoaderRunnerConfig) {
         super();
     }
 
-    public async run(config: IRunConfig): Promise<string | string[] | undefined> {
+    public async run(config: IRunConfig): Promise<void> {
         this.status = "running";
-
-        const r = await this.execRun(config);
+        await this.execRun(config);
         this.status = "success";
-        return r;
     }
 
-    public async execRun(config: IRunConfig): Promise<string | string[] | undefined> {
+    public async execRun(config: IRunConfig): Promise<void> {
         this.status = "running";
         const runnerArgs: string[][] = [];
-        for (let i = 0; i < this.c.numDocs; i++) {
+        let i = 0;
+        for (const docId of this.c.docIds) {
             const connection = this.c.connectionConfig;
             const childArgs: string[] = [
-                "./dist/docCreatorRunnerClient.js",
+                "./dist/docLoaderRunnerClient.js",
                 "--runId",
                 config.runId,
                 "--scenarioName",
                 config.scenarioName,
                 "--childId",
-                i.toString(),
+                (i++).toString(),
+                "--docId",
+                docId,
                 "--schema",
                 JSON.stringify(this.c.schema),
                 "--connType",
@@ -85,10 +85,6 @@ export class DocCreatorRunner extends TypedEventEmitter<IRunnerEvents> implement
         } catch {
             throw new Error("Not all clients closed sucesfully.");
         }
-
-        if(this.docIds.length > 0) {
-            return this.docIds.length === 1 ? this.docIds[0] : this.docIds;
-        }
     }
 
     public stop(): void {}
@@ -102,7 +98,7 @@ export class DocCreatorRunner extends TypedEventEmitter<IRunnerEvents> implement
     }
 
     private description(): string {
-        return `This stage creates empty document for the given schema.`;
+        return `This stage loads a list of documents, given their IDs`;
     }
 
     private async createChild(childArgs: string[]): Promise<boolean> {
@@ -110,14 +106,6 @@ export class DocCreatorRunner extends TypedEventEmitter<IRunnerEvents> implement
         const runnerProcess = child_process.spawn("node", childArgs, {
             stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
             env: envVar,
-        });
-
-        runnerProcess.stdout?.once("data", (data) => {
-            this.docIds.push(String(data))
-        });
-
-        runnerProcess.on('message', (id) => {
-            this.docIds.push(String(id))
         });
 
         return new Promise((resolve, reject) =>

--- a/azure/packages/test/scenario-runner/src/DocLoaderRunner.ts
+++ b/azure/packages/test/scenario-runner/src/DocLoaderRunner.ts
@@ -2,10 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
 import child_process from "child_process";
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";

--- a/azure/packages/test/scenario-runner/src/TestOrchestrator.ts
+++ b/azure/packages/test/scenario-runner/src/TestOrchestrator.ts
@@ -11,6 +11,7 @@ import { PerformanceEvent, TelemetryLogger } from "@fluidframework/telemetry-uti
 
 import { AzureClientRunner, AzureClientRunnerConfig } from "./AzureClientRunner";
 import { DocCreatorRunner, DocCreatorRunnerConfig } from "./DocCreatorRunner";
+import { DocLoaderRunner, DocLoaderRunnerConfig } from "./DocLoaderRunner";
 import { MapTrafficRunner, MapTrafficRunnerConfig } from "./MapTrafficRunner";
 import { IRunner } from "./interface";
 import { getLogger } from "./logger";
@@ -184,6 +185,9 @@ export class TestOrchestrator {
             }
             case "doc-creator": {
                 return new DocCreatorRunner(stage.params as unknown as DocCreatorRunnerConfig);
+            }
+            case "doc-loader": {
+                return new DocLoaderRunner(stage.params as unknown as DocLoaderRunnerConfig);
             }
             case "shared-map-traffic": {
                 return new MapTrafficRunner(stage.params as unknown as MapTrafficRunnerConfig);

--- a/azure/packages/test/scenario-runner/src/docCreatorRunnerClient.ts
+++ b/azure/packages/test/scenario-runner/src/docCreatorRunnerClient.ts
@@ -2,11 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
 import commander from "commander";
 
 import { ConnectionState } from "fluid-framework";

--- a/azure/packages/test/scenario-runner/src/docLoaderRunnerClient.ts
+++ b/azure/packages/test/scenario-runner/src/docLoaderRunnerClient.ts
@@ -3,10 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
 import commander from "commander";
 
 import { ConnectionState } from "fluid-framework";

--- a/azure/packages/test/scenario-runner/src/logger.ts
+++ b/azure/packages/test/scenario-runner/src/logger.ts
@@ -18,10 +18,11 @@ export interface LoggerConfig {
     runId?: string;
 }
 
-class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
+class ScenarioRunnerLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
     private error: boolean = false;
     private readonly schema = new Map<string, number>();
     private targetEvents: string[] = [];
+    private transformedEvents: Map<string, string> = new Map();
     private logs: ITelemetryBaseEvent[] = [];
 
     public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {
@@ -30,6 +31,13 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
 
     public registerExpectedEvent(expectedEventNames: string[]) {
         this.targetEvents = expectedEventNames;
+    }
+
+    public transformEvents(events: Map<string, string>) {
+        this.transformedEvents = events;
+        for (const k of events.keys()) {
+            this.targetEvents.push(k);
+        }
     }
 
     async flush(runInfo?: { url: string; runId?: number }): Promise<void> {
@@ -61,6 +69,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
     }
 
     send(event: ITelemetryBaseEvent): void {
+        // We want to log only events that are relevant to the test runner.
         if (this.targetEvents.length > 0) {
             const found = this.targetEvents.find((a) => event.eventName.startsWith(a));
             if (!found) {
@@ -68,13 +77,19 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
             }
         }
 
+        // Here we are remapping internal FF events to scenario runner events.
+        // TODO: Further cleanup needed.
+        for (const k of this.transformedEvents.keys()) {
+            if (event.eventName.startsWith(k)) {
+                event.eventName = `${this.transformedEvents.get(k)}${event.eventName.slice(
+                    k.length,
+                )}`;
+                break;
+            }
+        }
+
         if (typeof event.testCategoryOverride === "string") {
             event.category = event.testCategoryOverride;
-        } else if (
-            typeof event.message === "string" &&
-            event.message.includes("FaultInjectionNack")
-        ) {
-            event.category = "generic";
         }
         this.baseLogger?.send({ ...event, hostName: pkgName });
 
@@ -88,21 +103,28 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
     }
 }
 
-export const loggerP = new LazyPromise<FileLogger>(async () => {
+export const loggerP = new LazyPromise<ScenarioRunnerLogger>(async () => {
     if (process.env.FLUID_TEST_LOGGER_PKG_PATH !== undefined) {
         await import(process.env.FLUID_TEST_LOGGER_PKG_PATH);
         const logger = getTestLogger?.();
         assert(logger !== undefined, "Expected getTestLogger to return something");
-        return new FileLogger(logger);
+        return new ScenarioRunnerLogger(logger);
     } else {
-        return new FileLogger();
+        return new ScenarioRunnerLogger();
     }
 });
 
-export async function getLogger(config: LoggerConfig, events?: string[]): Promise<TelemetryLogger> {
+export async function getLogger(
+    config: LoggerConfig,
+    events?: string[],
+    transformEvents?: Map<string, string>,
+): Promise<TelemetryLogger> {
     const baseLogger = await loggerP;
-    if(events) {
+    if (events) {
         baseLogger.registerExpectedEvent(events);
+    }
+    if (transformEvents) {
+        baseLogger.transformEvents(transformEvents);
     }
     return ChildLogger.create(baseLogger, config.namespace, {
         all: {

--- a/azure/packages/test/scenario-runner/src/utils.ts
+++ b/azure/packages/test/scenario-runner/src/utils.ts
@@ -80,7 +80,7 @@ export async function createAzureClient(config: AzureClientConfig): Promise<Azur
     const connectionProps: AzureRemoteConnectionConfig | AzureLocalConnectionConfig = useAzure
         ? {
               tenantId,
-              tokenProvider: createAzureTokenProvider(fnUrl),
+              tokenProvider: createAzureTokenProvider(fnUrl, config.userId, config.userName),
               endpoint: config.connEndpoint,
               type: "remote",
           }

--- a/azure/packages/test/scenario-runner/testConfig.yml
+++ b/azure/packages/test/scenario-runner/testConfig.yml
@@ -6,8 +6,8 @@
         key1: SharedMap
         key2: SharedMap
     connectionConfig:
-      type: local
-      endpoint: http://localhost:7070
+      type: remote
+      endpoint: https://alfred.westus2.fluidrelay.azure.com
  stages:
   - stage-1:
     id: 1
@@ -20,25 +20,22 @@
     out: ${client}
   - stage-2:
     id: 2
-    name: Create empty document
+    name: Create empty documents
     package: doc-creator
     params:
       connectionConfig: ${connectionConfig}
       schema: ${schema}
-      numDocs: 1
-      clientStartDelayMs: 0
-    out: ${docId}
+      numDocs: 2
+      clientStartDelayMs: 10
+    out: ${docIds}
   - stage-3:
     id: 3
-    name: Create traffic on SharedMap
-    package: shared-map-traffic
+    name: Load documents
+    package: doc-loader
     params:
       connectionConfig: ${connectionConfig}
-      docId: ${docId}
       schema: ${schema}
-      numClients: 90
-      clientStartDelayMs: 100
-      writeRatePerMin: 120
-      sharedMapKey: key1
-      totalWriteCount: 60
+      docIds: ${docIds}
+      clientStartDelayMs: 10
+
 


### PR DESCRIPTION
Few additional improvements around scenario runner:

- Added doc loader stage that helps us inspect various loading aspects/metrics of container loader.
- Event transformation. Logger should be able to filter and transform telemetry events that are relevant to the stage. This is exploration only. We will likely adapt this logic as we land on structured telemetry relevant to external consumer.

As we further improve yaml syntax, we should be able to simplify some of this repetitive logic around stage kicking off series of clients at some specific interval.