### PR TITLE
Fix dynamic require for mocha-test-setup in memory perf tests

### DIFF
--- a/packages/dds/map/src/test/memory/.mocharc.js
+++ b/packages/dds/map/src/test/memory/.mocharc.js
@@ -14,7 +14,7 @@ module.exports = {
     recursive: true,
     reporter: "@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js",
     reporterOptions: ["reportDir=.memoryTestsOutput/"],
-    require: ["@fluidframework/mocha-test-setup"],
+    require: ["node_modules/@fluidframework/mocha-test-setup"],
     spec: ["dist/test/memory/**/*.spec.js", "--perfMode"],
     timeout: "60000"
 }

--- a/packages/dds/matrix/src/test/memory/.mocharc.js
+++ b/packages/dds/matrix/src/test/memory/.mocharc.js
@@ -14,7 +14,7 @@
     recursive: true,
     reporter: "@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js",
     reporterOptions: ["reportDir=.memoryTestsOutput/"],
-    require: ["@fluidframework/mocha-test-setup"],
+    require: ["node_modules/@fluidframework/mocha-test-setup"],
     spec: ["dist/test/memory/**/*.spec.js", "--perfMode"],
     timeout: "60000"
 }

--- a/packages/dds/sequence/src/test/memory/.mocharc.js
+++ b/packages/dds/sequence/src/test/memory/.mocharc.js
@@ -14,7 +14,7 @@
     recursive: true,
     reporter: "../../../node_modules/@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js", // Lerna hoists the external dependency on @fluid-tools/benchmark to the root
     reporterOptions: ["reportDir=.memoryTestsOutput/"],
-    require: ["@fluidframework/mocha-test-setup"],
+    require: ["node_modules/@fluidframework/mocha-test-setup"],
     spec: ["dist/test/memory/**/*.spec.js", "--perfMode"],
     timeout: "60000"
 }


### PR DESCRIPTION
## Description

Same issue as https://github.com/microsoft/FluidFramework/pull/12738, in other packages/tests.
