### PR TITLE
Update Fluid Framework examples links from documentation

### DIFF
--- a/docs/content/docs/recipes/collaborative-text-area.md
+++ b/docs/content/docs/recipes/collaborative-text-area.md
@@ -338,7 +338,7 @@ Paste the URL of the application into the address bar of another tab or even ano
 
 - Try extending the demo with more Fluid DDSes and a more complex UI.
 - Consider using the [Fluent UI React controls](https://aka.ms/fluentui/) to give the application the look and feel of Microsoft 365. To install them in your project run the following in the command prompt: `npm install @fluentui/react`.
-- For an example that will scale to larger applications and larger teams, check out the [React Starter Template in the FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/react-starter-template).
+- For an example that will scale to larger applications and larger teams, check out the [React Starter Template in the FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/examples/react-starter-template).
 
 {{< callout tip >}}
 

--- a/docs/content/docs/recipes/node.md
+++ b/docs/content/docs/recipes/node.md
@@ -8,7 +8,7 @@ aliases:
 
 In this tutorial, you'll learn about using the Fluid Framework by building a simple application in NodeJS that enables connected clients to generate random numbers and display the result of any changes to the shared state.  You'll also learn how to connect the Fluid data layer in [Node](https://nodejs.org/).
 
-To jump ahead into the finished demo, check out the [Node demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/node-demo).
+To jump ahead into the finished demo, check out the [Node demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/examples/node-demo).
 
 The following image shows the random number generated open in four terminals after every one second.
 
@@ -187,7 +187,7 @@ To create a new Fluid container press Enter. The container id will be printed in
 
 ## Next steps
 
-- You can find the completed code for this example in our Fluid Examples GitHub repository [here](https://github.com/microsoft/FluidExamples/tree/main/node-demo).
+- You can find the completed code for this example in our Fluid Examples GitHub repository [here](https://github.com/microsoft/FluidExamples/tree/main/examples/node-demo).
 - Try extending the demo with more key/value pairs and a more complex framework such as Express.
 - Try changing the container schema to use a different shared data object type or specify multiple objects in `initialObjects`.
 

--- a/docs/content/docs/recipes/react.md
+++ b/docs/content/docs/recipes/react.md
@@ -7,7 +7,7 @@ aliases:
 
 In this tutorial, you'll learn about using the Fluid Framework by building a simple application that enables every client of the application to change a dynamic time stamp on itself and all other clients almost instantly. You'll also learn how to connect the Fluid data layer with a view layer made in [React](https://reactjs.org/).
 
-To jump ahead into the finished demo, check out the [React demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/react-demo).
+To jump ahead into the finished demo, check out the [React demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/examples/react-demo).
 
 The following image shows the time stamp application open in four browsers. Each has a button labeled **click** and beside it a Unix epoch time. The same time is in all four. The cursor is on the button in one browser.
 
@@ -231,7 +231,7 @@ Paste the URL of the application into the address bar of another tab or even ano
 - Try extending the demo with more key/value pairs and a more complex UI.
 - Consider using the [Fluent UI React controls](https://aka.ms/fluentui/) to give the application the look and feel of Microsoft 365. To install them in your project run the following in the command prompt: `npm install @fluentui/react`.
 - Try changing the container schema to use a different shared data object type or specify multiple objects in `initialObjects`.
-- For an example that will scale to larger applications and larger teams, check out the [React Starter Template in the FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/react-starter-template).
+- For an example that will scale to larger applications and larger teams, check out the [React Starter Template in the FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/examples/react-starter-template).
 
 {{< callout tip >}}
 

--- a/docs/content/docs/recipes/teams.md
+++ b/docs/content/docs/recipes/teams.md
@@ -10,7 +10,7 @@ Concepts you will learn:
 2. How to run and connect your Teams application to a Fluid service (Azure Fluid Relay)
 3. How to create and get Fluid Containers and pass them to a React component
 
-For an example of how this recipe may be used to build a more complex application, check out the [Teams Fluid Hello World](https://github.com/microsoft/FluidExamples/tree/main/teams-fluid-hello-world) example in our FluidExamples repo.
+For an example of how this recipe may be used to build a more complex application, check out the [Teams Fluid Hello World](https://github.com/microsoft/FluidExamples/tree/main/examples/teams-fluid-hello-world) example in our FluidExamples repo.
 
 {{< callout note >}}
 

--- a/docs/content/docs/recipes/vue.md
+++ b/docs/content/docs/recipes/vue.md
@@ -4,4 +4,4 @@ menuPosition: 2
 discussion: 5463
 ---
 
-The Fluid Framework is view framework agnostic and works well with most view frameworks. Visit the [FluidExamples repo](https://github.com/microsoft/FluidExamples/blob/main/multi-framework-diceroller/src/view/vueView.js) to see how [Vue.js](https://vuejs.org/) can be used render the dice roller from the [QuickStart]({{< relref "quick-start.md" >}}).
+The Fluid Framework is view framework agnostic and works well with most view frameworks. Visit the [FluidExamples repo](https://github.com/microsoft/FluidExamples/blob/main/examples/multi-framework-diceroller/src/view/vueView.js) to see how [Vue.js](https://vuejs.org/) can be used render the dice roller from the [QuickStart]({{< relref "quick-start.md" >}}).

--- a/docs/content/docs/recipes/web-components.md
+++ b/docs/content/docs/recipes/web-components.md
@@ -4,4 +4,4 @@ menuPosition: 2
 discussion: 5465
 ---
 
-The Fluid Framework is view framework agnostic and works well with most view frameworks. Visit the [FluidExamples repo](https://github.com/microsoft/FluidExamples/blob/main/multi-framework-diceroller/src/view/wcView.js) to see how [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) can be used render the dice roller from the [QuickStart]({{< relref "quick-start.md" >}}).
+The Fluid Framework is view framework agnostic and works well with most view frameworks. Visit the [FluidExamples repo](https://github.com/microsoft/FluidExamples/blob/main/examples/multi-framework-diceroller/src/view/wcView.js) to see how [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) can be used render the dice roller from the [QuickStart]({{< relref "quick-start.md" >}}).

--- a/docs/content/docs/start/examples.md
+++ b/docs/content/docs/start/examples.md
@@ -20,13 +20,13 @@ voted for those ideas.
 
 ## Collaborative text area
 
-The [collaborative text area app](https://github.com/microsoft/FluidExamples/tree/main/collaborative-text-area) shows
+The [collaborative text area app](https://github.com/microsoft/FluidExamples/tree/main/examples/collaborative-text-area) shows
 how to create a text area that can be collaboratively edited by multiple clients. It uses React to create
 the view. See also [Building a collaborative TextArea]({{< relref "docs/recipes/collaborative-text-area.md" >}}).
 
 ## Separating the view from the Fluid business logic
 
-The [multiframework dice roller app](https://github.com/microsoft/FluidExamples/tree/main/multi-framework-diceroller)
+The [multiframework dice roller app](https://github.com/microsoft/FluidExamples/tree/main/examples/multi-framework-diceroller)
 shows you how to keep your view layer separate from your Fluid layer. By changing a single line
 of code, you can switch between views based on React, Vue, Web Components, and simple, no framework
 JavaScript. See also [Using Fluid with React]({{< relref "docs/recipes/react.md" >}}),
@@ -41,20 +41,20 @@ Angular framework. See also [Using Fluid with Angular]({{< relref "docs/recipes/
 
 ## React and Fluid
 
-The [React dice app](https://github.com/microsoft/FluidExamples/tree/main/react-starter-template) shows how
+The [React dice app](https://github.com/microsoft/FluidExamples/tree/main/examples/react-starter-template) shows how
 to make incorporate Fluid state into a React-based app. Use it as a starter template to implement a 
 React-based view for your own Fluid Framework application.
 
-The [React timestamp app](https://github.com/microsoft/FluidExamples/tree/main/react-demo) shows how to integrate Fluid into an app created with the [create-react-app](https://create-react-app.dev/) tool. See also [Using Fluid with React]({{< relref "docs/recipes/react.md" >}}).
+The [React timestamp app](https://github.com/microsoft/FluidExamples/tree/main/examples/react-demo) shows how to integrate Fluid into an app created with the [create-react-app](https://create-react-app.dev/) tool. See also [Using Fluid with React]({{< relref "docs/recipes/react.md" >}}).
 
 ## Fluid with command line clients
 
-The [NodeJS demo app](https://github.com/microsoft/FluidExamples/tree/main/node-demo) shows how clients
+The [NodeJS demo app](https://github.com/microsoft/FluidExamples/tree/main/examples/node-demo) shows how clients
 that don't have an HTTP canvas can participate in the Fluid Framework collaboration. See also
 [Using Fluid with NodeJS]({{< relref "docs/recipes/node.md" >}}).
 
 ## Fluid in a Microsoft 365 Teams tab
 
-The [Teams and Fluid "Hello World" app](https://github.com/microsoft/FluidExamples/tree/main/teams-fluid-hello-world)
+The [Teams and Fluid "Hello World" app](https://github.com/microsoft/FluidExamples/tree/main/examples/teams-fluid-hello-world)
 shows you how to integrate a Fluid Framework application into a custom Microsoft 365 Teams tab. See
 also [Using Fluid with Microsoft Teams](https://learn.microsoft.com/microsoftteams/platform/tabs/using-fluid-msteam).

--- a/docs/content/docs/start/tutorial.md
+++ b/docs/content/docs/start/tutorial.md
@@ -112,7 +112,7 @@ start().catch((error) => console.error(error));
 
 ## Write the dice view
 
-The Fluid Framework is agnostic about view frameworks and it works well with React, Vue, Angular and web components. This example uses standard HTML/DOM methods to render a view. You can see examples of the previously mentioned frameworks in the [FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/multi-framework-diceroller).
+The Fluid Framework is agnostic about view frameworks and it works well with React, Vue, Angular and web components. This example uses standard HTML/DOM methods to render a view. You can see examples of the previously mentioned frameworks in the [FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/examples/multi-framework-diceroller).
 
 The `renderDiceRoller` function runs only when the container is created or loaded. It appends the `diceTemplate` to the passed in HTML element, and creates a working dice roller with a random dice value each time the "Roll" button is clicked on a client. 
 


### PR DESCRIPTION
## Description

[The examples page ](https://fluidframework.com/docs/start/examples/) on the Fluid Framework website has outdated links to the reference examples. Seems like at some point the folder `/examples/` was added and the links were not updated accordingly.

Note: I noticed that there's an angular demo that's not in the same folder as every other demo, this should be fixed in the future (unless there's a reason for this)/