### PR TITLE
Fix some parameter values for the new task

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -214,7 +214,7 @@ stages:
           inputs:
             targetPath: '$(Build.SourcesDirectory)/docs/public'
             artifactName: 'fluidframework-docs'
-            publishLocation: 'Container'
+            publishLocation: 'pipeline'
 
   # BEGIN Secure development tasks
 - stage: guardian

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -316,7 +316,7 @@ stages:
           inputs:
             targetPath: '$(System.DefaultWorkingDirectory)/_api-extractor-temp'
             artifactName: _api-extractor-temp
-            publishLocation: 'Container'
+            publishLocation: 'pipeline'
 
     # Build
     - task: Docker@2

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -409,7 +409,7 @@ stages:
             inputs:
               targetPath: '${{ parameters.buildDirectory }}/_api-extractor-temp'
               artifactName: '_api-extractor-temp'
-              publishLocation: 'Container'
+              publishLocation: 'pipeline'
 
         - task: Bash@3
           displayName: Check for extraneous modified files


### PR DESCRIPTION
## Description

Follow-up to https://github.com/microsoft/FluidFramework/pull/12744. The valid values for `publishLocation` changed between the previous (deprecated) ADO task and the new one that we put in place in that PR. We missed updating the value in a few places.

This is currently causing silent-ish failures in our pipelines. E.g. [this step](https://dev.azure.com/fluidframework/internal/_build/results?buildId=106039&view=logs&j=8680be89-378c-5901-27b8-79bf589da266&t=7130c8c1-4cd0-5a79-3376-a67ca5339954) with the wrong parameter value didn't fail (strangely, IMO) but didn't actually publish the artifact, and then [this step](https://dev.azure.com/fluidframework/internal/_build/results?buildId=106039&view=logs&j=25db5cdf-ae19-553c-5168-215eaa605926&t=88cbfbce-9b81-5405-1c4a-f842871724d8) failed because it was expecting to find said artifact.