### PR TITLE
[bump] eslint-config-fluid: 1.1.0 => 1.2.0 (minor)

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@fluidframework/eslint-config-fluid",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {


### PR DESCRIPTION
### Description

https://dev.azure.com/fluidframework/internal/_workitems/edit/2113/
ADO Pipeline: https://dev.azure.com/fluidframework/internal/_build/results?buildId=103129&view=results
Previous Related PR: https://dev.azure.com/fluidframework/internal/_workitems/edit/2113/

After publishing the minor release to npm, this PR bumps the version of `@fluidframework/eslint-config-fluid` in `package-lock.json` from `1.1.0` to `1.2.0`

### After this PR is Merged
Update all packages in the repo to use the newly published version by running `flub bump deps`