### PR TITLE
Tree: fix `getFieldPath()` and adopt it in `cursor.fork()`

### DIFF
--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -437,9 +437,16 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
     }
 
     fork(observer?: ObservingDependent): ITreeSubscriptionCursor {
+        assert(this.innerCursor !== undefined, "Cursor must be current to be used");
         const other = this.forest.allocateCursor();
-        const path = this.getPath();
-        this.forest.moveCursorToPath(path, other, observer);
+        if (this.innerCursor.mode === CursorLocationType.Fields) {
+            const path = this.getFieldPath();
+            this.forest.moveCursorToPath(path.parent, other, observer);
+            other.enterField(path.field);
+        } else {
+            const path = this.getPath();
+            this.forest.moveCursorToPath(path, other, observer);
+        }
         return other;
     }
 

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -185,7 +185,7 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
 
         path = {
             parent: path,
-            parentIndex: this.index,
+            parentIndex: offset === 0 ? this.index : this.getStackedNodeIndex(length),
             parentField: this.getStackedFieldKey(length - 1),
         };
         return path;

--- a/packages/dds/tree/src/test/cursor.spec.ts
+++ b/packages/dds/tree/src/test/cursor.spec.ts
@@ -516,16 +516,20 @@ export function testJsonableTreeCursor(
                                 type: brand("Bar"),
                                 fields: { [EmptyKey]: [{ type: brand("Baz") }] },
                             },
+                            {
+                                type: brand("Bar"),
+                                fields: { [EmptyKey]: [{ type: brand("Baz") }] },
+                            },
                         ],
                     },
                 });
                 cursor.enterField(brand("a"));
-                cursor.enterNode(0);
+                cursor.enterNode(1);
                 cursor.enterField(EmptyKey);
                 const initialPath = {
                     parent,
                     parentField: "a",
-                    parentIndex: 0,
+                    parentIndex: 1,
                 };
                 assert.deepEqual(cursor.getFieldPath(), {
                     parent: initialPath,


### PR DESCRIPTION
This PR fixes two things:
1. `getFieldPath` properly returns the parent node index within the parent path. The issue was caused by the fact that, when being in the field and using `getOffsetPath`, `this.index` actually gives an "initial" state of the cursor, as the parent node's index is already "stacked", so the index must be fetched from the stack instead.
2. It allows to `fork` cursors in field mode by means of `getFieldPath`.