### PR TITLE
Use dev feed for @fluid-internal packages

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -80,6 +80,12 @@ jobs:
       - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')) }}:
         - name: feed
           value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+      - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}:
+        - name: devFeed
+          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+      - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')) }}:
+        - name: devFeed
+          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
       - ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
         - name: artifactPipeline
           value: Build - azure
@@ -181,7 +187,7 @@ jobs:
 
             echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
-            echo "@fluid-internal:registry=${{ variables.feed }}" >> ./.npmrc
+            echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
             echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
             echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
             echo "always-auth=true" >> ./.npmrc
@@ -191,7 +197,7 @@ jobs:
               echo "##vso[task.setvariable variable=testPackageTgz;isOutput=true]`ls ${{ variables.testPackagePathPattern }}`"
             else
               ls -1 ${{ variables.testPackagePathPattern }}
-              echo "##vso[task.logissue type=error]Test package '${{ parameters.testPackage }}' not found, or there are more then one found"
+              echo "##vso[task.logissue type=error]Test package '${{ parameters.testPackage }}' not found, or there are more than one found"
             fi
 
       # Auth to internal feed


### PR DESCRIPTION
## Description

This fixes the `include-real-test-service` template to follow our new publish setup for @fluid-internal packages. It's a subset of the changes in #12304.
