### PR TITLE
Ensure the output match explicitly in logger validate

### DIFF
--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -4,6 +4,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -249,7 +250,7 @@ describe("client.applyMsg", () => {
         const initialMsg = client.makeOpMessage(client.insertTextLocal(0, "-"), ++seq);
 
         clients.forEach((c) => c.applyMsg(initialMsg));
-        logger.validate();
+        logger.validate({ baseText: "-hello world" });
 
         const messages = [
             client.makeOpMessage(client.insertTextLocal(0, "L"), ++seq),
@@ -263,7 +264,7 @@ describe("client.applyMsg", () => {
             clients.forEach((c) => c.applyMsg(msg));
         }
 
-        logger.validate();
+        logger.validate({ baseText: "RLhello world" });
     });
 
     it("intersecting insert after local delete", () => {
@@ -282,7 +283,7 @@ describe("client.applyMsg", () => {
             clients.all.forEach((c) => c.applyMsg(msg));
         }
 
-        logger.validate();
+        logger.validate({ baseText: "cb" });
     });
 
     it("conflicting insert after shared delete", () => {
@@ -301,7 +302,7 @@ describe("client.applyMsg", () => {
             clients.all.forEach((c) => c.applyMsg(msg));
         }
 
-        logger.validate();
+        logger.validate({ baseText: "CB" });
     });
 
     it("local remove followed by conflicting insert", () => {
@@ -322,7 +323,7 @@ describe("client.applyMsg", () => {
             clients.all.forEach((c) => c.applyMsg(msg));
         }
 
-        logger.validate();
+        logger.validate({ baseText: "cb" });
     });
 
     it("intersecting insert with un-acked insert and delete", () => {
@@ -341,7 +342,7 @@ describe("client.applyMsg", () => {
             clients.all.forEach((c) => c.applyMsg(msg));
         }
 
-        logger.validate();
+        logger.validate({ baseText: "bc" });
     });
 
     it("conflicting insert over local delete", () => {
@@ -360,7 +361,7 @@ describe("client.applyMsg", () => {
             });
         }
         const logger = new TestClientLogger(clients.all);
-        logger.validate();
+        logger.validate({ baseText: "CC" });
 
         messages.push(
             clients.C.makeOpMessage(clients.C.removeRangeLocal(0, 1), ++seq),
@@ -371,7 +372,7 @@ describe("client.applyMsg", () => {
             const msg = messages.shift()!;
             clients.all.forEach((c) => c.applyMsg(msg));
         }
-        logger.validate();
+        logger.validate({ baseText: "CCBBBC" });
     });
 
     it("Local insert after acked local delete", () => {
@@ -401,7 +402,7 @@ describe("client.applyMsg", () => {
             clients.all.forEach((c) => c.applyMsg(msg));
         }
 
-        logger.validate();
+        logger.validate({ baseText: "CB" });
     });
 
     it("Remote Remove before conflicting insert", () => {
@@ -426,7 +427,7 @@ describe("client.applyMsg", () => {
             clients.all.forEach((c) => c.applyMsg(msg));
         }
 
-        logger.validate();
+        logger.validate({ baseText: "CB" });
     });
 
     it("Conflicting inserts at deleted segment position", () => {
@@ -451,7 +452,7 @@ describe("client.applyMsg", () => {
                     }
                 });
         }
-        logger.validate();
+        logger.validate({ baseText: "ab" });
     });
 
     it("Inconsistent shared string after pausing connection #9703", () => {
@@ -480,7 +481,7 @@ describe("client.applyMsg", () => {
                     }
                 });
         }
-        logger.validate();
+        logger.validate({ baseText: "ayzXd" });
     });
 
     it("regenerate annotate op over removed range", () => {

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -4,7 +4,6 @@
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -654,6 +653,6 @@ describe("client.applyMsg", () => {
             c.applyMsg(op);
         }));
 
-        logger.validate();
+        logger.validate({ baseText: "DDDDDDcbD" });
     });
 });

--- a/packages/dds/merge-tree/src/test/revertibles.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibles.spec.ts
@@ -224,7 +224,7 @@ describe("MergeTree.Revertibles", () => {
         ops.push(clients.C.makeOpMessage(clients.C.annotateRangeLocal(3, 4, { test: "C" }, undefined), ++seq));
 
         ops.splice(0).forEach((op) => clients.all.forEach((c) => c.applyMsg(op)));
-        logger.validate();
+        logger.validate({ baseText: "134" });
 
         try {
             revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
@@ -233,6 +233,6 @@ describe("MergeTree.Revertibles", () => {
             throw logger.addLogsToError(e);
         }
 
-        logger.validate();
+        logger.validate({ baseText: "1234" });
     });
 });


### PR DESCRIPTION
## Description

For the deterministic merge tree tests, the existing `logger.validate` ensures the clients' states consistent within the logger. This update makes the improvement that all clients' states will match the expected base text explicitly. 
## PR Checklist

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] My code follows the code style of this project.
-   [X] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

### Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

### Testing

Run the test `client.applyMsg.spec.ts` and `revertibles.spec.ts`
