### PR TITLE
Shorten PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).
+[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).
 
-For specific guidelines for Pull Requests in this repo, visit [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
+[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
 
 The sections included below are suggestions for what you may want to include.
 Feel free to remove or alter parts of this template that do not offer value for your specific change.
@@ -14,7 +14,15 @@ Feel free to remove or alter parts of this template that do not offer value for 
 
 > If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.
 
+## Breaking Changes
+
+> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
+> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
+> If there are no breaking changes, delete this section.
+
 ## Reviewer Guidance
+
+The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
 
 > List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
 > Things you might want to include:
@@ -25,19 +33,3 @@ Feel free to remove or alter parts of this template that do not offer value for 
 > -   etc.
 >
 > If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
-
-## Does this introduce a breaking change?
-
-> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
-> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
-> If there are no breaking changes, delete this section.
-
-## Any relevant logs or outputs
-
-> -   Use this section to provide either screenshots or output of logs as code snippets
-
-## Other information or known dependencies
-
-> -   Any other information or known dependencies that is important to this PR.
-> -   Links to internal bug/work tracker items.
-> -   TODO that are to be done after this PR.


### PR DESCRIPTION
## Description

Updates PR description template to be more concise, puts link to PR guidelines in the reviewer guidance section.