### PR TITLE
feat(build-cli): Add --exact flag to bump command

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -17,7 +17,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version|-V)
-@fluid-tools/build-cli/0.4.9000
+@fluid-tools/build-cli/0.5.0
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -12,18 +12,19 @@ Bumps the version of a release group or package to the next minor, major, or pat
 
 ```
 USAGE
-  $ flub bump [PACKAGE_OR_RELEASE_GROUP] -t major|minor|patch [--scheme semver|internal|virtualPatch] [-x
-    | --install | --commit |  |  | ] [-v]
+  $ flub bump [PACKAGE_OR_RELEASE_GROUP] [-t major|minor|patch | --exact <value>] [--scheme
+    semver|internal|virtualPatch | ] [-x | --install | --commit |  |  | ] [-v]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
 
 FLAGS
-  -t, --bumpType=<option>  (required) Bump the release group or package to the next version according to this bump type.
+  -t, --bumpType=<option>  Bump the release group or package to the next version according to this bump type.
                            <options: major|minor|patch>
   -v, --verbose            Verbose logging.
   -x, --skipChecks         Skip all checks.
   --[no-]commit            Commit changes to a new branch.
+  --exact=<value>          An exact string to use as the version. The string must be a valid semver string.
   --[no-]install           Update lockfiles by running 'npm install' automatically.
   --scheme=<option>        Override the version scheme used by the release group or package.
                            <options: semver|internal|virtualPatch>

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -25,6 +25,7 @@ import {
     generateBumpVersionCommitMessage,
 } from "../lib";
 import { isReleaseGroup } from "../releaseGroups";
+import { Flags } from "@oclif/core";
 
 export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
     static summary =
@@ -39,11 +40,17 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
             char: "t",
             description:
                 "Bump the release group or package to the next version according to this bump type.",
-            required: true,
+            }),
+            exclusive: ["exact"],
+        exact: Flags.string({
+            description:
+                "An exact string to use as the version. The string must be a valid semver string.",
+            exclusive: ["bumpType", "scheme"],
         }),
         scheme: versionSchemeFlag({
             description: "Override the version scheme used by the release group or package.",
             required: false,
+            exclusive: ["exact"],
         }),
         commit: checkFlags.commit,
         install: checkFlags.install,

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -2,18 +2,23 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { Flags } from "@oclif/core";
 import type { ArgInput } from "@oclif/core/lib/interfaces";
 import { strict as assert } from "assert";
 import chalk from "chalk";
 import inquirer from "inquirer";
+import * as semver from "semver";
 
 import { FluidRepo, MonoRepo, Package } from "@fluidframework/build-tools";
 
 import {
     ReleaseVersion,
+    VersionBumpType,
+    VersionChangeType,
     VersionScheme,
     bumpVersionScheme,
     detectVersionScheme,
+    isVersionBumpType,
 } from "@fluid-tools/version-tools";
 
 import { packageOrReleaseGroupArg } from "../args";
@@ -25,7 +30,6 @@ import {
     generateBumpVersionCommitMessage,
 } from "../lib";
 import { isReleaseGroup } from "../releaseGroups";
-import { Flags } from "@oclif/core";
 
 export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
     static summary =
@@ -40,8 +44,8 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
             char: "t",
             description:
                 "Bump the release group or package to the next version according to this bump type.",
-            }),
             exclusive: ["exact"],
+        }),
         exact: Flags.string({
             description:
                 "An exact string to use as the version. The string must be a valid semver string.",
@@ -85,10 +89,11 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
         const flags = this.processedFlags;
 
         const context = await this.getContext();
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const bumpType = flags.bumpType!;
-        const shouldInstall = flags.install && !flags.skipChecks;
-        const shouldCommit = flags.commit && !flags.skipChecks;
+        const bumpType: VersionBumpType | undefined = flags.bumpType;
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        const shouldInstall: boolean = flags.install && !flags.skipChecks;
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        const shouldCommit: boolean = flags.commit && !flags.skipChecks;
 
         if (args.package_or_release_group === undefined) {
             this.error("ERROR: No dependency provided.");
@@ -97,7 +102,12 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
         let repoVersion: ReleaseVersion;
         let packageOrReleaseGroup: Package | MonoRepo;
         let scheme: VersionScheme | undefined;
+        const exactVersion: semver.SemVer | null = semver.parse(flags.exact);
         const updatedPackages: Package[] = [];
+
+        if (bumpType === undefined && exactVersion === null) {
+            this.error(`Either --bumpType or --exact must be provided.`);
+        }
 
         if (isReleaseGroup(args.package_or_release_group)) {
             const releaseRepo = context.repo.releaseGroups.get(args.package_or_release_group);
@@ -133,11 +143,26 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
             packageOrReleaseGroup = releasePackage;
         }
 
-        const newVersion = bumpVersionScheme(repoVersion, bumpType, scheme).version;
+        const newVersion =
+            exactVersion === null
+                ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  bumpVersionScheme(repoVersion, bumpType!, scheme).version
+                : exactVersion.version;
+
+        let bumpArg: VersionChangeType;
+        if (bumpType === undefined) {
+            if (exactVersion === null) {
+                this.error(`bumpType and exactVersion are both null/undefined.`);
+            } else {
+                bumpArg = exactVersion;
+            }
+        } else {
+            bumpArg = bumpType;
+        }
 
         this.logHr();
         this.log(`Release group: ${chalk.blueBright(args.package_or_release_group)}`);
-        this.log(`Bump type: ${chalk.blue(bumpType)}`);
+        this.log(`Bump type: ${chalk.blue(bumpType ?? "exact")}`);
         this.log(`Versions: ${newVersion} <== ${repoVersion}`);
         this.log(`Install: ${shouldInstall ? chalk.green("yes") : "no"}`);
         this.log(`Commit: ${shouldCommit ? chalk.green("yes") : "no"}`);
@@ -156,7 +181,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
             this.exit(0);
         }
 
-        const logs = await bumpReleaseGroup(context, bumpType, packageOrReleaseGroup, scheme);
+        const logs = await bumpReleaseGroup(context, bumpArg, packageOrReleaseGroup, scheme);
         this.verbose(logs);
 
         if (shouldInstall) {
@@ -170,14 +195,14 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
         if (shouldCommit) {
             const commitMessage = generateBumpVersionCommitMessage(
                 args.package_or_release_group,
-                bumpType,
+                bumpArg,
                 repoVersion,
                 scheme,
             );
 
             const bumpBranch = generateBumpVersionBranchName(
                 args.package_or_release_group,
-                bumpType,
+                bumpArg,
                 repoVersion,
                 scheme,
             );

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -18,7 +18,6 @@ import {
     VersionScheme,
     bumpVersionScheme,
     detectVersionScheme,
-    isVersionBumpType,
 } from "@fluid-tools/version-tools";
 
 import { packageOrReleaseGroupArg } from "../args";
@@ -90,9 +89,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
 
         const context = await this.getContext();
         const bumpType: VersionBumpType | undefined = flags.bumpType;
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const shouldInstall: boolean = flags.install && !flags.skipChecks;
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const shouldCommit: boolean = flags.commit && !flags.skipChecks;
 
         if (args.package_or_release_group === undefined) {
@@ -169,16 +166,19 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand.flags> {
         this.logHr();
         this.log("");
 
-        const confirmIntegratedQuestion: inquirer.ConfirmQuestion = {
-            type: "confirm",
-            name: "proceed",
-            message: `Proceed with the bump?`,
-        };
+        // If a bump type was provided, ask the user to confirm. This is skipped when --exact is used.
+        if (bumpType !== undefined) {
+            const confirmIntegratedQuestion: inquirer.ConfirmQuestion = {
+                type: "confirm",
+                name: "proceed",
+                message: `Proceed with the bump?`,
+            };
 
-        const answers = await inquirer.prompt(confirmIntegratedQuestion);
-        if (answers.proceed !== true) {
-            this.info(`Cancelled.`);
-            this.exit(0);
+            const answers = await inquirer.prompt(confirmIntegratedQuestion);
+            if (answers.proceed !== true) {
+                this.info(`Cancelled.`);
+                this.exit(0);
+            }
         }
 
         const logs = await bumpReleaseGroup(context, bumpArg, packageOrReleaseGroup, scheme);

--- a/build-tools/packages/build-cli/src/lib/branches.ts
+++ b/build-tools/packages/build-cli/src/lib/branches.ts
@@ -11,11 +11,13 @@ import {
     ReleaseVersion,
     VersionBumpType,
     VersionBumpTypeExtended,
+    VersionChangeTypeExtended,
     VersionScheme,
     bumpVersionScheme,
     detectVersionScheme,
     fromInternalScheme,
     fromVirtualPatchScheme,
+    isVersionBumpTypeExtended,
     toVirtualPatchScheme,
 } from "@fluid-tools/version-tools";
 
@@ -64,15 +66,18 @@ export async function createBumpBranch(
  */
 export function generateBumpVersionBranchName(
     releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
-    bumpType: VersionBumpTypeExtended,
+    bumpType: VersionChangeTypeExtended,
     version: ReleaseVersion,
     scheme?: VersionScheme,
 ) {
-    const newVersion = bumpVersionScheme(version, bumpType, scheme);
+    const newVersion = isVersionBumpTypeExtended(bumpType)
+        ? bumpVersionScheme(version, bumpType, scheme)
+        : bumpType.version;
     const name = isReleaseGroup(releaseGroupOrPackage)
         ? releaseGroupOrPackage
         : PackageName.getUnscopedName(releaseGroupOrPackage);
-    const branchName = `bump_${name.toLowerCase()}_${bumpType}_${newVersion}`;
+    const bumpTypeLog = isVersionBumpTypeExtended(bumpType) ? bumpType : "exact";
+    const branchName = `bump_${name.toLowerCase()}_${bumpTypeLog}_${newVersion}`;
     return branchName;
 }
 
@@ -163,15 +168,18 @@ export function generateReleaseBranchName(releaseGroup: ReleaseGroup, version: s
  */
 export function generateBumpVersionCommitMessage(
     releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
-    bumpType: VersionBumpTypeExtended,
+    bumpType: VersionChangeTypeExtended,
     version: ReleaseVersion,
     scheme?: VersionScheme,
 ): string {
-    const newVersion = bumpVersionScheme(version, bumpType, scheme);
+    const newVersion = isVersionBumpTypeExtended(bumpType)
+        ? bumpVersionScheme(version, bumpType, scheme)
+        : bumpType.version;
     const name = isReleaseGroup(releaseGroupOrPackage)
         ? releaseGroupOrPackage
         : PackageName.getUnscopedName(releaseGroupOrPackage);
-    const message = `[bump] ${name}: ${version} => ${newVersion} (${bumpType})\n\nBumped ${name} from ${version} to ${newVersion}.`;
+    const bumpTypeLog = isVersionBumpTypeExtended(bumpType) ? bumpType : "exact";
+    const message = `[bump] ${name}: ${version} => ${newVersion} (${bumpTypeLog})\n\nBumped ${name} from ${version} to ${newVersion}.`;
     return message;
 }
 

--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -138,7 +138,7 @@ export async function bumpPackageDependencies(
  * Bumps a release group or standalone package by the bumpType.
  *
  * @param context - The {@link Context}.
- * @param bumpType - The bump type.
+ * @param bumpType - The bump type. Can be a SemVer object to set an exact version.
  * @param releaseGroupOrPackage - A release group repo or package to bump.
  * @param scheme - The version scheme to use.
  *

--- a/build-tools/packages/build-tools/src/buildVersion/buildVersionLib.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersionLib.ts
@@ -107,7 +107,13 @@ export function getSimpleVersion(
     // Get the Build number and ignore the attempt number.
     const buildId = patch ? parseInt(argBuildNum.split(".")[0]) : undefined;
 
-    if (isInternalVersionScheme(fileVersion, /* allowPrereleases */ true)) {
+    if (
+        isInternalVersionScheme(
+            fileVersion,
+            /* allowPrereleases */ true,
+            /* prereleaseIdentifier */ undefined,
+        )
+    ) {
         if (patch) {
             throw new Error(
                 `Cannot use simple patch versioning with Fluid internal versions. Version: ${fileVersion}`,

--- a/build-tools/packages/build-tools/src/buildVersion/buildVersionLib.ts
+++ b/build-tools/packages/build-tools/src/buildVersion/buildVersionLib.ts
@@ -107,13 +107,7 @@ export function getSimpleVersion(
     // Get the Build number and ignore the attempt number.
     const buildId = patch ? parseInt(argBuildNum.split(".")[0]) : undefined;
 
-    if (
-        isInternalVersionScheme(
-            fileVersion,
-            /* allowPrereleases */ true,
-            /* prereleaseIdentifier */ undefined,
-        )
-    ) {
+    if (isInternalVersionScheme(fileVersion, /* allowPrereleases */ true)) {
         if (patch) {
             throw new Error(
                 `Cannot use simple patch versioning with Fluid internal versions. Version: ${fileVersion}`,

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -74,7 +74,7 @@ $ npm install -g @fluid-tools/version-tools
 $ fluv COMMAND
 running command...
 $ fluv (--version|-V)
-@fluid-tools/version-tools/0.4.9000
+@fluid-tools/version-tools/0.5.0
 $ fluv --help [COMMAND]
 USAGE
   $ fluv COMMAND

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -13,7 +13,7 @@ export function bumpRange(range: string, bumpType: VersionBumpTypeExtended, prer
 // @public
 export function bumpVersionScheme(version: string | semver.SemVer | undefined, bumpType: VersionBumpTypeExtended, scheme?: VersionScheme): semver.SemVer;
 
-// @public (undocumented)
+// @public
 export function changePreReleaseIdentifier(version: semver.SemVer | string, newIdentifier: string): string;
 
 // @public
@@ -23,7 +23,7 @@ export function detectBumpType(v1: semver.SemVer | string | null, v2: semver.Sem
 export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): VersionScheme;
 
 // @public
-export function fromInternalScheme(internalVersion: semver.SemVer | string, allowPrereleases?: boolean): [publicVersion: semver.SemVer, internalVersion: semver.SemVer];
+export function fromInternalScheme(internalVersion: semver.SemVer | string, allowPrereleases?: boolean, allowAnyPrereleaseId?: boolean): [publicVersion: semver.SemVer, internalVersion: semver.SemVer, prereleaseIndentifier: string];
 
 // @public
 export function fromVirtualPatchScheme(virtualPatchVersion: semver.SemVer | string): semver.SemVer;
@@ -38,7 +38,7 @@ export function getPreviousVersions(version: ReleaseVersion): [ReleaseVersion | 
 export function getVersionRange(version: semver.SemVer | string, maxAutomaticBump: "minor" | "patch" | "~" | "^"): string;
 
 // @public
-export function isInternalVersionScheme(version: semver.SemVer | string | undefined, allowPrereleases?: boolean): boolean;
+export function isInternalVersionScheme(version: semver.SemVer | string | undefined, allowPrereleases?: boolean, allowAnyPrereleaseId?: boolean): boolean;
 
 // @public
 export function isPrereleaseVersion(version: string | semver.SemVer | undefined): boolean;
@@ -59,7 +59,7 @@ export type ReleaseVersion = string;
 export function sortVersions(versionList: string[], allowPrereleases?: boolean): string[];
 
 // @public
-export function toInternalScheme(publicVersion: semver.SemVer | string, version: semver.SemVer | string, allowPrereleases?: boolean): semver.SemVer;
+export function toInternalScheme(publicVersion: semver.SemVer | string, version: semver.SemVer | string, allowPrereleases?: boolean, prereleaseIdentifier?: string): semver.SemVer;
 
 // @public
 export function toVirtualPatchScheme(version: semver.SemVer | string): semver.SemVer;

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -173,9 +173,9 @@ function validateVersionScheme(
         throw new Error(`Couldn't parse ${version} as a semver.`);
     }
 
-    // extract what semver calls the "prerelease identifier," which is the first section of the prerelease field.
-    const prereleaseId = parsedVersion.prerelease[0];
     if (prereleaseIdentifier !== undefined) {
+        // the "prerelease identifier" is the first section of the prerelease field
+        const prereleaseId = parsedVersion.prerelease[0];
         if (prereleaseId !== prereleaseIdentifier) {
             throw new Error(
                 `First prerelease component should be '${prereleaseIdentifier}'; found ${prereleaseId}`,
@@ -207,8 +207,8 @@ function validateVersionScheme(
  *
  * @param version - The version to check. If it is `undefined`, returns false.
  * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
- * @param prereleaseIdentifier - If provided, the version must use this prereleaseIdentifier to be considered a valid
- * internal version. When set to undefined any prerelease identifier will be considered valid.
+ * @param allowAnyPrereleaseId - If true, allows any prerelease identifier string. When false, only allows
+ * {@link REQUIRED_PRERELEASE_IDENTIFIER}.
  * @returns True if the version matches the Fluid internal version scheme.
  */
 export function isInternalVersionScheme(
@@ -286,14 +286,11 @@ export function bumpInternalVersion(
  * @param maxAutomaticBump - The maximum level of semver bumps you want the range to allow. For example, if you want the
  * dependency range to allow more recent patch versions, pass the value "patch". You can also pass "~" and "^" to
  * generate a range equivalent to those shorthands.
- * @param prereleaseIdentifier - If provided, the version must use this prereleaseIdentifier to be considered a valid
- * internal version. When set to undefined any prerelease identifier will be considered valid.
  * @returns A dependency range string. If the generated range is invalid an Error will be thrown.
  */
 export function getVersionRange(
     version: semver.SemVer | string,
     maxAutomaticBump: "minor" | "patch" | "~" | "^",
-    // prereleaseIdentifier: string | undefined = REQUIRED_PRERELEASE_IDENTIFIER,
 ): string {
     validateVersionScheme(version, false, undefined);
 

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -48,17 +48,27 @@ const REQUIRED_PRERELEASE_IDENTIFIER = "internal";
  *
  * @param internalVersion - A version in the Fluid internal version scheme.
  * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
- * @returns A tuple of [publicVersion, internalVersion]
+ * @param allowAnyPrereleaseId - If true, allows any prerelease identifier string. When false, only allows
+ * {@link REQUIRED_PRERELEASE_IDENTIFIER}.
+ * @returns A tuple of [publicVersion, internalVersion, prereleaseIdentifier]
  */
 export function fromInternalScheme(
     internalVersion: semver.SemVer | string,
     allowPrereleases = false,
-): [publicVersion: semver.SemVer, internalVersion: semver.SemVer] {
+    allowAnyPrereleaseId = false,
+): [publicVersion: semver.SemVer, internalVersion: semver.SemVer, prereleaseIndentifier: string] {
     const parsedVersion = semver.parse(internalVersion);
-    validateVersionScheme(parsedVersion, allowPrereleases);
+    validateVersionScheme(
+        parsedVersion,
+        allowPrereleases,
+        allowAnyPrereleaseId ? undefined : REQUIRED_PRERELEASE_IDENTIFIER,
+    );
 
     assert(parsedVersion !== null);
     const prereleaseSections = parsedVersion.prerelease;
+
+    const prereleaseIdentifier = prereleaseSections[0];
+    assert(typeof prereleaseIdentifier === "string");
 
     const newSemVerString =
         prereleaseSections.length > 4
@@ -75,7 +85,7 @@ export function fromInternalScheme(
         throw new Error(`Couldn't convert ${publicVersionString} to a standard semver.`);
     }
 
-    return [publicVersion, newSemVer];
+    return [publicVersion, newSemVer, prereleaseIdentifier];
 }
 
 /**
@@ -101,12 +111,15 @@ export function fromInternalScheme(
  * @param publicVersion - The public version.
  * @param version - The internal version.
  * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
+ * @param prereleaseIdentifier - The prerelease indentifier to use in the Fluid internal version. Defaults to
+ * {@link REQUIRED_PRERELEASE_IDENTIFIER}.
  * @returns A version in the Fluid internal version scheme.
  */
 export function toInternalScheme(
     publicVersion: semver.SemVer | string,
     version: semver.SemVer | string,
     allowPrereleases = false,
+    prereleaseIdentifier = REQUIRED_PRERELEASE_IDENTIFIER,
 ): semver.SemVer {
     const parsedVersion = semver.parse(version);
     if (parsedVersion === null) {
@@ -121,7 +134,7 @@ export function toInternalScheme(
 
     const prereleaseSections = parsedVersion.prerelease;
     const newPrerelease = prereleaseSections.length > 0 ? `.${prereleaseSections.join(".")}` : "";
-    const newSemVerString = `${publicVersion}-internal.${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch}${newPrerelease}`;
+    const newSemVerString = `${publicVersion}-${prereleaseIdentifier}.${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch}${newPrerelease}`;
     const newSemVer = semver.parse(newSemVerString);
     if (newSemVer === null) {
         throw new Error(
@@ -129,7 +142,7 @@ export function toInternalScheme(
         );
     }
 
-    if (!isInternalVersionScheme(newSemVer, allowPrereleases)) {
+    if (!isInternalVersionScheme(newSemVer, allowPrereleases, true)) {
         throw new Error(`Converted version is not a valid Fluid internal version: ${newSemVer}`);
     }
 
@@ -141,14 +154,20 @@ export function toInternalScheme(
  *
  * @param version - The version to check.
  * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
+ * @param prereleaseIdentifier - If provided, the version must use this prereleaseIdentifier to be considered a valid
+ * internal version. When set to undefined any prerelease identifier will be considered valid.
  * @returns True if the version matches the Fluid internal version scheme. Throws if not.
  *
  * @remarks
  *
  * This function is not typically used. {@link isInternalVersionScheme} is more useful since it does not throw.
  */
-// eslint-disable-next-line @rushstack/no-new-null
-function validateVersionScheme(version: semver.SemVer | string | null, allowPrereleases = false) {
+function validateVersionScheme(
+    // eslint-disable-next-line @rushstack/no-new-null
+    version: semver.SemVer | string | null,
+    allowPrereleases = false,
+    prereleaseIdentifier?: string,
+) {
     const parsedVersion = semver.parse(version);
     if (parsedVersion === null) {
         throw new Error(`Couldn't parse ${version} as a semver.`);
@@ -156,10 +175,12 @@ function validateVersionScheme(version: semver.SemVer | string | null, allowPrer
 
     // extract what semver calls the "prerelease identifier," which is the first section of the prerelease field.
     const prereleaseId = parsedVersion.prerelease[0];
-    if (prereleaseId !== REQUIRED_PRERELEASE_IDENTIFIER) {
-        throw new Error(
-            `First prerelease component should be '${REQUIRED_PRERELEASE_IDENTIFIER}'; found ${prereleaseId}`,
-        );
+    if (prereleaseIdentifier !== undefined) {
+        if (prereleaseId !== prereleaseIdentifier) {
+            throw new Error(
+                `First prerelease component should be '${prereleaseIdentifier}'; found ${prereleaseId}`,
+            );
+        }
     }
 
     if (parsedVersion.major < MINIMUM_PUBLIC_MAJOR) {
@@ -186,15 +207,22 @@ function validateVersionScheme(version: semver.SemVer | string | null, allowPrer
  *
  * @param version - The version to check. If it is `undefined`, returns false.
  * @param allowPrereleases - If true, allow prerelease Fluid internal versions.
+ * @param prereleaseIdentifier - If provided, the version must use this prereleaseIdentifier to be considered a valid
+ * internal version. When set to undefined any prerelease identifier will be considered valid.
  * @returns True if the version matches the Fluid internal version scheme.
  */
 export function isInternalVersionScheme(
     version: semver.SemVer | string | undefined,
     allowPrereleases = false,
+    allowAnyPrereleaseId = false,
 ): boolean {
     const parsedVersion = semver.parse(version);
     try {
-        validateVersionScheme(parsedVersion, allowPrereleases);
+        validateVersionScheme(
+            parsedVersion,
+            allowPrereleases,
+            allowAnyPrereleaseId ? undefined : REQUIRED_PRERELEASE_IDENTIFIER,
+        );
     } catch (error) {
         return false;
     }
@@ -206,9 +234,11 @@ export function isInternalVersionScheme(
  * Checks if a version matches the Fluid internal version scheme.
  *
  * @param range - The range string to check.
+ * @param allowAnyPrereleaseId - If true, allows any prerelease identifier string. When false, only allows
+ * {@link REQUIRED_PRERELEASE_IDENTIFIER}.
  * @returns True if the range string matches the Fluid internal version scheme.
  */
-export function isInternalVersionRange(range: string): boolean {
+export function isInternalVersionRange(range: string, allowAnyPrereleaseId = false): boolean {
     if (semver.validRange(range) === null) {
         return false;
     }
@@ -222,7 +252,7 @@ export function isInternalVersionRange(range: string): boolean {
         return false;
     }
 
-    return isInternalVersionScheme(minVer);
+    return isInternalVersionScheme(minVer, false, allowAnyPrereleaseId);
 }
 
 /**
@@ -238,9 +268,9 @@ export function bumpInternalVersion(
     bumpType: VersionBumpTypeExtended,
 ): semver.SemVer {
     validateVersionScheme(version);
-    const [pubVer, intVer] = fromInternalScheme(version);
+    const [pubVer, intVer, prereleaseId] = fromInternalScheme(version, false, true);
     const newIntVer = bumpType === "current" ? intVer : intVer.inc(bumpType);
-    return toInternalScheme(pubVer, newIntVer);
+    return toInternalScheme(pubVer, newIntVer, false, prereleaseId);
 }
 
 /**
@@ -256,13 +286,16 @@ export function bumpInternalVersion(
  * @param maxAutomaticBump - The maximum level of semver bumps you want the range to allow. For example, if you want the
  * dependency range to allow more recent patch versions, pass the value "patch". You can also pass "~" and "^" to
  * generate a range equivalent to those shorthands.
+ * @param prereleaseIdentifier - If provided, the version must use this prereleaseIdentifier to be considered a valid
+ * internal version. When set to undefined any prerelease identifier will be considered valid.
  * @returns A dependency range string. If the generated range is invalid an Error will be thrown.
  */
 export function getVersionRange(
     version: semver.SemVer | string,
     maxAutomaticBump: "minor" | "patch" | "~" | "^",
+    // prereleaseIdentifier: string | undefined = REQUIRED_PRERELEASE_IDENTIFIER,
 ): string {
-    validateVersionScheme(version);
+    validateVersionScheme(version, false, undefined);
 
     const lowVersion = version;
     let highVersion: semver.SemVer;
@@ -291,6 +324,13 @@ export function getVersionRange(
     return range;
 }
 
+/**
+ * Given a version with a string prerelease indentifier, updates the version to use a new prerelease identifier.
+ *
+ * @param version - The version to update.
+ * @param newIdentifier - The new prerelease identifier to set.
+ * @returns The updated version string.
+ */
 export function changePreReleaseIdentifier(
     version: semver.SemVer | string,
     newIdentifier: string,

--- a/build-tools/packages/version-tools/src/semver.ts
+++ b/build-tools/packages/version-tools/src/semver.ts
@@ -120,8 +120,8 @@ export function detectBumpType(
         throw new Error(`Invalid version: ${v2}`);
     }
 
-    const v1IsInternal = isInternalVersionScheme(v1, true);
-    const v2IsInternal = isInternalVersionScheme(v2, true);
+    const v1IsInternal = isInternalVersionScheme(v1, true, true);
+    const v2IsInternal = isInternalVersionScheme(v2, true, true);
 
     if (v1IsInternal) {
         const [, internalVer] = fromInternalScheme(v1, true);

--- a/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
@@ -57,6 +57,12 @@ describe("internalScheme", () => {
             assert.isFalse(result);
         });
 
+        it("2.0.0-dev.1.1.0 is a valid internal version when allowAnyPrereleaseId is true", () => {
+            const input = `2.0.0-dev.1.1.0`;
+            const result = isInternalVersionScheme(input, false, true);
+            assert.isTrue(result);
+        });
+
         it(">=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0 is internal", () => {
             const input = `>=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0`;
             assert.isTrue(isInternalVersionRange(input));
@@ -65,6 +71,16 @@ describe("internalScheme", () => {
         it(">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0 is internal", () => {
             const input = `>=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0`;
             assert.isTrue(isInternalVersionRange(input));
+        });
+
+        it(">=2.0.0-alpha.2.2.1 <2.0.0-alpha.3.0.0 is not internal", () => {
+            const input = `>=2.0.0-alpha.2.2.1 <2.0.0-alpha.3.0.0`;
+            assert.isFalse(isInternalVersionRange(input));
+        });
+
+        it(">=2.0.0-alpha.2.2.1 <2.0.0-alpha.3.0.0 is internal when allowAnyPrereleaseId is true", () => {
+            const input = `>=2.0.0-alpha.2.2.1 <2.0.0-alpha.3.0.0`;
+            assert.isTrue(isInternalVersionRange(input, true));
         });
 
         it(">=1.0.0 <2.0.0 is not internal", () => {
@@ -91,7 +107,16 @@ describe("internalScheme", () => {
             assert.strictEqual(calculated.version, expected);
         });
 
-        it("parses 2.0.0-internal.1.1.0.12345", () => {
+        it("parses 3.0.0-internal.1.0.0", () => {
+            const input = `3.0.0-internal.1.0.0`;
+            const expectedInt = `1.0.0`;
+            const expectedPub = `3.0.0`;
+            const [pubVer, intVer] = fromInternalScheme(input);
+            assert.strictEqual(intVer.version, expectedInt);
+            assert.strictEqual(pubVer.version, expectedPub);
+        });
+
+        it("throws on 2.0.0-internal.1.1.0.12345", () => {
             const input = `2.0.0-internal.1.1.0.12345`;
             const expected = `1.1.0-12345`;
             const [_, calculated] = fromInternalScheme(input, true);
@@ -103,6 +128,14 @@ describe("internalScheme", () => {
         it("throws on 2.0.0-alpha.1.0.0 (must use internal)", () => {
             const input = `2.0.0-alpha.1.0.0`;
             assert.throws(() => fromInternalScheme(input));
+        });
+
+        it("parses 2.0.0-alpha.1.0.0 when allowAnyPrereleaseId is true", () => {
+            const input = `2.0.0-alpha.1.0.0`;
+            const expected = `1.0.0`;
+            const [_, intVer, prereleaseId] = fromInternalScheme(input, false, true);
+            assert.strictEqual(intVer.version, expected);
+            assert.strictEqual(prereleaseId, "alpha");
         });
 
         it("throws on 1.1.1-alpha.1.0.0 (public must be 2.0.0+)", () => {
@@ -121,6 +154,13 @@ describe("internalScheme", () => {
             const input = `1.0.0`;
             const expected = `2.2.2-internal.1.0.0`;
             const calculated = toInternalScheme("2.2.2", input);
+            assert.strictEqual(calculated.version, expected);
+        });
+
+        it("converts 1.2.3 to internal version with public version 2.0.0, dev prerelease identifier", () => {
+            const input = `1.2.3`;
+            const expected = `2.0.0-dev.1.2.3`;
+            const calculated = toInternalScheme("2.0.0", input, false, "dev");
             assert.strictEqual(calculated.version, expected);
         });
 
@@ -195,6 +235,9 @@ describe("internalScheme", () => {
                     `2.0.0-dev.1.5.0.95400`,
                     `>=2.0.0-internal.1.4.0 <2.0.0-internal.2.0.0`,
                 ),
+            );
+            assert.isFalse(
+                semver.satisfies(`2.0.0-dev.1.5.0`, `>=2.0.0-internal.1.4.0 <2.0.0-internal.2.0.0`),
             );
         });
     });


### PR DESCRIPTION
The --exact flag allows setting the version of a package or release group to a precise version. This is useful in the CI pipeline where we need to adjust the versions for dev/test/etc. as part of the build. This is currently done with lerna directly:

https://github.com/microsoft/FluidFramework/blob/9080963a1194be9d02fdfec69026cb482a1cabfa/tools/pipelines/templates/include-set-package-version.yml#L92-L112

This new command will replace that in our build pipeline. We need to do this because lerna produces invalid version ranges for Fluid internal versions.

This change required some upstream changes in Fluid internal version calculations. In particular, I needed to relax the requirement that the prerelease identifier be "internal" for Fluid internal versions. Fortunately, I was able to do this with minimal additions to existing APIs; there is now a flag on some APIs that will allow/disallow arbitrary prerelease identifier strings. Existing calls will continue to enforce the "internal" prerelease identifier. To use a custom one, you must opt in by setting the flag to true.