### PR TITLE
fix(build-cli): Add option to include .generated in type test file names

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -116,7 +116,7 @@ USAGE
   $ flub generate typetests [-d <value> | --packages | -g client|server|azure|build-tools] [--prepare | --generate]
     (--exact <value> |  | -s
     ^previousMajor|^previousMinor|~previousMajor|~previousMinor|previousMajor|previousMinor|baseMinor|baseMajor)
-    [--reset | ] [-v]
+    [--reset | ] [--generateInName] [-v]
 
 FLAGS
   -d, --dir=<value>                 Run on the package in this directory.
@@ -130,6 +130,7 @@ FLAGS
   --exact=<value>                   An exact string to use as the previous version constraint. The string will be used
                                     as-is. Only applies to the prepare phase.
   --generate                        Generates tests only. Doesn't prepare the package.json.
+  --[no-]generateInName             Includes .generated in the generated type test filenames.
   --packages                        Run on all independent packages in the repo.
   --prepare                         Prepares the package.json only. Doesn't generate tests. Note that npm install may
                                     need to be run after preparation.

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -74,6 +74,11 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
                 "Resets the broken type test settings in package.json. Only applies to the prepare phase.",
             exclusive: ["generate"],
         }),
+        generateInName: Flags.boolean({
+            description: "Includes .generated in the generated type test filenames.",
+            default: true,
+            allowNo: true,
+        }),
         ...BaseCommand.flags,
     };
 
@@ -191,7 +196,7 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
                         } else if (runGenerate === true && packageData.oldVersions.length > 0) {
                             // eslint-disable-next-line @typescript-eslint/no-shadow
                             const start = Date.now();
-                            await generateTests(packageData)
+                            await generateTests(packageData, flags.generateInName)
                                 .then((s) =>
                                     output.push(
                                         `dirs(${s.dirs}) files(${s.files}) tests(${s.tests})`,

--- a/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
@@ -25,7 +25,18 @@ type TypeOnly<T> = {
 };
 `;
 
-export async function generateTests(packageDetails: PackageDetails) {
+const generateFilename = (
+    oldVersionFileName: string,
+    path: string,
+    includeGeneratedInName: boolean,
+): string => {
+    return `${path}/validate${oldVersionFileName}.${includeGeneratedInName ? "generated." : ""}ts`;
+};
+
+export async function generateTests(
+    packageDetails: PackageDetails,
+    includeGeneratedInName: boolean,
+) {
     const currentProjectData = await generateTypeDataForProject(
         packageDetails.packageDir,
         undefined,
@@ -105,13 +116,13 @@ export async function generateTests(packageDetails: PackageDetails) {
                 : oldVersion;
 
         stats.files++;
-        await util.promisify(fs.writeFile)(
-            `${testPath}/validate${oldVersionNameForFile
-                .split("-")
-                .map((p) => p[0].toUpperCase() + p.substring(1))
-                .join("")}.ts`,
-            testString.join("\n"),
-        );
+        const oldVersionFileName = oldVersionNameForFile
+            .split("-")
+            .map((p) => p[0].toUpperCase() + p.substring(1))
+            .join("");
+        const filePath = generateFilename(oldVersionFileName, testPath, includeGeneratedInName);
+
+        await util.promisify(fs.writeFile)(filePath, testString.join("\n"));
     }
     return stats;
 }

--- a/build-tools/packages/build-tools/src/typeValidator/typeValidator.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/typeValidator.ts
@@ -24,6 +24,7 @@ program
         "-g|--generateOnly",
         "This only generates the tests. If does not prepare the package.json",
     )
+    .option("--generateInName", "Includes .generated in the output filename.")
     .option("-v|--verbose", "Verbose logging mode")
     .parse(process.argv);
 
@@ -76,7 +77,7 @@ async function run(): Promise<boolean> {
                         program.preinstallOnly === undefined
                     ) {
                         const start = Date.now();
-                        await generateTests(packageData)
+                        await generateTests(packageData, program.generateInName ?? false)
                             .then((s) =>
                                 output.push(`dirs(${s.dirs}) files(${s.files}) tests(${s.tests})`),
                             )


### PR DESCRIPTION
This PR makes generated files clear from their file name so reviewers can see the generated file warning when reviewing deltas in PRs. This change adopts the .generated.* convention from https://github.com/microsoft/TypeScript/wiki/Coding-guidelines#components.

I've added new flags to both the old fluid-type-validator CLI and the new flub generate typetests entrypoint. The default for the old CLI is false, so files will continue to have their old names by default. The default for the new CLI is true, but it can be set to false manullay when needed while we transition to the new CLI. When we fully adopt the new typetests tool in CI we will rename the files.