### PR TITLE
Tree: remove duplicated assignment

### DIFF
--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -118,7 +118,6 @@ export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
             mapCursorFields(reader, (cursor) => {
                 const key = cursor.getFieldKey() as LocalFieldKey;
                 assert(cursor.firstNode(), 0x420 /* expected non-empty field */);
-                result[key] = cursorToJsonObject(reader);
                 // like `result[key] = cursorToJsonObject(reader);` except safe when keyString == "__proto__".
                 Object.defineProperty(result, key, {
                     enumerable: true,


### PR DESCRIPTION
## Description

Fix bug in #12692 . Old version of the assignment was accidently left in one spot after restoring it to do performance comparison.