### PR TITLE
feat(build-cli): Add autocomplete support for bash and zsh

### DIFF
--- a/build-tools/lerna-package-lock.json
+++ b/build-tools/lerna-package-lock.json
@@ -4433,6 +4433,129 @@
 			"resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
 			"integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
 		},
+		"@oclif/plugin-autocomplete": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-1.3.5.tgz",
+			"integrity": "sha512-86vKJATapihZohK81oLZKqxGebYvRQ4cK61sM68sKUsznfECevz7m3VHUDxhH/TwXttKc8Dv0LbBPBM/FiNAfQ==",
+			"requires": {
+				"@oclif/core": "^1.20.0",
+				"chalk": "^4.1.0",
+				"debug": "^4.3.4",
+				"fs-extra": "^9.0.1"
+			},
+			"dependencies": {
+				"@oclif/core": {
+					"version": "1.20.2",
+					"resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.20.2.tgz",
+					"integrity": "sha512-c6CpDbDPS9UuKwGoajzsjrjfnwQywWEV3WI5FDvb87h0/WW2tGf1QwHUWgdKOojafEcMAa9DnP5j+mXdUTtpCg==",
+					"requires": {
+						"@oclif/linewrap": "^1.0.0",
+						"@oclif/screen": "^3.0.2",
+						"ansi-escapes": "^4.3.2",
+						"ansi-styles": "^4.3.0",
+						"cardinal": "^2.1.1",
+						"chalk": "^4.1.2",
+						"clean-stack": "^3.0.1",
+						"cli-progress": "^3.10.0",
+						"debug": "^4.3.4",
+						"ejs": "^3.1.6",
+						"fs-extra": "^9.1.0",
+						"get-package-type": "^0.1.0",
+						"globby": "^11.1.0",
+						"hyperlinker": "^1.0.0",
+						"indent-string": "^4.0.0",
+						"is-wsl": "^2.2.0",
+						"js-yaml": "^3.14.1",
+						"natural-orderby": "^2.0.3",
+						"object-treeify": "^1.1.33",
+						"password-prompt": "^1.1.2",
+						"semver": "^7.3.7",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"supports-color": "^8.1.1",
+						"supports-hyperlinks": "^2.2.0",
+						"tslib": "^2.3.1",
+						"widest-line": "^3.1.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+							"requires": {
+								"has-flag": "^4.0.0"
+							}
+						}
+					}
+				},
+				"clean-stack": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
+					"integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
+					"requires": {
+						"escape-string-regexp": "4.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"@oclif/plugin-commands": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@oclif/plugin-commands/-/plugin-commands-2.2.0.tgz",

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -28,6 +28,7 @@ USAGE
 <!-- commands -->
 # Command Topics
 
+* [`flub autocomplete`](docs/autocomplete.md) - display autocomplete installation instructions
 * [`flub bump`](docs/bump.md) - Bump the version of packages, release groups, and their dependencies.
 * [`flub check`](docs/check.md) - Check commands are used to verify repo state, apply policy, etc.
 * [`flub commands`](docs/commands.md) - list all the commands

--- a/build-tools/packages/build-cli/docs/autocomplete.md
+++ b/build-tools/packages/build-cli/docs/autocomplete.md
@@ -1,0 +1,35 @@
+`flub autocomplete`
+===================
+
+display autocomplete installation instructions
+
+* [`flub autocomplete [SHELL]`](#flub-autocomplete-shell)
+
+## `flub autocomplete [SHELL]`
+
+display autocomplete installation instructions
+
+```
+USAGE
+  $ flub autocomplete [SHELL] [-r]
+
+ARGUMENTS
+  SHELL  shell type
+
+FLAGS
+  -r, --refresh-cache  Refresh cache (ignores displaying instructions)
+
+DESCRIPTION
+  display autocomplete installation instructions
+
+EXAMPLES
+  $ flub autocomplete
+
+  $ flub autocomplete bash
+
+  $ flub autocomplete zsh
+
+  $ flub autocomplete --refresh-cache
+```
+
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v1.3.5/src/commands/autocomplete/index.ts)_

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -74,6 +74,7 @@
     "@fluidframework/build-tools": "^0.5.0",
     "@fluidframework/bundle-size-tools": "^0.5.0",
     "@oclif/core": "^1.9.5",
+    "@oclif/plugin-autocomplete": "^1.3.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.1",
@@ -149,6 +150,7 @@
       "-V"
     ],
     "plugins": [
+      "@oclif/plugin-autocomplete",
       "@oclif/plugin-commands",
       "@oclif/plugin-help",
       "@oclif/plugin-not-found"

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -85,9 +85,39 @@ USAGE
 # Commands
 
 <!-- commands -->
+* [`fluv autocomplete [SHELL]`](#fluv-autocomplete-shell)
 * [`fluv help [COMMAND]`](#fluv-help-command)
 * [`fluv version VERSION`](#fluv-version-version)
 * [`fluv version latest`](#fluv-version-latest)
+
+## `fluv autocomplete [SHELL]`
+
+display autocomplete installation instructions
+
+```
+USAGE
+  $ fluv autocomplete [SHELL] [-r]
+
+ARGUMENTS
+  SHELL  shell type
+
+FLAGS
+  -r, --refresh-cache  Refresh cache (ignores displaying instructions)
+
+DESCRIPTION
+  display autocomplete installation instructions
+
+EXAMPLES
+  $ fluv autocomplete
+
+  $ fluv autocomplete bash
+
+  $ fluv autocomplete zsh
+
+  $ fluv autocomplete --refresh-cache
+```
+
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v1.3.5/src/commands/autocomplete/index.ts)_
 
 ## `fluv help [COMMAND]`
 

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@oclif/core": "^1.9.5",
+    "@oclif/plugin-autocomplete": "^1.3.5",
     "@oclif/plugin-commands": "^2.2.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.1",
@@ -118,6 +119,7 @@
       "-V"
     ],
     "plugins": [
+      "@oclif/plugin-autocomplete",
       "@oclif/plugin-help"
     ],
     "repositoryPrefix": "<%- repo %>/blob/main/build-tools/packages/version-tools/<%- commandPath %>",


### PR DESCRIPTION
Adds an `autocomplete` command to flub which can be used to generate autocomplete config for bash and zsh. This is provided "for free" by using [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete).

fish is not supported, but possibly could be with this PR: https://github.com/oclif/plugin-autocomplete/pull/38 We could either wait for the feature to come, release a custom plugin with that PR in the meantime, or open our own PR to add it.