### PR TITLE
Add retry rules on mongo side

### DIFF
--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -1,5 +1,12 @@
 > **Note:** These breaking changes are only relevant to the server packages and images released from `./routerlicious`.
 
+## 0.1038 Breaking Changes
+- [aggregate function from mongodb.ts become async](#aggregate-function-in-mongodb-ts-become-async)
+#### `aggregate` function in mongodb.ts become async
+Before: `const cursor = collection.aggregate([ ... ]);`
+
+Now: `const cursor = await collection.aggregate([ ... ]);`
+
 ## 0.1037 Breaking Changes
 - [IDeltaService added to alfred runnerFactory and resource](#IDeltaService-added-to-alfred-runnerFactory-and-resource)
 #### `IDeltaService` added to alfred `runnerFactory` and `resource`

--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -7,6 +7,7 @@ import {
     ICollection,
     IContext,
     IDocument,
+    isRetryAble,
     IScribe,
     ISequencedOperationMessage,
     runWithRetry,
@@ -18,6 +19,7 @@ import { ICheckpointManager } from "./interfaces";
  * MongoDB specific implementation of ICheckpointManager
  */
 export class CheckpointManager implements ICheckpointManager {
+    private readonly clientFacadeRetryEnabled: boolean;
     constructor(
         protected readonly context: IContext,
          private readonly tenantId: string,
@@ -25,6 +27,7 @@ export class CheckpointManager implements ICheckpointManager {
          private readonly documentCollection: ICollection<IDocument>,
          private readonly opCollection: ICollection<ISequencedOperationMessage>,
     ) {
+        this.clientFacadeRetryEnabled = isRetryAble(this.opCollection);
      }
 
     /**
@@ -54,7 +57,9 @@ export class CheckpointManager implements ICheckpointManager {
                 3 /* maxRetries */,
                 1000 /* retryAfterMs */,
                 getLumberBaseProperties(this.documentId, this.tenantId),
-                (error) => error.code === 11000 /* shouldIgnoreError */);
+                (error) => error.code === 11000 /* shouldIgnoreError */,
+                (error) => !this.clientFacadeRetryEnabled, /* shouldRetry */
+            );
         }
 
         // Write out the full state first that we require

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -12,6 +12,7 @@ import {
     ISequencedOperationMessage,
     SequencedOperationType,
     runWithRetry,
+    isRetryAble,
 } from "@fluidframework/server-services-core";
 import { getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
 
@@ -19,12 +20,14 @@ export class ScriptoriumLambda implements IPartitionLambda {
     private pending = new Map<string, ISequencedOperationMessage[]>();
     private pendingOffset: IQueuedMessage | undefined;
     private current = new Map<string, ISequencedOperationMessage[]>();
+    private readonly clientFacadeRetryEnabled: boolean;
 
     constructor(
         private readonly opCollection: ICollection<any>,
         protected context: IContext,
         protected readonly tenantId: string,
         protected readonly documentId: string) {
+        this.clientFacadeRetryEnabled = isRetryAble(this.opCollection);
     }
 
     public handler(message: IQueuedMessage) {
@@ -109,6 +112,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
             3 /* maxRetries */,
             1000 /* retryAfterMs */,
             getLumberBaseProperties(this.documentId, this.tenantId),
-            (error) => error.code === 11000 /* shouldIgnoreError */);
+            (error) => error.code === 11000,
+            (error) => !this.clientFacadeRetryEnabled, /* shouldRetry */
+        );
     }
 }

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -140,6 +140,14 @@ export interface ICollection<T> {
     createTTLIndex?(index: any, mongoExpireAfterSeconds?: number): Promise<void>;
 }
 
+export interface IRetryAble {
+    retryEnabled: boolean;
+}
+
+export function isRetryAble<T>(collection: ICollection<T>): collection is ICollection<T> {
+    return "retryEnabled" in collection;
+}
+
 export type IDbEvents = "close" | "reconnect" | "error" | "reconnectFailed";
 
 export interface IDb {

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -22,7 +22,7 @@ export {
 	IServerConfiguration,
 	IServiceConfiguration,
 } from "./configuration";
-export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory } from "./database";
+export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory, IRetryAble, isRetryAble } from "./database";
 export { IDeltaService } from "./delta";
 export { IClientSequenceNumber, IDeliState, IDocument, IDocumentDetails, IDocumentStorage, IScribe } from "./document";
 export { EmptyTaskMessageSender } from "./emptyTaskMessageSender";

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -21,9 +21,10 @@ export async function deleteSummarizedOps(
             return Promise.reject(error);
         }
 
-        const uniqueDocuments = await documentsCollection.aggregate([
+    const uniqueDocumentsCursor = await documentsCollection.aggregate([
             { $group: { _id: { documentId: "$documentId", tenantId: "$tenantId" } } },
-        ]).toArray();
+    ]);
+    const uniqueDocuments = await uniqueDocumentsCursor.toArray();
 
         const currentEpochTime = new Date().getTime();
         const epochTimeBeforeOfflineWindow = currentEpochTime - offlineWindowMs;

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface IMongoExceptionRetryRule {
+	match: (error: any) => boolean;
+	shouldRetry: boolean;
+}

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { IMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
+
+export class DefaultExceptionRule implements IMongoExceptionRetryRule {
+	match(error: any): boolean {
+		Lumberjack.error("DefaultRule.match() called for unknown error", undefined, error);
+		return true;
+	}
+
+	shouldRetry: boolean = false;
+}

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { MongoErrorRetryAnalyzer } from "./mongoErrorRetryAnalyzer";

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -1,0 +1,172 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
+class InternalErrorRule implements IMongoExceptionRetryRule {
+    private static readonly codeName = "InternalError";
+    match(error: any): boolean {
+        return error.code === 1
+            && error.codeName
+            && (error.codeName as string) === InternalErrorRule.codeName;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// This handles the requested queued on client side buffer overflow. Should relies on reconnect instead of retry?
+class NoConnectionAvailableRule implements IMongoExceptionRetryRule {
+    private static readonly messagePrefix = "no connection available for operation and number of stored operation";
+    match(error: any): boolean {
+        // TODO: This timed out actually included two different messages:
+        // 1. Retries due to rate limiting: False.
+        // 2. Retries due to rate limiting: True.
+        // We might need to split this into two different rules after consult with DB team.
+        return error.message
+            && (error.message as string).startsWith(NoConnectionAvailableRule.messagePrefix);
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// This handles the no primary found in replicaset or invalid replica set name from client
+// Should not retry but relays on reconnect.
+class NoPrimaryInReplicasetRule implements IMongoExceptionRetryRule {
+    private static readonly message = "no primary found in replicaset or invalid replica set name";
+    match(error: any): boolean {
+        // TODO: This timed out actually included two different messages:
+        // 1. Retries due to rate limiting: False.
+        // 2. Retries due to rate limiting: True.
+        // We might need to split this into two different rules after consult with DB team.
+        return error.message
+            && (error.message as string) === NoPrimaryInReplicasetRule.message;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// this handles the pool destroyed error from client side. Should relies on reconnect instead of retry?
+class PoolDestroyedRule implements IMongoExceptionRetryRule {
+    private static readonly message1 = "pool destroyed";
+    private static readonly message2 = "server instance pool was destroyed";
+    match(error: any): boolean {
+        return error.code === 16
+            && error.message
+            && ((error.message as string) === PoolDestroyedRule.message1
+                || (error.message as string) === PoolDestroyedRule.message2);
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// this handles the case where the request payload is too large from server.
+class RequestSizeLargeRule implements IMongoExceptionRetryRule {
+    private static readonly errorMsgPrefix =
+        "Error=16, Details='Response status code does not indicate success: RequestEntityTooLarge (413)";
+    match(error: any): boolean {
+        return error.code === 16
+            && error.errmsg
+            && (error.errmsg as string).startsWith(RequestSizeLargeRule.errorMsgPrefix);
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// This handles request timeout from server without additional rate limit info.
+class RequestTimedNoRateLimitInfo implements IMongoExceptionRetryRule {
+    private static readonly errmsg = "Request timed out.";
+    match(error: any): boolean {
+        return error.code === 50
+            && error.errmsg
+            && (error.errmsg as string) === RequestTimedNoRateLimitInfo.errmsg;
+    }
+
+    shouldRetry: boolean = true;
+}
+
+// This handles request timeout from server with http info.
+class RequestTimedOutWithHttpInfo implements IMongoExceptionRetryRule {
+    private static readonly errmsgPrefix =
+        "Error=50, Details='Response status code does not indicate success: RequestTimeout (408);";
+    match(error: any): boolean {
+        return error.code === 50
+            && error.errmsg
+            && (error.errmsg as string).startsWith(RequestTimedOutWithHttpInfo.errmsgPrefix);
+    }
+
+    shouldRetry: boolean = true;
+}
+
+// This handles request timeout from server with additional rate limit info.
+class RequestTimedOutWithRateLimit implements IMongoExceptionRetryRule {
+    private static readonly codeName = "ExceededTimeLimit";
+    match(error: any): boolean {
+        // TODO: This timed out actually included two different messages:
+        // 1. Retries due to rate limiting: False.
+        // 2. Retries due to rate limiting: True.
+        // We might need to split this into two different rules after consult with DB team.
+        return error.code === 50
+            && error.errmsg
+            && (error.errmsg as string) === RequestTimedOutWithRateLimit.codeName;
+    }
+    shouldRetry: boolean = true;
+}
+
+// This handles server side temporary 503 issue
+class ServiceUnavailableRule implements IMongoExceptionRetryRule {
+    private static readonly errorDetails = "Response status code does not indicate success: ServiceUnavailable (503)";
+    match(error: any): boolean {
+        return error.code === 50
+            && error.errorDetails
+            && (error.errorDetails as string).includes(ServiceUnavailableRule.errorDetails);
+    }
+
+    shouldRetry: boolean = true;
+}
+
+// this handles the pool destroyed error from client side. Should relies on reconnect instead of retry?
+class TopologyDestroyed implements IMongoExceptionRetryRule {
+    private static readonly message = "Topology was destroyed";
+    match(error: any): boolean {
+        return error.code === 16
+            && error.message
+            && (error.message as string) === TopologyDestroyed.message;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// this handles the incorrect credentials set. Should not retry
+class UnUnauthorizedRule implements IMongoExceptionRetryRule {
+    private static readonly codeName = "Unauthorized";
+    match(error: any): boolean {
+        return error.code === 13
+            && error.codeName
+            && (error.codeName as string) === UnUnauthorizedRule.codeName;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// Maintain the list from more strick faster comparison to less strict slower comparison
+export const mongoErrorRetryRuleset: IMongoExceptionRetryRule[] = [
+    // The rules are using exactly equal
+    new InternalErrorRule(),
+    new NoPrimaryInReplicasetRule(),
+    new RequestTimedNoRateLimitInfo(),
+    new RequestTimedOutWithRateLimit(),
+    new TopologyDestroyed(),
+    new UnUnauthorizedRule(),
+
+    // The rules are using multiple compare
+    new PoolDestroyedRule(),
+
+    // The rules are using string startWith
+    new NoConnectionAvailableRule(),
+    new RequestSizeLargeRule(),
+    new RequestTimedOutWithHttpInfo(),
+
+    // The rules are using string contains
+    new ServiceUnavailableRule(),
+];

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { DefaultExceptionRule } from "./defaultExceptionRule";
+import { IMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
+import { mongoErrorRetryRuleset } from "./mongoError";
+import { mongoNetworkErrorRetryRuleset } from "./mongoNetworkError";
+
+export const MongoErrorRetryAnalyzer = {
+    shouldRetry(error: Error): boolean {
+        const rule = MongoErrorRetryAnalyzer.getRetryRule(error);
+        if (!rule) {
+            // This should not happen.
+            Lumberjack.error("MongoErrorRetryAnalyzer.shouldRetry() didn't get a rule", undefined, error);
+            return false;
+        }
+
+        return rule.shouldRetry;
+    },
+
+    getRetryRule(error: Error): IMongoExceptionRetryRule {
+        if (error.name === "MongoNetworkError") {
+            return MongoErrorRetryAnalyzer.getRetryRuleFromSet(error, mongoNetworkErrorRetryRuleset);
+        }
+
+        if (error.name === "MongoError") {
+            return MongoErrorRetryAnalyzer.getRetryRuleFromSet(error, mongoErrorRetryRuleset);
+        }
+
+        return new DefaultExceptionRule();
+    },
+
+    getRetryRuleFromSet(error: any, ruleSet: IMongoExceptionRetryRule[]): IMongoExceptionRetryRule {
+        const resultRule = ruleSet.find((rule) => rule.match(error)) || new DefaultExceptionRule();
+        Lumberjack.info(`Error rule used ${resultRule.constructor.name}, shouldRetry: ${resultRule.shouldRetry}`);
+        return ruleSet.find((rule) => rule.match(error)) || new DefaultExceptionRule();
+    },
+};

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
+
+class MongoNetworkTransientTransactionError implements IMongoExceptionRetryRule {
+    match(error: any): boolean {
+        return error.errorLabels?.length && (error.errorLabels as string[]).includes("TransientTransactionError");
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// Maintain the list from more strick faster comparison to less strict slower comparison
+export const mongoNetworkErrorRetryRuleset: IMongoExceptionRetryRule[] = [
+    new MongoNetworkTransientTransactionError(),
+];


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

For specific guidelines for Pull Requests in this repo, visit [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description
Add retry logic to different kind of mongo exceptions.


## Reviewer Guidance

I divided the the mongo exceptions into a known list, and based on analysis, decide to retry or not. Inject the logics together into analyzer and mongo facade we are using to make code more configurable and organizable.

## Does this introduce a breaking change?

No

## Any relevant logs or outputs

Not yet, draft PR

## Other information or known dependencies

na
