### PR TITLE
fix(bump): Fix detection of version scheme for internal/dev builds

### DIFF
--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -173,6 +173,18 @@ export function validateVersionScheme(
         throw new Error(`Couldn't parse ${version} as a semver.`);
     }
 
+    if (parsedVersion.prerelease.length === 0) {
+        throw new Error(`No prerelease section in ${version}`);
+    }
+
+    if (typeof parsedVersion.prerelease[0] !== "string") {
+        throw new TypeError(
+            `Expected a string; found a ${typeof parsedVersion.prerelease[0]} instead: ${
+                parsedVersion.prerelease[0]
+            }`,
+        );
+    }
+
     if (prereleaseIdentifier !== undefined) {
         // the "prerelease identifier" is the first section of the prerelease field
         const prereleaseId = parsedVersion.prerelease[0];
@@ -272,7 +284,14 @@ export function bumpInternalVersion(
 ): semver.SemVer {
     validateVersionScheme(version, true, undefined);
     const [pubVer, intVer, prereleaseId] = fromInternalScheme(version, true, true);
-    const newIntVer = bumpType === "current" ? intVer : intVer.inc(bumpType);
+
+    const newIntVer =
+        bumpType === "current"
+            ? intVer
+            : semver.inc(`${intVer.major}.${intVer.minor}.${intVer.patch}`, bumpType);
+
+    assert(newIntVer !== null, `newIntVer should not be null: ${version}`);
+
     return toInternalScheme(pubVer, newIntVer, true, prereleaseId);
 }
 

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -49,7 +49,7 @@ export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): Ver
         return "internal";
     }
 
-    if (isInternalVersionScheme(rangeOrVersion, true)) {
+    if (isInternalVersionScheme(rangeOrVersion, true, true)) {
         return "internalPrerelease";
     }
 

--- a/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
@@ -94,6 +94,12 @@ describe("internalScheme", () => {
             assert.isFalse(result);
         });
 
+        it("2.4.3 is a not valid even when allowPrereleases and allowAnyPrereleaseId are true", () => {
+            const input = `2.4.3`;
+            const result = isInternalVersionScheme(input, true, true);
+            assert.isFalse(result);
+        });
+
         it(">=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0 is internal", () => {
             const input = `>=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0`;
             assert.isTrue(isInternalVersionRange(input));
@@ -111,6 +117,11 @@ describe("internalScheme", () => {
 
         it(">=2.0.0-alpha.2.2.1 <2.0.0-alpha.3.0.0 is internal when allowAnyPrereleaseId is true", () => {
             const input = `>=2.0.0-alpha.2.2.1 <2.0.0-alpha.3.0.0`;
+            assert.isTrue(isInternalVersionRange(input, true));
+        });
+
+        it(">=2.0.0-dev.2.2.1.12345 <2.0.0-dev.3.0.0 is internal when allowAnyPrereleaseId is true", () => {
+            const input = `>=2.0.0-dev.2.2.1.12345 <2.0.0-dev.3.0.0`;
             assert.isTrue(isInternalVersionRange(input, true));
         });
 
@@ -244,15 +255,15 @@ describe("internalScheme", () => {
         });
 
         it("caret ^ dependency equivalent for prerelease/dev versions", () => {
-            const input = `2.0.0-dev.1.2.3.12345`;
-            const expected = `>=2.0.0-dev.1.2.3.12345 <2.0.0-dev.2.0.0`;
+            const input = `2.0.0-dev.3.0.0.105091`;
+            const expected = `>=2.0.0-dev.3.0.0.105091 <2.0.0-dev.4.0.0`;
             const range = getVersionRange(input, "^");
             assert.strictEqual(range, expected);
         });
 
         it("tilde ~ dependency equivalent for prerelease/dev versions", () => {
-            const input = `2.0.0-dev.1.2.3.12345`;
-            const expected = `>=2.0.0-dev.1.2.3.12345 <2.0.0-dev.1.3.0`;
+            const input = `2.0.0-dev.3.1.0.105091`;
+            const expected = `>=2.0.0-dev.3.1.0.105091 <2.0.0-dev.3.2.0`;
             const range = getVersionRange(input, "~");
             assert.strictEqual(range, expected);
         });

--- a/build-tools/packages/version-tools/src/test/schemes.test.ts
+++ b/build-tools/packages/version-tools/src/test/schemes.test.ts
@@ -48,6 +48,12 @@ describe("detectVersionScheme", () => {
         assert.strictEqual(detectVersionScheme(input), expected);
     });
 
+    it("detects 2.0.0-dev.3.0.0.105091 is internalPrerelease", () => {
+        const input = `2.0.0-dev.3.0.0.105091`;
+        const expected = "internalPrerelease";
+        assert.strictEqual(detectVersionScheme(input), expected);
+    });
+
     it("detects >=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0 is internal", () => {
         const input = `>=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0`;
         const expected = "internal";
@@ -80,6 +86,12 @@ describe("detectVersionScheme", () => {
 
     it("detects 1.2.1001 is semver", () => {
         const input = `1.2.1001`;
+        const expected = "semver";
+        assert.strictEqual(detectVersionScheme(input), expected);
+    });
+
+    it("detects 2.4.3 is semver", () => {
+        const input = `2.4.3`;
         const expected = "semver";
         assert.strictEqual(detectVersionScheme(input), expected);
     });


### PR DESCRIPTION
This is a cherry-pick of b586d7fba3, which was added to _next_ as part of resolving a build break. This just brings the change to the _main_ branch.