### PR TITLE
Tree: improve and test cursor fork

### DIFF
--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -300,10 +300,20 @@ type ObjectField = MapTree[];
  * (which can be undefined when cleared), instead of sub-classing it.
  */
 class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
-    state: ITreeSubscriptionCursorState = ITreeSubscriptionCursorState.Cleared;
-    private innerCursor?: CursorWithNode<MapTree>;
-    public constructor(public readonly forest: ObjectForest) {
+    state: ITreeSubscriptionCursorState;
+    /**
+     * @param forest - forest this cursor navigates
+     * @param innerCursor - underlying cursor implementation this wraps. `undefined` when state is not `Current`
+     */
+    public constructor(
+        public readonly forest: ObjectForest,
+        private innerCursor?: CursorWithNode<MapTree>,
+    ) {
         super();
+        this.state =
+            innerCursor === undefined
+                ? ITreeSubscriptionCursorState.Cleared
+                : ITreeSubscriptionCursorState.Current;
     }
     buildFieldAnchor(): FieldAnchor {
         const path = this.getFieldPath();
@@ -438,16 +448,7 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 
     fork(observer?: ObservingDependent): ITreeSubscriptionCursor {
         assert(this.innerCursor !== undefined, "Cursor must be current to be used");
-        const other = this.forest.allocateCursor();
-        if (this.innerCursor.mode === CursorLocationType.Fields) {
-            const path = this.getFieldPath();
-            this.forest.moveCursorToPath(path.parent, other, observer);
-            other.enterField(path.field);
-        } else {
-            const path = this.getPath();
-            this.forest.moveCursorToPath(path, other, observer);
-        }
-        return other;
+        return new Cursor(this.forest, this.innerCursor.fork());
     }
 
     free(): void {

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -300,6 +300,7 @@ type ObjectField = MapTree[];
  * (which can be undefined when cleared), instead of sub-classing it.
  */
 class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
+
     state: ITreeSubscriptionCursorState;
     /**
      * @param forest - forest this cursor navigates
@@ -315,6 +316,7 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
                 ? ITreeSubscriptionCursorState.Cleared
                 : ITreeSubscriptionCursorState.Current;
     }
+
     buildFieldAnchor(): FieldAnchor {
         const path = this.getFieldPath();
         const anchor =

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -300,8 +300,8 @@ type ObjectField = MapTree[];
  * (which can be undefined when cleared), instead of sub-classing it.
  */
 class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
-
     state: ITreeSubscriptionCursorState;
+
     /**
      * @param forest - forest this cursor navigates
      * @param innerCursor - underlying cursor implementation this wraps. `undefined` when state is not `Current`

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -94,17 +94,18 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
      * Might start at special root where fields are detached sequences.
      *
      * @param adapter - policy logic.
-     * @param indexStack - Indices traversed to visit this node: does not include current level (which is stored in `index`).
-     * Even indexes are of nodes and odd indexes are for fields.
-     * @param siblingStack - Siblings into which indexStack indexes: does not include current level (which is stored in `siblings`).
-     * Even indexes are of nodes and odd indexes are for fields.
-     * @param siblings - Siblings at the current level (not included in siblingStack).
+     * @param siblingStack - Stack of collections of siblings along the path through the tree:
+     * does not include current level (which is stored in `siblings`).
+     * Even levels in the stack (starting from 0) are sequences of nodes and odd levels
+     * are for fields keys on a node.
+     * @param indexStack - Stack of indices into the corosponding levels in `siblingStack`.
+     * @param siblings - Siblings at the current level (not included in `siblingStack`).
      * @param index - Index into `siblings`.
      */
     public constructor(
         private readonly adapter: CursorAdapter<TNode>,
-        private readonly indexStack: number[],
         private readonly siblingStack: SiblingsOrKey<TNode>[],
+        private readonly indexStack: number[],
         private siblings: SiblingsOrKey<TNode>,
         private index: number,
     ) {
@@ -196,12 +197,12 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
     }
 
     public fork(): StackCursor<TNode> {
+        // Siblings arrays are not modified during navigation and do not need be be copied.
+        // This allows this copy to be shallow, and `this.siblings` below to not be copied as all.
         return new StackCursor<TNode>(
             this.adapter,
-            [...this.indexStack],
-            // Siblings arrays are not modified during navigation and do not need be be copied.
-            // This allows this copy to be shallow, and `this.siblings` below to not be copied as all.
             [...this.siblingStack],
+            [...this.indexStack],
             this.siblings,
             this.index,
         );


### PR DESCRIPTION
## Description

Add and use fast fork implementation from underling cursors in ObjectForest.

Add tests for forest cursor's fork.