### PR TITLE
Timer class will call setTimeout with a negative integer depending on race outcome

### DIFF
--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -224,7 +224,6 @@ describe("Timers", () => {
 
             // Restart right before we execute the handler.
             clock.tick(defaultTimeout - 1);
-            assert.strictEqual(runCount, initialRunCount, "Should not have executed yet");
             timer.restart();
 
             setImmediate(() => {
@@ -232,6 +231,13 @@ describe("Timers", () => {
                 // first time our timer executes its handler, it is late by design.
                 clock.tick(defaultTimeout * 2);
             });
+
+            flushPromises().then(
+                () => {},
+                () => {
+                    assert.fail("Promise flushing failed");
+                },
+            );
 
             assert.strictEqual(
                 runCount,

--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -218,13 +218,6 @@ describe("Timers", () => {
             assert.strictEqual(runCount, 0, "Should not run default handler");
         });
 
-        it("Should immediately execute at negative time", () => {
-            const overrideTimeout = -100; // a negative time
-            const initialRunCount = runCount;
-            timer.start(overrideTimeout);
-            assert.strictEqual(runCount, initialRunCount + 1, "Should have executed immediately");
-        });
-
         it("Should immediately execute if the handler is late even accounting for the restart", () => {
             const initialRunCount = runCount;
             timer.start(defaultTimeout);
@@ -238,9 +231,13 @@ describe("Timers", () => {
                 // use a microtask to advance the clock by a lot, that way, we ensure that the
                 // first time our timer executes its handler, it is late by design.
                 clock.tick(defaultTimeout * 2);
-              });
-        
-            assert.strictEqual(runCount, initialRunCount + 1, "Should have executed immediately because the handler was late");
+            });
+
+            assert.strictEqual(
+                runCount,
+                initialRunCount + 1,
+                "Should have executed immediately because the handler was late",
+            );
         });
     });
 

--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -226,11 +226,9 @@ describe("Timers", () => {
             clock.tick(defaultTimeout - 1);
             timer.restart();
 
-            setImmediate(() => {
-                // use a microtask to advance the clock by a lot, that way, we ensure that the
-                // first time our timer executes its handler, it is late by design.
-                clock.tick(defaultTimeout * 2);
-            });
+            // Advance the clock by a lot, that way, we ensure that the
+            // first time our timer executes its handler, it is late by design.
+            clock.tick(defaultTimeout * 2);
 
             flushPromises().then(
                 () => {},

--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -217,6 +217,31 @@ describe("Timers", () => {
             testExactTimeout(defaultTimeout, () => specialRunCount);
             assert.strictEqual(runCount, 0, "Should not run default handler");
         });
+
+        it("Should immediately execute at negative time", () => {
+            const overrideTimeout = -100; // a negative time
+            const initialRunCount = runCount;
+            timer.start(overrideTimeout);
+            assert.strictEqual(runCount, initialRunCount + 1, "Should have executed immediately");
+        });
+
+        it("Should immediately execute if the handler is late even accounting for the restart", () => {
+            const initialRunCount = runCount;
+            timer.start(defaultTimeout);
+
+            // Restart right before we execute the handler.
+            clock.tick(defaultTimeout - 1);
+            assert.strictEqual(runCount, initialRunCount, "Should not have executed yet");
+            timer.restart();
+
+            setImmediate(() => {
+                // use a microtask to advance the clock by a lot, that way, we ensure that the
+                // first time our timer executes its handler, it is late by design.
+                clock.tick(defaultTimeout * 2);
+              });
+        
+            assert.strictEqual(runCount, initialRunCount + 1, "Should have executed immediately because the handler was late");
+        });
     });
 
     describe("PromiseTimer", () => {

--- a/common/lib/common-utils/src/timer.ts
+++ b/common/lib/common-utils/src/timer.ts
@@ -200,13 +200,20 @@ export class Timer implements ITimer {
         if (restart !== undefined) {
             // Restart with remaining time
             const remainingTime = this.calculateRemainingTime(restart);
-            this.startCore(remainingTime, () => restart.handler(), restart.duration);
-        } else {
-            // Run clear first, in case the handler decides to start again
-            const handler = this.runningState.handler;
-            this.clear();
-            handler();
+
+            if (remainingTime > 0)
+            {
+                this.startCore(remainingTime, () => restart.handler(), restart.duration);
+                return;
+            }
+            // If remainingTime were not a postive integer, we don't want to defer and schedule
+            // another task. Execute the handler now.
         }
+
+        // Run clear first, in case the handler decides to start again
+        const handler = this.runningState.handler;
+        this.clear();
+        handler();
     }
 
     private calculateRemainingTime(runningTimeout: ITimeout): number {

--- a/common/lib/common-utils/src/timer.ts
+++ b/common/lib/common-utils/src/timer.ts
@@ -201,8 +201,7 @@ export class Timer implements ITimer {
             // Restart with remaining time
             const remainingTime = this.calculateRemainingTime(restart);
 
-            if (remainingTime > 0)
-            {
+            if (remainingTime > 0) {
                 this.startCore(remainingTime, () => restart.handler(), restart.duration);
                 return;
             }


### PR DESCRIPTION
According to the W3C spec, it actually looks like the standard says that a negative timeout into setTimeout should be treated as a 0ms delay timer, so strictly speaking, there is nothing wrong with Fluid scheduling a job with a negative timeout. It is well-defined behavior.

Still, I am sharing the condition of Fluid's Timer class that ends up causing setTImeout to be called in case this is something we are interested in addressing, since scheduling a job with a negative timeout is conceptually strange.

The condition is this:
Code schedules a job with a Fluid Timer for X seconds. Before X seconds has elapsed (let's call the amount of seconds that has elapsed Y, such that Y < X), someone calls .restart() on the Timer, causing the timer's restart info field to be filled.

Now, if the first time the JSEngine flushes the queued tasks is after X + Y seconds have elapsed (let's call the total amount of time elapsed Z, timer.handler() will decide that "yes, we were asked to restart, let's schedule another task with setTimeout with a duration of X +Y - Z". Notice that this is a negative number in this case.

In plain English, it doesn't look like Timer's restart logic is explicitly watching out for the case where the first time the scheduled handler gets to execute occurs after ultimately the desired point in time (taking into account one or more restarts)

The proposed fix is to watch out for `Timer.handler()` inadvertently triggering a `setTimeout` with a negative duration. Instead, if the timer realizes that it would have asked for a negative duration when attempting to fulfill the restart, it should just execute the requested lambda immediately. 

Explicitly setting "allow edits by maintainers" to true because I would love some assistance on validating this idea.