### PR TITLE
Adding metrics to track inner steps of CreateDocument and ConnectDocument

### DIFF
--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -124,7 +124,6 @@ export class DocumentStorage implements IDocumentStorage {
         const tenant = await this.tenantManager.getTenant(tenantId, documentId);
         const gitManager = tenant.gitManager;
 
-        const messageMetaData = { documentId, tenantId };
         const lumberjackProperties = {
             [BaseTelemetryProperties.tenantId]: tenantId,
             [BaseTelemetryProperties.documentId]: documentId,
@@ -137,28 +136,33 @@ export class DocumentStorage implements IDocumentStorage {
         const uploadManager = this.enableWholeSummaryUpload ?
             new WholeSummaryUploadManager(gitManager) :
             new SummaryTreeUploadManager(gitManager, blobsShaCache, async () => undefined);
-        const handle = await uploadManager.writeSummaryTree(fullTree, "", "container", 0);
 
-        winston.info(`Tree reference: ${JSON.stringify(handle)}`, { messageMetaData });
-        Lumberjack.info(`Tree reference: ${JSON.stringify(handle)}`, lumberjackProperties);
+        const initialSummaryUploadMetric =
+            Lumberjack.newLumberMetric(LumberEventName.CreateDocInitialSummaryWrite, lumberjackProperties);
+        try {
+            const handle = await uploadManager.writeSummaryTree(fullTree, "", "container", 0);
+            let initialSummaryUploadSuccessMessage = `Tree reference: ${JSON.stringify(handle)}`;
 
-        if (!this.enableWholeSummaryUpload) {
-            const commitParams: ICreateCommitParams = {
-                author: {
-                    date: new Date().toISOString(),
-                    email: "dummy@microsoft.com",
-                    name: "Routerlicious Service",
-                },
-                message: "New document",
-                parents: [],
-                tree: handle,
-            };
+            if (!this.enableWholeSummaryUpload) {
+                const commitParams: ICreateCommitParams = {
+                    author: {
+                        date: new Date().toISOString(),
+                        email: "dummy@microsoft.com",
+                        name: "Routerlicious Service",
+                    },
+                    message: "New document",
+                    parents: [],
+                    tree: handle,
+                };
 
-            const commit = await gitManager.createCommit(commitParams);
-            await gitManager.createRef(documentId, commit.sha);
-
-            winston.info(`Commit sha: ${JSON.stringify(commit.sha)}`, { messageMetaData });
-            Lumberjack.info(`Commit sha: ${JSON.stringify(commit.sha)}`, lumberjackProperties);
+                const commit = await gitManager.createCommit(commitParams);
+                await gitManager.createRef(documentId, commit.sha);
+                initialSummaryUploadSuccessMessage += ` - Commit sha: ${JSON.stringify(commit.sha)}`;
+            }
+            initialSummaryUploadMetric.success(initialSummaryUploadSuccessMessage);
+        } catch (error: any) {
+            initialSummaryUploadMetric.error("Error during initial summary upload", error);
+            throw error;
         }
 
         const deli: Omit<IDeliState, "epoch"> = {
@@ -197,9 +201,9 @@ export class DocumentStorage implements IDocumentStorage {
             isSessionActive: false,
         };
 
-        const message: string = `Create session with enableDiscovery as ${enableDiscovery}: ${JSON.stringify(session)}`;
-        winston.info(message, { messageMetaData });
-        Lumberjack.info(message, lumberjackProperties);
+        Lumberjack.info(
+            `Create session with enableDiscovery as ${enableDiscovery}: ${JSON.stringify(session)}`,
+            lumberjackProperties);
 
         const updateDocumentCollectionMetric =
             Lumberjack.newLumberMetric(LumberEventName.CreateDocumentUpdateDocumentCollection, lumberjackProperties);

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -35,5 +35,6 @@ export enum LumberEventName {
     ConnectDocumentGetClients = "ConnectDocumentGetClients",
     ConnectDocumentOrdererConnection = "ConnectDocumentOrdererConnection",
     CreateDocumentUpdateDocumentCollection = "CreateDocumentUpdateDocumentCollection",
+    CreateDocInitialSummaryWrite = "CreateDocInitialSummaryWrite",
     HttpRequest = "HttpRequest",
 }

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -31,5 +31,9 @@ export enum LumberEventName {
 
     // Miscellaneous
     ConnectDocument = "ConnectDocument",
+    ConnectDocumentAddClient = "ConnectDocumentAddClient",
+    ConnectDocumentGetClients = "ConnectDocumentGetClients",
+    ConnectDocumentOrdererConnection = "ConnectDocumentOrdererConnection",
+    CreateDocumentUpdateDocumentCollection = "CreateDocumentUpdateDocumentCollection",
     HttpRequest = "HttpRequest",
 }


### PR DESCRIPTION
## Description

Adding more granular metrics within the CreateDocument and ConnectDocument flows to track inner/granular operations such as updating information in the documents collection, adding information to Redis, etc. The primary goal here is to be able to track how long those operations made. We've had issues in the past where we detected CreateDocument or ConnectDocument flows were taking abnormally long. We then looked into more granular HTTP metrics associated with HTTP requests that happen within those flows. And what we learned is that the HTTP requests were not taking long to complete. That made us believe that other parts of the flow might be taking long. So these new metrics should help gather more data around that.

As for performance, I believe this change should have little to no impact, especially since CreateDocument and ConnectDocument happen much less often than websocket events (such as submitting ops).