### PR TITLE
Emit events on failed reverts for legacy SharedTree

### DIFF
--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -1519,7 +1519,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * @internal
 	 */
 	public revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined {
-		return revert(changes as unknown as readonly ChangeInternal[], before, this.logger);
+		return revert(changes as unknown as readonly ChangeInternal[], before, this.logger, this.emit.bind(this));
 	}
 
 	/**


### PR DESCRIPTION
- Allow an event emitter to be passed into `revert`
- Check emitted events in HistoryEditFactory tests