### PR TITLE
feat(build-cli): Add handler exclusion and listing to check policy command

### DIFF
--- a/build-tools/packages/build-cli/docs/check.md
+++ b/build-tools/packages/build-cli/docs/check.md
@@ -36,13 +36,13 @@ USAGE
 FLAGS
   -D, --excludeHandler=<value>...  Exclude handler by name. Can be specified multiple times to exclude multiple
                                    handlers.
-  -d, --handler=<value>            Filter handler names by <regex>
-  -e, --exclusions=<value>         (required) Path to the exclusions.json file
-  -f, --fix                        Fix errors if possible
-  -p, --path=<value>               Filter file paths by <regex>
+  -d, --handler=<value>            Filter handler names by <regex>.
+  -e, --exclusions=<value>         (required) Path to the exclusions.json file.
+  -f, --fix                        Fix errors if possible.
+  -p, --path=<value>               Filter file paths by <regex>.
   -v, --verbose                    Verbose logging.
   --listHandlers                   List all policy handlers by name.
-  --stdin                          Get file from stdin
+  --stdin                          Read list of files from stdin.
 
 DESCRIPTION
   Checks and applies policies to the files in the repository, such as ensuring a consistent header comment in files,

--- a/build-tools/packages/build-cli/docs/check.md
+++ b/build-tools/packages/build-cli/docs/check.md
@@ -31,15 +31,18 @@ Checks and applies policies to the files in the repository, such as ensuring a c
 
 ```
 USAGE
-  $ flub check policy -e <value> [-f] [-d <value>] [-p <value>] [--stdin] [-v]
+  $ flub check policy -e <value> [-D <value> | -d <value>] [--listHandlers | --stdin | -p <value> | -f | ] [-v]
 
 FLAGS
-  -d, --handler=<value>     Filter handler names by <regex>
-  -e, --exclusions=<value>  (required) Path to the exclusions.json file
-  -f, --fix                 Fix errors if possible
-  -p, --path=<value>        Filter file paths by <regex>
-  -v, --verbose             Verbose logging.
-  --stdin                   Get file from stdin
+  -D, --excludeHandler=<value>...  Exclude handler by name. Can be specified multiple times to exclude multiple
+                                   handlers.
+  -d, --handler=<value>            Filter handler names by <regex>
+  -e, --exclusions=<value>         (required) Path to the exclusions.json file
+  -f, --fix                        Fix errors if possible
+  -p, --path=<value>               Filter file paths by <regex>
+  -v, --verbose                    Verbose logging.
+  --listHandlers                   List all policy handlers by name.
+  --stdin                          Get file from stdin
 
 DESCRIPTION
   Checks and applies policies to the files in the repository, such as ensuring a consistent header comment in files,

--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -8,7 +8,7 @@ import * as fs from "fs";
 import { EOL as newline } from "os";
 import path from "path";
 
-import { policyHandlers, readJsonAsync } from "@fluidframework/build-tools";
+import { Handler, policyHandlers, readJsonAsync } from "@fluidframework/build-tools";
 
 import { BaseCommand } from "../../base";
 
@@ -59,6 +59,12 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
             required: false,
             char: "d",
         }),
+        excludeHandler: Flags.string({
+            char: "D",
+            description: `Exclude handler by name. Can be specified multiple times to exclude multiple handlers.`,
+            exclusive: ["handler"],
+            multiple: true,
+        }),
         path: Flags.string({
             description: `Filter file paths by <regex>`,
             required: false,
@@ -74,6 +80,11 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
             description: `Get file from stdin`,
             required: false,
         }),
+        listHandlers: Flags.boolean({
+            description: `List all policy handlers by name.`,
+            required: false,
+            exclusive: ["stdin", "path", "fix", "handler"],
+        }),
         ...BaseCommand.flags,
     };
 
@@ -83,6 +94,29 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
     static pathToGitRoot = "";
 
     async run() {
+        const handlersToRun: Handler[] = policyHandlers.filter(
+            (h) => {
+                const shouldRun = !this.processedFlags.excludeHandler?.includes(h.name);
+                if(!shouldRun) {
+                    this.info(`Excluding handler: ${h.name}`);
+                }
+                return shouldRun;
+            }
+        );
+
+        // list the handlers then exit
+        if (this.processedFlags.listHandlers) {
+            for (const h of handlersToRun) {
+                this.log(
+                    `${h.name}\nresolver: ${h.resolver !== undefined} finalHandler: ${
+                        h.final !== undefined
+                    }\n`,
+                );
+            }
+            this.log(`${handlersToRun.length} TOTAL POLICY HANDLERS`);
+            this.exit(0);
+        }
+
         const handlerRegex: RegExp =
             this.processedFlags.handler === undefined
                 ? /.?/
@@ -126,10 +160,20 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
                     pipeString
                         .split("\n")
                         .map((line: string) =>
-                            this.handleLine(line, handlerRegex, pathRegex, exclusions),
+                            this.handleLine(
+                                line,
+                                handlerRegex,
+                                pathRegex,
+                                exclusions,
+                                handlersToRun,
+                            ),
                         );
                 } finally {
-                    this.onExit();
+                    try {
+                        runPolicyCheck(handlersToRun, this.processedFlags.fix);
+                    } finally {
+                        this.logStats();
+                    }
                 }
             }
 
@@ -156,26 +200,22 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
                 scriptOutput
                     .split("\n")
                     .map((line: string) =>
-                        this.handleLine(line, handlerRegex, pathRegex, exclusions),
+                        this.handleLine(line, handlerRegex, pathRegex, exclusions, handlersToRun),
                     );
             } finally {
-                this.onExit();
+                try {
+                    runPolicyCheck(handlersToRun, this.processedFlags.fix);
+                } finally {
+                    this.logStats();
+                }
             }
         });
     }
 
-    onExit() {
-        try {
-            runPolicyCheck(this.processedFlags.fix);
-        } finally {
-            this.logStats();
-        }
-    }
-
     // route files to their handlers by regex testing their full paths
     // synchronize output, exit code, and resolve decision for all handlers
-    routeToHandlers(file: string, handlerRegex: RegExp): void {
-        policyHandlers
+    routeToHandlers(file: string, handlerRegex: RegExp, handlers: Handler[]): void {
+        handlers
             .filter((handler) => handler.match.test(file) && handlerRegex.test(handler.name))
             // eslint-disable-next-line unicorn/no-array-for-each
             .forEach((handler) => {
@@ -225,7 +265,13 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
         }
     }
 
-    handleLine(line: string, handlerRegex: RegExp, pathRegex: RegExp, exclusions: RegExp[]) {
+    handleLine(
+        line: string,
+        handlerRegex: RegExp,
+        pathRegex: RegExp,
+        exclusions: RegExp[],
+        handlers: Handler[],
+    ) {
         const filePath = path.join(CheckPolicy.pathToGitRoot, line).trim().replace(/\\/g, "/");
 
         if (!pathRegex.test(line) || !fs.existsSync(filePath)) {
@@ -239,7 +285,7 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
         }
 
         try {
-            this.routeToHandlers(filePath, handlerRegex);
+            this.routeToHandlers(filePath, handlerRegex, handlers);
         } catch {
             throw new Error("Line error");
         }
@@ -261,8 +307,8 @@ function runWithPerf<T>(name: string, action: policyAction, run: () => T): T {
     return result;
 }
 
-function runPolicyCheck(fix: boolean) {
-    for (const h of policyHandlers) {
+function runPolicyCheck(handlers: Handler[], fix: boolean) {
+    for (const h of handlers) {
         const final = h.final;
         if (final) {
             const result = runWithPerf(h.name, "final", () =>

--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -94,15 +94,13 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
     static pathToGitRoot = "";
 
     async run() {
-        const handlersToRun: Handler[] = policyHandlers.filter(
-            (h) => {
-                const shouldRun = !this.processedFlags.excludeHandler?.includes(h.name);
-                if(!shouldRun) {
-                    this.info(`Excluding handler: ${h.name}`);
-                }
-                return shouldRun;
+        const handlersToRun: Handler[] = policyHandlers.filter((h) => {
+            const shouldRun = !this.processedFlags.excludeHandler?.includes(h.name);
+            if (!shouldRun) {
+                this.info(`Excluding handler: ${h.name}`);
             }
-        );
+            return shouldRun;
+        });
 
         // list the handlers then exit
         if (this.processedFlags.listHandlers) {

--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -50,12 +50,12 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
 
     static flags = {
         fix: Flags.boolean({
-            description: `Fix errors if possible`,
+            description: `Fix errors if possible.`,
             required: false,
             char: "f",
         }),
         handler: Flags.string({
-            description: `Filter handler names by <regex>`,
+            description: `Filter handler names by <regex>.`,
             required: false,
             char: "d",
         }),
@@ -66,18 +66,18 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy.flags> {
             multiple: true,
         }),
         path: Flags.string({
-            description: `Filter file paths by <regex>`,
+            description: `Filter file paths by <regex>.`,
             required: false,
             char: "p",
         }),
         exclusions: Flags.file({
-            description: `Path to the exclusions.json file`,
+            description: `Path to the exclusions.json file.`,
             exists: true,
             required: true,
             char: "e",
         }),
         stdin: Flags.boolean({
-            description: `Get file from stdin`,
+            description: `Read list of files from stdin.`,
             required: false,
         }),
         listHandlers: Flags.boolean({


### PR DESCRIPTION
Adds an `--excludeHandler` flag to the `check policy` command that can be used to exclude one or more handlers by name. The main use-case for this is to run policy check with or without the assert-shortcodes handler more easily. Technically it's possible to exclude a single handler using the regex argument, but this is much simpler.

Also, there is a new `--listHandlers` flag that will list all the handlers including their names, so one can now query the system for handlers, then exclude those handlers by name easily. 