### PR TITLE
fix(build-cli): Exclude independent packages when bumping release groups

### DIFF
--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -58,9 +58,9 @@ Update the dependency version of a specified package or release group. That is, 
 
 ```
 USAGE
-  $ flub bump deps [PACKAGE_OR_RELEASE_GROUP] [-p -t latest|newest|greatest|minor|patch|@next|@canary]
-    [--onlyBumpPrerelease] [-g client|server|azure|build-tools | --package <value>] [-x | --install | --commit |  |  | ]
-    [-v]
+  $ flub bump deps [PACKAGE_OR_RELEASE_GROUP] [--prerelease -t
+    latest|newest|greatest|minor|patch|@next|@canary] [--onlyBumpPrerelease] [-g client|server|azure|build-tools | -p
+    <value>] [-x | --install | --commit |  |  | ] [-v]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
@@ -68,7 +68,7 @@ ARGUMENTS
 FLAGS
   -g, --releaseGroup=<option>  Only bump dependencies within this release group.
                                <options: client|server|azure|build-tools>
-  -p, --prerelease             Treat prerelease versions as valid versions to update to.
+  -p, --package=<value>        Only bump dependencies of this package.
   -t, --updateType=<option>    [default: minor] Bump the current version of the dependency according to this bump type.
                                <options: latest|newest|greatest|minor|patch|@next|@canary>
   -v, --verbose                Verbose logging.
@@ -76,7 +76,7 @@ FLAGS
   --[no-]commit                Commit changes to a new branch.
   --[no-]install               Update lockfiles by running 'npm install' automatically.
   --onlyBumpPrerelease         Only bump dependencies that are on pre-release versions.
-  --package=<value>            Only bump dependencies of this package.
+  --prerelease                 Treat prerelease versions as valid versions to update to.
 
 DESCRIPTION
   Update the dependency version of a specified package or release group. That is, if one or more packages in the repo

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -59,7 +59,8 @@ Update the dependency version of a specified package or release group. That is, 
 ```
 USAGE
   $ flub bump deps [PACKAGE_OR_RELEASE_GROUP] [-p -t latest|newest|greatest|minor|patch|@next|@canary]
-    [--onlyBumpPrerelease] [-g client|server|azure|build-tools] [-x | --install | --commit |  |  | ] [-v]
+    [--onlyBumpPrerelease] [-g client|server|azure|build-tools | --package <value>] [-x | --install | --commit |  |  | ]
+    [-v]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
@@ -68,13 +69,14 @@ FLAGS
   -g, --releaseGroup=<option>  Only bump dependencies within this release group.
                                <options: client|server|azure|build-tools>
   -p, --prerelease             Treat prerelease versions as valid versions to update to.
-  -t, --updateType=<option>    Bump the current version of the dependency according to this bump type.
+  -t, --updateType=<option>    [default: minor] Bump the current version of the dependency according to this bump type.
                                <options: latest|newest|greatest|minor|patch|@next|@canary>
   -v, --verbose                Verbose logging.
   -x, --skipChecks             Skip all checks.
   --[no-]commit                Commit changes to a new branch.
   --[no-]install               Update lockfiles by running 'npm install' automatically.
   --onlyBumpPrerelease         Only bump dependencies that are on pre-release versions.
+  --package=<value>            Only bump dependencies of this package.
 
 DESCRIPTION
   Update the dependency version of a specified package or release group. That is, if one or more packages in the repo

--- a/build-tools/packages/build-cli/src/commands/bump/deps.ts
+++ b/build-tools/packages/build-cli/src/commands/bump/deps.ts
@@ -49,7 +49,6 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand.flags> {
             default: "minor",
         }),
         prerelease: Flags.boolean({
-            char: "p",
             dependsOn: ["updateType"],
             description: "Treat prerelease versions as valid versions to update to.",
         }),
@@ -61,7 +60,6 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand.flags> {
             exclusive: ["package"],
         }),
         package: packageSelectorFlag({
-            char: undefined,
             description: "Only bump dependencies of this package.",
             exclusive: ["releaseGroup"],
         }),

--- a/build-tools/packages/build-cli/src/commands/bump/deps.ts
+++ b/build-tools/packages/build-cli/src/commands/bump/deps.ts
@@ -11,7 +11,13 @@ import { FluidRepo } from "@fluidframework/build-tools";
 
 import { packageOrReleaseGroupArg } from "../../args";
 import { BaseCommand } from "../../base";
-import { checkFlags, dependencyUpdateTypeFlag, releaseGroupFlag, skipCheckFlag } from "../../flags";
+import {
+    checkFlags,
+    dependencyUpdateTypeFlag,
+    packageSelectorFlag,
+    releaseGroupFlag,
+    skipCheckFlag,
+} from "../../flags";
 import {
     generateBumpDepsBranchName,
     generateBumpDepsCommitMessage,
@@ -40,6 +46,7 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand.flags> {
         updateType: dependencyUpdateTypeFlag({
             char: "t",
             description: "Bump the current version of the dependency according to this bump type.",
+            default: "minor",
         }),
         prerelease: Flags.boolean({
             char: "p",
@@ -51,6 +58,12 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand.flags> {
         }),
         releaseGroup: releaseGroupFlag({
             description: "Only bump dependencies within this release group.",
+            exclusive: ["package"],
+        }),
+        package: packageSelectorFlag({
+            char: undefined,
+            description: "Only bump dependencies of this package.",
+            exclusive: ["releaseGroup"],
         }),
         commit: checkFlags.commit,
         install: checkFlags.install,
@@ -103,11 +116,6 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand.flags> {
         }
 
         /**
-         * The version range or bump type (depending on the CLI arguments) to set.
-         */
-        const versionToSet = flags.updateType ?? "current";
-
-        /**
          * A list of package names on which to update dependencies.
          */
         const depsToUpdate: string[] = [];
@@ -137,9 +145,11 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand.flags> {
 
         this.logHr();
         this.log(`Dependencies: ${chalk.blue(args.package_or_release_group)}`);
-        this.log(`Packages: ${chalk.blueBright(flags.releaseGroup ?? "all packages")}`);
+        this.log(
+            `Packages: ${chalk.blueBright(flags.releaseGroup ?? flags.package ?? "all packages")}`,
+        );
         this.log(`Prerelease: ${flags.prerelease ? chalk.green("yes") : "no"}`);
-        this.log(`Bump type: ${chalk.bold(versionToSet)}`);
+        this.log(`Bump type: ${chalk.bold(flags.updateType ?? "unknown")}`);
         this.logHr();
         this.log("");
 
@@ -149,7 +159,7 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand.flags> {
 
         const { updatedPackages, updatedDependencies } = await npmCheckUpdates(
             context,
-            flags.releaseGroup, // if undefined the whole repo will be checked
+            flags.releaseGroup ?? flags.package, // if undefined the whole repo will be checked
             depsToUpdate,
             args.package_or_release_group,
             flags.updateType,

--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -81,7 +81,7 @@ export async function npmCheckUpdates(
 
     const packagesToCheck =
         releaseGroup === undefined // run on the whole repo
-            ? [...context.independentPackages] // include ll independent packages
+            ? [...context.independentPackages] // include all independent packages
             : isReleaseGroup(releaseGroup)
             ? [] // run on a release group so no independent packages should be included
             : [context.fullPackageMap.get(releaseGroup)]; // the releaseGroup argument must be a package

--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -70,30 +70,23 @@ export async function npmCheckUpdates(
     // There can be a lot of duplicate log lines from npm-check-updates, so collect and dedupe before logging.
     const upgradeLogLines = new Set<string>();
     const searchGlobs: string[] = [];
-    let repoPath: string;
+    const repoPath = context.repo.resolvedRoot;
 
     const releaseGroupsToCheck =
-        releaseGroup === undefined
+        releaseGroup === undefined // run on the whole repo
             ? [...context.repo.releaseGroups.keys()]
-            : isReleaseGroup(releaseGroup)
+            : isReleaseGroup(releaseGroup) // run on just this release group
             ? [releaseGroup]
             : undefined;
 
-    const packagesToCheck = isReleaseGroup(releaseGroup) ? undefined : releaseGroup;
+    const packagesToCheck =
+        releaseGroup === undefined // run on the whole repo
+            ? [...context.independentPackages] // include ll independent packages
+            : isReleaseGroup(releaseGroup)
+            ? [] // run on a release group so no independent packages should be included
+            : [context.fullPackageMap.get(releaseGroup)]; // the releaseGroup argument must be a package
 
-    // Run on the whole repo
-    if (releaseGroupsToCheck === undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const pkg = context.fullPackageMap.get(releaseGroup!);
-        if (pkg === undefined) {
-            throw new Error(`Package not found in context: ${releaseGroup}`);
-        }
-
-        repoPath = pkg.directory;
-        searchGlobs.push(pkg.directory);
-    } else {
-        repoPath = context.repo.resolvedRoot;
-
+    if (releaseGroupsToCheck !== undefined) {
         for (const group of releaseGroupsToCheck) {
             if (group === releaseGroupFilter) {
                 log?.verbose(
@@ -113,21 +106,19 @@ export async function npmCheckUpdates(
 
             searchGlobs.push(
                 ...releaseGroupRoot.workspaceGlobs.map((g) =>
-                    path.join(
-                        path.relative(context.repo.resolvedRoot, releaseGroupRoot.repoPath),
-                        g,
-                    ),
+                    path.join(path.relative(repoPath, releaseGroupRoot.repoPath), g),
                 ),
                 // Includes the root package.json, in case there are deps there that also need upgrade.
-                // path.join(releaseGroupRoot.repoPath, "package.json"),
-                path.relative(context.repo.resolvedRoot, releaseGroupRoot.repoPath),
+                path.relative(repoPath, releaseGroupRoot.repoPath),
             );
         }
     }
 
-    if (packagesToCheck === undefined) {
-        for (const pkg of context.independentPackages) {
-            searchGlobs.push(path.relative(context.repo.resolvedRoot, pkg.directory));
+    if (packagesToCheck !== undefined) {
+        for (const pkg of packagesToCheck) {
+            if (pkg !== undefined) {
+                searchGlobs.push(path.relative(repoPath, pkg.directory));
+            }
         }
     }
 


### PR DESCRIPTION
When bumping deps scoped to a single release group, the `bump deps` tool was including independent
packages. This change corrects that behavior so that only the release group specified will be
updated.

BREAKING CHANGE: The `-p` flag has been changed to specify a package name, which is consistent with
other commands. Use `--prerelease` to replace former uses of `-p`.

[AB#2245](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2245)