### PR TITLE
Add eslint rules to require source-code docs on *most* module-exported members

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -18,7 +18,7 @@ import { IUser } from '@fluidframework/protocol-definitions';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 import { ServiceAudience } from '@fluidframework/fluid-static';
 
-// @public (undocumented)
+// @public
 export class AzureAudience extends ServiceAudience<AzureMember> implements IAzureAudience {
     // @internal
     protected createServiceMember(audienceMember: IClient): AzureMember;

--- a/azure/packages/azure-client/.eslintrc.js
+++ b/azure/packages/azure-client/.eslintrc.js
@@ -5,8 +5,40 @@
 
 module.exports = {
     extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
+    plugins: ["eslint-plugin-jsdoc"],
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    rules: {},
+    rules: {
+        // Require jsdoc/tsdoc comments on public/exported API items.
+        "jsdoc/require-jsdoc": [
+            "error",
+            {
+                // Indicates that only module exports should be flagged for lacking jsdoc comments
+                publicOnly: true,
+                enableFixer: false, // Prevents eslint from adding empty comment blocks when run with `--fix`
+                require: {
+                    ClassDeclaration: true,
+                    FunctionDeclaration: true,
+
+                    // Will report for any methods on exported types, regardless of whether or not they are public
+                    MethodDefinition: false,
+                },
+                contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],
+            },
+        ],
+
+        // Ensure jsdoc/tsdoc comments contain a main description component
+        // (disallows empty comments / only tags).
+        "jsdoc/require-description": ["error", { checkConstructors: false }],
+    },
+    overrides: [
+        {
+            files: ["packageVersion.ts"],
+            rules: {
+                "jsdoc/require-jsdoc": "off",
+                "jsdoc/require-description": "off",
+            },
+        },
+    ],
 };

--- a/azure/packages/azure-client/.eslintrc.js
+++ b/azure/packages/azure-client/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
                     ClassDeclaration: true,
                     FunctionDeclaration: true,
 
-                    // Will report for any methods on exported types, regardless of whether or not they are public
+                    // Will report for *any* methods on exported classes, regardless of whether or not they are public
                     MethodDefinition: false,
                 },
                 contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],

--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -78,6 +78,7 @@
     "cross-env": "^7.0.2",
     "eslint": "~8.6.0",
     "eslint-config-prettier": "~8.5.0",
+    "eslint-plugin-jsdoc": "~39.3.0",
     "mocha": "^10.0.0",
     "prettier": "~2.6.2",
     "rimraf": "^2.6.2",

--- a/azure/packages/azure-client/src/AzureAudience.ts
+++ b/azure/packages/azure-client/src/AzureAudience.ts
@@ -8,6 +8,11 @@ import { IClient } from "@fluidframework/protocol-definitions";
 
 import { AzureMember, AzureUser, IAzureAudience } from "./interfaces";
 
+/**
+ * Azure-specific {@link @fluidframework/fluid-static#ServiceAudience} implementation.
+ *
+ * @remarks Operates in terms of {@link AuzreMember}s.
+ */
 export class AzureAudience extends ServiceAudience<AzureMember> implements IAzureAudience {
     /**
      * Creates a {@link @fluidframework/fluid-static#ServiceAudience} from the provided

--- a/azure/packages/azure-client/src/AzureAudience.ts
+++ b/azure/packages/azure-client/src/AzureAudience.ts
@@ -11,7 +11,7 @@ import { AzureMember, AzureUser, IAzureAudience } from "./interfaces";
 /**
  * Azure-specific {@link @fluidframework/fluid-static#ServiceAudience} implementation.
  *
- * @remarks Operates in terms of {@link AuzreMember}s.
+ * @remarks Operates in terms of {@link AzureMember}s.
  */
 export class AzureAudience extends ServiceAudience<AzureMember> implements IAzureAudience {
     /**

--- a/azure/packages/azure-local-service/.eslintrc.js
+++ b/azure/packages/azure-local-service/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/strict")],
     plugins: ["eslint-plugin-jsdoc"],
     parserOptions: {
         project: ["./tsconfig.json"],

--- a/azure/packages/azure-local-service/.eslintrc.js
+++ b/azure/packages/azure-local-service/.eslintrc.js
@@ -3,15 +3,42 @@
  * Licensed under the MIT License.
  */
 
- module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json"]
+module.exports = {
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
+    plugins: ["eslint-plugin-jsdoc"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
-        "import/no-unassigned-import": "off",
-        "@typescript-eslint/strict-boolean-expressions": "off"
-    }
-}
+    rules: {
+        // Require jsdoc/tsdoc comments on public/exported API items.
+        "jsdoc/require-jsdoc": [
+            "error",
+            {
+                // Indicates that only module exports should be flagged for lacking jsdoc comments
+                publicOnly: true,
+                enableFixer: false, // Prevents eslint from adding empty comment blocks when run with `--fix`
+                require: {
+                    ClassDeclaration: true,
+                    FunctionDeclaration: true,
+
+                    // Will report for any methods on exported types, regardless of whether or not they are public
+                    MethodDefinition: false,
+                },
+                contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],
+            },
+        ],
+
+        // Ensure jsdoc/tsdoc comments contain a main description component
+        // (disallows empty comments / only tags).
+        "jsdoc/require-description": ["error", { checkConstructors: false }],
+    },
+    overrides: [
+        {
+            files: ["packageVersion.ts"],
+            rules: {
+                "jsdoc/require-jsdoc": "off",
+                "jsdoc/require-description": "off",
+            },
+        },
+    ],
+};

--- a/azure/packages/azure-local-service/.eslintrc.js
+++ b/azure/packages/azure-local-service/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
                     ClassDeclaration: true,
                     FunctionDeclaration: true,
 
-                    // Will report for any methods on exported types, regardless of whether or not they are public
+                    // Will report for *any* methods on exported classes, regardless of whether or not they are public
                     MethodDefinition: false,
                 },
                 contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],

--- a/azure/packages/azure-local-service/.eslintrc.js
+++ b/azure/packages/azure-local-service/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-    extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
+    extends: [require.resolve("@fluidframework/eslint-config-fluid")],
     plugins: ["eslint-plugin-jsdoc"],
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],

--- a/azure/packages/azure-local-service/.eslintrc.js
+++ b/azure/packages/azure-local-service/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     extends: [require.resolve("@fluidframework/eslint-config-fluid")],
     plugins: ["eslint-plugin-jsdoc"],
     parserOptions: {
-        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
+        project: ["./tsconfig.json"],
     },
     rules: {
         // Require jsdoc/tsdoc comments on public/exported API items.

--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -42,6 +42,7 @@
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",
     "eslint": "~8.6.0",
+    "eslint-plugin-jsdoc": "~39.3.0",
     "forever": "^4.0.3",
     "rimraf": "^2.6.2",
     "ts-node": "^8.6.2",

--- a/azure/packages/azure-local-service/src/index.ts
+++ b/azure/packages/azure-local-service/src/index.ts
@@ -4,4 +4,5 @@
  * Licensed under the MIT License.
  */
 
+// eslint-disable-next-line import/no-unassigned-import
 import "tinylicious";

--- a/azure/packages/azure-local-service/tsconfig.json
+++ b/azure/packages/azure-local-service/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [],
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/azure/packages/azure-service-utils/.eslintrc.js
+++ b/azure/packages/azure-service-utils/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
                     ClassDeclaration: true,
                     FunctionDeclaration: true,
 
-                    // Will report for any methods on exported types, regardless of whether or not they are public
+                    // Will report for *any* methods on exported classes, regardless of whether or not they are public
                     MethodDefinition: false,
                 },
                 contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],

--- a/azure/packages/azure-service-utils/.eslintrc.js
+++ b/azure/packages/azure-service-utils/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-    extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
     plugins: ["eslint-plugin-jsdoc"],
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],

--- a/azure/packages/azure-service-utils/.eslintrc.js
+++ b/azure/packages/azure-service-utils/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-    extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
     plugins: ["eslint-plugin-jsdoc"],
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],

--- a/azure/packages/azure-service-utils/.eslintrc.js
+++ b/azure/packages/azure-service-utils/.eslintrc.js
@@ -4,9 +4,44 @@
  */
 
 module.exports = {
-    extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
+    plugins: ["eslint-plugin-jsdoc"],
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    rules: {},
+    rules: {
+        "import/no-unassigned-import": "off",
+        "@typescript-eslint/strict-boolean-expressions": "off",
+
+        // Require jsdoc/tsdoc comments on public/exported API items.
+        "jsdoc/require-jsdoc": [
+            "error",
+            {
+                // Indicates that only module exports should be flagged for lacking jsdoc comments
+                publicOnly: true,
+                enableFixer: false, // Prevents eslint from adding empty comment blocks when run with `--fix`
+                require: {
+                    ClassDeclaration: true,
+                    FunctionDeclaration: true,
+
+                    // Will report for any methods on exported types, regardless of whether or not they are public
+                    MethodDefinition: false,
+                },
+                contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],
+            },
+        ],
+
+        // Ensure jsdoc/tsdoc comments contain a main description component
+        // (disallows empty comments / only tags).
+        "jsdoc/require-description": ["error", { checkConstructors: false }],
+    },
+    overrides: [
+        {
+            files: ["packageVersion.ts"],
+            rules: {
+                "jsdoc/require-jsdoc": "off",
+                "jsdoc/require-description": "off",
+            },
+        },
+    ],
 };

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -56,6 +56,7 @@
     "copyfiles": "^2.4.1",
     "eslint": "~8.6.0",
     "eslint-config-prettier": "~8.5.0",
+    "eslint-plugin-jsdoc": "~39.3.0",
     "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5",


### PR DESCRIPTION
Adds linter settings for the azure release group packages (just the public ones), which require source-code documentation on most kinds of module-exported members.

The tooling has some issues around variable assignments, and properties / methods on interfaces / classes, so there is currently no enforcement on those. But this will ensure most root-level exports are documented at the type-level, and will offer a friendly reminder to developers that it is important to document the contents of our libraries (even if they don't ultimately get exported as a part of the package).