### PR TITLE
[bump] build-tools: 0.4.9000 => 0.5.0 (minor)

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/**"
   ],
-  "version": "0.4.9000"
+  "version": "0.5.0"
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/build-cli",
-  "version": "0.4.9000",
+  "version": "0.5.0",
   "description": "Build tools for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {
@@ -70,9 +70,9 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluid-tools/version-tools": "^0.4.9000",
-    "@fluidframework/build-tools": "^0.4.9000",
-    "@fluidframework/bundle-size-tools": "^0.4.9000",
+    "@fluid-tools/version-tools": "^0.5.0",
+    "@fluidframework/build-tools": "^0.5.0",
+    "@fluidframework/bundle-size-tools": "^0.5.0",
     "@oclif/core": "^1.9.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",

--- a/build-tools/packages/build-cli/src/packageVersion.ts
+++ b/build-tools/packages/build-cli/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/build-cli";
-export const pkgVersion = "0.4.9000";
+export const pkgVersion = "0.5.0";

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/build-tools",
-  "version": "0.4.9000",
+  "version": "0.5.0",
   "description": "Fluid Build tools",
   "homepage": "https://fluidframework.com",
   "repository": {
@@ -52,8 +52,8 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluid-tools/version-tools": "^0.4.9000",
-    "@fluidframework/bundle-size-tools": "^0.4.9000",
+    "@fluid-tools/version-tools": "^0.5.0",
+    "@fluidframework/bundle-size-tools": "^0.5.0",
     "async": "^3.2.0",
     "chalk": "^2.4.2",
     "commander": "^6.2.1",

--- a/build-tools/packages/build-tools/src/packageVersion.ts
+++ b/build-tools/packages/build-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/build-tools";
-export const pkgVersion = "0.4.9000";
+export const pkgVersion = "0.5.0";

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/bundle-size-tools",
-  "version": "0.4.9000",
+  "version": "0.5.0",
   "description": "Utility for analyzing bundle size regressions",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/build-tools/packages/bundle-size-tools/src/packageVersion.ts
+++ b/build-tools/packages/bundle-size-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/bundle-size-tools";
-export const pkgVersion = "0.4.9000";
+export const pkgVersion = "0.5.0";

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/version-tools",
-  "version": "0.4.9000",
+  "version": "0.5.0",
   "description": "Versioning tools for Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/build-tools/packages/version-tools/src/packageVersion.ts
+++ b/build-tools/packages/version-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/version-tools";
-export const pkgVersion = "0.4.9000";
+export const pkgVersion = "0.5.0";


### PR DESCRIPTION
Bumped build-tools from 0.4.9000 to 0.5.0. This also switches build-tools back to standard semver versions instead of our "virtualPatch" format. That format was useful when developing the build-tools themselves to handle various version styles, but that is no longer the case.

Command used:

```shell
flub bump build-tools -t minor --no-install --scheme semver
```