### PR TITLE
Routerlicious doc service telemetry

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -88,16 +88,15 @@ export class DocumentService implements api.IDocumentService {
             }
             if (!this.storageManager || !this.noCacheStorageManager || shouldUpdateDiscoveredSessionInfo) {
                 const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentStorageRequests);
-                const storageRestWrapper =
-                    await RouterliciousStorageRestWrapper.load(
-                        this.tenantId,
-                        this.documentId,
-                        this.tokenProvider,
-                        this.logger,
-                        rateLimiter,
-                        this.driverPolicies.enableRestLess,
-                        this.storageUrl
-                    );
+                const storageRestWrapper = await RouterliciousStorageRestWrapper.load(
+                    this.tenantId,
+                    this.documentId,
+                    this.tokenProvider,
+                    this.logger,
+                    rateLimiter,
+                    this.driverPolicies.enableRestLess,
+                    this.storageUrl
+                );
 
                 const historian = new Historian(
                     this.storageUrl,
@@ -154,15 +153,14 @@ export class DocumentService implements api.IDocumentService {
             }
             if (!this.ordererRestWrapper || shouldUpdateDiscoveredSessionInfo) {
                 const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
-                this.ordererRestWrapper =
-                    await RouterliciousOrdererRestWrapper.load(
-                        this.tenantId,
-                        this.documentId,
-                        this.tokenProvider,
-                        this.logger,
-                        rateLimiter,
-                        this.driverPolicies.enableRestLess
-                    );
+                this.ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
+                    this.tenantId,
+                    this.documentId,
+                    this.tokenProvider,
+                    this.logger,
+                    rateLimiter,
+                    this.driverPolicies.enableRestLess
+                );
             }
             return this.ordererRestWrapper;
         };

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -95,9 +95,8 @@ export class DocumentService implements api.IDocumentService {
                     this.logger,
                     rateLimiter,
                     this.driverPolicies.enableRestLess,
-                    this.storageUrl
+                    this.storageUrl,
                 );
-
                 const historian = new Historian(
                     this.storageUrl,
                     true,
@@ -159,7 +158,7 @@ export class DocumentService implements api.IDocumentService {
                     this.tokenProvider,
                     this.logger,
                     rateLimiter,
-                    this.driverPolicies.enableRestLess
+                    this.driverPolicies.enableRestLess,
                 );
             }
             return this.ordererRestWrapper;

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -88,28 +88,16 @@ export class DocumentService implements api.IDocumentService {
             }
             if (!this.storageManager || !this.noCacheStorageManager || shouldUpdateDiscoveredSessionInfo) {
                 const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentStorageRequests);
-                const storageRestWrapper = await PerformanceEvent.timedExecAsync(
-                    this.logger,
-                    {
-                        eventName: "GetStorageToken",
-                        docId: this.documentId,
-                        details: JSON.stringify({
-                            enableRestless: this.driverPolicies.enableRestLess,
-                            disableCache,
-                        }),
-                    },
-                    async () => {
-                        return RouterliciousStorageRestWrapper.load(
-                            this.tenantId,
-                            this.documentId,
-                            this.tokenProvider,
-                            this.logger,
-                            rateLimiter,
-                            this.driverPolicies.enableRestLess,
-                            this.storageUrl,
-                        );
-                    }
-                );
+                const storageRestWrapper =
+                    await RouterliciousStorageRestWrapper.load(
+                        this.tenantId,
+                        this.documentId,
+                        this.tokenProvider,
+                        this.logger,
+                        rateLimiter,
+                        this.driverPolicies.enableRestLess,
+                        this.storageUrl
+                    );
 
                 const historian = new Historian(
                     this.storageUrl,
@@ -166,26 +154,15 @@ export class DocumentService implements api.IDocumentService {
             }
             if (!this.ordererRestWrapper || shouldUpdateDiscoveredSessionInfo) {
                 const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
-                this.ordererRestWrapper = await PerformanceEvent.timedExecAsync(
-                    this.logger,
-                    {
-                        eventName: "GetDeltaStorageToken",
-                        docId: this.documentId,
-                        details: JSON.stringify({
-                            enableRestless: this.driverPolicies.enableRestLess,
-                        }),
-                    },
-                    async () => {
-                        return RouterliciousOrdererRestWrapper.load(
-                            this.tenantId,
-                            this.documentId,
-                            this.tokenProvider,
-                            this.logger,
-                            rateLimiter,
-                            this.driverPolicies.enableRestLess,
-                        );
-                    }
-                );
+                this.ordererRestWrapper =
+                    await RouterliciousOrdererRestWrapper.load(
+                        this.tenantId,
+                        this.documentId,
+                        this.tokenProvider,
+                        this.logger,
+                        rateLimiter,
+                        this.driverPolicies.enableRestLess
+                    );
             }
             return this.ordererRestWrapper;
         };

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -98,7 +98,6 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 
         const logger2 = ChildLogger.create(logger, "RouterliciousDriver");
         const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
-
         const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
             tenantId,
             undefined,
@@ -106,7 +105,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             logger2,
             rateLimiter,
             this.driverPolicies.enableRestLess,
-            resolvedUrl.endpoints.ordererUrl
+            resolvedUrl.endpoints.ordererUrl,
         );
 
         const res = await PerformanceEvent.timedExecAsync(
@@ -225,14 +224,14 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             }
             const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
             const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
-                        tenantId,
-                        documentId,
-                        this.tokenProvider,
-                        logger2,
-                        rateLimiter,
-                        this.driverPolicies.enableRestLess,
-                        resolvedUrl.endpoints.ordererUrl,
-                    );
+                tenantId,
+                documentId,
+                this.tokenProvider,
+                logger2,
+                rateLimiter,
+                this.driverPolicies.enableRestLess,
+                resolvedUrl.endpoints.ordererUrl,
+            );
 
             const discoveredSession = await PerformanceEvent.timedExecAsync(
                 logger2,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -121,23 +121,23 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             async (event) => {
                 // @TODO: Remove returned "string" type when removing back-compat code
                 const postRes = await ordererRestWrapper.post<
-                { id: string; token?: string; session?: ISession; } | string
-                >(
-                    `/documents/${tenantId}`,
-                    {
-                        summary: convertSummaryToCreateNewSummary(appSummary),
-                        sequenceNumber: documentAttributes.sequenceNumber,
-                        values: quorumValues,
-                        enableDiscovery: this.driverPolicies.enableDiscovery,
-                        generateToken: this.tokenProvider.documentPostCreateCallback !== undefined,
-                    },
-                );
+                    { id: string; token?: string; session?: ISession } | string
+                >(`/documents/${tenantId}`, {
+                    summary: convertSummaryToCreateNewSummary(appSummary),
+                    sequenceNumber: documentAttributes.sequenceNumber,
+                    values: quorumValues,
+                    enableDiscovery: this.driverPolicies.enableDiscovery,
+                    generateToken:
+                        this.tokenProvider.documentPostCreateCallback !==
+                        undefined,
+                });
 
                 event.end({
-                    docId: (typeof postRes === "string") ? postRes : postRes.id,
+                    docId: typeof postRes === "string" ? postRes : postRes.id,
                 });
                 return postRes;
-            });
+            }
+        );
 
         // For supporting backward compatibility, when the request has generateToken === true, it will return
         // an object instead of string

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -120,7 +120,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             async (event) => {
                 // @TODO: Remove returned "string" type when removing back-compat code
                 const postRes = await ordererRestWrapper.post<
-                    { id: string; token?: string; session?: ISession } | string
+                    { id: string; token?: string; session?: ISession; } | string
                 >(`/documents/${tenantId}`, {
                     summary: convertSummaryToCreateNewSummary(appSummary),
                     sequenceNumber: documentAttributes.sequenceNumber,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -237,7 +237,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             const discoveredSession = await PerformanceEvent.timedExecAsync(
                 logger2,
                 {
-                    eventName: "CreateSession",
+                    eventName: "DiscoverSession",
                     docId: documentId,
                 },
                 async () => {

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -241,6 +241,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                     docId: documentId,
                 },
                 async () => {
+                    // The service responds with the current document session associated with the container.
                     return ordererRestWrapper.get<ISession>(
                         `/documents/${tenantId}/session/${documentId}`);
                 });

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -130,6 +130,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 }),
             },
             async (event) => {
+                // @TODO: Remove returned "string" type when removing back-compat code
                 const postRes = await ordererRestWrapper.post<
                 { id: string; token?: string; session?: ISession; } | string
                 >(
@@ -184,7 +185,6 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 throw new DocumentPostCreateError(error);
             }
         }
-
 
         parsedUrl.set("pathname", replaceDocumentIdInPath(parsedUrl.pathname, documentId));
         const deltaStorageUrl = resolvedUrl.endpoints.deltaStorageUrl;

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -11,6 +11,7 @@ import {
     RestLessClient,
     RestWrapper,
 } from "@fluidframework/server-services-client";
+import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import fetch from "cross-fetch";
 import type { AxiosRequestConfig, AxiosRequestHeaders } from "axios";
 import safeStringify from "json-stringify-safe";
@@ -144,18 +145,32 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
         const defaultQueryString = {
             token: `${fromUtf8ToBase64(tenantId)}`,
         };
-        const getAuthorizationHeader: AuthorizationHeaderGetter = async (refreshToken?: boolean): Promise<string> => {
-            // Craft credentials using tenant id and token
-            const storageToken = await tokenProvider.fetchStorageToken(
-                tenantId,
-                documentId,
-                refreshToken,
+        const getAuthorizationHeader: AuthorizationHeaderGetter = async (
+            refreshToken?: boolean
+        ): Promise<string> => {
+            return PerformanceEvent.timedExecAsync(
+                logger,
+                {
+                    eventName: "FetchStorageToken",
+                    docId: documentId,
+                    details: JSON.stringify({
+                        useRestLess,
+                    }),
+                },
+                async () => {
+                    // Craft credentials using tenant id and token
+                    const storageToken = await tokenProvider.fetchStorageToken(
+                        tenantId,
+                        documentId,
+                        refreshToken
+                    );
+                    const credentials = {
+                        password: storageToken.jwt,
+                        user: tenantId,
+                    };
+                    return getAuthorizationTokenFromCredentials(credentials);
+                }
             );
-            const credentials = {
-                password: storageToken.jwt,
-                user: tenantId,
-            };
-            return getAuthorizationTokenFromCredentials(credentials);
         };
 
         const restWrapper = new RouterliciousStorageRestWrapper(
@@ -194,12 +209,24 @@ export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
         baseurl?: string,
     ): Promise<RouterliciousOrdererRestWrapper> {
         const getAuthorizationHeader: AuthorizationHeaderGetter = async (refreshToken?: boolean): Promise<string> => {
-            const ordererToken = await tokenProvider.fetchOrdererToken(
-                tenantId,
-                documentId,
-                refreshToken,
+            return PerformanceEvent.timedExecAsync(
+                logger,
+                {
+                    eventName: "FetchOrdererToken",
+                    docId: documentId,
+                    details: JSON.stringify({
+                        useRestLess,
+                    }),
+                },
+                async () => {
+                    const ordererToken = await tokenProvider.fetchOrdererToken(
+                        tenantId,
+                        documentId,
+                        refreshToken,
+                    );
+                    return `Basic ${ordererToken.jwt}`;
+                }
             );
-            return `Basic ${ordererToken.jwt}`;
         };
 
         const restWrapper = new RouterliciousOrdererRestWrapper(

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -145,9 +145,7 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
         const defaultQueryString = {
             token: `${fromUtf8ToBase64(tenantId)}`,
         };
-        const getAuthorizationHeader: AuthorizationHeaderGetter = async (
-            refreshToken?: boolean
-        ): Promise<string> => {
+        const getAuthorizationHeader: AuthorizationHeaderGetter = async (refreshToken?: boolean): Promise<string> => {
             return PerformanceEvent.timedExecAsync(
                 logger,
                 {

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -153,9 +153,6 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
                 {
                     eventName: "FetchStorageToken",
                     docId: documentId,
-                    details: JSON.stringify({
-                        useRestLess,
-                    }),
                 },
                 async () => {
                     // Craft credentials using tenant id and token
@@ -214,9 +211,6 @@ export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
                 {
                     eventName: "FetchOrdererToken",
                     docId: documentId,
-                    details: JSON.stringify({
-                        useRestLess,
-                    }),
                 },
                 async () => {
                     const ordererToken = await tokenProvider.fetchOrdererToken(


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

## Description

Adding telemetry around routerlicious doc service telemetry. This group of telemetry should help us with server perf observability around create/load paths. 

## Breaking Changes

None

## Reviewer Guidance

Given that token provider is driver's extensibility point and implemented by app developer, I have introduced some explicit telemetry around those APIs, just so we can clearly distinguish FF perf and separate it from any numbers driven by host/app logic. I'm happy to scale this down, if we have valid concerns here. I have tried to align event naming with odsp where possible, but I'll give it another look before merging these changes.
