### PR TITLE
fix(version-tools): Correct handling of internal dev/prerelease versions

### DIFF
--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -251,7 +251,11 @@ export function isInternalVersionRange(range: string, allowAnyPrereleaseId = fal
     }
 
     // if allowAnyPrereleaseId === true, then allowPrereleases is implied to be true
-    return isInternalVersionScheme(minVer, /* allowPrereleases */ allowAnyPrereleaseId, allowAnyPrereleaseId);
+    return isInternalVersionScheme(
+        minVer,
+        /* allowPrereleases */ allowAnyPrereleaseId,
+        allowAnyPrereleaseId,
+    );
 }
 
 /**

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -267,9 +267,7 @@ export function bumpInternalVersion(
 ): semver.SemVer {
     validateVersionScheme(version, true, undefined);
     const [pubVer, intVer, prereleaseId] = fromInternalScheme(version, true, true);
-    console.log(intVer.version);
     const newIntVer = bumpType === "current" ? intVer : intVer.inc(bumpType);
-    console.log(newIntVer.version);
     return toInternalScheme(pubVer, newIntVer, true, prereleaseId);
 }
 

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -250,7 +250,8 @@ export function isInternalVersionRange(range: string, allowAnyPrereleaseId = fal
         return false;
     }
 
-    return isInternalVersionScheme(minVer, allowAnyPrereleaseId, allowAnyPrereleaseId);
+    // if allowAnyPrereleaseId === true, then allowPrereleases is implied to be true
+    return isInternalVersionScheme(minVer, /* allowPrereleases */ allowAnyPrereleaseId, allowAnyPrereleaseId);
 }
 
 /**

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -250,7 +250,7 @@ export function isInternalVersionRange(range: string, allowAnyPrereleaseId = fal
         return false;
     }
 
-    return isInternalVersionScheme(minVer, false, allowAnyPrereleaseId);
+    return isInternalVersionScheme(minVer, allowAnyPrereleaseId, allowAnyPrereleaseId);
 }
 
 /**
@@ -265,10 +265,12 @@ export function bumpInternalVersion(
     version: semver.SemVer | string,
     bumpType: VersionBumpTypeExtended,
 ): semver.SemVer {
-    validateVersionScheme(version);
-    const [pubVer, intVer, prereleaseId] = fromInternalScheme(version, false, true);
+    validateVersionScheme(version, true, undefined);
+    const [pubVer, intVer, prereleaseId] = fromInternalScheme(version, true, true);
+    console.log(intVer.version);
     const newIntVer = bumpType === "current" ? intVer : intVer.inc(bumpType);
-    return toInternalScheme(pubVer, newIntVer, false, prereleaseId);
+    console.log(newIntVer.version);
+    return toInternalScheme(pubVer, newIntVer, true, prereleaseId);
 }
 
 /**
@@ -290,7 +292,7 @@ export function getVersionRange(
     version: semver.SemVer | string,
     maxAutomaticBump: "minor" | "patch" | "~" | "^",
 ): string {
-    validateVersionScheme(version, false, undefined);
+    validateVersionScheme(version, true, undefined);
 
     const lowVersion = version;
     let highVersion: semver.SemVer;

--- a/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
@@ -243,6 +243,20 @@ describe("internalScheme", () => {
             assert.isFalse(semver.satisfies(`2.0.0-internal.3.1.0`, range));
         });
 
+        it("caret ^ dependency equivalent for prerelease/dev versions", () => {
+            const input = `2.0.0-dev.1.2.3.12345`;
+            const expected = `>=2.0.0-dev.1.2.3.12345 <2.0.0-dev.2.0.0`;
+            const range = getVersionRange(input, "^");
+            assert.strictEqual(range, expected);
+        });
+
+        it("tilde ~ dependency equivalent for prerelease/dev versions", () => {
+            const input = `2.0.0-dev.1.2.3.12345`;
+            const expected = `>=2.0.0-dev.1.2.3.12345 <2.0.0-dev.1.3.0`;
+            const range = getVersionRange(input, "~");
+            assert.strictEqual(range, expected);
+        });
+
         /**
          * Builds that are produced from dev builds or other non-release builds don't have the "internal" prerelease
          * identifier intentionally to ensure they don't satisfy the caret/tilde-equivalent semver ranges we provide to

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -86,27 +86,25 @@ steps:
       echo VERSION_PATCH=$VERSION_PATCH
       echo VERSION_INCLUDE_INTERNAL_VERSIONS=$VERSION_INCLUDE_INTERNAL_VERSIONS
 
-      # Generate the build version
+      # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
+      # These are referenced in following steps prefixed by this task name. E.g. SetVersion.version
       flub generate buildVersion
 
 - task: Bash@3
   displayName: Update Package Version
   env:
     VERSION_RELEASE: $(release)
+    RELEASE_GROUP: ${{ parameters.tagName }}
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
       echo SETVERSION_VERSION=$SETVERSION_VERSION
       echo SETVERSION_CODEVERSION=$SETVERSION_CODEVERSION
+      echo RELEASE_GROUP=$RELEASE_GROUP
 
       if [ -f "lerna.json" ]; then
-        if [ "$VERSION_RELEASE" = "release" ]; then
-          # no need to run anything here, as the version in the package should be correct
-          npx lerna exec "if [ \`npm -s run env echo '\$npm_package_version'\` != '$(SetVersion.version)' ]; then ( exit 1 ) fi"
-          exit $?
-        fi
-        npx lerna version $(SetVersion.version) --no-git-tag-version --no-push --yes --exact
+        flub bump $RELEASE_GROUP --exact $(SetVersion.version) -xv
       else
         npm version $(SetVersion.version) --no-git-tag-version -f --allow-same-version
       fi

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -86,25 +86,27 @@ steps:
       echo VERSION_PATCH=$VERSION_PATCH
       echo VERSION_INCLUDE_INTERNAL_VERSIONS=$VERSION_INCLUDE_INTERNAL_VERSIONS
 
-      # Generate the build version. Sets the environment variables version, codeVersion, and isLatest.
-      # These are referenced in following steps prefixed by this task name. E.g. SetVersion.version
+      # Generate the build version
       flub generate buildVersion
 
 - task: Bash@3
   displayName: Update Package Version
   env:
     VERSION_RELEASE: $(release)
-    RELEASE_GROUP: ${{ parameters.tagName }}
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
       echo SETVERSION_VERSION=$SETVERSION_VERSION
       echo SETVERSION_CODEVERSION=$SETVERSION_CODEVERSION
-      echo RELEASE_GROUP=$RELEASE_GROUP
 
       if [ -f "lerna.json" ]; then
-        flub bump $RELEASE_GROUP --exact $(SetVersion.version) -xv
+        if [ "$VERSION_RELEASE" = "release" ]; then
+          # no need to run anything here, as the version in the package should be correct
+          npx lerna exec "if [ \`npm -s run env echo '\$npm_package_version'\` != '$(SetVersion.version)' ]; then ( exit 1 ) fi"
+          exit $?
+        fi
+        npx lerna version $(SetVersion.version) --no-git-tag-version --no-push --yes --exact
       else
         npm version $(SetVersion.version) --no-git-tag-version -f --allow-same-version
       fi


### PR DESCRIPTION
Some necessary changes were missing from #12721 that made it incomplete. This PR includes those changes, which should address that PR's goals of accommodating versions that have more than 4 prerelease sections and versions that use a non-internal prerelease identifier.

Prior to this change, versions like 2.0.0-dev.2.1.0.104436, which is set in our CI pipeline, would cause a build failure.