### PR TITLE
fix(build-cli): Read layer config file without using require()

### DIFF
--- a/build-tools/packages/build-cli/docs/check.md
+++ b/build-tools/packages/build-cli/docs/check.md
@@ -12,14 +12,14 @@ Checks that the dependencies between Fluid Framework packages are properly layer
 
 ```
 USAGE
-  $ flub check layers [--md <value>] [--dot <value>] [--info <value>] [--logtime] [-v]
+  $ flub check layers --info <value> [--md <value>] [--dot <value>] [--logtime] [-v]
 
 FLAGS
   -v, --verbose   Verbose logging.
   --dot=<value>   Generate *.dot for GraphViz
-  --info=<value>  Path to the layer graph json file
+  --info=<value>  (required) Path to the layer graph json file
   --logtime       Display the current time on every status message for logging
-  --md=<value>    [default: .] Generate PACKAGES.md file at this path relative to repo root
+  --md=<value>    Generate PACKAGES.md file at this path relative to repo root
 
 DESCRIPTION
   Checks that the dependencies between Fluid Framework packages are properly layered.

--- a/build-tools/packages/build-cli/src/commands/check/layers.ts
+++ b/build-tools/packages/build-cli/src/commands/check/layers.ts
@@ -26,7 +26,8 @@ export class CheckLayers extends BaseCommand<typeof CheckLayers.flags> {
         }),
         info: Flags.file({
             description: "Path to the layer graph json file",
-            required: false,
+            required: true,
+            exists: true,
         }),
         logtime: Flags.boolean({
             description: "Display the current time on every status message for logging",

--- a/build-tools/packages/build-cli/src/commands/check/layers.ts
+++ b/build-tools/packages/build-cli/src/commands/check/layers.ts
@@ -19,7 +19,6 @@ export class CheckLayers extends BaseCommand<typeof CheckLayers.flags> {
         md: Flags.string({
             description: `Generate ${packagesMdFileName} file at this path relative to repo root`,
             required: false,
-            default: ".", // default is repo root (relative path to repo root)
         }),
         dot: Flags.file({
             description: "Generate *.dot for GraphViz",

--- a/build-tools/packages/build-tools/src/layerCheck/layerGraph.ts
+++ b/build-tools/packages/build-tools/src/layerCheck/layerGraph.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 
 import { defaultLogger } from "../common/logging";
 import { Package, Packages } from "../common/npmPackage";
+import { readJsonSync } from "../common/utils";
 
 const { verbose } = defaultLogger;
 
@@ -566,8 +567,9 @@ ${lines.join(newline)}
     }
 
     public static load(root: string, packages: Packages, info?: string): LayerGraph {
-        const layerInfoFile = require(info ??
-            path.join(__dirname, "..", "..", "data", "layerInfo.json"));
-        return new LayerGraph(root, layerInfoFile, packages);
+        const layerInfoFile = info ??
+            path.join(__dirname, "..", "..", "data", "layerInfo.json");
+            const layerData: ILayerInfoFile = readJsonSync(layerInfoFile);
+        return new LayerGraph(root, layerData, packages);
     }
 }

--- a/build-tools/packages/build-tools/src/layerCheck/layerGraph.ts
+++ b/build-tools/packages/build-tools/src/layerCheck/layerGraph.ts
@@ -567,9 +567,8 @@ ${lines.join(newline)}
     }
 
     public static load(root: string, packages: Packages, info?: string): LayerGraph {
-        const layerInfoFile = info ??
-            path.join(__dirname, "..", "..", "data", "layerInfo.json");
-            const layerData: ILayerInfoFile = readJsonSync(layerInfoFile);
+        const layerInfoFile = info ?? path.join(__dirname, "..", "..", "data", "layerInfo.json");
+        const layerData: ILayerInfoFile = readJsonSync(layerInfoFile);
         return new LayerGraph(root, layerData, packages);
     }
 }


### PR DESCRIPTION
Fixes the following issues with the `check layers` command:

1. Replace use of `require` for JSON files with filesystem APIs.
2. `--md` flag no longer has a default, so the command no longer outputs the markdown file all the time.
3. `--info` is now a required flag.

BREAKING CHANGE: The `--info` flag is now required.
