### PR TITLE
Tree: Add  buildFieldAnchor, and fix Bug

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -366,6 +366,12 @@ export const enum FieldScope {
 }
 
 // @public
+export interface FieldUpPath {
+    readonly field: FieldKey;
+    readonly parent: UpPath | undefined;
+}
+
+// @public
 export type ForestLocation = ITreeSubscriptionCursor | Anchor;
 
 // @public
@@ -530,6 +536,8 @@ export interface ITreeCursor {
     // (undocumented)
     getFieldLength(): number;
     // (undocumented)
+    getFieldPath(): FieldUpPath;
+    // (undocumented)
     getPath(): UpPath | undefined;
     readonly mode: CursorLocationType;
     nextField(): boolean;
@@ -551,6 +559,7 @@ export interface ITreeCursorSynchronous extends ITreeCursor {
 // @public
 export interface ITreeSubscriptionCursor extends ITreeCursor {
     buildAnchor(): Anchor;
+    buildFieldAnchor(): FieldAnchor;
     clear(): void;
     // (undocumented)
     fork(observer?: ObservingDependent): ITreeSubscriptionCursor;
@@ -1238,7 +1247,6 @@ export type UnwrappedEditableTree = EditableTreeOrPrimitive | readonly Unwrapped
 
 // @public
 export interface UpPath {
-    // (undocumented)
     readonly parent: UpPath | undefined;
     readonly parentField: FieldKey;
     readonly parentIndex: number;

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -26,6 +26,7 @@ export {
     AnchorSet,
     DetachedField,
     UpPath,
+    FieldUpPath,
     Anchor,
     RootField,
     ChildCollection,

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -32,6 +32,7 @@ import {
     getMapTreeField,
     FieldAnchor,
     afterChangeToken,
+    FieldUpPath,
 } from "../../core";
 import { brand, fail } from "../../util";
 import { CursorWithNode, SynchronousCursor } from "../treeCursorUtils";
@@ -303,6 +304,16 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
     private innerCursor?: CursorWithNode<MapTree>;
     public constructor(public readonly forest: ObjectForest) {
         super();
+    }
+    buildFieldAnchor(): FieldAnchor {
+        const path = this.getFieldPath();
+        const anchor =
+            path.parent === undefined ? undefined : this.forest.anchors.track(path.parent);
+        return { parent: anchor, fieldKey: path.field };
+    }
+    getFieldPath(): FieldUpPath {
+        assert(this.innerCursor !== undefined, "Cursor must be current to be used");
+        return this.innerCursor.getFieldPath();
     }
     get mode(): CursorLocationType {
         assert(this.innerCursor !== undefined, "Cursor must be current to be used");

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -11,6 +11,7 @@ import {
     CursorLocationType,
     ITreeCursorSynchronous,
     Value,
+    FieldUpPath,
 } from "../core";
 import { fail } from "../util";
 
@@ -143,11 +144,25 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
 
     public getPath(): UpPath | undefined {
         assert(this.mode === CursorLocationType.Nodes, 0x3b9 /* must be in nodes mode */);
-        // Even since in nodes mode
-        const length = this.indexStack.length;
+        return this.getOffsetPath(0);
+    }
+
+    public getFieldPath(): FieldUpPath {
+        assert(this.mode === CursorLocationType.Fields, "must be in fields mode");
+        return {
+            field: this.getFieldKey(),
+            parent: this.getOffsetPath(1),
+        };
+    }
+
+    private getOffsetPath(offset: number): UpPath | undefined {
+        const length = this.indexStack.length - offset;
         if (length === 0) {
             return undefined; // At root
         }
+
+        assert(length > 0, "invalid offset to above root");
+        assert(length % 2 === 0, "offset path must point to node not field");
 
         // Perf Note:
         // This is O(depth) in tree.

--- a/packages/dds/tree/src/forest/forest.ts
+++ b/packages/dds/tree/src/forest/forest.ts
@@ -103,7 +103,7 @@ export function moveToDetachedField(
 
 /**
  * Anchor to a field.
- * This is structurally based on the parent, so it will move only as the parent moves.W
+ * This is structurally based on the parent, so it will move only as the parent moves.
  */
 export interface FieldAnchor {
     /**
@@ -152,8 +152,18 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
     /**
      * Construct an `Anchor` which the IForestSubscription will keep rebased to `current`.
      * Note that maintaining an Anchor has cost: free them to stop incurring that cost.
+     *
+     * Only valid when `mode` is `Nodes`.
      */
     buildAnchor(): Anchor;
+
+    /**
+     * Construct a `FieldAnchor` which the IForestSubscription will keep rebased to `current`.
+     * Note that maintaining an Anchor has cost: free them to stop incurring that cost.
+     *
+     * Only valid when `mode` is `Fields`.
+     */
+    buildFieldAnchor(): FieldAnchor;
 
     /**
      * Current state.

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -19,6 +19,7 @@ export {
     AnchorSet,
     DetachedField,
     UpPath,
+    FieldUpPath,
     Anchor,
     RootField,
     ChildCollection,

--- a/packages/dds/tree/src/test/cursor.spec.ts
+++ b/packages/dds/tree/src/test/cursor.spec.ts
@@ -455,13 +455,14 @@ export function testJsonableTreeCursor(
                       parentField: rootFieldKeySymbol,
                       parentIndex: 0,
                   };
+
             it("at root", () => {
                 const cursor = factory({
                     type: brand("Foo"),
                 });
                 assert.deepEqual(cursor.getPath(), parent);
             });
-            
+
             it("getFieldPath in root field", () => {
                 const cursor = factory({
                     type: brand("Foo"),
@@ -472,6 +473,7 @@ export function testJsonableTreeCursor(
                     field: "key",
                 });
             });
+
             it("first node in a root field", () => {
                 const cursor = factory({
                     type: brand("Foo"),

--- a/packages/dds/tree/src/test/cursor.spec.ts
+++ b/packages/dds/tree/src/test/cursor.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { GlobalFieldKey, LocalFieldKey } from "../schema-stored";
 
 import {
     EmptyKey,
@@ -13,6 +14,8 @@ import {
     mapCursorFields,
     CursorLocationType,
     rootFieldKeySymbol,
+    symbolFromKey,
+    setGenericTreeField,
 } from "../tree";
 import { brand } from "../util";
 
@@ -25,20 +28,37 @@ export const cursorTestCases: [string, JsonableTree][] = [
     ["string with escaped characters", { type: brand("Foo"), value: '\\"\b\f\n\r\t' }],
     ["string with emoticon", { type: brand("Foo"), value: "😀" }],
     [
-        "nested",
+        "local field",
         {
             type: brand("Foo"),
             fields: { x: [{ type: brand("Bar") }, { type: brand("Foo"), value: 6 }] },
         },
     ],
     [
-        "multiple fields",
+        "global field",
+        {
+            type: brand("Foo"),
+            globalFields: { x: [{ type: brand("Bar") }] },
+        },
+    ],
+    [
+        "multiple local fields",
         {
             type: brand("Foo"),
             fields: {
                 a: [{ type: brand("Bar") }],
                 b: [{ type: brand("Baz") }],
             },
+        },
+    ],
+    [
+        "global and local fields",
+        {
+            type: brand("Foo"),
+            fields: {
+                a: [{ type: brand("Bar") }],
+            },
+            globalFields: { a: [{ type: brand("Baz") }] },
         },
     ],
     [
@@ -427,7 +447,7 @@ export function testJsonableTreeCursor(
             });
         });
 
-        describe("getPath() returns correct path for", () => {
+        describe("getPath() and getFieldPath()", () => {
             const parent = testRooted
                 ? undefined
                 : {
@@ -435,7 +455,23 @@ export function testJsonableTreeCursor(
                       parentField: rootFieldKeySymbol,
                       parentIndex: 0,
                   };
-            it(`first node in a root trait`, () => {
+            it("at root", () => {
+                const cursor = factory({
+                    type: brand("Foo"),
+                });
+                assert.deepEqual(cursor.getPath(), parent);
+            });
+            it("getFieldPath in root field", () => {
+                const cursor = factory({
+                    type: brand("Foo"),
+                });
+                cursor.enterField(brand("key"));
+                assert.deepEqual(cursor.getFieldPath(), {
+                    parent,
+                    field: "key",
+                });
+            });
+            it("first node in a root field", () => {
                 const cursor = factory({
                     type: brand("Foo"),
                     fields: { key: [{ type: brand("Bar"), value: 0 }] },
@@ -449,7 +485,7 @@ export function testJsonableTreeCursor(
                 });
             });
 
-            it(`node in a root trait`, () => {
+            it("node in a root field", () => {
                 const cursor = factory({
                     type: brand("Foo"),
                     fields: {
@@ -468,7 +504,7 @@ export function testJsonableTreeCursor(
                 });
             });
 
-            it(`first node in a nested trait`, () => {
+            it("in a nested field", () => {
                 const cursor = factory({
                     type: brand("Foo"),
                     fields: {
@@ -481,37 +517,69 @@ export function testJsonableTreeCursor(
                     },
                 });
                 cursor.enterField(brand("a"));
-                assert.equal(cursor.firstNode(), true);
+                cursor.enterNode(0);
                 cursor.enterField(EmptyKey);
-                assert.equal(cursor.firstNode(), true);
+                const initialPath = {
+                    parent,
+                    parentField: "a",
+                    parentIndex: 0,
+                };
+                assert.deepEqual(cursor.getFieldPath(), {
+                    parent: initialPath,
+                    field: EmptyKey,
+                });
+                cursor.enterNode(0);
                 assert.deepEqual(cursor.getPath(), {
-                    parent: {
-                        parent,
-                        parentField: brand<FieldKey>("a"),
-                        parentIndex: 0,
-                    },
+                    parent: initialPath,
                     parentField: EmptyKey,
                     parentIndex: 0,
                 });
             });
         });
 
-        for (const [name, data] of cursorTestCases) {
-            const restrictedKeys: FieldKey[] = [
+        describe("key tests", () => {
+            const testGlobalKey = symbolFromKey(brand("testGlobalKey"));
+            const testKeys: FieldKey[] = [
                 brand("__proto__"),
                 brand("toString"),
                 brand("toFixed"),
                 brand("hasOwnProperty"),
+                EmptyKey,
+                testGlobalKey,
+                rootFieldKeySymbol,
             ];
+            const unrelatedKey: LocalFieldKey = brand("unrelated");
+            const unrelatedGlobalKey: GlobalFieldKey = brand("unrelatedGlobal");
+            for (const key of testKeys) {
+                it(`returns no values for key: ${key.toString()}`, () => {
+                    const trees: JsonableTree[] = [
+                        // Test an empty tree, and one with unrelated fields
+                        { type: brand("Foo") },
+                        {
+                            type: brand("Foo"),
+                            fields: { [unrelatedKey]: [{ type: brand("Foo") }] },
+                            globalFields: { [unrelatedGlobalKey]: [{ type: brand("Foo") }] },
+                        },
+                    ];
+                    for (const data of trees) {
+                        const cursor = factory({ type: brand("Foo") });
+                        cursor.enterField(key);
+                        assert.equal(cursor.getFieldLength(), 0);
+                    }
+                });
 
-            it(`returns no values for retricted keys on ${name} tree`, () => {
-                for (const key of restrictedKeys) {
-                    const cursor = factory(data);
+                it(`handles values for key: ${key.toString()}`, () => {
+                    const tree: JsonableTree = { type: brand("Foo") };
+                    const child: JsonableTree[] = [{ type: brand("Bar") }];
+                    setGenericTreeField(tree, key, child);
+                    const cursor = factory(tree);
                     cursor.enterField(key);
-                    assert.equal(cursor.getFieldLength(), 0);
-                }
-            });
-        }
+                    assert.equal(cursor.getFieldLength(), 1);
+                    cursor.enterNode(0);
+                    assert.equal(cursor.type, "Bar");
+                });
+            }
+        });
     });
 }
 

--- a/packages/dds/tree/src/test/cursor.spec.ts
+++ b/packages/dds/tree/src/test/cursor.spec.ts
@@ -461,6 +461,7 @@ export function testJsonableTreeCursor(
                 });
                 assert.deepEqual(cursor.getPath(), parent);
             });
+            
             it("getFieldPath in root field", () => {
                 const cursor = factory({
                     type: brand("Foo"),

--- a/packages/dds/tree/src/tree/cursor.ts
+++ b/packages/dds/tree/src/tree/cursor.ts
@@ -97,13 +97,13 @@ export interface ITreeCursor {
     enterNode(childIndex: number): void;
 
     /**
-     * @returns a path to the current node.
+     * @returns a path to the current field. See {@link FieldUpPath}.
      *
-     * Only valid when `mode` is `Nodes`.
+     * Only valid when `mode` is `Fields`.
      * Assumes this cursor has a root node where its field keys are actually detached sequences.
      * If the cursor is not rooted at such a node,
-     * calling this function is invalid, and the returned UpPath (if any) may not be meaningful.
-     * This requirement exists because {@link UpPath}s are absolute paths
+     * calling this function is invalid, and the returned FieldUpPath (if any) may not be meaningful.
+     * This requirement exists because {@link FieldUpPath}s are absolute paths
      * and thus must be rooted in a detached sequence.
      * TODO: consider adding an optional base path to append to remove/clarify this restriction.
      */
@@ -112,7 +112,7 @@ export interface ITreeCursor {
     // ********** APIs for when mode = Nodes ********** //
 
     /**
-     * @returns a path to the current node.
+     * @returns a path to the current node. See {@link UpPath}.
      *
      * Only valid when `mode` is `Nodes`.
      * Assumes this cursor has a root node where its field keys are actually detached sequences.

--- a/packages/dds/tree/src/tree/cursor.ts
+++ b/packages/dds/tree/src/tree/cursor.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { UpPath } from "./pathTree";
+import { FieldUpPath, UpPath } from "./pathTree";
 import { FieldKey, TreeType, Value } from "./types";
 
 /**
@@ -95,6 +95,19 @@ export interface ITreeCursor {
      * Sets mode to `Nodes`.
      */
     enterNode(childIndex: number): void;
+
+    /**
+     * @returns a path to the current node.
+     *
+     * Only valid when `mode` is `Nodes`.
+     * Assumes this cursor has a root node where its field keys are actually detached sequences.
+     * If the cursor is not rooted at such a node,
+     * calling this function is invalid, and the returned UpPath (if any) may not be meaningful.
+     * This requirement exists because {@link UpPath}s are absolute paths
+     * and thus must be rooted in a detached sequence.
+     * TODO: consider adding an optional base path to append to remove/clarify this restriction.
+     */
+    getFieldPath(): FieldUpPath;
 
     // ********** APIs for when mode = Nodes ********** //
 

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -20,7 +20,7 @@ export {
     symbolIsFieldKey,
 } from "./globalFieldKeySymbol";
 export { getMapTreeField, MapTree } from "./mapTree";
-export { clonePath, getDepth, UpPath } from "./pathTree";
+export { clonePath, getDepth, UpPath, FieldUpPath } from "./pathTree";
 export {
     FieldMapObject,
     FieldScope,

--- a/packages/dds/tree/src/tree/pathTree.ts
+++ b/packages/dds/tree/src/tree/pathTree.ts
@@ -19,18 +19,35 @@ import { FieldKey } from "./types";
  */
 export interface UpPath {
     /**
-     * @returns the parent, or undefined in the case where this path is a member of a detached sequence.
+     * The parent, or undefined in the case where this path is a member of a detached sequence.
      */
     readonly parent: UpPath | undefined;
     /**
      * The Field under which this path points.
-     * Note that if `parent` returns `undefined`, this key is a LocalFieldKey that corresponds to a detached sequence.
+     * Note that if `parent` returns `undefined`, this key corresponds to a detached sequence.
      */
     readonly parentField: FieldKey; // TODO: Type information, including when in DetachedField.
     /**
      * The index within `parentField` this path is pointing to.
      */
     readonly parentIndex: number; // TODO: field index branded type?
+}
+
+/**
+ * Path from a field in the tree upward.
+ *
+ * See {@link UpPath}.
+ */
+export interface FieldUpPath {
+    /**
+     * The parent, or undefined in the case where this path is to a detached sequence.
+     */
+    readonly parent: UpPath | undefined;
+    /**
+     * The Field to which this path points.
+     * Note that if `parent` returns `undefined`, this key  corresponds to a detached sequence.
+     */
+    readonly field: FieldKey; // TODO: Type information, including when in DetachedField.
 }
 
 /**

--- a/packages/dds/tree/src/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/tree/treeTextFormat.ts
@@ -153,7 +153,13 @@ export function setGenericTreeField<T>(
 ): void {
     const [scope, keyString] = scopeFromKey(key);
     const children = getGenericTreeFieldMap(node, scope, true);
-    children[keyString] = content;
+    // like `children[keyString] = content;` except safe when keyString == "__proto__".
+    Object.defineProperty(children, keyString, {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value: content,
+    });
 }
 
 /**
@@ -170,14 +176,14 @@ export function genericTreeKeys<T>(tree: GenericFieldsNode<T>): readonly FieldKe
         if (global === undefined) {
             return [];
         }
-        return (Object.getOwnPropertyNames(global) as GlobalFieldKey[]).map(symbolFromKey);
+        return (Object.keys(global) as GlobalFieldKey[]).map(symbolFromKey);
     }
     if (global === undefined) {
-        return Object.getOwnPropertyNames(local) as LocalFieldKey[];
+        return Object.keys(local) as LocalFieldKey[];
     }
     return [
-        ...(Object.getOwnPropertyNames(local) as LocalFieldKey[]),
-        ...(Object.getOwnPropertyNames(global) as GlobalFieldKey[]).map(symbolFromKey),
+        ...(Object.keys(local) as LocalFieldKey[]),
+        ...(Object.keys(global) as GlobalFieldKey[]).map(symbolFromKey),
     ];
 }
 
@@ -197,7 +203,7 @@ export function genericTreeDeleteIfEmpty<T>(
             // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
             delete children[keyString];
             if (removeMapObject) {
-                if (Object.getOwnPropertyNames(children).length === 0) {
+                if (Object.keys(children).length === 0) {
                     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                     delete node[scope];
                 }


### PR DESCRIPTION
## Description

This adds ITreeSubscriptionCursor.buildFieldAnchor and ITreeCursor.getFieldPath to support it.

Additionally, this tweaks the Cursor tests cover a few more cases, and caught and fixes a bug in the handling of fields named __proto__: object.DefineProperty must be used to set such fields on objects!

This also changes a few uses of Object.getOwnPropertyNames() to Object.keys() where enumerating fields from map like objects. Both actually work (as long as there are no non enumerable properties like methods), but only including enumerable properties seems more semantically correct and would work in more cases (though we don't care about those cases, it seems more robust).
