### PR TITLE
Fix execution of performance benchmarks pipeline

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -34,7 +34,7 @@
     "prettier": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",
     "prettier:fix": "prettier --write \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",
     "test": "nyc npm run test:mocha",
-    "test:benchmark:report": "mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r @fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
+    "test:benchmark:report": "mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r node_modules/@fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
     "test:mocha": "mocha \"dist/**/*.tests.js\" --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
     "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
     "test:stress": "cross-env FUZZ_TEST_COUNT=10 FUZZ_STRESS_RUN=true npm run test:mocha",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -37,7 +37,7 @@
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
     "test": "npm run test:mocha",
-    "test:benchmark:report": "mocha \"dist/**/*.bench.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r @fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
+    "test:benchmark:report": "mocha \"dist/**/*.bench.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r node_modules/@fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "test:mocha": "mocha --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup -r source-map-support/register --unhandled-rejections=strict",
     "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",


### PR DESCRIPTION
## Description

After something else apparently resolved a bug we had, where `@fluidframework/mocha-test-setup` was getting installed at the root of the repo during `npm i`, our performance benchmark pipelines started failing, complaining about not being able to find the `@fluidframework/mocha-test-setup` package (now not installed at the root of the repo) during a `mocha` invocation.

Specifying dynamically required packages with a path instead of just the module name makes mocha/node smart enough to resolve them from the working dir instead of the folder where the mocha executable lives. This is how we do it many times across the repository already.
