### PR TITLE
docs: Update API docs on Handle types

### DIFF
--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -124,7 +124,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     waitAttached(): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export class FluidObjectHandle<T extends FluidObject = FluidObject> implements IFluidHandle {
     constructor(value: T | Promise<T>, path: string, routeContext: IFluidHandleContext);
     // (undocumented)

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -14,7 +14,7 @@ export interface IProvideFluidHandleContext {
 }
 
 /**
- * An IFluidHandleContext describes a routing context from which other IFluidHandleContexts are defined
+ * Describes a routing context from which other `IFluidHandleContext`s are defined.
  */
 export interface IFluidHandleContext extends IProvideFluidHandleContext {
     /**
@@ -48,7 +48,7 @@ export interface IProvideFluidHandle {
 }
 
 /**
- * Handle to a shared FluidObject
+ * Handle to a shared {@link FluidObject}.
  */
 export interface IFluidHandle<
     // REVIEW: Constrain `T` to something? How do we support dds and datastores safely?

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -3,19 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import {
-    IFluidHandleContext,
-} from "@fluidframework/core-interfaces";
+import { IFluidHandleContext } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle } from "@fluidframework/datastore";
 import { ISharedObject } from "./types";
 
 /**
- * Handle for shared object
- * This object is used for already loaded (in-memory) shared object
- * and is used only for serialization purposes.
- * De-serialization process goes through FluidObjectHandle and request flow:
- * FluidDataStoreRuntime.request() recognizes requests in the form of '/\<shared object id\>'
- * and loads shared object.
+ * Handle for a shared object.
+ *
+ * @remarks
+ *
+ * This object is used for already loaded (in-memory) shared objects and is used only for serialization purposes.
+ *
+ * De-serialization process goes through {@link @fluidframework/datastore#FluidObjectHandle}, and request flow:
+ * {@link @fluidframework/datastore#FluidDataStoreRuntime.request} recognizes requests in the form of
+ * '/\<shared object id\>' and loads shared object.
  */
 export class SharedObjectHandle extends FluidObjectHandle<ISharedObject> {
     /**
@@ -29,7 +30,8 @@ export class SharedObjectHandle extends FluidObjectHandle<ISharedObject> {
      * Creates a new SharedObjectHandle.
      * @param value - The shared object this handle is for.
      * @param path - The id of the shared object. It is also the path to this object relative to the routeContext.
-     * @param routeContext - The parent IFluidHandleContext that has a route to this handle.
+     * @param routeContext - The parent {@link @fluidframework/core-interfaces#IFluidHandleContext} that has a route
+     * to this handle.
      */
     constructor(
         protected readonly value: ISharedObject,

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -13,9 +13,7 @@ import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 /**
  * Handle for a shared {@link @fluidframework/core-interfaces#FluidObject}.
  */
-export class FluidObjectHandle<T extends FluidObject = FluidObject>
-    implements IFluidHandle
-{
+export class FluidObjectHandle<T extends FluidObject = FluidObject> implements IFluidHandle {
     private readonly pendingHandlesToMakeVisible: Set<IFluidHandle> = new Set();
 
     /**
@@ -72,7 +70,7 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject>
     constructor(
         protected readonly value: T | Promise<T>,
         public readonly path: string,
-        public readonly routeContext: IFluidHandleContext
+        public readonly routeContext: IFluidHandleContext,
     ) {
         this.absolutePath = generateHandleContextPath(path, this.routeContext);
     }

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -10,12 +10,29 @@ import {
 } from "@fluidframework/core-interfaces";
 import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 
-export class FluidObjectHandle<T extends FluidObject = FluidObject> implements IFluidHandle {
+/**
+ * Handle for a shared {@link @fluidframework/core-interfaces#FluidObject}.
+ */
+export class FluidObjectHandle<T extends FluidObject = FluidObject>
+    implements IFluidHandle
+{
     private readonly pendingHandlesToMakeVisible: Set<IFluidHandle> = new Set();
+
+    /**
+     * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.absolutePath}
+     */
     public readonly absolutePath: string;
 
-    public get IFluidHandle(): IFluidHandle { return this; }
+    /**
+     * {@inheritDoc @fluidframework/core-interfaces#IProvideFluidHandle.IFluidHandle}
+     */
+    public get IFluidHandle(): IFluidHandle {
+        return this;
+    }
 
+    /**
+     * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.isAttached}
+     */
     public get isAttached(): boolean {
         return this.routeContext.isAttached;
     }
@@ -45,24 +62,32 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
     private locallyVisible: boolean = false;
 
     /**
-     * Creates a new FluidObjectHandle.
-     * @param value - The FluidObject object this handle is for.
-     * @param path - The path to this handle relative to the routeContext.
-     * @param routeContext - The parent IFluidHandleContext that has a route to this handle.
+     * Creates a new `FluidObjectHandle`.
+     *
+     * @param value - The {@link @fluidframework/core-interfaces#FluidObject} object this handle is for.
+     * @param path - The path to this handle relative to the `routeContext`.
+     * @param routeContext - The parent {@link @fluidframework/core-interfaces#IFluidHandleContext} that has a route
+     * to this handle.
      */
     constructor(
         protected readonly value: T | Promise<T>,
         public readonly path: string,
-        public readonly routeContext: IFluidHandleContext,
+        public readonly routeContext: IFluidHandleContext
     ) {
         this.absolutePath = generateHandleContextPath(path, this.routeContext);
     }
 
+    /**
+     * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.get}
+     */
     public async get(): Promise<any> {
         // Note that this return works whether we received a T or a Promise<T> for this.value in the constructor.
         return this.value;
     }
 
+    /**
+     * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.attachGraph }
+     */
     public attachGraph(): void {
         if (this.visible) {
             return;
@@ -76,6 +101,9 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
         this.routeContext.attachGraph();
     }
 
+    /**
+     * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.bind}
+     */
     public bind(handle: IFluidHandle) {
         // If this handle is visible, attach the graph of the incoming handle as well.
         if (this.visible) {


### PR DESCRIPTION
Adds missing `inheritDoc` comments, adds reference links where appropriate, and cleans up formatting.