### PR TITLE
Remove incorrect input from npm task in pipeline

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -388,8 +388,6 @@ stages:
               command: 'custom'
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run bundle-analysis:run'
-              script: |
-                echo $(System.PullRequest.TargetBranch)
 
         # Docs
         - ${{ if ne(parameters.taskBuildDocs, false) }}:


### PR DESCRIPTION
## Description

Remove unnecessary/incorrect input from Npm task in pipeline. [Docs for the Npm task](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/package/npm?view=azure-devops) suggest there's no `script` input, and I looked at its [code](https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/NpmV1/task.json) just in case, which confirmed it.

## Reviewer Guidance

Wait for the pipeline run for this PR to complete, to confirm that the task still runs successfully.