### PR TITLE
LTS: fix undefined message contents bug

### DIFF
--- a/packages/runtime/container-runtime/src/opTelemetry.ts
+++ b/packages/runtime/container-runtime/src/opTelemetry.ts
@@ -43,7 +43,7 @@ export class OpTracker {
             // so stringifying them again will add inaccurate overhead.
             const messageContent = typeof message.contents === "string" ?
                 message.contents :
-                JSON.stringify(message.contents);
+                JSON.stringify(message.contents) ?? "";
             const messageData = OpTracker.messageHasData(message) ? message.data : "";
             this.messageSize[OpTracker.messageId(message)] = messageContent.length + messageData.length;
         });

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -900,5 +900,34 @@ describe("Runtime", () => {
                         && e.message === `Id cannot contain slashes: '${invalidId}'`);
             });
         });
+
+        describe("op format", () => {
+            const getMockContext = ((deltaManager): Partial<IContainerContext> => {
+                return {
+                    deltaManager,
+                    quorum: new MockQuorumClients(),
+                    taggedLogger: new MockLogger(),
+                    clientDetails: { capabilities: { interactive: true } },
+                    closeFn: (_error?: ICriticalContainerError): void => { },
+                    updateDirtyContainerState: (_dirty: boolean) => { },
+                };
+            });
+
+            it("handles message with undefined contents", async () => {
+                const deltaManager = new MockDeltaManager();
+                const runtime = await ContainerRuntime.load(
+                    getMockContext(deltaManager) as IContainerContext,
+                    [],
+                    undefined, // requestHandler
+                    {}, // runtimeOptions
+                );
+                const op: ISequencedDocumentMessage = {
+                    contents: undefined,
+                    clientId: "a client",
+                } as any;
+                deltaManager.inbound.push(op as any);
+                runtime.process(op, false);
+            });
+        });
     });
 });


### PR DESCRIPTION
Fix an error when we get an op with `undefined` contents.

This bug was fixed already on 2.0.0-internal.1.4.0 branch. 