### PR TITLE
fix(version-tools): Relax handling of internal dev/prerelease versions

### DIFF
--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -176,7 +176,7 @@ export async function bumpReleaseGroup(
 
     // the lerna version command sets the dependency range of managed packages to a caret (^) dependency range. However,
     // for the internal version scheme, the range needs to be a >= < range.
-    if (scheme === "internal") {
+    if (scheme === "internal" || scheme === "internalPrerelease") {
         const range = getVersionRange(translatedVersion, "^");
         if (releaseGroupOrPackage instanceof MonoRepo) {
             const packagesToCheckAndUpdate = releaseGroupOrPackage.packages;

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -219,47 +219,8 @@ export function isInternalVersionScheme(
     const parsedVersion = semver.parse(version);
     const prereleaseId = allowAnyPrereleaseId ? undefined : REQUIRED_PRERELEASE_IDENTIFIER;
 
-    // if(allowPrereleases && !allowAnyPrereleaseId) {
-    //     try {
-    //         validateVersionScheme(
-    //             parsedVersion,
-    //             true,
-    //             REQUIRED_PRERELEASE_IDENTIFIER,
-    //         );
-    //         return true;
-    //     } catch (error) {
-    //         return false;
-    //     }
-    // } else if (allowPrereleases && allowAnyPrereleaseId) {
-    //     try {
-    //         validateVersionScheme(
-    //             parsedVersion,
-    //             true,
-    //             undefined,
-    //         );
-    //         return true;
-    //     } catch (error) {
-    //         return false;
-    //     }
-    // } else if(!allowPrereleases && allowAnyPrereleaseId) {
-    //     try {
-    //         validateVersionScheme(
-    //             parsedVersion,
-    //             false,
-    //             undefined,
-    //         );
-    //         return true;
-    //     } catch (error) {
-    //         return false;
-    //     }
-    // }
-
     try {
-        validateVersionScheme(
-            parsedVersion,
-            allowPrereleases,
-            prereleaseId,
-        );
+        validateVersionScheme(parsedVersion, allowPrereleases, prereleaseId);
     } catch (error) {
         return false;
     }

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -23,7 +23,7 @@ const MINIMUM_SEMVER_PRERELEASE_SECTIONS = 4;
  * The first part of the semver prerelease value is called the "prerelease identifier". For Fluid internal versions, the
  * value must always match this constant.
  */
-const REQUIRED_PRERELEASE_IDENTIFIER = "internal";
+export const REQUIRED_PRERELEASE_IDENTIFIER = "internal";
 
 /**
  * Translates a version using the Fluid internal version scheme into two parts: the public version, and the internal
@@ -162,7 +162,7 @@ export function toInternalScheme(
  *
  * This function is not typically used. {@link isInternalVersionScheme} is more useful since it does not throw.
  */
-function validateVersionScheme(
+export function validateVersionScheme(
     // eslint-disable-next-line @rushstack/no-new-null
     version: semver.SemVer | string | null,
     allowPrereleases = false,
@@ -217,11 +217,48 @@ export function isInternalVersionScheme(
     allowAnyPrereleaseId = false,
 ): boolean {
     const parsedVersion = semver.parse(version);
+    const prereleaseId = allowAnyPrereleaseId ? undefined : REQUIRED_PRERELEASE_IDENTIFIER;
+
+    // if(allowPrereleases && !allowAnyPrereleaseId) {
+    //     try {
+    //         validateVersionScheme(
+    //             parsedVersion,
+    //             true,
+    //             REQUIRED_PRERELEASE_IDENTIFIER,
+    //         );
+    //         return true;
+    //     } catch (error) {
+    //         return false;
+    //     }
+    // } else if (allowPrereleases && allowAnyPrereleaseId) {
+    //     try {
+    //         validateVersionScheme(
+    //             parsedVersion,
+    //             true,
+    //             undefined,
+    //         );
+    //         return true;
+    //     } catch (error) {
+    //         return false;
+    //     }
+    // } else if(!allowPrereleases && allowAnyPrereleaseId) {
+    //     try {
+    //         validateVersionScheme(
+    //             parsedVersion,
+    //             false,
+    //             undefined,
+    //         );
+    //         return true;
+    //     } catch (error) {
+    //         return false;
+    //     }
+    // }
+
     try {
         validateVersionScheme(
             parsedVersion,
             allowPrereleases,
-            allowAnyPrereleaseId ? undefined : REQUIRED_PRERELEASE_IDENTIFIER,
+            prereleaseId,
         );
     } catch (error) {
         return false;

--- a/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
@@ -11,6 +11,7 @@ import {
     isInternalVersionRange,
     isInternalVersionScheme,
     toInternalScheme,
+    validateVersionScheme,
 } from "../internalVersionScheme";
 
 describe("internalScheme", () => {
@@ -27,6 +28,18 @@ describe("internalScheme", () => {
             assert.isFalse(result);
         });
 
+        it("2.0.0-alpha.1.0.0 is valid when allowAnyPrereleaseId is true", () => {
+            const input = `2.0.0-alpha.1.0.0`;
+            const result = isInternalVersionScheme(input, false, true);
+            assert.isTrue(result);
+        });
+
+        it("2.0.0-alpha.1.0.0.0 is valid when allowAnyPrereleaseId is true", () => {
+            const input = `2.0.0-alpha.1.0.0.0`;
+            const result = isInternalVersionScheme(input, true, true);
+            assert.isTrue(result);
+        });
+
         it("1.1.1-internal.1.0.0 is not internal scheme (public must be 2.0.0+)", () => {
             const input = `1.1.1-internal.1.0.0`;
             const result = isInternalVersionScheme(input);
@@ -37,6 +50,12 @@ describe("internalScheme", () => {
             const input = `2.0.0-internal.1.1.0.0`;
             const result = isInternalVersionScheme(input);
             assert.isFalse(result);
+        });
+
+        it("validateVersionScheme: 2.0.0-dev.1.1.0.123 is valid when allowAnyPrereleaseId is true", () => {
+            const input = `2.0.0-dev.1.1.0.123`;
+            const result = validateVersionScheme(input, true, "dev");
+            assert.isTrue(result);
         });
 
         it("2.0.0-internal.1.1.0.123 is a valid internal prerelease version", () => {
@@ -61,6 +80,18 @@ describe("internalScheme", () => {
             const input = `2.0.0-dev.1.1.0`;
             const result = isInternalVersionScheme(input, false, true);
             assert.isTrue(result);
+        });
+
+        it("2.0.0-dev.2.1.0.104414 is a valid internal version when prerelease and allowAnyPrereleaseId are true", () => {
+            const input = `2.0.0-dev.2.1.0.104414`;
+            const result = isInternalVersionScheme(input, true, true);
+            assert.isTrue(result);
+        });
+
+        it("2.0.0-dev.2.1.0.104414 is a not valid when prerelease is false and allowAnyPrereleaseId are true", () => {
+            const input = `2.0.0-dev.2.1.0.104414`;
+            const result = isInternalVersionScheme(input, false, true);
+            assert.isFalse(result);
         });
 
         it(">=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0 is internal", () => {


### PR DESCRIPTION
Further relaxes the "rules" around the Fluid internal version scheme. This change should accommodate versions that have more than 4 prerelease sections and versions that use a non-internal prerelease identifier.

Prior to this change, versions like `2.0.0-dev.2.1.0.104436`, which is set in our CI pipeline, would cause a build failure.