### PR TITLE
Tests for LocalDetachedDataStoreContext

### DIFF
--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "assert";
 
 import { ITaggedTelemetryPropertyType } from "@fluidframework/common-definitions";
 import { stringToBuffer } from "@fluidframework/common-utils";
-import { ContainerErrorType } from "@fluidframework/container-definitions";
+import { AttachState, ContainerErrorType } from "@fluidframework/container-definitions";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { BlobCacheStorageService } from "@fluidframework/driver-utils";
@@ -35,6 +35,7 @@ import { isFluidError, TelemetryNullLogger } from "@fluidframework/telemetry-uti
 import { MockFluidDataStoreRuntime, validateAssertionError } from "@fluidframework/test-runtime-utils";
 
 import {
+    LocalDetachedFluidDataStoreContext,
     LocalFluidDataStoreContext,
     RemoteFluidDataStoreContext,
 } from "../dataStoreContext";
@@ -746,6 +747,108 @@ describe("Data Store Context Tests", () => {
                 assert.doesNotThrow(() => {
                     remoteDataStoreContext.tombstone();
                 }, `Should be able to tombstone a non-root remote datastore!`);
+            });
+        });
+    });
+
+    describe("LocalDetachedFluidDataStoreContext", () => {
+        let localDataStoreContext: LocalDetachedFluidDataStoreContext;
+        let storage: IDocumentStorageService;
+        let scope: FluidObject;
+        let factory: IFluidDataStoreFactory;
+        const makeLocallyVisibleFn = () => {};
+        let containerRuntime: ContainerRuntime;
+
+        beforeEach(async () => {
+            const summarizerNode: IRootSummarizerNodeWithGC = createRootSummarizerNodeWithGC(
+                new TelemetryNullLogger(),
+                (() => undefined) as unknown as SummarizeInternalFn,
+                0,
+                0);
+            summarizerNode.startSummary(0, new TelemetryNullLogger());
+
+            createSummarizerNodeFn = (
+                summarizeInternal: SummarizeInternalFn,
+                getGCDataFn: () => Promise<IGarbageCollectionData>,
+                getBaseGCDetailsFn: () => Promise<IGarbageCollectionDetailsBase>,
+            ) => summarizerNode.createChild(
+                summarizeInternal,
+                dataStoreId,
+                { type: CreateSummarizerNodeSource.Local },
+                // DDS will not create failure summaries
+                { throwOnFailure: true },
+                getGCDataFn,
+                getBaseGCDetailsFn,
+            );
+
+            factory = {
+                type: "store-type",
+                get IFluidDataStoreFactory() { return factory; },
+                instantiateDataStore: async (context: IFluidDataStoreContext, existing: boolean) =>
+                    new MockFluidDataStoreRuntime()
+            };
+            const registry: IFluidDataStoreRegistry = {
+                get IFluidDataStoreRegistry() { return registry; },
+                get: async (pkg) => (pkg === factory.type ? factory : undefined),
+            };
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            containerRuntime = {
+                IFluidDataStoreRegistry: registry,
+                on: (event, listener) => { },
+                logger: new TelemetryNullLogger(),
+            } as ContainerRuntime;
+        });
+
+        describe("Initialization", () => {
+            it("rejects ids with forward slashes", async () => {
+                const invalidId = "beforeSlash/afterSlash";
+                const codeBlock = () => new LocalDetachedFluidDataStoreContext({
+                    id: invalidId,
+                    pkg: [factory.type],
+                    runtime: containerRuntime,
+                    storage,
+                    scope,
+                    createSummarizerNodeFn,
+                    makeLocallyVisibleFn,
+                    snapshotTree: undefined,
+                    isRootDataStore: true,
+                });
+
+                assert.throws(codeBlock,
+                    (e: Error) => validateAssertionError(e, "Data store ID contains slash"));
+            });
+
+            describe("should error on attach if data object cannot be constructed", () => {
+                // Tests in this suite should be scenarios that lead to a data store which cannot be constructed for
+                // some reason.
+
+                it("because of package type for data store not present in registry", async () => {
+                    let exceptionOccurred = false;
+                    localDataStoreContext = new LocalDetachedFluidDataStoreContext({
+                            id: dataStoreId,
+                            pkg: ["some-datastore-type-not-present-in-registry"],
+                            runtime: containerRuntime,
+                            storage,
+                            scope,
+                            createSummarizerNodeFn,
+                            makeLocallyVisibleFn,
+                            snapshotTree: undefined,
+                            isRootDataStore: false,
+                        },
+                    );
+
+                    const dataStore = await factory.instantiateDataStore(localDataStoreContext, false);
+                    await localDataStoreContext.attachRuntime(factory, dataStore)
+                        .catch((error) => {
+                            assert.strictEqual(
+                                error.message,
+                                "Registry does not contain entry for the package",
+                                "Unexpected exception thrown");
+                            exceptionOccurred = true;
+                        });
+                    assert.strictEqual(exceptionOccurred, true, "attachRuntime() call did not fail as expected.");
+                    assert.strictEqual(localDataStoreContext.attachState, AttachState.Detached);
+                });
             });
         });
     });

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -818,7 +818,7 @@ describe("Data Store Context Tests", () => {
                     (e: Error) => validateAssertionError(e, "Data store ID contains slash"));
             });
 
-            describe("should error on attach if data object cannot be constructed", () => {
+            describe("should error on attach if data store cannot be constructed/initialized", () => {
                 // Tests in this suite should be scenarios that lead to a data store which cannot be constructed for
                 // some reason.
 


### PR DESCRIPTION
## Description

Adds a few unit tests for `LocalDetachedDataStoreContext` which had none. A simple test for parameter validation, and a more interesting test that was motivated by the changes in https://github.com/microsoft/FluidFramework/pull/11887 (originally in the experiments in https://github.com/microsoft/FluidFramework/pull/12701), about ensuring that a detached data store cannot be attached if its runtime cannot be created/initialized successfully.
