### PR TITLE
Remove offline config until we better understand the error: "Nack (BadRequestError): Gap detected in incoming op"

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -14,16 +14,6 @@
                 "min": 0,
                 "max": 150000
             },
-            "offline": {
-                "delayMs": {
-                    "min": 0,
-                    "max": 150000
-                },
-                "durationMs": {
-                    "min": 5000,
-                    "max": 15000
-                }
-            },
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
@@ -123,16 +113,6 @@
             "faultInjectionMs": {
                 "min": 0,
                 "max": 10000
-            },
-            "offline": {
-                "delayMs": {
-                    "min": 0,
-                    "max": 30000
-                },
-                "durationMs": {
-                    "min": 5000,
-                    "max": 15000
-                }
             },
             "totalBlobCount": 300,
             "blobSize": 10240,


### PR DESCRIPTION
We've been getting fluid:telemetry:Container:ConnectionStateChange_Disconnected events with a "Nack (BadRequestError): Gap detected in incoming op" during the stress tests runs and they seem to be causing the clients to get disconnected and the summarizer ends up not being run. Ex. [Incident 344437165](https://portal.microsofticm.com/imp/v3/incidents/details/344437165/home) 

 These "nacks" started to happen on build 102486 in which we checked in [stress test: add scheduleOffline() (#12214) · microsoft/FluidFramework@1d4e80d (github.com)](https://github.com/microsoft/FluidFramework/commit/1d4e80d11eb985ced1af497e8b6bb028b5ac0841#diff-8b81ea995991eead8f8c5a29b72b76fdb1056487d44080b54e35eefdbef493ef)

Also, we are seeing several of the errors: Runner Failed error ("Failed to get Channel: Error: simulated offline error" that started to happen on the same build. 

This PR is trying to revert part of the original PR  so we can better understand why we got into this situation. It can even be a bug on our side that got uncovered by the offline injection. 

@anthony-murphy  @wes-carlson  I just want to confirm if you believe this change to be enough or if we should change more. 