### PR TITLE
fix(fluid-build): Support flub generate typetests tasks in fluid-build

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -56,6 +56,7 @@ const executableToLeafTask: {
     "gen-version": GenVerTask,
     "api-extractor": ApiExtractorTask,
     "fluid-type-validator": TypeValidationTask,
+    "flub generate typetests": TypeValidationTask,
 };
 
 export class TaskFactory {


### PR DESCRIPTION
This enables fluid-build to parse `flub generate typetests` as a typetest task. This should enable fluid-build to correctly cache type test task results as we switch to the new CLI.