### PR TITLE
Fix perf tests pipeline execution - port to release/v2int/2.0

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -33,7 +33,7 @@
     "prettier": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",
     "prettier:fix": "prettier --write \"**/*.{js,json,jsx,md,ts,tsx,yml,yaml}\"",
     "test": "nyc npm run test:mocha",
-    "test:benchmark:report": "mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r @fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
+    "test:benchmark:report": "mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r node_modules/@fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
     "test:mocha": "mocha \"dist/**/*.tests.js\" --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
     "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
     "test:stress": "cross-env FUZZ_TEST_COUNT=10 FUZZ_STRESS_RUN=true npm run test:mocha",

--- a/packages/dds/map/src/test/memory/.mocharc.js
+++ b/packages/dds/map/src/test/memory/.mocharc.js
@@ -14,7 +14,7 @@ module.exports = {
     recursive: true,
     reporter: "@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js",
     reporterOptions: ["reportDir=.memoryTestsOutput/"],
-    require: ["@fluidframework/mocha-test-setup"],
+    require: ["node_modules/@fluidframework/mocha-test-setup"],
     spec: ["dist/test/memory/**/*.spec.js", "--perfMode"],
     timeout: "60000"
 }

--- a/packages/dds/matrix/src/test/memory/.mocharc.js
+++ b/packages/dds/matrix/src/test/memory/.mocharc.js
@@ -14,7 +14,7 @@
     recursive: true,
     reporter: "@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js",
     reporterOptions: ["reportDir=.memoryTestsOutput/"],
-    require: ["@fluidframework/mocha-test-setup"],
+    require: ["node_modules/@fluidframework/mocha-test-setup"],
     spec: ["dist/test/memory/**/*.spec.js", "--perfMode"],
     timeout: "60000"
 }

--- a/packages/dds/sequence/src/test/memory/.mocharc.js
+++ b/packages/dds/sequence/src/test/memory/.mocharc.js
@@ -14,7 +14,7 @@
     recursive: true,
     reporter: "../../../node_modules/@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js", // Lerna hoists the external dependency on @fluid-tools/benchmark to the root
     reporterOptions: ["reportDir=.memoryTestsOutput/"],
-    require: ["@fluidframework/mocha-test-setup"],
+    require: ["node_modules/@fluidframework/mocha-test-setup"],
     spec: ["dist/test/memory/**/*.spec.js", "--perfMode"],
     timeout: "60000"
 }

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -37,7 +37,7 @@
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
     "test": "npm run test:mocha",
-    "test:benchmark:report": "mocha \"dist/**/*.bench.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r @fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
+    "test:benchmark:report": "mocha \"dist/**/*.bench.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark -r node_modules/@fluidframework/mocha-test-setup --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "test:mocha": "mocha --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup -r source-map-support/register --unhandled-rejections=strict",
     "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",


### PR DESCRIPTION
## Description

Porting https://github.com/microsoft/FluidFramework/pull/12738 and https://github.com/microsoft/FluidFramework/pull/12741 to the `release/v2int/2.0` branch which is also affected. See [here](https://dev.azure.com/fluidframework/internal/_build?definitionId=96&view=branches) (Microsoft internal) for the affected branches.