### PR TITLE
Fix issues with __proto__ fields in json domain

### DIFF
--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -119,6 +119,13 @@ export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
                 const key = cursor.getFieldKey() as LocalFieldKey;
                 assert(cursor.firstNode(), 0x420 /* expected non-empty field */);
                 result[key] = cursorToJsonObject(reader);
+                // like `result[key] = cursorToJsonObject(reader);` except safe when keyString == "__proto__".
+                Object.defineProperty(result, key, {
+                    enumerable: true,
+                    configurable: true,
+                    writable: true,
+                    value: cursorToJsonObject(reader),
+                });
                 assert(!cursor.nextNode(), 0x421 /* expected exactly one node */);
             });
             return result;

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -41,7 +41,13 @@ function cloneObject<T, J = Jsonable<T>>(obj: J): J {
         // PERF: Nested array allocs make 'Object.entries()' ~2.4x slower than reading
         //       value via 'value[key]', even when destructuring. (node 14 x64)
         for (const key of Object.keys(obj)) {
-            result[key] = clone((obj as any)[key]);
+            // Like `result[key] = clone((obj as any)[key]);` but safe for when key == "__proto__"
+            Object.defineProperty(result, key, {
+                enumerable: true,
+                configurable: true,
+                writable: true,
+                value: clone((obj as any)[key]),
+            });
         }
         return result as J;
     }

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { EmptyKey, ITreeCursor, singleJsonCursor, cursorToJsonObject } from "../../..";
-import { CursorLocationType, FieldKey, mapCursorFields } from "../../../tree";
+import { CursorLocationType, FieldKey, mapCursorFields, rootFieldKeySymbol } from "../../../tree";
 import { brand } from "../../../util";
 import { testCursors } from "../../cursor.spec";
 
@@ -29,6 +29,17 @@ const testCases = [
                 a2: [null, true, 0, "", { n: null, b: true, i: 0, s: "", a2: [0] }],
             },
             [null, true, 0, "", { n: null, b: true, i: 0, s: "", a2: [null, true, 0, "", {}] }],
+        ],
+    ],
+    [
+        "problematic field names",
+        [
+            {
+                ["__proto__"]: 1,
+                [""]: 2,
+                hasOwnProperty: 3,
+                toString: 4,
+            },
         ],
     ],
 ];
@@ -64,7 +75,25 @@ describe("JsonCursor", () => {
         const getFieldKey = (cursor: ITreeCursor) => cursor.getFieldKey();
         const getKeysAsSet = (cursor: ITreeCursor) => new Set(mapCursorFields(cursor, getFieldKey));
 
+        function doesNotHaveKeys(cursor: ITreeCursor, keys: (string | FieldKey)[]): void {
+            const actualKeys = getKeysAsSet(cursor);
+            for (const key of keys) {
+                assert(!actualKeys.has(key as FieldKey));
+                cursor.enterField(key as FieldKey);
+                assert(!cursor.firstField());
+            }
+        }
+
+        const unexpectedKeys = [
+            "__proto__",
+            rootFieldKeySymbol,
+            "hasOwnProperty",
+            "toString",
+            "toFixed",
+        ];
+
         it("object", () => {
+            doesNotHaveKeys(singleJsonCursor({}), unexpectedKeys);
             assert.deepEqual(getKeysAsSet(singleJsonCursor({})), new Set());
             assert.deepEqual(getKeysAsSet(singleJsonCursor({ x: {} })), new Set(["x"]));
             assert.deepEqual(
@@ -74,22 +103,26 @@ describe("JsonCursor", () => {
         });
 
         it("array", () => {
+            doesNotHaveKeys(singleJsonCursor([]), unexpectedKeys);
             assert.deepEqual(getKeysAsSet(singleJsonCursor([])), new Set([]));
             assert.deepEqual(getKeysAsSet(singleJsonCursor([0])), new Set([EmptyKey]));
             assert.deepEqual(getKeysAsSet(singleJsonCursor(["test", {}])), new Set([EmptyKey]));
         });
 
         it("string", () => {
+            doesNotHaveKeys(singleJsonCursor("x"), unexpectedKeys);
             assert.deepEqual(getKeysAsSet(singleJsonCursor("")), new Set());
             assert.deepEqual(getKeysAsSet(singleJsonCursor("test")), new Set());
         });
 
         it("number", () => {
+            doesNotHaveKeys(singleJsonCursor(0), unexpectedKeys);
             assert.deepEqual(getKeysAsSet(singleJsonCursor(0)), new Set());
             assert.deepEqual(getKeysAsSet(singleJsonCursor(6.5)), new Set());
         });
 
         it("boolean", () => {
+            doesNotHaveKeys(singleJsonCursor(true), unexpectedKeys);
             assert.deepEqual(getKeysAsSet(singleJsonCursor(false)), new Set());
             assert.deepEqual(getKeysAsSet(singleJsonCursor(true)), new Set());
         });


### PR DESCRIPTION
## Description

Fix same bug as in #12687 except in cursorToJsonObject and generic JS object clone code for perf comparison.

The old code would change the prototype of the object (via the __proto__ field defined on the prototype), while the new code adds an enumerable own property that shadows __proto__.

benchmarks show a slight slowdown with this change, around 2-3% for cursorToJsonObject, and around 6% for the raw JS object clone reference.