### PR TITLE
[Port PR #12764 to release/azure/1.1] Force e2e test that target real service run one at a time 

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -24,11 +24,15 @@ variables:
 - name: testWorkspace
   value: $(Pipeline.Workspace)/test
 
+lockBehavior: sequential
 stages:
-    # stress tests odsp
+  # stress tests odsp
   - stage:
     displayName:  Stress tests - Odsp
     dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: stress-odsp-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
@@ -43,10 +47,13 @@ stages:
           login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 
-    # stress tests odsp dogfood
+  # stress tests odsp dogfood
   - stage:
     displayName:  Stress tests - Odspdf
     dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: stress-odspdf-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
@@ -80,6 +87,9 @@ stages:
   - stage:
     displayName: Stress tests - frs
     dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: stress-frs-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -24,6 +24,7 @@ variables:
 - name: testWorkspace
   value: $(Pipeline.Workspace)/test
 
+lockBehavior: sequential
 stages:
   # end-to-end tests local server
   - stage:
@@ -57,6 +58,9 @@ stages:
   - stage:
     displayName: e2e - routerlicious
     dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: e2e-r11s-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
@@ -83,6 +87,9 @@ stages:
   - stage:
     displayName: e2e - frs
     dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: e2e-frs-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
@@ -109,6 +116,9 @@ stages:
   - stage:
     displayName:  e2e - odsp
     dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: e2e-odsp-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:


### PR DESCRIPTION
Using a variable group for each of the e2e/stress test targeting a real service (r11s,frs,odsp,odspdf) to limit runs to one at a time, so to avoid overloading the service/throttling, and reduce noise to the test result.

Fix
[AB#2345](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2345)
