### PR TITLE
Catch and report op reentry

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -186,6 +186,8 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string): void;
     assertMatchNone(disallowedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string): void;
     // (undocumented)
+    assertMatchOnly(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string): void;
+    // (undocumented)
     clear(): void;
     // (undocumented)
     events: ITelemetryBaseEvent[];

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -258,7 +258,14 @@ export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> imp
             if (this.isActive() && currentClient === this.clientId) {
                 this.onNewTaskAssigned(key);
             } else {
-                await this.onTaskReassigned(key, currentClient);
+                // The call below mutates the consensusRegisterCollection in
+                // its event handler, which is not safe.
+                // We need to force this to be part of a different batch of ops by
+                // scheduling a microtask in order to work around the current validations.
+                // This is not recommended and should be avoided.
+                await Promise.resolve().then(async () => {
+                    await this.onTaskReassigned(key, currentClient);
+                });
             }
         });
 

--- a/packages/runtime/container-runtime/src/test/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/batchManager.spec.ts
@@ -4,11 +4,25 @@
  */
 
 import { strict as assert } from "assert";
+import {
+    ConfigTypes,
+    IConfigProviderBase,
+    loggerToMonitoringContext,
+    mixinMonitoringContext,
+    MockLogger,
+} from "@fluidframework/telemetry-utils";
 import { BatchManager, BatchMessage } from "../batchManager";
 
 describe("BatchManager", () => {
-    beforeEach(() => {
-    });
+    const configProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+        getRawConfig: (name: string): ConfigTypes => settings[name],
+    }));
+
+    const getMonitoringContext = (settings: Record<string, ConfigTypes>) =>
+        loggerToMonitoringContext(
+            mixinMonitoringContext(new MockLogger(), configProvider(settings)) as unknown as MockLogger);
+
+    const defaultMonitoringContext = getMonitoringContext({});
 
     const softLimit = 1024;
     const hardLimit = 950 * 1024;
@@ -19,7 +33,7 @@ describe("BatchManager", () => {
 
     it("BatchManager's soft limit: a bunch of small messages", () => {
         const message = { contents: generateStringOfSize(softLimit / 2) } as any as BatchMessage;
-        const batchManager = new BatchManager(hardLimit, softLimit);
+        const batchManager = new BatchManager(defaultMonitoringContext, hardLimit, softLimit);
 
         // Can push one large message
         assert.equal(batchManager.push(message), true);
@@ -47,7 +61,7 @@ describe("BatchManager", () => {
 
     it("BatchManager's soft limit: single large message", () => {
         const message = { contents: generateStringOfSize(softLimit * 2) } as any as BatchMessage;
-        const batchManager = new BatchManager(hardLimit, softLimit);
+        const batchManager = new BatchManager(defaultMonitoringContext, hardLimit, softLimit);
 
         // Can push one large message, even above soft limit
         assert.equal(batchManager.push(message), true);
@@ -70,7 +84,7 @@ describe("BatchManager", () => {
     });
 
     it("BatchManager: no soft limit", () => {
-        const batchManager = new BatchManager(hardLimit);
+        const batchManager = new BatchManager(defaultMonitoringContext, hardLimit);
         const third = Math.floor(hardLimit / 3) + 1;
         const message = { contents: generateStringOfSize(third) } as any as BatchMessage;
 
@@ -102,7 +116,7 @@ describe("BatchManager", () => {
     });
 
     it("BatchManager: soft limit is higher than hard limit", () => {
-        const batchManager = new BatchManager(hardLimit, hardLimit * 2);
+        const batchManager = new BatchManager(defaultMonitoringContext, hardLimit, hardLimit * 2);
         const twoThird = Math.floor(hardLimit * 2 / 3);
         const message = { contents: generateStringOfSize(twoThird) } as any as BatchMessage;
         const largeMessage = { contents: generateStringOfSize(hardLimit + 1) } as any as BatchMessage;
@@ -126,11 +140,27 @@ describe("BatchManager", () => {
 
     it("BatchManager: 'infinity' hard limit allows everything", () => {
         const message = { contents: generateStringOfSize(softLimit) } as any as BatchMessage;
-        const batchManager = new BatchManager(Infinity);
+        const batchManager = new BatchManager(defaultMonitoringContext, Infinity);
 
         for (let i = 1; i <= 10; i++) {
             assert.equal(batchManager.push(message), true);
             assert.equal(batchManager.length, i);
         }
+    });
+
+    it("Reports out-of-order messages within object lifetime limits", () => {
+        const mockLogger = new MockLogger();
+        const batchManager = new BatchManager(loggerToMonitoringContext(mockLogger), hardLimit);
+        const messageCount = 41;
+        for (let i = 0; i <= messageCount; i++) {
+            assert.equal(batchManager.push({ ...smallMessage, referenceSequenceNumber: i }), true);
+        }
+
+        // We expect only 30 events
+        mockLogger.assertMatchStrict(Array.from(Array(30).keys()).map((sequenceNumber) => ({
+            eventName: "Out of order message detected",
+            referenceSequenceNumber: 0,
+            messageReferenceSequenceNumber: sequenceNumber + 1,
+        })));
     });
 });

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -7,6 +7,7 @@ import assert from "assert";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { DataProcessingError } from "@fluidframework/container-utils";
+import { loggerToMonitoringContext, MockLogger } from "@fluidframework/telemetry-utils";
 import { PendingStateManager } from "../pendingStateManager";
 import { BatchManager, BatchMessage } from "../batchManager";
 
@@ -34,7 +35,7 @@ describe("Pending State Manager", () => {
             rollbackContent = [];
             rollbackShouldThrow = false;
 
-            batchManager = new BatchManager(950 * 1024);
+            batchManager = new BatchManager(loggerToMonitoringContext(new MockLogger()), 950 * 1024);
         });
 
         it("should do nothing when rolling back empty pending stack", () => {

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -94,6 +94,10 @@
   },
   "typeValidation": {
     "version": "2.0.0-internal.2.1.0",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_MockLogger": {
+          "forwardCompat": false
+        }
+      }
   }
 }

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -28,7 +28,7 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
      * events in order.
      * @param expectedEvents - events in order that are expected to appear in the recorded log.
      * These event objects may be subsets of the logged events.
-     * Note: category is ommitted from the type because it's usually uninteresting and tedious to type.
+     * Note: category is omitted from the type because it's usually uninteresting and tedious to type.
      */
     matchEvents(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): boolean {
         const matchedExpectedEventCount = this.getMatchedEventsCount(expectedEvents);
@@ -55,7 +55,7 @@ ${JSON.stringify(actualEvents)}`);
      * expected events.
      * @param expectedEvents - events that are expected to appear in the recorded log.
      * These event objects may be subsets of the logged events.
-     * Note: category is ommitted from the type because it's usually uninteresting and tedious to type.
+     * Note: category is omitted from the type because it's usually uninteresting and tedious to type.
      * @returns if any of the expected events is found.
      */
     matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): boolean {
@@ -73,7 +73,31 @@ ${JSON.stringify(expectedEvents)}
 
 actual:
 ${JSON.stringify(actualEvents)}`);
-            }
+        }
+    }
+
+    /**
+     * Search events logged since the last time matchEvents was called, looking only for the given expected
+     * events in order.
+     * @param expectedEvents - events in order that are expected to be the only events in the recorded log.
+     * These event objects may be subsets of the logged events.
+     * Note: category is omitted from the type because it's usually uninteresting and tedious to type.
+     */
+    matchEventStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): boolean {
+        return expectedEvents.length === this.events.length && this.matchEvents(expectedEvents);
+    }
+
+    /** Asserts that matchEvents is true, and prints the actual/expected output if not */
+    assertMatchStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
+        const actualEvents = this.events;
+        if (!this.matchEventStrict(expectedEvents)) {
+            throw new Error(`${message}
+expected:
+${JSON.stringify(expectedEvents)}
+
+actual:
+${JSON.stringify(actualEvents)}`);
+        }
     }
 
     /** Asserts that matchAnyEvent is false for the given events, and prints the actual/expected output if not */
@@ -86,7 +110,7 @@ ${JSON.stringify(disallowedEvents)}
 
 actual:
 ${JSON.stringify(actualEvents)}`);
-            }
+        }
     }
 
     private getMatchedEventsCount(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): number {

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.ts
@@ -695,6 +695,7 @@ declare function get_old_ClassDeclaration_MockLogger():
 declare function use_current_ClassDeclaration_MockLogger(
     use: TypeOnly<current.MockLogger>);
 use_current_ClassDeclaration_MockLogger(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockLogger());
 
 /*


### PR DESCRIPTION
ADO:1834

The idea is to catch instances of op reentry before https://github.com/microsoft/FluidFramework/pull/12326 reaches our customers. The log can be very noisy as this refers to ops, so I believe a handful (30) of events per object lifetime is enough for us to figure out if the pattern is in use, considering this change also adjusting the `AgentScheduler` to schedule the state change in a different batch within the event handler (that change was already done in `next`).

I will port this manually to `next` as there's a great chance of creating a merge conflict during the automatic integration.