### PR TITLE
Tombstoned datastores 404 with tombstone info

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1412,10 +1412,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const wait = typeof request.headers?.[RuntimeHeaders.wait] === "boolean"
             ? request.headers?.[RuntimeHeaders.wait]
             : true;
+        const viaHandle = typeof request.headers?.[RuntimeHeaders.viaHandle] === "boolean"
+            ? request.headers?.[RuntimeHeaders.viaHandle]
+            : false;
 
         await this.dataStores.waitIfPendingAlias(id);
         const internalId = this.internalId(id);
-        const dataStoreContext = await this.dataStores.getDataStore(internalId, wait);
+        const dataStoreContext = await this.dataStores.getDataStore(internalId, wait, viaHandle);
 
         /**
          * If GC should run and this an external app request with "externalRequest" header, we need to return

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1821,7 +1821,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private async getRootDataStoreChannel(id: string, wait = true): Promise<IFluidDataStoreChannel> {
         await this.dataStores.waitIfPendingAlias(id);
         const internalId = this.internalId(id);
-        const context = await this.dataStores.getDataStore(internalId, wait);
+        const context = await this.dataStores.getDataStore(internalId, wait, false /* viaHandle */);
         assert(await context.isRoot(), 0x12b /* "did not get root data store" */);
         return context.realize();
     }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -755,11 +755,11 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
     private verifyNotClosed(callSite: string, checkTombstone = true, safeTelemetryProps: ITelemetryProperties = {}) {
         if (this._disposed) {
-            throw new Error(`Context is closed: Call site - ${callSite}!`);
+            throw new Error(`Context is closed! Call site [${callSite}]`);
         }
 
         if (checkTombstone && this.tombstoned) {
-            const messageString = `Context is tombstoned: Call site -  ${callSite}!`;
+            const messageString = `Context is tombstoned! Call site [${callSite}]`;
             throw new DataCorruptionError(messageString, {
                 errorMessage: messageString,
                 ...safeTelemetryProps,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -420,7 +420,7 @@ export class DataStores implements IDisposable {
         );
     }
 
-    public async getDataStore(id: string, wait: boolean, viaHandle: boolean = false): Promise<FluidDataStoreContext> {
+    public async getDataStore(id: string, wait: boolean, viaHandle: boolean): Promise<FluidDataStoreContext> {
         const context = await this.contexts.getBoundOrRemoted(id, wait);
         const request = { url: id };
         if (context === undefined) {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
@@ -5,9 +5,10 @@
 
 import { strict as assert } from "assert";
 import {
-    ISummarizer,
+    ISummarizer, RuntimeHeaders,
 } from "@fluidframework/container-runtime";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
+import {
+    requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ITestObjectProvider,
     createSummarizerWithContainer,
@@ -18,7 +19,8 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat, ITestDataObject, itExpects, TestDataObjectType } from "@fluidframework/test-version-utils";
 import { delay } from "@fluidframework/common-utils";
-import { IErrorBase } from "@fluidframework/container-definitions";
+import { IContainer, IErrorBase } from "@fluidframework/container-definitions";
+import { IRequest } from "@fluidframework/core-interfaces";
 
 /**
  * When a datastore is tombstoned it should be unable to send and receive ops
@@ -84,7 +86,8 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
 
     // This function creates an unreferenced datastore and returns the datastore's id and the summary version that
     // datastore was unreferenced in.
-    const getUnreferencedDataStoreIdAndSummaryVersion = async () => {
+    const summarizationWithUnreferencedDataStoreAfterTime =
+    async (approximateUnreferenceTimestampMs: number) => {
         const container = await makeContainer();
         const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
         await waitForContainerConnection(container);
@@ -92,7 +95,7 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         const handleKey = "handle";
         const dataStore = await defaultDataObject._context.containerRuntime.createDataStore(TestDataObjectType);
         const testDataObject = await requestFluidObject<ITestDataObject>(dataStore, "");
-        const testDataObjectId = testDataObject._context.id;
+        const unreferencedId = testDataObject._context.id;
 
         // Reference a datastore - important for making it live
         defaultDataObject._root.set(handleKey, testDataObject.handle);
@@ -115,101 +118,97 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         container.close();
         summarizingContainer1.close();
 
+        // Wait some time, the datastore can be in many different unreference states
+        await delay(approximateUnreferenceTimestampMs);
+
+        // Load a new container and summarizer based on the latest summary, summarize
+        const {
+            container: summarizingContainer2,
+            summarizer: summarizer2,
+        } = await loadSummarizerAndContainer(summaryVersion);
+
         return {
-            testDataObjectId,
+            unreferencedId,
+            summarizingContainer: summarizingContainer2,
+            summarizer: summarizer2,
             summaryVersion,
         };
     };
 
+    const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
+        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+        defaultDataObject._root.set("send a", "op");
+    };
+
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Container loaded after sweep timeout expires can't send ops for tombstoned datastores",
+    itExpects("Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
     [
-        {
-            eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
-        },
+        { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
     ],
     async () => {
-        const { testDataObjectId, summaryVersion } = await getUnreferencedDataStoreIdAndSummaryVersion();
-
-        // Wait a sweep worthy amount of time (all containers should have closed by now)
-        await delay(sweepTimeoutMs);
-
-        // Load a new container and summarizer based on the latest summary, summarize
         const {
-            container: summarizingContainer2,
-            summarizer: summarizer2,
-        } = await loadSummarizerAndContainer(summaryVersion);
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 
         // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
         // production application - causes a sweep ready loaded error
-        const testDataObject2 = await requestFluidObject<ITestDataObject>(summarizingContainer2, testDataObjectId);
+        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
 
         // The datastore should be tombstoned now
-        await summarize(summarizer2);
+        await summarize(summarizer);
 
         // Modifying a testDataObject substantiated from the request pattern should fail!
-        assert.throws(() => testDataObject2._root.set("send", "op"),
+        assert.throws(() => dataObject._root.set("send", "op"),
             (error) => {
                 const correctErrorType = error.errorType === "dataCorruptionError";
                 const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
                 return correctErrorType && correctErrorMessage;
             },
-            `Should not be able to send ops for a tombstoned datastore.`);
+            `Should not be able to send ops for a tombstoned datastore.`,
+        );
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Container loaded before sweep timeout expires can't send ops for tombstoned datastores",
+    itExpects("Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
     [
-        {
-            eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded",
-        },
-        {
-            eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Changed",
-        },
+        { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
     ],
     async () => {
-        const { testDataObjectId, summaryVersion } = await getUnreferencedDataStoreIdAndSummaryVersion();
-
-        // Wait some time, the datastore should not be sweep ready after this wait
-        await delay(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
-
-        // Load a new container and summarizer based on the latest summary, summarize
         const {
-            container: summarizingContainer2,
-            summarizer: summarizer2,
-        } = await loadSummarizerAndContainer(summaryVersion);
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
 
         // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
         // production application - causes an inactive loaded and changed error
-        const testDataObject2 = await requestFluidObject<ITestDataObject>(summarizingContainer2, testDataObjectId);
-        testDataObject2._root.set("send a", "op via unreferenced content");
+        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
 
         // Wait enough time so that the datastore is sweep ready
         await delay(waitLessThanSweepTimeoutMs);
 
-        // Send an op to update the currentTimestampMs to now
-        const mainDataStore2 = await requestFluidObject<ITestDataObject>(summarizingContainer2, "default");
-        mainDataStore2._root.set("send a", "op");
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
         // The datastore should be tombstoned now
-        await summarize(summarizer2);
+        await summarize(summarizer);
 
         // Sending an op from a datastore substantiated from the request pattern should fail!
-        assert.throws(() => testDataObject2._root.set("send", "op"),
+        assert.throws(() => dataObject._root.set("send", "op"),
             (error) => {
                 const correctErrorType = error.errorType === "dataCorruptionError";
                 const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
                 return correctErrorType && correctErrorMessage;
             },
-            `Should not be able to send ops for a tombstoned datastore.`);
+            `Should not be able to send ops for a tombstoned datastore.`,
+        );
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Container loaded after sweep timeout expires closes on receiving ops for tombstoned datastores",
+    itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
     [
-        {
-            eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-        },
+        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
         {
             eventName: "fluid:telemetry:Container:ContainerClose",
             error: "Context is tombstoned: Call site -  process!",
@@ -217,50 +216,44 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         },
     ],
     async () => {
-        const { testDataObjectId, summaryVersion } = await getUnreferencedDataStoreIdAndSummaryVersion();
-
-        // Wait a sweep worthy amount of time (all containers should have closed by now)
-        await delay(sweepTimeoutMs);
-
-        // Load a new container and summarizer based on the latest summary, summarize
         const {
-            container: summarizingContainer2,
-            summarizer: summarizer2,
-        } = await loadSummarizerAndContainer(summaryVersion);
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+            summaryVersion,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
         // Setup close validation
         let closeError: IErrorBase | undefined;
-        summarizingContainer2.on("closed", (error) => {
+        summarizingContainer.on("closed", (error) => {
             closeError = error;
         });
 
         // The datastore should be tombstoned now
-        await summarize(summarizer2);
+        await summarize(summarizer);
 
         // We load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-        const container2 = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
+        const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
         // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
         // production application
         // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
         // ready was set
-        const testDataObject2 = await requestFluidObject<ITestDataObject>(container2, testDataObjectId);
+        const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
 
         // Receive an op - the summarizing container does not log a sweep ready changed error as it closes before
         // the op is processed. The summarizing container does log a sweep ready loaded error and then it should
         // process the op which causes the container to close.
-        testDataObject2._root.set("receive", "op");
+        dataObject._root.set("send an op to be received", "op");
         await provider.ensureSynchronized();
-        assert(summarizingContainer2.closed === true, `Summarizing container should close.`);
+        assert(summarizingContainer.closed === true, `Summarizing container should close.`);
         assert(closeError !== undefined, `Expecting an error!`);
         assert(closeError.errorType === "dataCorruptionError");
         assert(closeError.message === "Context is tombstoned: Call site -  process!");
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Container loaded before sweep timeout expires closes on receiving ops for tombstoned datastores",
+    itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
     [
-        {
-            eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
-        },
+        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded" },
         {
             eventName: "fluid:telemetry:Container:ContainerClose",
             error: "Context is tombstoned: Call site -  process!",
@@ -268,134 +261,173 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         },
     ],
     async () => {
-        const { testDataObjectId, summaryVersion } = await getUnreferencedDataStoreIdAndSummaryVersion();
-
-        // Wait some time, the datastore should not be sweep ready after this wait
-        await delay(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
-
-        // Load a new container and summarizer based on the latest summary
         const {
-            container: summarizingContainer2,
-            summarizer: summarizer2,
-        } = await loadSummarizerAndContainer(summaryVersion);
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+            summaryVersion,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+
         // Setup close validation
         let closeError: IErrorBase | undefined;
-        summarizingContainer2.on("closed", (error) => {
+        summarizingContainer.on("closed", (error) => {
             closeError = error;
         });
 
         // We load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-        const container2 = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
+        const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
         // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
         // production application. Causes an inactiveObject loaded error
-        const testDataObject2 = await requestFluidObject<ITestDataObject>(container2, testDataObjectId);
+        const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
 
         // Wait enough time so that the datastore is sweep ready
         await delay(waitLessThanSweepTimeoutMs);
 
-        // Send an op to update the currentTimestampMs to now
-        const mainDataStore2 = await requestFluidObject<ITestDataObject>(summarizingContainer2, "default");
-        mainDataStore2._root.set("send a", "op");
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
         // The datastore should be tombstoned now
-        await summarize(summarizer2);
+        await summarize(summarizer);
 
-        // Send an op - no sweep changed or loaded - the summarizing container does not log sweep ready errors as it
-        // closes before the op is processed and the datastore is realized
-        testDataObject2._root.set("receive", "op");
+        // Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep ready
+        // errors as it closes before the op is processed and the datastore is realized
+        dataObject._root.set("send an op to be received", "op");
         await provider.ensureSynchronized();
-        assert(summarizingContainer2.closed === true, `Summarizing container should close.`);
+        assert(summarizingContainer.closed === true, `Summarizing container should close.`);
         assert(closeError !== undefined, `Expecting an error!`);
         assert(closeError.errorType === "dataCorruptionError");
         assert(closeError.message === "Context is tombstoned: Call site -  process!");
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Container loaded after sweep timeout expires is unable to load tombstoned datastores",
+    itExpects("Requesting tombstoned datastores fails in summarizing container loaded after sweep timeout",
     [
         {
-            eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+            error: "TombstonedDataStoreRequested",
+            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+            viaHandle: false,
         },
     ],
     async () => {
-        const { testDataObjectId, summaryVersion } = await getUnreferencedDataStoreIdAndSummaryVersion();
-
-        // Wait some time, the datastore should not be sweep ready after this wait
-        await delay(sweepTimeoutMs);
-
-        // Load a new container and summarizer based on the latest summary, summarize
         const {
-            container: summarizingContainer2,
-            summarizer: summarizer2,
-        } = await loadSummarizerAndContainer(summaryVersion);
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application - causes an inactive loaded and changed error
-        await assert.doesNotReject(
-            async () => requestFluidObject<ITestDataObject>(summarizingContainer2, testDataObjectId),
-            `Should be able to still request unreferenced datastores`,
-        );
-
-        // Send an op to update the currentTimestampMs to now
-        const mainDataStore2 = await requestFluidObject<ITestDataObject>(summarizingContainer2, "default");
-        mainDataStore2._root.set("send a", "op");
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
         // The datastore should be tombstoned now
-        await summarize(summarizer2);
+        await summarize(summarizer);
 
-        // Sending an op from a datastore substantiated from the request pattern should fail!
-        await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer2, testDataObjectId),
+        // Requesting a tombstoned datastore should fail!
+        await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId),
             (error) => {
                 const correctErrorType = error.code === 404;
-                const correctErrorMessage = error.message.startsWith(`Datastore tombstoned:`) === true;
+                const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
                 return correctErrorType && correctErrorMessage;
             },
-            `Should not be able to retrieve a tombstoned datastore.`);
+            `Should not be able to retrieve a tombstoned datastore.`,
+        );
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Container loaded before sweep timeout expires is unable to load tombstoned datastores",
+    itExpects("Requesting tombstoned datastores fails in summarizing container loaded before sweep timeout",
     [
         {
-            eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded",
+            error: "TombstonedDataStoreRequested",
+            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+            viaHandle: false,
         },
     ],
     async () => {
-        const { testDataObjectId, summaryVersion } = await getUnreferencedDataStoreIdAndSummaryVersion();
-
-        // Wait some time, the datastore should not be sweep ready after this wait
-        await delay(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
-
-        // Load a new container and summarizer based on the latest summary, summarize
         const {
-            container: summarizingContainer2,
-            summarizer: summarizer2,
-        } = await loadSummarizerAndContainer(summaryVersion);
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+        // Wait enough time so that the datastore is sweep ready
+        await delay(waitLessThanSweepTimeoutMs);
 
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application - causes an inactive loaded and changed error
-        await assert.doesNotReject(
-            async () => requestFluidObject<ITestDataObject>(summarizingContainer2, testDataObjectId),
-            `Should be able to still request unreferenced datastores`,
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+        // The datastore should be tombstoned now
+        await summarize(summarizer);
+
+        // Requesting a tombstoned datastore should fail!
+        await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId),
+            (error) => {
+                const correctErrorType = error.code === 404;
+                const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
+                return correctErrorType && correctErrorMessage;
+            },
+            `Should not be able to retrieve a tombstoned datastore.`,
         );
+    });
+
+    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+    itExpects("Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
+    [
+        { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
+        {
+            error: "TombstonedDataStoreRequested",
+            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+            viaHandle: true,
+        },
+    ],
+    async () => {
+        const {
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+
+        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+        // The datastore should be tombstoned now
+        await summarize(summarizer);
+
+        // Note: if a user makes a request that looks like this, we will also think that the request is via handle
+        const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
+        const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+
+        assert(response !== undefined, `Expecting a response!`);
+        assert(response.status === 404);
+        assert(response.value.startsWith(`Datastore removed by gc`));
+    });
+
+    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+    itExpects("Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
+    [
+        { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
+        {
+            error: "TombstonedDataStoreRequested",
+            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+            viaHandle: true,
+        },
+    ],
+    async () => {
+        const {
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
 
         // Wait enough time so that the datastore is sweep ready
         await delay(waitLessThanSweepTimeoutMs);
 
-        // Send an op to update the currentTimestampMs to now
-        const mainDataStore2 = await requestFluidObject<ITestDataObject>(summarizingContainer2, "default");
-        mainDataStore2._root.set("send a", "op");
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
         // The datastore should be tombstoned now
-        await summarize(summarizer2);
+        await summarize(summarizer);
 
-        // Sending an op from a datastore substantiated from the request pattern should fail!
-        await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer2, testDataObjectId),
-            (error) => {
-                const correctErrorType = error.code === 404;
-                const correctErrorMessage = error.message.startsWith(`Datastore tombstoned:`) === true;
-                return correctErrorType && correctErrorMessage;
-            },
-            `Should not be able to retrieve a tombstoned datastore.`);
+        // Note: if a user makes a request that looks like this, we will also think that the request is via handle
+        const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
+        const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+
+        assert(response !== undefined, `Expecting a response!`);
+        assert(response.status === 404);
+        assert(response.value.startsWith(`Datastore removed by gc`));
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
@@ -211,7 +211,7 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
         {
             eventName: "fluid:telemetry:Container:ContainerClose",
-            error: "Context is tombstoned: Call site -  process!",
+            error: "Context is tombstoned! Call site [process]",
             errorType: "dataCorruptionError",
         },
     ],
@@ -247,7 +247,7 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         assert(summarizingContainer.closed === true, `Summarizing container should close.`);
         assert(closeError !== undefined, `Expecting an error!`);
         assert(closeError.errorType === "dataCorruptionError");
-        assert(closeError.message === "Context is tombstoned: Call site -  process!");
+        assert(closeError.message === "Context is tombstoned! Call site [process]");
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
@@ -256,7 +256,7 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded" },
         {
             eventName: "fluid:telemetry:Container:ContainerClose",
-            error: "Context is tombstoned: Call site -  process!",
+            error: "Context is tombstoned! Call site [process]",
             errorType: "dataCorruptionError",
         },
     ],
@@ -295,7 +295,7 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         assert(summarizingContainer.closed === true, `Summarizing container should close.`);
         assert(closeError !== undefined, `Expecting an error!`);
         assert(closeError.errorType === "dataCorruptionError");
-        assert(closeError.message === "Context is tombstoned: Call site -  process!");
+        assert(closeError.message === "Context is tombstoned! Call site [process]");
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
@@ -397,7 +397,7 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
     });
 
     // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
+    itExpects("Handle request for tombstoned datastores fails in summarizing container loaded before sweep timeout",
     [
         { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
         {


### PR DESCRIPTION
[AB#2129](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2129)

Tombstoned datastores return a 404 when requested. The message lets users know that the 404 is because of a tombstoned datastore.

Future work:
- Persist the tombstone state in the summary so that tombstoned datastores are tombstoned when the summary loads