### PR TITLE
Address CVE-2021-23358 in `underscore` by removing `jsonlint` which depends on it

### DIFF
--- a/experimental/PropertyDDS/services/property-query-service/package.json
+++ b/experimental/PropertyDDS/services/property-query-service/package.json
@@ -58,7 +58,6 @@
     "http-status-codes": "1.3.0",
     "ioredis": "4.5.1",
     "joi": "14.3.1",
-    "jsonlint": "^1.6.3",
     "lodash": "^4.17.21",
     "long": "^4.0.0",
     "lru-cache": "^6.0.0",

--- a/experimental/PropertyDDS/services/property-query-service/src/server/utils/settings.js
+++ b/experimental/PropertyDDS/services/property-query-service/src/server/utils/settings.js
@@ -12,7 +12,6 @@
 var fs = require('fs'),
     path = require('path'),
     nconf = require('nconf'),
-    jsonlint = require('jsonlint'),
     utils = require('./settings_utils.js');
 
 /**
@@ -117,7 +116,7 @@ function Settings(in_configJSONPaths, in_dynamicDefaults, in_options) {
     for (itr = 0; itr < configJSONPaths.length; itr++) {
       const fileText = fs.readFileSync(configJSONPaths[itr], 'utf8');
       try {
-        availableData.push(jsonlint.parse(fileText, configJSONPaths[itr]));
+        availableData.push(JSON.parse(fileText, configJSONPaths[itr]));
       } catch (err) {
         console.error('Error parsing: ', configJSONPaths[itr]);
         if (exitOnError) {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -37273,11 +37273,6 @@
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
 			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
 		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw=="
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -41439,15 +41434,6 @@
 			"resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
 			"integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==",
 			"dev": true
-		},
-		"jsonlint": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
-			"integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
-			"requires": {
-				"JSV": "^4.0.x",
-				"nomnom": "^1.5.x"
-			}
 		},
 		"jsonparse": {
 			"version": "1.3.1",
@@ -46715,42 +46701,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"nomnom": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-			"integrity": "sha512-5s0JxqhDx9/rksG2BTMVN1enjWSvPidpoSgViZU4ZXULyTe+7jxcCRLB6f42Z0l1xYJpleCBtSyY6Lwg3uu5CQ==",
-			"requires": {
-				"chalk": "~0.4.0",
-				"underscore": "~1.6.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA=="
-				},
-				"chalk": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-					"integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
-					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-				},
-				"underscore": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 				}
 			}
 		},


### PR DESCRIPTION
## Description

Address CVE-2021-23358 in `underscore` by removing `jsonlint` which depends on it. Since jsonlint is only being used to parse json and there seems to be no reason not to use `JSON.parse`. Even the creator of mentions there is no real reason to use the [jsonlint](https://www.npmjs.com/package/jsonlint) for just parsing.

[Internal ADO Ticket](https://dev.azure.com/fluidframework/internal/_componentGovernance/17385/alert/525742?typeId=55946)

## Reviewer Guidance

- Confirm impacted `underscore` dependency has been removed.
- Confirm that the change to `experimental/PropertyDDS/services/property-query-service` is acceptable.