### PR TITLE
Fix the Routing Error by Setting the isSessionAlive when open a session

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -212,7 +212,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
             });
         });
 
-        // Fire-and-forget sessionActive update for session-boot performance.
+        // Fire-and-forget sessionAlive and sessionActive update for session-boot performance.
         // Worst case is that document is allowed to be deleted while active.
         this.collection.update(
             { documentId, tenantId },
@@ -222,7 +222,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
             },
             null,
         ).catch((error) => {
-            const errMsg = "Deli Lambda failed to mark session as active.";
+            const errMsg = "Deli Lambda failed to mark session as alive and active.";
             context.log?.error(`${errMsg}. Exception: ${inspect(error)}`, { messageMetaData });
         });
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -214,6 +214,10 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
 
         // Fire-and-forget sessionAlive and sessionActive update for session-boot performance.
         // Worst case is that document is allowed to be deleted while active.
+        context.log?.info(
+            `Deli Lambda is marking session as alive and active as true.`,
+            { messageMetaData },
+        );
         this.collection.update(
             { documentId, tenantId },
             {

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -421,7 +421,7 @@ describe("Routerlicious", () => {
                                     historianUrl: defaultProvider.get("worker:blobStorageUrl"),
                                     deltaStreamUrl: defaultProvider.get("worker:deltaStreamUrl"),
                                     isSessionAlive: false,
-                                    isSessionActive: false
+                                    isSessionActive: true
                                 })
                             });
                     });

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -213,8 +213,8 @@ export async function getSession(
         return convertSessionToFreshSession(newSession, lumberjackProperties);
     }
 
-    if (existingSession.isSessionAlive) {
-        // Existing session is considered alive/discovered, so return to consumer as-is.
+    if (existingSession.isSessionAlive || existingSession.isSessionActive) {
+        // Existing session is considered alive/discovered or active, so return to consumer as-is.
         return existingSession;
     }
 


### PR DESCRIPTION
When we open a session in Deli LambdaFactory, we mark both isSessionAlive and isSessionActive as true.

There is a session in cluster 1 that ends at time t0, another session that starts at t0+4hrs, and a third session that begins at t0+4hrs+a couple of mins. 
In this case, when the last session reads the truth, the lastAccessTime is > 3hrs (since session 2 is not finished and lastAccessTime is updated only on the session end). This is fine but the strange thing is that we are seeing that when session 3 reads the truth, it has "isSessionAlive":false, and"isSessionActive":true. This should be a "never" case. This is weird because we thought session 2 would have made "isSessionAlive": true after it went through discovery. 
We would like to introduce this fix to mark both isSessionAlive and isSessionActive as true, when opening a session in the deli lambda factory so that it would still use the urls stored in the truth. 

![MicrosoftTeams-image](https://user-images.githubusercontent.com/66701969/199107141-492da277-9f6f-4524-befb-0c64f0198f55.png)

