### PR TITLE
Implement and test AttributionCollection

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -27,7 +27,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     // (undocumented)
     protected addSerializedProps(jseg: IJSONSegment): void;
     // (undocumented)
-    abstract append(segment: ISegment): void;
+    append(segment: ISegment): void;
     // (undocumented)
     canAppend(segment: ISegment): boolean;
     // (undocumented)

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -71,6 +71,7 @@
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.5.0-103719",
+    "@fluidframework/common-utils": "^1.0.0",
     "@fluidframework/eslint-config-fluid": "^1.1.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -60,6 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluidframework/common-utils": "^1.0.0",
     "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
@@ -71,7 +72,6 @@
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.5.0-103719",
-    "@fluidframework/common-utils": "^1.0.0",
     "@fluidframework/eslint-config-fluid": "^1.1.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
     BaseSegment,
@@ -10,7 +11,6 @@ import {
     IJSONSegment,
     IMergeTreeDeltaOp,
     ISegment,
-    LocalReferenceCollection,
     PropertySet,
 } from "@fluidframework/merge-tree";
 import {
@@ -73,15 +73,8 @@ export class PaddingSegment extends BaseSegment {
     }
 
     public append(segment: ISegment) {
-        if (!PaddingSegment.is(segment)) {
-            throw new Error("can only append padding segment");
-        }
-
-        // Note: Must call 'appendLocalRefs' before modifying this segment's length as
-        //       'this.cachedLength' is used to adjust the offsets of the local refs.
-        LocalReferenceCollection.append(this, segment);
-
-        this.cachedLength += segment.cachedLength;
+        assert(PaddingSegment.is(segment), "can only append padding segment");
+        super.append(segment);
     }
 
     // Returns true if entire run removed

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2180,6 +2180,7 @@
 			"resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.0.0.tgz",
 			"integrity": "sha512-l2UdVP3sZRlqm0FD0GRVF5VJGrFI2FgD9hYzCMRXCk1m6jaNmkNB0rtf8LboczoTu3NMad3IEz+bOKbLCHrr/Q==",
 			"requires": {
+				"@fluidframework/common-utils": "^1.0.0",
 				"@fluidframework/core-interfaces": "^2.0.0-internal.2.0.0",
 				"@fluidframework/datastore-definitions": "^2.0.0-internal.2.0.0",
 				"@fluidframework/merge-tree": "^2.0.0-internal.2.0.0",

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -10,7 +10,6 @@ import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import {
     BaseSegment,
     ISegment,
-    LocalReferenceCollection,
     Client,
     IMergeTreeDeltaOpArgs,
     IMergeTreeDeltaCallbackArgs,
@@ -112,14 +111,6 @@ export class PermutationSegment extends BaseSegment {
         return this.start === Handle.unallocated
             ? asPerm.start === Handle.unallocated
             : asPerm.start === this.start + this.cachedLength;
-    }
-
-    public append(segment: ISegment) {
-        // Note: Must call 'LocalReferenceCollection.append(..)' before modifying this segment's length as
-        //       'this.cachedLength' is used to adjust the offsets of the local refs.
-        LocalReferenceCollection.append(this, segment);
-
-        this.cachedLength += segment.cachedLength;
     }
 
     protected createSplitSegmentAt(pos: number) {

--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -1,0 +1,148 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/common-utils";
+import { RedBlackTree } from "./collections";
+import { compareNumbers, ISegment as ISegmentCurrent } from "./mergeTreeNodes";
+
+// TODO: Once integrated into merge-tree, this interface can be removed
+interface ISegment extends ISegmentCurrent {
+    attribution?: AttributionCollection<unknown>;
+}
+
+export interface SerializedAttributionCollection {
+    keys: unknown[];
+    posBreakpoints: number[];
+    /* Total length; only necessary for validation */
+    length: number;
+}
+
+export class AttributionCollection<T> {
+    private readonly entries: RedBlackTree<number, T> = new RedBlackTree(compareNumbers);
+
+    public constructor(baseEntry: T, private _length: number) {
+        this.entries.put(0, baseEntry);
+    }
+
+    public getAtOffset(offset: number): T {
+        assert(offset >= 0 && offset < this._length, "Requested offset should be valid");
+        const node = this.entries.floor(offset);
+        assert(node !== undefined, "Collection should have at least one entry");
+        return node.data;
+    }
+
+    public get length(): number {
+        return this._length;
+    }
+
+    /**
+     * Splits this attribution collection into two with entries for [0, pos) and [pos, length).
+     */
+    public splitAt(pos: number): AttributionCollection<T> {
+        const splitBaseEntry = this.getAtOffset(pos);
+        const splitCollection = new AttributionCollection(splitBaseEntry, this.length - pos);
+        for (let current = this.entries.ceil(pos); current !== undefined; current = this.entries.ceil(pos)) {
+            // If there happened to be an attribution change at exactly pos, it's already set in the base entry
+            if (current.key !== pos) {
+                splitCollection.entries.put(current.key - pos, current.data);
+            }
+            this.entries.remove(current.key);
+        }
+        this._length = pos;
+        return splitCollection;
+    }
+
+    public append(other: AttributionCollection<T>): void {
+        const lastEntry = this.getAtOffset(this.length - 1);
+        other.entries.map(({ key, data }) => {
+            if (key !== 0 || lastEntry !== data) {
+                this.entries.put(key + this.length, data);
+            }
+            return true;
+        });
+        this._length += other.length;
+    }
+
+    public getAll(): { offset: number; key: T; }[] {
+        const results: { offset: number; key: T; }[] = [];
+        this.entries.map(({ key, data }) => {
+            results.push({ offset: key, key: data });
+            return true;
+        });
+        return results;
+    }
+
+    public clone(): AttributionCollection<T> {
+        const copy = new AttributionCollection(this.getAtOffset(0), this.length);
+        this.entries.map(({ key, data }) => {
+            copy.entries.put(key, data);
+            return true;
+        });
+        return copy;
+    }
+
+    /**
+     * Rehydrates attribution information from its serialized form into the provided iterable of consecutive segments.
+     */
+    public static populateAttributionCollections(
+        segments: Iterable<ISegment>,
+        summary: SerializedAttributionCollection,
+    ): void {
+        const { keys, posBreakpoints } = summary;
+        assert(keys.length === posBreakpoints.length && keys.length > 0, "Invalid attribution summary blob provided");
+        let curIndex = 0;
+        let cumulativeSegPos = 0;
+        let currentInfo = keys[curIndex];
+
+        for (const segment of segments) {
+            const attribution = new AttributionCollection(currentInfo, segment.cachedLength);
+            while (posBreakpoints[curIndex] < cumulativeSegPos + segment.cachedLength) {
+                currentInfo = keys[curIndex];
+                attribution.entries.put(posBreakpoints[curIndex] - cumulativeSegPos, currentInfo);
+                curIndex++;
+            }
+
+            segment.attribution = attribution;
+            cumulativeSegPos += segment.cachedLength;
+        }
+    }
+
+    /**
+     * Condenses attribution information on consecutive segments into a `SerializedAttributionCollection`
+     */
+    public static serializeAttributionCollections(
+        segments: Iterable<ISegment>,
+    ): SerializedAttributionCollection {
+        const posBreakpoints: number[] = [];
+        const keys: unknown[] = [];
+        let mostRecentAttributionKey: unknown | undefined;
+        let cumulativePos = 0;
+
+        let segmentsWithAttribution = 0;
+        let segmentsWithoutAttribution = 0;
+        for (const segment of segments) {
+            if (segment.attribution) {
+                segmentsWithAttribution++;
+                for (const { offset, key: info } of segment.attribution.getAll() ?? []) {
+                    if (info !== mostRecentAttributionKey) {
+                        posBreakpoints.push(offset + cumulativePos);
+                        keys.push(info);
+                    }
+                    mostRecentAttributionKey = info;
+                }
+            } else {
+                segmentsWithoutAttribution++;
+            }
+
+            cumulativePos += segment.cachedLength;
+        }
+
+        assert(segmentsWithAttribution === 0 || segmentsWithoutAttribution === 0,
+            "Expected either all segments or no segments to have attribution information.");
+
+        const blobContents: SerializedAttributionCollection = { keys, posBreakpoints, length: cumulativePos };
+        return blobContents;
+    }
+}

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -496,7 +496,14 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     }
 
     public abstract clone(): ISegment;
-    public abstract append(segment: ISegment): void;
+
+    public append(segment: ISegment) {
+        // Note: Must call 'appendLocalRefs' before modifying this segment's length as
+        //       'this.cachedLength' is used to adjust the offsets of the local refs.
+        LocalReferenceCollection.append(this, segment);
+        this.cachedLength += segment.cachedLength;
+    }
+
     protected abstract createSplitSegmentAt(pos: number): BaseSegment | undefined;
 }
 

--- a/packages/dds/merge-tree/src/test/attributionCollection.spec.ts
+++ b/packages/dds/merge-tree/src/test/attributionCollection.spec.ts
@@ -1,0 +1,403 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    createWeightedGenerator,
+    Generator,
+    IRandom,
+    makeRandom,
+    performFuzzActions,
+    take,
+} from "@fluid-internal/stochastic-test-utils";
+import { AttributionCollection, SerializedAttributionCollection } from "../attributionCollection";
+import { BaseSegment, ISegment as ISegmentCurrent } from "../mergeTreeNodes";
+
+// TODO: Once integrated into merge-tree, this interface can be removed.
+interface ISegment extends ISegmentCurrent {
+    attribution?: AttributionCollection<unknown>;
+}
+
+describe("AttributionCollection", () => {
+    describe(".getAtOffset", () => {
+        describe("on a collection with a single entry", () => {
+            const collection = new AttributionCollection<string>("foo", 5);
+
+            it("returns the entry for offsets within the length range", () => {
+                for (let i = 0; i < 5; i++) {
+                    assert.equal(collection.getAtOffset(i), "foo");
+                }
+            });
+
+            it("throws for queries outside the range", () => {
+                assert.throws(() => collection.getAtOffset(-1));
+                assert.throws(() => collection.getAtOffset(5));
+            });
+        });
+
+        describe("on a collection with multiple entries", () => {
+            const collection = new AttributionCollection("foo", 3);
+            collection.append(new AttributionCollection("bar", 5));
+            it("returns the correct entries", () => {
+                for (let i = 0; i < 3; i++) {
+                    assert.equal(collection.getAtOffset(i), "foo");
+                }
+
+                for (let i = 3; i < 8; i++) {
+                    assert.equal(collection.getAtOffset(i), "bar");
+                }
+            });
+        });
+    });
+
+    describe(".splitAt", () => {
+        describe("on a collection with 3 entries", () => {
+            let collection: AttributionCollection<string>;
+            beforeEach(() => {
+                collection = new AttributionCollection("base", 3);
+                collection.append(new AttributionCollection("val1", 2));
+                collection.append(new AttributionCollection("val2", 1));
+            });
+
+            it("can split on non-breakpoints", () => {
+                const splitCollection = collection.splitAt(4);
+                assert.deepEqual(collection.getAll(), [
+                    { offset: 0, key: "base" },
+                    { offset: 3, key: "val1" },
+                ]);
+                assert.equal(collection.length, 4);
+                assert.deepEqual(splitCollection.getAll(), [
+                    { offset: 0, key: "val1" },
+                    { offset: 1, key: "val2" },
+                ]);
+                assert.equal(splitCollection.length, 2);
+            });
+
+            it("can split on breakpoints", () => {
+                const splitCollection = collection.splitAt(5);
+                assert.deepEqual(collection.getAll(), [
+                    { offset: 0, key: "base" },
+                    { offset: 3, key: "val1" },
+                ]);
+                assert.equal(collection.length, 5);
+                assert.deepEqual(splitCollection.getAll(), [
+                    { offset: 0, key: "val2" },
+                ]);
+                assert.equal(splitCollection.length, 1);
+            });
+        });
+
+        it("can split collection with a single value", () => {
+            const collection = new AttributionCollection("val", 5);
+            const splitCollection = collection.splitAt(3);
+            assert.equal(collection.length, 3);
+            assert.equal(splitCollection.length, 2);
+            assert.deepEqual(collection.getAll(), [{ offset: 0, key: "val" }]);
+            assert.deepEqual(splitCollection.getAll(), [{ offset: 0, key: "val" }]);
+        });
+    });
+
+    describe(".append", () => {
+        it("modifies the receiving collection", () => {
+            const collection = new AttributionCollection("foo", 2);
+            assert.deepEqual(collection.getAll(), [{ offset: 0, key: "foo" }]);
+            collection.append(new AttributionCollection("bar", 1));
+            assert.deepEqual(collection.getAll(), [{ offset: 0, key: "foo" }, { offset: 2, key: "bar" }]);
+        });
+
+        it("does not modify the argument collection", () => {
+            const collection = new AttributionCollection("foo", 2);
+            const appendedCollection = new AttributionCollection("bar", 1);
+            assert.deepEqual(appendedCollection.getAll(), [{ offset: 0, key: "bar" }]);
+            collection.append(appendedCollection);
+            assert.deepEqual(appendedCollection.getAll(), [{ offset: 0, key: "bar" }]);
+        });
+
+        it("coalesces referentially equal values at the join point", () => {
+            const collection = new AttributionCollection("foo", 2);
+            collection.append(new AttributionCollection("foo", 7));
+            assert.deepEqual(collection.getAll(), [{ offset: 0, key: "foo" }]);
+            assert.equal(collection.length, 9);
+        });
+    });
+
+    describe(".populateAttributionCollections", () => {
+        it("correctly splits segment boundaries on breakpoints", () => {
+            const segments = [{ cachedLength: 5 }, { cachedLength: 4 }] as ISegment[];
+            AttributionCollection.populateAttributionCollections(segments, {
+                length: 9,
+                posBreakpoints: [0, 2, 5, 7],
+                keys: [0, 2, 5, 7].map((key) => `val${key}`),
+            });
+            assert.deepEqual(segments[0].attribution?.getAll(), [
+                { offset: 0, key: "val0" },
+                { offset: 2, key: "val2" },
+            ]);
+
+            assert.deepEqual(segments[1].attribution?.getAll(), [
+                { offset: 0, key: "val5" },
+                { offset: 2, key: "val7" },
+            ]);
+
+            for (const segment of segments) {
+                assert.equal(segment.attribution?.length, segment.cachedLength);
+            }
+        });
+
+        it("correctly splits segment boundaries between breakpoints", () => {
+            const segments = [{ cachedLength: 4 }, { cachedLength: 5 }] as ISegment[];
+            AttributionCollection.populateAttributionCollections(segments, {
+                length: 9,
+                posBreakpoints: [0, 2, 5, 7],
+                keys: [0, 2, 5, 7].map((key) => `val${key}`),
+            });
+            assert.deepEqual(segments[0].attribution?.getAll(), [
+                { offset: 0, key: "val0" },
+                { offset: 2, key: "val2" },
+            ]);
+
+            assert.deepEqual(segments[1].attribution?.getAll(), [
+                { offset: 0, key: "val2" },
+                { offset: 1, key: "val5" },
+                { offset: 3, key: "val7" },
+            ]);
+
+            for (const segment of segments) {
+                assert.equal(segment.attribution?.length, segment.cachedLength);
+            }
+        });
+    });
+
+    describe("serializeAttributionCollections", () => {
+        it("combines equal values on endpoints", () => {
+            const segments = [
+                { attribution: new AttributionCollection(0, 4), cachedLength: 4 },
+                { attribution: new AttributionCollection(0, 5), cachedLength: 5 },
+            ] as ISegment[];
+            const blob = AttributionCollection.serializeAttributionCollections(segments);
+            assert.deepEqual(blob, {
+                posBreakpoints: [0],
+                keys: [0],
+                length: 9,
+            });
+        });
+
+        it("validates either all segments or no segments have attribution tracking", () => {
+            const segments = [
+                { attribution: new AttributionCollection(0, 4), cachedLength: 4 },
+                { cachedLength: 5 },
+            ] as ISegment[];
+            assert.throws(() => AttributionCollection.serializeAttributionCollections(segments));
+        });
+    });
+
+    describe("serializeAttributionCollections and populateAttributionCollections round-trip", () => {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const seg = (length: number): ISegment => ({ cachedLength: length }) as ISegment;
+        const testCases: { name: string; blob: SerializedAttributionCollection; segments: ISegment[]; }[] = [
+            {
+                name: "single key",
+                blob: {
+                    length: 3,
+                    posBreakpoints: [0],
+                    keys: ["foo"],
+                },
+                segments: [seg(3)],
+            },
+            {
+                name: "several keys on a single segment",
+                blob: {
+                    length: 7,
+                    posBreakpoints: [0, 1, 3, 5],
+                    keys: [1, 2, 3, 4],
+                },
+                segments: [seg(7)],
+            },
+            {
+                name: "key spanning multiple segments",
+                blob: {
+                    length: 7,
+                    posBreakpoints: [0],
+                    keys: [1],
+                },
+                segments: [seg(3), seg(4)],
+            },
+            {
+                name: "key and segment boundary that align",
+                blob: {
+                    length: 7,
+                    posBreakpoints: [0, 3],
+                    keys: [0, 1],
+                },
+                segments: [seg(3), seg(4)],
+            },
+        ];
+
+        for (const { name, blob, segments } of testCases) {
+            it(name, () => {
+                AttributionCollection.populateAttributionCollections(segments, blob);
+                assert.deepEqual(
+                    AttributionCollection.serializeAttributionCollections(segments),
+                    blob,
+                );
+            });
+        }
+    });
+
+    describe(".clone", () => {
+        it("copies the original collection", () => {
+            const collection = new AttributionCollection("foo", 2);
+            const appendedCollection = new AttributionCollection("bar", 1);
+            const copy = collection.clone();
+            collection.append(appendedCollection);
+            assert.deepEqual(collection.getAll(), [{ offset: 0, key: "foo" }, { offset: 2, key: "bar" }]);
+            assert.deepEqual(copy.getAll(), [{ offset: 0, key: "foo" }]);
+        });
+    });
+
+    describe("serialized structure is independent of segment lengths", () => {
+        interface State {
+            random: IRandom;
+            segments: ISegment[];
+        }
+
+        interface InsertAction {
+            type: "insert";
+            length: number;
+            attributionKey: number;
+        }
+
+        interface SplitAction {
+            type: "split";
+            segIndex: number;
+            offset: number;
+        }
+
+        interface AppendAction {
+            type: "append";
+            segIndex: number;
+        }
+
+        // TODO: Once integrated into merge-tree, much of the interactions with attribution on this segment
+        // can be removed, as they'll be handled in base classes
+        class Segment extends BaseSegment implements ISegment {
+            public attribution?: AttributionCollection<unknown>;
+            public readonly type = "testSeg";
+            public constructor(length: number) {
+                super();
+                this.cachedLength = length;
+            }
+
+            public toJSONObject() {
+                return { length: this.cachedLength, props: this.properties };
+            }
+
+            public clone(): ISegment {
+                const seg = new Segment(this.cachedLength);
+                this.cloneInto(seg);
+                // TODO: Remove
+                seg.attribution = this.attribution?.clone();
+                return seg;
+            }
+
+            protected createSplitSegmentAt(pos: number): BaseSegment | undefined {
+                if (pos > 0) {
+                    const leafSegment = new Segment(this.cachedLength - pos);
+                    // TODO: Remove
+                    leafSegment.attribution = this.attribution?.splitAt(pos);
+                    this.cachedLength = pos;
+                    return leafSegment;
+                }
+            }
+
+            // TODO: Remove
+            public append(segment: ISegment): void {
+                if (segment.attribution) {
+                    this.attribution?.append(segment.attribution);
+                }
+                super.append(segment);
+            }
+        }
+
+        for (let seed = 0; seed < 10; seed++) {
+            const segmentCount = 100;
+            it(`with randomly generated segments, seed ${seed}`, () => {
+                const insertGenerator: Generator<InsertAction, State> = take(segmentCount, ({ random }) => ({
+                    type: "insert",
+                    length: random.integer(1, 20),
+                    attributionKey: random.integer(0, 10),
+                }));
+
+                const initialState = performFuzzActions<InsertAction, State>(
+                    insertGenerator,
+                    {
+                        insert: (state, { length, attributionKey }) => {
+                            const { segments } = state;
+                            const seg = new Segment(length);
+                            seg.attribution = new AttributionCollection(attributionKey, length);
+                            segments.push(seg);
+                            return state;
+                        },
+                    },
+                    { random: makeRandom(seed), segments: [] },
+                );
+
+                const expected = AttributionCollection.serializeAttributionCollections(initialState.segments);
+
+                const split: Generator<SplitAction, State> = ({ segments, random }) => {
+                    const validIndices = segments
+                        .map((seg, i) => seg.cachedLength > 1 ? i : -1)
+                        .filter((i) => i >= 0);
+
+                    const segIndex = random.pick(validIndices);
+                    const offset = random.integer(1, segments[segIndex].cachedLength - 1);
+                    return {
+                        type: "split",
+                        segIndex,
+                        offset,
+                    };
+                };
+                const append: Generator<AppendAction, State> = ({ random, segments }) => {
+                    return {
+                        type: "append",
+                        segIndex: random.integer(0, segments.length - 2),
+                    };
+                };
+                const finalState = performFuzzActions<SplitAction | AppendAction, State>(
+                    take(
+                        segmentCount,
+                        // Note: if playing around with constants in this test, it may be necessary to
+                        // introduce acceptance criteria here for split.
+                        createWeightedGenerator<SplitAction | AppendAction, State>([
+                            [split, 1],
+                            [append, 1, ({ segments }) => segments.length > 1],
+                        ]),
+                    ),
+                    {
+                        split: (state, { segIndex, offset }) => {
+                            const { segments } = state;
+                            const splitSeg = segments[segIndex].splitAt(offset);
+                            assert(splitSeg !== undefined);
+                            segments.splice(segIndex + 1, 0, splitSeg);
+                            return state;
+                        },
+                        append: (state, { segIndex }) => {
+                            const { segments } = state;
+                            segments[segIndex].append(segments[segIndex + 1]);
+                            segments.splice(segIndex + 1, 1);
+                            return state;
+                        },
+                    },
+                    initialState,
+                );
+
+                assert.deepEqual(
+                    AttributionCollection.serializeAttributionCollections(finalState.segments),
+                    expected,
+                );
+            });
+        }
+    });
+});

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { BaseSegment, ISegment } from "./mergeTreeNodes";
 import { IJSONSegment } from "./ops";
 import { PropertySet } from "./properties";
-import { LocalReferenceCollection } from "./localReference";
 
 // Maximum length of text segment to be considered to be merged with other segment.
 // Maximum segment length is at least 2x of it (not taking into account initial segment creation).
@@ -81,16 +81,9 @@ export class TextSegment extends BaseSegment {
     }
 
     public append(segment: ISegment) {
-        if (TextSegment.is(segment)) {
-            // Note: Must call 'appendLocalRefs' before modifying this segment's length as
-            // 'this.cachedLength' is used to adjust the offsets of the local refs.
-            LocalReferenceCollection.append(this, segment);
-
-            this.text += segment.text;
-            this.cachedLength = this.text.length;
-        } else {
-            throw new Error("can only append text segment");
-        }
+        assert(TextSegment.is(segment), "can only append text segment");
+        super.append(segment);
+        this.text += segment.text;
     }
 
     // TODO: retain removed text for undo

--- a/packages/dds/sequence/src/sharedSequence.ts
+++ b/packages/dds/sequence/src/sharedSequence.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import {
-    BaseSegment, IJSONSegment, ISegment, PropertySet, LocalReferenceCollection,
+    BaseSegment, IJSONSegment, ISegment, PropertySet,
 } from "@fluidframework/merge-tree";
 import { IChannelAttributes, IFluidDataStoreRuntime, Serializable } from "@fluidframework/datastore-definitions";
 import { SharedSegmentSequence } from "./sequence";
@@ -61,16 +62,9 @@ export class SubSequence<T> extends BaseSegment {
     }
 
     public append(segment: ISegment) {
-        if (!SubSequence.is(segment)) {
-            throw new Error("can only append another run segment");
-        }
-
-        // Note: Must call 'appendLocalRefs' before modifying this segment's length as
-        //       'this.cachedLength' is used to adjust the offsets of the local refs.
-        LocalReferenceCollection.append(this, segment);
-
+        assert(SubSequence.is(segment), "can only append to another run segment");
+        super.append(segment);
         this.items = this.items.concat(segment.items);
-        this.cachedLength = this.items.length;
     }
 
     // TODO: retain removed items for undo


### PR DESCRIPTION
## Description

This implements and tests `AttributionCollection`, a class aimed at associating attribution keys to merge-tree segments. Attribution keys are opaque values that can be used to look up user information: near-future plan is to use sequence numbers as attribution keys, but longer-term we may make this extensible via application-provided attribution information.

attribution information has no impact on whether adjacent segments can be merged. As such, a given segment may have different attribution information for each of its `offset`s.

#12634 provides a more complete picture of how this component integrates into the broader attribution story.

