### PR TITLE
Add a new pipeline to test stability of CI build client

### DIFF
--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -86,6 +86,7 @@ jobs:
             Test=${{ convertToJson(parameters.taskTest) }}
             BuildDoc=${{ parameters.taskBuildDocs }}
             TestCoverage=$(testCoverage)
+          "
 
           # Error checking
           if [[ "$(release)" == "release" ]]; then

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -1,0 +1,254 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-test-stability template to build and test NPM packages/projects
+
+parameters:
+- name: buildDirectory
+  type: string
+
+- name: taskBuild
+  type: string
+  default: ci:build
+
+- name: taskBuildDocs
+  type: boolean
+  default: true
+
+- name: taskLint
+  type: boolean
+  default: true
+
+- name: taskTest
+  type: object
+  default:
+  - ci:test
+
+- name: poolCG
+  type: object
+  default: Small
+
+- name: poolBuild
+  type: object
+  default: Large
+
+- name: checkoutSubmodules
+  type: boolean
+  default: false
+
+- name: buildNumberInPatch
+  type: string
+  default:
+
+- name: nonScopedPackages
+  type: object
+  default: []
+
+- name: publishOverride
+  type: string
+
+- name: releaseBuildOverride
+  type: string
+
+- name: tagName
+  type: string
+
+- name: buildToolsVersionToInstall
+  type: string
+  default: repo
+
+- name: timeoutInMinutes
+  type: number
+  default: 60
+
+jobs:
+  # Job - Build
+  - job: build
+    displayName: Build
+    pool: ${{ parameters.poolBuild }}
+    variables:
+      testCoverage: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
+      releaseBuildVar: $[variables.releaseBuild]
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    steps:
+    # Setup
+    - checkout: self
+      clean: true
+      lfs: ${{ parameters.checkoutSubmodules }}
+      submodules: ${{ parameters.checkoutSubmodules }}
+
+    - task: Bash@3
+      displayName: Parameters
+      inputs:
+        targetType: 'inline'
+        workingDirectory: ${{ parameters.buildDirectory }}
+        script: |
+          # Show all task group conditions
+
+          echo "
+          Pipeline Variables:
+            releaseBuild=$(releaseBuildVar)
+
+          Override Parameters:
+            publishOverride=${{ parameters.publishOverride }}
+            releaseBuildOverride=${{ parameters.releaseBuildOverride }}
+
+          Tasks Parameters:
+            BuildDir=${{ parameters.buildDirectory }}
+            Build=${{ parameters.taskBuild }}
+            Lint=${{ parameters.taskLint }}
+            Test=${{ convertToJson(parameters.taskTest) }}
+            BuildDoc=${{ parameters.taskBuildDocs }}
+            TestCoverage=$(testCoverage)
+
+          Publish Parameters:
+            nonScopedPackages=${{ join(', ', parameters.nonScopedPackages) }}
+
+          Computed variables:
+            shouldPublish=${{ variables.shouldPublish }}
+            componentDetection=${{ variables.componentDetection }}
+            publish=${{ variables.publish }}
+            canRelease=${{ variables.canRelease }}
+            publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
+            targetBranchName = $(System.PullRequest.TargetBranch)
+
+            release=$(release)"
+
+          # Error checking
+          if [[ "$(release)" == "release" ]]; then
+            if [[ "${{ variables.canRelease }}" == "False" ]]; then
+              echo "##vso[task.logissue type=error]Invalid branch ${{ variables['Build.SourceBranch'] }} for release"
+              exit -1;
+            fi
+
+            if [ -f "lerna.json" ]; then
+              grep -e fluid.*[0-9]-[0-9] `find packages -name 'package.json'`
+            else
+              grep -e fluid.*[0-9]-[0-9] `find . -name 'package.json'`
+            fi
+
+            if [[ $? == 0 ]]; then
+              echo "##vso[task.logissue type=error]Release shouldn't contain prerelease dependencies"
+              exit -1;
+            fi
+          fi
+
+          if [[ "$(release)" == "prerelease" ]]; then
+            if [[ "${{ parameters.buildNumberInPatch }}" == "true" ]]; then
+              echo "##vso[task.logissue type=error] Prerelease not allow for builds that put build number as the patch version"
+              exit -1;
+            fi
+          fi
+
+          if [[ "$(release)" != "none" ]] && [[ "$(release)" != "" ]]; then
+            if [[ "${{ variables.publish }}" != "True" ]]; then
+              echo "##vso[task.logissue type=error]'$(release)'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
+              exit -1;
+            fi
+          fi
+
+    # Install
+    - task: UseNode@1
+      displayName: Use Node 14.x
+      inputs:
+        version: 14.x
+    - task: Npm@1
+      displayName: npm ci
+      inputs:
+        command: 'custom'
+        workingDir: ${{ parameters.buildDirectory }}
+        customCommand: 'ci --unsafe-perm'
+        customRegistry: 'useNpmrc'
+
+    # Set version
+    - template: include-set-package-version.yml
+      parameters:
+        buildDirectory: ${{ parameters.buildDirectory }}
+        buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+        buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
+        tagName: ${{ parameters.tagName }}
+
+    # Build
+    - ${{ if ne(parameters.taskBuild, 'false') }}:
+      - task: Npm@1
+        displayName: npm run ${{ parameters.taskBuild }}
+        inputs:
+          command: 'custom'
+          workingDir: ${{ parameters.buildDirectory }}
+          customCommand: 'run ${{ parameters.taskBuild }}'
+
+    # Lint
+    - ${{ if ne(parameters.taskLint, false) }}:
+      - task: Npm@1
+        displayName: npm run lint
+        inputs:
+          command: 'custom'
+          workingDir: ${{ parameters.buildDirectory }}
+          customCommand: 'run lint'
+
+    # Test
+    - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:
+      # Set variable startTest if the build succeed so that we can run all the test tasks whether they are failed or not
+      - script: |
+          echo "##vso[task.setvariable variable=startTest]true"
+        displayName: Start Test
+
+      - ${{ each taskTestStep in parameters.taskTest }}:
+        # Test - With coverage
+        - ${{ if and(eq(variables['testCoverage'], true), startsWith(taskTestStep, 'ci:test')) }}:
+          - task: Npm@1
+            displayName: npm run ${{ taskTestStep }}:coverage
+            inputs:
+              command: 'custom'
+              workingDir: ${{ parameters.buildDirectory }}
+              customCommand: 'run ${{ taskTestStep }}:coverage'
+            condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+        # Test - No coverage
+        - ${{ if or(eq(variables['testCoverage'], false), eq(startsWith(taskTestStep, 'ci:test'), false)) }}:
+            - task: Npm@1
+              displayName: npm run ${{ taskTestStep }}
+              inputs:
+                command: 'custom'
+                workingDir: ${{ parameters.buildDirectory }}
+                customCommand: 'run ${{ taskTestStep }}'
+              condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+
+      # Test - Upload coverage results
+      # Some webpacked file using externals introduce file name with quotes in them
+      # and Istanbul's cobertura reporter doesn't escape them causing parse error when we publish
+      # A quick fix to patch the file with sed. (See https://github.com/bcoe/c8/issues/302)
+      - ${{ if eq(variables['testCoverage'], true) }}:
+        - task: Bash@3
+          displayName: 'Check for nyc/report directory'
+          inputs:
+            targetType: 'inline'
+            workingDirectory: ${{ parameters.buildDirectory }}
+            script: |
+              test -d nyc/report && echo '##vso[task.setvariable variable=ReportDirExists;]true' || echo 'No nyc/report directory'
+          condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+        - task: Bash@3
+          displayName: Patch Coverage Results
+          inputs:
+            targetType: 'inline'
+            workingDirectory: ${{ parameters.buildDirectory }}/nyc/report
+            script: |
+              sed -e 's/\(filename=\".*[\\/]external .*\)"\(.*\)""/\1\&quot;\2\&quot;"/' cobertura-coverage.xml > cobertura-coverage-patched.xml
+          condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
+        - task: PublishCodeCoverageResults@1
+          displayName: Publish Code Coverage
+          inputs:
+            codeCoverageTool: Cobertura
+            summaryFileLocation: ${{ parameters.buildDirectory }}/nyc/report/cobertura-coverage-patched.xml
+            reportDirectory: ${{ parameters.buildDirectory }}/nyc/report
+            failIfCoverageEmpty: true
+          condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
+
+      # Test - Upload results
+      - task: PublishTestResults@2
+        displayName: Publish Test Results
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/*junit-report.xml'
+          searchFolder: ${{ parameters.buildDirectory }}/nyc
+          mergeTestResults: false
+        condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -24,10 +24,6 @@ parameters:
   default:
   - ci:test
 
-- name: poolCG
-  type: object
-  default: Small
-
 - name: poolBuild
   type: object
   default: Large
@@ -39,16 +35,6 @@ parameters:
 - name: buildNumberInPatch
   type: string
   default:
-
-- name: nonScopedPackages
-  type: object
-  default: []
-
-- name: publishOverride
-  type: string
-
-- name: releaseBuildOverride
-  type: string
 
 - name: tagName
   type: string
@@ -100,19 +86,6 @@ jobs:
             Test=${{ convertToJson(parameters.taskTest) }}
             BuildDoc=${{ parameters.taskBuildDocs }}
             TestCoverage=$(testCoverage)
-
-          Publish Parameters:
-            nonScopedPackages=${{ join(', ', parameters.nonScopedPackages) }}
-
-          Computed variables:
-            shouldPublish=${{ variables.shouldPublish }}
-            componentDetection=${{ variables.componentDetection }}
-            publish=${{ variables.publish }}
-            canRelease=${{ variables.canRelease }}
-            publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
-            targetBranchName = $(System.PullRequest.TargetBranch)
-
-            release=$(release)"
 
           # Error checking
           if [[ "$(release)" == "release" ]]; then

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -11,10 +11,6 @@ parameters:
   type: string
   default: ci:build
 
-- name: taskBuildDocs
-  type: boolean
-  default: true
-
 - name: taskLint
   type: boolean
   default: true
@@ -84,7 +80,6 @@ jobs:
             Build=${{ parameters.taskBuild }}
             Lint=${{ parameters.taskLint }}
             Test=${{ convertToJson(parameters.taskTest) }}
-            BuildDoc=${{ parameters.taskBuildDocs }}
             TestCoverage=$(testCoverage)
           "
 

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -125,14 +125,6 @@ parameters:
   type: string
   default: ci:build
 
-- name: taskBuildDocs
-  type: boolean
-  default: false
-
-- name: taskLint
-  type: boolean
-  default: false
-
 - name: taskTest
   type: object
   default:
@@ -147,42 +139,10 @@ parameters:
   type: boolean
   default: true
 
-- name: namespace
-  type: boolean
-  default: true
-
-- name: buildNumberInPatch
-  type: string
-  default: false
-
-- name: publishOverride
-  displayName: Publish Override (default = based on branch)
-  type: string
-  default: default
-  values:
-    - default
-    - skip
-    - force
-
 - name: buildToolsVersionToInstall
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
   default: repo
-
-- name: nonScopedPackages
-  displayName: Non-scoped packages to publish
-  type: object
-  default:
-  - fluid-framework
-
-- name: releaseBuildOverride
-  displayName: Release Build (default = not released)
-  type: string
-  default: none
-  values:
-    - none
-    - prerelease
-    - release
 
 - name: tagName
   type: string
@@ -208,12 +168,6 @@ variables:
   # basic ANSI color support though, so force that in the pipeline
 - name: FORCE_COLOR
   value: 1
-- template: templates/include-vars.yml
-  parameters:
-    publishOverride: ${{ parameters.publishOverride }}
-    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-    buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
-    nonScopedPackages: ${{ parameters.nonScopedPackages }}
 
 stages:
   - ${{ each stageName in parameters.stageNames }}:
@@ -223,15 +177,12 @@ stages:
       jobs:
       - template: templates/include-test-stability.yml
         parameters:
-          publishOverride: ${{ parameters.publishOverride }}
-          releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
-          nonScopedPackages: ${{ parameters.nonScopedPackages }}
           buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
           buildDirectory: .
           tagName: ${{ parameters.tagName }}
           poolBuild: Large
           checkoutSubmodules: true
-          timeoutInMinutes: 1440
+          timeoutInMinutes: 360
           taskTest:
           - ci:test:mocha
           - ci:test:jest

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -117,10 +117,6 @@ parameters:
   - Test99
   - Test100
 
-- name: buildDirectory
-  type: string
-  default: .
-
 - name: taskBuild
   type: string
   default: ci:build
@@ -147,10 +143,6 @@ parameters:
 - name: tagName
   type: string
   default: TestStability
-
-- name: includeInternalVersions
-  type: boolean
-  default: false
 
 schedules:
   - cron: "00 03 * * SUN"
@@ -180,13 +172,8 @@ stages:
           buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
           buildDirectory: .
           tagName: ${{ parameters.tagName }}
-          poolBuild: Large
-          checkoutSubmodules: true
+          poolBuild: ${{ parameters.poolBuild }}
+          checkoutSubmodules: ${{ parameters.checkoutSubmodules }}
           timeoutInMinutes: 360
-          taskTest:
-          - ci:test:mocha
-          - ci:test:jest
-          - ci:test:realsvc:local
-          - ci:test:realsvc:tinylicious
-          - ci:test:stress:tinylicious
-          - test:copyresults
+          taskBuild : ${{ parameters.taskBuild }}
+          taskTest: ${{ parameters.taskTest }}

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -1,0 +1,241 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# test-stability pipeline (for the purpose of detecting intermittent and flaky failures)
+
+name: $(Build.BuildId)
+
+trigger: none
+pr: none
+
+parameters:
+- name: poolBuild
+  type: object
+  default: Large
+
+- name: stageNames
+  type: object
+  default:
+  - Test1
+  - Test2
+  - Test3
+  - Test4
+  - Test5
+  - Test6
+  - Test7
+  - Test8
+  - Test9
+  - Test10
+  - Test11
+  - Test12
+  - Test13
+  - Test14
+  - Test15
+  - Test16
+  - Test17
+  - Test18
+  - Test19
+  - Test20
+  - Test21
+  - Test22
+  - Test23
+  - Test24
+  - Test25
+  - Test26
+  - Test27
+  - Test28
+  - Test29
+  - Test30
+  - Test31
+  - Test32
+  - Test33
+  - Test34
+  - Test35
+  - Test36
+  - Test37
+  - Test38
+  - Test39
+  - Test40
+  - Test41
+  - Test42
+  - Test43
+  - Test44
+  - Test45
+  - Test46
+  - Test47
+  - Test48
+  - Test49
+  - Test50
+  - Test51
+  - Test52
+  - Test53
+  - Test54
+  - Test55
+  - Test56
+  - Test57
+  - Test58
+  - Test59
+  - Test60
+  - Test61
+  - Test62
+  - Test63
+  - Test64
+  - Test65
+  - Test66
+  - Test67
+  - Test68
+  - Test69
+  - Test70
+  - Test71
+  - Test72
+  - Test73
+  - Test74
+  - Test75
+  - Test76
+  - Test77
+  - Test78
+  - Test79
+  - Test80
+  - Test81
+  - Test82
+  - Test83
+  - Test84
+  - Test85
+  - Test86
+  - Test87
+  - Test88
+  - Test89
+  - Test90
+  - Test91
+  - Test92
+  - Test93
+  - Test94
+  - Test95
+  - Test96
+  - Test97
+  - Test98
+  - Test99
+  - Test100
+
+- name: buildDirectory
+  type: string
+  default: .
+
+- name: taskBuild
+  type: string
+  default: ci:build
+
+- name: taskBuildDocs
+  type: boolean
+  default: false
+
+- name: taskLint
+  type: boolean
+  default: false
+
+- name: taskTest
+  type: object
+  default:
+  - ci:test:mocha
+  - ci:test:jest
+  - ci:test:realsvc:local
+  - ci:test:realsvc:tinylicious
+  - ci:test:stress:tinylicious
+  - test:copyresults
+
+- name: checkoutSubmodules
+  type: boolean
+  default: true
+
+- name: namespace
+  type: boolean
+  default: true
+
+- name: buildNumberInPatch
+  type: string
+  default: false
+
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
+
+- name: buildToolsVersionToInstall
+  displayName: Fluid build tools version (default = installs version in repo)
+  type: string
+  default: repo
+
+- name: nonScopedPackages
+  displayName: Non-scoped packages to publish
+  type: object
+  default:
+  - fluid-framework
+
+- name: releaseBuildOverride
+  displayName: Release Build (default = not released)
+  type: string
+  default: none
+  values:
+    - none
+    - prerelease
+    - release
+
+- name: tagName
+  type: string
+  default: TestStability
+
+- name: includeInternalVersions
+  type: boolean
+  default: false
+
+schedules:
+  - cron: "00 03 * * SUN"
+    displayName: Scheduled Tests weekly at Saturday night
+    branches:
+      include:
+      - main
+      - next
+    always: true
+
+variables:
+- group: prague-key-vault
+  # We use 'chalk' to colorize output, which auto-detects color support in the
+  # running terminal.  The log output shown in Azure DevOps job runs only has
+  # basic ANSI color support though, so force that in the pipeline
+- name: FORCE_COLOR
+  value: 1
+- template: templates/include-vars.yml
+  parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+    nonScopedPackages: ${{ parameters.nonScopedPackages }}
+
+stages:
+  - ${{ each stageName in parameters.stageNames }}:
+    - stage:
+      displayName: ${{ stageName }}
+      dependsOn: []
+      jobs:
+      - template: templates/include-test-stability.yml
+        parameters:
+          publishOverride: ${{ parameters.publishOverride }}
+          releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+          nonScopedPackages: ${{ parameters.nonScopedPackages }}
+          buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
+          buildDirectory: .
+          tagName: ${{ parameters.tagName }}
+          poolBuild: Large
+          checkoutSubmodules: true
+          timeoutInMinutes: 1440
+          taskTest:
+          - ci:test:mocha
+          - ci:test:jest
+          - ci:test:realsvc:local
+          - ci:test:realsvc:tinylicious
+          - ci:test:stress:tinylicious
+          - test:copyresults


### PR DESCRIPTION
## Description

The test stability pipeline is proposed to run weekly on weekends off-peak hours to detect intermittent and "flaky" failures. It runs the CI client building as well as testing together for 100 times. For the purpose of reducing cost, the steps in build client pipeline like Pack, Bundle analysis, Build Docs, Component Detections are ignored. The pool can handle 22 ~ 26 stages of building combined with testing in parallel, each stage takes around 30 ~ 35 minutes, so the total time is within a reasonable range. The timeout threshold value is also set just in case. 

### Testing

The original implementation and testing are done on individual [test branch](https://github.com/microsoft/FluidFramework/tree/test/clarenceli3)

Some testing demos:

- [Manually trigger the pipeline](https://dev.azure.com/fluidframework/internal/_build/results?buildId=104264&view=results)

- [Trigger the pipeline using scheduler](https://dev.azure.com/fluidframework/internal/_build/results?buildId=104395&view=results)

- [The pipeline results after breaking an e2e test on purpose](https://dev.azure.com/fluidframework/internal/_build/results?buildId=104396&view=results)

### Follow-up work


- OCEs will receive emails on completion.
- Look at the results and compare any failures against the [known bugs](https://dev.azure.com/fluidframework/internal/_queries/query/dccd077e-fb72-47e1-92d9-f677ae93ee44/).
  - If it's a known active bug, add the new run info to the bug.
  - If it's a known recent No Repro bug, reactivate the bug with the new run info.
  - If any failures are not known, open bugs with [this template](https://dev.azure.com/fluidframework/internal/_workitems/create/Bug?templateId=f23d4a9e-9782-44ce-b647-3dc7559cf654&ownerId=1a47cc07-b6ef-420b-b6de-8b13565da0d3). If the causal change is obvious, assign to author; otherwise assign to [area owner](https://eng.ms/docs/experiences-devices/oxo/office-shared/wacbohemia/fluid-framework-internal/fluid-framework/docs/overview/area-owners) or set area path appropriately. Do not spend a lot of time investigating.
- Consider disabling tests or escalating bug priority if it is happening frequently. We strive for 99% run reliability, so it is appropriate to escalate if the overall reliability is low, even if no individual bug is a high hitter.

### PR Checklist

-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] My code follows the code style of this project.
-   [X] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

### Does this introduce a breaking change?

-   [ ] Yes
-   [X] No
