### PR TITLE
Port fluid-runner exports fix internal 1.4

### DIFF
--- a/packages/tools/fluid-runner/bin/fluid-runner
+++ b/packages/tools/fluid-runner/bin/fluid-runner
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require("../dist/fluidRunner.js");
+require("../dist/fluidRunner.js").fluidRunner();

--- a/packages/tools/fluid-runner/src/fluidRunner.ts
+++ b/packages/tools/fluid-runner/src/fluidRunner.ts
@@ -101,6 +101,4 @@ export function fluidRunner(fluidFileConverter?: IFluidFileConverter) {
         .help()
         .demandCommand().argv;
 }
-
-fluidRunner();
 /* eslint-enable max-len */

--- a/packages/tools/fluid-runner/src/test/exportFile.spec.ts
+++ b/packages/tools/fluid-runner/src/test/exportFile.spec.ts
@@ -31,7 +31,7 @@ describe("exportFile", () => {
         describe(`Export using snapshot [${snapshotFileName}]`, () => {
             it("Output file is correct", async () => {
                 const exportFileResult = await exportFile(
-                    await fluidExport,
+                    fluidExport,
                     path.join(snapshotFolder, snapshotFileName),
                     outputFilePath,
                     telemetryFile,
@@ -48,7 +48,7 @@ describe("exportFile", () => {
             it("Execution result is correct", async () => {
                 const result = await createContainerAndExecute(
                     getSnapshotFileContent(path.join(snapshotFolder, snapshotFileName)),
-                    await fluidExport,
+                    fluidExport,
                     new MockLogger(),
                 );
                 assert.deepStrictEqual(result, executeResult, "result objects do not match");
@@ -61,7 +61,7 @@ describe("exportFile", () => {
 
         it("input file", async () => {
             const result = await exportFile(
-                await fluidExport,
+                fluidExport,
                 "nonExistentFile.json",
                 outputFilePath,
                 telemetryFile,
@@ -74,7 +74,7 @@ describe("exportFile", () => {
 
         it("output file", async () => {
             const result = await exportFile(
-                await fluidExport,
+                fluidExport,
                 snapshotFilePath,
                 snapshotFilePath, // output file already exists
                 telemetryFile,

--- a/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
+++ b/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
@@ -89,3 +89,54 @@ describe("fluid-runner from command line", () => {
         });
     });
 });
+
+describe("custom fluidFileConverter provided", () => {
+    const command = path.join(__dirname, "../../src/test/sampleCodeLoaders", "sample-executable");
+
+    describe("exportFile", () => {
+        const folderRoot = path.join(__dirname, "../../src/test");
+        const codeLoader = path.join(__dirname, "sampleCodeLoaders", "sampleCodeLoader.js");
+        const snapshot = path.join(folderRoot, "localOdspSnapshots", "odspSnapshot2.json");
+        const outputFolder = path.join(folderRoot, "outputFolder");
+        const outputFilePath = path.join(outputFolder, "result.txt");
+        const telemetryFile = path.join(outputFolder, "telemetryFile.txt");
+
+        beforeEach(() => {
+            fs.mkdirSync(outputFolder);
+        });
+
+        afterEach(() => {
+            fs.rmdirSync(outputFolder, { recursive: true });
+        });
+
+        it("codeLoader command line arg is not needed", () => {
+            const exportFile = spawnSync("node", [
+                command,
+                "exportFile",
+                `--inputFile=${snapshot}`,
+                `--outputFile=${outputFilePath}`,
+                `--telemetryFile=${telemetryFile}`,
+                `--telemetryFormat=CSV`,
+            ], { encoding: "utf-8" });
+
+            assert.strictEqual(exportFile.status, 0,
+                `Process was not exited with code 0. Error: [${exportFile.stderr}]`);
+        });
+
+        it("Process exits with code 1 when both codeLoader and command line argument are provided", () => {
+            const exportFile = spawnSync("node", [
+                command,
+                "exportFile",
+                `--codeLoader=${codeLoader}`,
+                `--inputFile=${snapshot}`,
+                `--outputFile=${outputFilePath}`,
+                `--telemetryFile=${telemetryFile}`,
+            ], { encoding: "utf-8" });
+
+            assert.strictEqual(exportFile.status, 1,
+                `Process was not exited with code 1. Error: [${exportFile.stderr}]`);
+            assert.notStrictEqual(exportFile.stderr, "", "Expect some error output");
+            assert(exportFile.stderr.includes("cannot both be provided"), `unexpected error message [${exportFile.stderr}]`);
+        });
+    });
+});

--- a/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
+++ b/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
@@ -136,7 +136,8 @@ describe("custom fluidFileConverter provided", () => {
             assert.strictEqual(exportFile.status, 1,
                 `Process was not exited with code 1. Error: [${exportFile.stderr}]`);
             assert.notStrictEqual(exportFile.stderr, "", "Expect some error output");
-            assert(exportFile.stderr.includes("cannot both be provided"), `unexpected error message [${exportFile.stderr}]`);
+            assert(exportFile.stderr.includes("cannot both be provided"),
+                `unexpected error message [${exportFile.stderr}]`);
         });
     });
 });

--- a/packages/tools/fluid-runner/src/test/sampleCodeLoaders/sample-executable
+++ b/packages/tools/fluid-runner/src/test/sampleCodeLoaders/sample-executable
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const fluidRunnerModule = require("../../../dist/fluidRunner.js");
+const sampleCodeLoadeModule = require("../../../dist/test/sampleCodeLoaders/sampleCodeLoader.js");
+fluidRunnerModule.fluidRunner(sampleCodeLoadeModule.fluidExport);

--- a/packages/tools/fluid-runner/src/test/sampleCodeLoaders/sampleCodeLoader.ts
+++ b/packages/tools/fluid-runner/src/test/sampleCodeLoaders/sampleCodeLoader.ts
@@ -24,7 +24,7 @@ async function execute(_container: IContainer, _options?: string): Promise<strin
     return executeResult;
 }
 
-async function getFluidExport(): Promise<IFluidFileConverter> {
+function getFluidExport(): IFluidFileConverter {
     return {
         getCodeLoader,
         execute,

--- a/packages/tools/fluid-runner/src/test/utils.spec.ts
+++ b/packages/tools/fluid-runner/src/test/utils.spec.ts
@@ -32,7 +32,7 @@ describe("utils", () => {
     describe("validateCommandLineArgs", () => {
         describe("codeLoader and fluidFileConverter", () => {
             it("disallow providing both", async () => {
-                const result = validateCommandLineArgs("value", await fluidExport);
+                const result = validateCommandLineArgs("value", fluidExport);
                 assert.notStrictEqual(result, undefined, "expected an error");
             });
 
@@ -53,11 +53,11 @@ describe("utils", () => {
                     assert.strictEqual(result, undefined, `unexpected error [${result}]`);
                 }
                 {
-                    const result = validateCommandLineArgs(undefined, await fluidExport);
+                    const result = validateCommandLineArgs(undefined, fluidExport);
                     assert.strictEqual(result, undefined, `unexpected error [${result}]`);
                 }
                 {
-                    const result = validateCommandLineArgs("", await fluidExport);
+                    const result = validateCommandLineArgs("", fluidExport);
                     assert.strictEqual(result, undefined, `unexpected error [${result}]`);
                 }
             });


### PR DESCRIPTION
[How contribute to this
repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull
Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

`fluidRunner.ts` was running the same method it was exporting, thus causing errors at runtime when calling `require` on this file. Instead, the bin file now runs this method.

https://github.com/microsoft/FluidFramework/pull/12753
https://github.com/microsoft/FluidFramework/commit/03b9c2970bd51ab60077c07ac36f3e9d0b3046de