### PR TITLE
Mark lambda as corrupt when producing a message that exceeds the kafka max message size

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -73,7 +73,9 @@ export class DocumentPartition {
         this.q.pause();
 
         this.context.on("error", (error: any, errorData: IContextErrorData) => {
-            if (errorData.restart) {
+            if (errorData.markAsCorrupt) {
+                this.markAsCorrupt(error, errorData.markAsCorrupt);
+            } else if (errorData.restart) {
                 // ensure no more messages are processed by this partition
                 // while the process is restarting / closing
                 this.close(LambdaCloseType.Error);

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -39,6 +39,13 @@ export interface IContextErrorData {
      */
     restart: boolean;
 
+    /**
+     * Indicates if the document should be marked as corrupt.
+     * Further messages will be dead-lettered.
+     * It should be set to the message that caused the corruption.
+     */
+    markAsCorrupt?: IQueuedMessage;
+
     tenantId?: string;
     documentId?: string;
 }


### PR DESCRIPTION
A follow up on #11780. 

Deli can sends large batches when the `maintainBatches` config is enabled. This PR fixes handling for the case where the batch exceeds the kafka max message size.
Restarting the process/lambda and reprocessing the message will not resolve the issue - it will infinite loop until the message expires from kafka. The document/lambda needs to be marked as corrupt to ensure the rest of the kafka partition keeps moving forward.