### PR TITLE
feat(check:policy): Add handler to verify azure-client peerDependencies are set correctly

### DIFF
--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -34,7 +34,7 @@ interface IPerson {
     url: string;
 }
 
-interface IPackage {
+export interface IPackage {
     name: string;
     version: string;
     private: boolean;

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/index.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/index.ts
@@ -9,11 +9,13 @@ import { handler as dockerfilePackageHandler } from "./dockerfilePackages";
 import { handler as fluidCaseHandler } from "./fluidCase";
 import { handlers as lockfilesHandlers } from "./lockfiles";
 import { handlers as npmPackageContentsHandlers } from "./npmPackages";
+import { handler as peerDepsHandler } from "./peerDependencies";
 
 /**
  * declared file handlers
  */
 export const policyHandlers: Handler[] = [
+    peerDepsHandler,
     ...copyrightFileHeaderHandlers,
     ...npmPackageContentsHandlers,
     dockerfilePackageHandler,

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/peerDependencies.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/peerDependencies.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { EOL as newline } from "os";
+import sortPackageJson from "sort-package-json";
+
+import { IPackage } from "../../common/npmPackage";
+import { Handler, readFile, writeFile } from "../common";
+
+export const handler: Handler = {
+    name: "azure-client-peerDependencies",
+    match: /.*?azure-client\/package\.json/i,
+    handler: (file) => {
+        let jsonStr: string;
+        let pkgJson: IPackage;
+        try {
+            jsonStr = readFile(file);
+            pkgJson = JSON.parse(jsonStr);
+        } catch (err) {
+            return "Error parsing JSON file: " + file;
+        }
+
+        if (pkgJson.peerDependencies === undefined) {
+            return `azure-client must have a peerDependencies field in package.json`;
+        }
+
+        if (
+            pkgJson.peerDependencies["fluid-framework"] !==
+            pkgJson.peerDependencies["@fluidframework/core-interfaces"]
+        ) {
+            return `azure-client peerDependencies are invalid: ${pkgJson.peerDependencies["fluid-framework"]}`;
+        }
+
+        return undefined;
+    },
+    resolver: (file) => {
+        let jsonStr: string;
+        let pkgJson: IPackage;
+        try {
+            jsonStr = readFile(file);
+            pkgJson = JSON.parse(jsonStr);
+        } catch (err) {
+            return { resolved: false, message: "Error parsing JSON file: " + file };
+        }
+
+        if (pkgJson.peerDependencies === undefined) {
+            pkgJson.peerDependencies = {
+                "fluid-framework": pkgJson.dependencies["@fluidframework/core-interfaces"],
+            };
+        }
+
+        if (
+            pkgJson.peerDependencies["fluid-framework"] !==
+            pkgJson.dependencies["@fluidframework/core-interfaces"]
+        ) {
+            pkgJson.peerDependencies["fluid-framework"] =
+                pkgJson.dependencies["@fluidframework/core-interfaces"];
+        }
+
+        const output = JSON.stringify(sortPackageJson(pkgJson), undefined, 2).concat(newline);
+        try {
+            writeFile(file, output);
+        } catch (error: any) {
+            return { resolved: false, message: error.toString() };
+        }
+
+        return { resolved: true };
+    },
+};

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/peerDependencies.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/peerDependencies.ts
@@ -29,7 +29,7 @@ export const handler: Handler = {
             pkgJson.peerDependencies["fluid-framework"] !==
             pkgJson.peerDependencies["@fluidframework/core-interfaces"]
         ) {
-            return `azure-client peerDependencies are invalid: ${pkgJson.peerDependencies["fluid-framework"]}`;
+            return `azure-client peerDependencies are invalid: fluid-framework = ${pkgJson.peerDependencies["fluid-framework"]} -- expected ${pkgJson.peerDependencies["@fluidframework/core-interfaces"]}`;
         }
 
         return undefined;


### PR DESCRIPTION
Adds a policy handler that checks the azure-client package has a peerDependency on fluid-framework at the same version as the dependency on @fluidframework/core-interfaces.