### PR TITLE
fix(build-cli): Add baseline version and normalize JSON

### DIFF
--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -36,9 +36,25 @@ interface PackageJson {
     private: boolean | undefined;
     devDependencies: Record<string, string>;
     typeValidation?: {
+        /**
+         * The version of the package. Should match the version field in package.json.
+         */
         version: string;
+
+        /**
+         * An object containing types that are known to be broken.
+         */
         broken: BrokenCompatTypes;
+
+        /**
+         * If true, disables type test preparation and generation for the package.
+         */
         disabled?: boolean;
+
+        /**
+         * The version used as the "previous" version to compare against when generating type tests.
+         */
+        baselineVersion?: string;
     };
 }
 
@@ -301,6 +317,7 @@ export async function getAndUpdatePackageDetails(
 
         packageDetails.pkg.typeValidation = {
             version,
+            baselineVersion: prevVersion,
             broken: resetBroken === true ? {} : packageDetails.pkg.typeValidation?.broken ?? {},
         };
 
@@ -311,7 +328,7 @@ export async function getAndUpdatePackageDetails(
         if ((writeUpdates ?? false) === true) {
             await util.promisify(fs.writeFile)(
                 `${packageDir}/package.json`,
-                JSON.stringify(packageDetails.pkg, undefined, 2),
+                JSON.stringify(packageDetails.pkg, undefined, 2).concat("\n"),
             );
         }
     }


### PR DESCRIPTION
Updates the typetests command to add the baseline version as a property in the typetests node of package.json. The baseline version is helpful information and previously you had to parse it out of the \*-previous dependency string.

This change also always appends a trailing newline when writing JSON files, which is consistent with our repo settings.