### PR TITLE
Tree: reorganize cursor tests

### DIFF
--- a/packages/dds/tree/src/test/cursorTestSuite.ts
+++ b/packages/dds/tree/src/test/cursorTestSuite.ts
@@ -128,6 +128,7 @@ export function testJsonableTreeCursor<T>(
         // Use text cursor to provide input data
         return dataFromCursor(singleTextCursor(data));
     }
+
     function factory(data: JsonableTree): ITreeCursor {
         return cursorFactory(dataFromJsonableTree(data));
     }
@@ -138,7 +139,7 @@ export function testJsonableTreeCursor<T>(
                     const convertedData = dataFromJsonableTree(data);
                     const cursor = cursorFactory(convertedData);
                     const convertedClone = dataFromCursor(cursor);
-                    // This assumes `T` is works with deepEqual.
+                    // This assumes `T` works with deepEqual.
                     assert.deepEqual(convertedClone, convertedData);
                     const clone = jsonableTreeFromCursor(cursor);
                     assert.deepEqual(clone, data);

--- a/packages/dds/tree/src/test/cursorTestSuite.ts
+++ b/packages/dds/tree/src/test/cursorTestSuite.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { jsonableTreeFromCursor, singleTextCursor } from "../feature-libraries";
 import { GlobalFieldKey, LocalFieldKey } from "../schema-stored";
 
 import {
@@ -117,18 +118,29 @@ export const cursorTestCases: [string, JsonableTree][] = [
  * @param factory - Creates the cursor to be tested with or without provided data.
  * @param dataFromCursor - Gets a JsonableTree from the provided cursor.
  */
-export function testJsonableTreeCursor(
+export function testJsonableTreeCursor<T>(
     cursorName: string,
-    factory: (data: JsonableTree) => ITreeCursor,
-    dataFromCursor: (cursor: ITreeCursor) => JsonableTree,
+    cursorFactory: (data: T) => ITreeCursor,
+    dataFromCursor: (cursor: ITreeCursor) => T,
     testRooted = true,
 ): void {
+    function dataFromJsonableTree(data: JsonableTree): T {
+        // Use text cursor to provide input data
+        return dataFromCursor(singleTextCursor(data));
+    }
+    function factory(data: JsonableTree): ITreeCursor {
+        return cursorFactory(dataFromJsonableTree(data));
+    }
     describe(`${cursorName} cursor implementation`, () => {
         describe("extract roundtrip", () => {
             for (const [name, data] of cursorTestCases) {
                 it(`${name}: ${JSON.stringify(data)}`, () => {
-                    const cursor = factory(data);
-                    const clone = dataFromCursor(cursor);
+                    const convertedData = dataFromJsonableTree(data);
+                    const cursor = cursorFactory(convertedData);
+                    const convertedClone = dataFromCursor(cursor);
+                    // This assumes `T` is works with deepEqual.
+                    assert.deepEqual(convertedClone, convertedData);
+                    const clone = jsonableTreeFromCursor(cursor);
                     assert.deepEqual(clone, data);
                     // Check objects are actually json compatible
                     const text = JSON.stringify(clone);
@@ -137,6 +149,14 @@ export function testJsonableTreeCursor(
                 });
             }
         });
+
+        testCursors(
+            "default test data cursor testing",
+            cursorTestCases.map(([name, data]) => ({
+                cursorName: name,
+                cursor: factory(data),
+            })),
+        );
 
         // TODO: revisit spec for forest cursors and root and clarify what should be tested for them regarding Up from root.
         if (testRooted) {

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { EmptyKey, ITreeCursor, singleJsonCursor, cursorToJsonObject } from "../../..";
 import { CursorLocationType, FieldKey, mapCursorFields, rootFieldKeySymbol } from "../../../tree";
 import { brand } from "../../../util";
-import { testCursors } from "../../cursor.spec";
+import { testCursors } from "../../cursorTestSuite";
 
 const testCases = [
     ["null", [null]],

--- a/packages/dds/tree/src/test/feature-libraries/mapTreeCursor.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mapTreeCursor.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { jsonableTreeFromCursor, singleTextCursor } from "../../feature-libraries";
+import { mapTreeFromCursor, singleMapTreeCursor } from "../../feature-libraries";
 import { testJsonableTreeCursor } from "../cursorTestSuite";
 
-testJsonableTreeCursor("textTreeFormat", singleTextCursor, jsonableTreeFromCursor);
+testJsonableTreeCursor("mapTreeCursor", singleMapTreeCursor, mapTreeFromCursor);

--- a/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
@@ -93,24 +93,6 @@ function testForest(
             }
         });
 
-        it("cursor use", () => {
-            //
-            const forest = factory(new InMemoryStoredSchemaRepository(defaultSchemaPolicy));
-            const content: JsonableTree = { type: jsonNumber.name, value: 1 };
-            initializeForest(forest, [singleTextCursor(content)]);
-
-            const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: 2 };
-            // TODO: make type-safe
-            const delta: Delta.Root = new Map([[rootFieldKeySymbol, [setValue]]]);
-            forest.applyDelta(delta);
-
-            const reader = forest.allocateCursor();
-            moveToDetachedField(forest, reader);
-            assert(reader.firstNode());
-
-            assert.equal(reader.value, 2);
-        });
-
         it("setValue", () => {
             const forest = factory(new InMemoryStoredSchemaRepository(defaultSchemaPolicy));
             const content: JsonableTree = { type: jsonNumber.name, value: 1 };


### PR DESCRIPTION
## Description

Cleanup cursor test organization.  Adds more test coverage more mapTree and forest cursors.
