### PR TITLE
Tree: Support edits prior to attach summarization

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { IChannel } from '@fluidframework/datastore-definitions';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
@@ -1130,7 +1129,7 @@ export class SharedTreeFactory implements IChannelFactory {
     // (undocumented)
     create(runtime: IFluidDataStoreRuntime, id: string): ISharedTree;
     // (undocumented)
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<IChannel>;
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<ISharedTree>;
     // (undocumented)
     type: string;
 }

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -5,7 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-    IChannel,
     IChannelAttributes,
     IChannelFactory,
     IChannelServices,
@@ -205,7 +204,7 @@ export class SharedTreeFactory implements IChannelFactory {
         id: string,
         services: IChannelServices,
         channelAttributes: Readonly<IChannelAttributes>,
-    ): Promise<IChannel> {
+    ): Promise<ISharedTree> {
         const tree = new SharedTree(id, runtime, channelAttributes, "SharedTree");
         await tree.load(services);
         return tree;

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -23,7 +23,7 @@ import {
     Value,
 } from "../../tree";
 import { moveToDetachedField } from "../../forest";
-import { TestTreeProvider } from "../utils";
+import { SharedTreeTestFactory, TestTreeProvider } from "../utils";
 import { ISharedTree } from "../../shared-tree";
 import { TransactionResult } from "../../checkout";
 import { fieldSchema, GlobalFieldKey, namedTreeSchema, SchemaData } from "../../schema-stored";
@@ -91,28 +91,6 @@ describe("SharedTree", () => {
     });
 
     it("can process ops after loading from summary", async () => {
-        function insert(tree: ISharedTree, index: number, value: string): void {
-            tree.runTransaction((forest, editor) => {
-                const field = editor.sequenceField(undefined, rootFieldKeySymbol);
-                field.insert(index, singleTextCursor({ type: brand("Node"), value }));
-                return TransactionResult.Apply;
-            });
-        }
-
-        // Validate that the given tree is made up of nodes with the expected value
-        function validateTree(tree: ISharedTree, expected: Value[]): void {
-            const readCursor = tree.forest.allocateCursor();
-            moveToDetachedField(tree.forest, readCursor);
-            let hasNode = readCursor.firstNode();
-            for (const value of expected) {
-                assert(hasNode);
-                assert.equal(readCursor.value, value);
-                hasNode = readCursor.nextNode();
-            }
-            assert.equal(hasNode, false);
-            readCursor.free();
-        }
-
         const provider = await TestTreeProvider.create(1, true);
         const tree1 = provider.trees[0];
         const tree2 = await provider.createTree();
@@ -186,6 +164,38 @@ describe("SharedTree", () => {
         // Without that, it will interpret the insertion of B based on the current state, yielding
         // the order ACB.
         validateTree(tree4, expectedValues);
+    });
+
+    it("can summarize local edits in the attach summary", async () => {
+        const onCreate = (tree: ISharedTree) => {
+            const schema: SchemaData = {
+                treeSchema: new Map([[rootNodeSchema.name, rootNodeSchema]]),
+                globalFieldSchema: new Map([
+                    // This test requires the use of a sequence field
+                    [rootFieldKey, fieldSchema(FieldKinds.sequence)],
+                ]),
+            };
+            tree.storedSchema.update(schema);
+            insert(tree, 0, "A");
+            insert(tree, 1, "C");
+            validateTree(tree, ["A", "C"]);
+        };
+        const provider = await TestTreeProvider.create(
+            1,
+            true,
+            new SharedTreeTestFactory(onCreate),
+        );
+        const [tree1] = provider.trees;
+        validateTree(tree1, ["A", "C"]);
+        const tree2 = await provider.createTree();
+        // Check that the joining tree was initialized with data from the attach summary
+        validateTree(tree2, ["A", "C"]);
+
+        // Check that further edits are interpreted properly
+        insert(tree1, 1, "B");
+        await provider.ensureSynchronized();
+        validateTree(tree1, ["A", "B", "C"]);
+        validateTree(tree2, ["A", "B", "C"]);
     });
 
     describe("Editing", () => {
@@ -507,4 +517,45 @@ function getTestValue({ forest }: ISharedTree): TreeValue | undefined {
     const { value } = readCursor;
     readCursor.free();
     return value;
+}
+
+/**
+ * Helper function to insert node at a given index.
+ *
+ * TODO: delete once the JSON editing API is ready for use.
+ *
+ * @param tree - The tree on which to perform the insert.
+ * @param index - The index in the root field at which to insert.
+ * @param value - The value of the inserted node.
+ */
+function insert(tree: ISharedTree, index: number, value: string): void {
+    tree.runTransaction((forest, editor) => {
+        const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+        field.insert(index, singleTextCursor({ type: brand("Node"), value }));
+        return TransactionResult.Apply;
+    });
+}
+
+/**
+ * Checks that the root field of the given tree contains nodes with the given values.
+ * Fails if the given tree contains fewer or more nodes in the root trait.
+ * Fails if the given tree contains nodes with different values in the root trait.
+ * Does not check if nodes in the root trait have any children.
+ *
+ * TODO: delete once the JSON reading API is ready for use.
+ *
+ * @param tree - The tree to verify.
+ * @param expected - The expected values for the nodes in the root field of the tree.
+ */
+function validateTree(tree: ISharedTree, expected: Value[]): void {
+    const readCursor = tree.forest.allocateCursor();
+    moveToDetachedField(tree.forest, readCursor);
+    let hasNode = readCursor.firstNode();
+    for (const value of expected) {
+        assert(hasNode);
+        assert.equal(readCursor.value, value);
+        hasNode = readCursor.nextNode();
+    }
+    assert.equal(hasNode, false);
+    readCursor.free();
 }


### PR DESCRIPTION
## Description

It's possible for client to create a SharedTree instance make edits to it *before* attaching to the service. When that's the case, the edits performed prior to the attach workflow will never be sent for sequencing and never be received by clients. To remedy this, the attach summary needs to contain whatever data is relevant from these initial local edits.

This PR adds support for this pre-attach-editing workflow. This is accomplished by notifying the `EditManager` those local edits are immediately "sequenced". See comments in `SharedTreeCore.ts` for details.