### PR TITLE
Convert all remaining usage of getTinyliciousContainer to use model loading

### DIFF
--- a/examples/apps/collaborative-textarea/src/container.ts
+++ b/examples/apps/collaborative-textarea/src/container.ts
@@ -34,8 +34,8 @@ export class CollaborativeTextContainerRuntimeFactory
      * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const inventoryList = await runtime.createDataStore(CollaborativeText.getFactory().type);
-        await inventoryList.trySetAlias(collaborativeTextId);
+        const collaborativeText = await runtime.createDataStore(CollaborativeText.getFactory().type);
+        await collaborativeText.trySetAlias(collaborativeTextId);
     }
 
     /**

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -47,7 +47,6 @@
     "@fluid-example/multiview-coordinate-model": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-example/multiview-slider-coordinate-view": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-example/prosemirror": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/apps/data-object-grid/src/container.ts
+++ b/examples/apps/data-object-grid/src/container.ts
@@ -43,8 +43,8 @@ export class DataObjectGridContainerRuntimeFactory
      * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const inventoryList = await runtime.createDataStore(DataObjectGrid.getFactory().type);
-        await inventoryList.trySetAlias(dataObjectGridId);
+        const dataObjectGrid = await runtime.createDataStore(DataObjectGrid.getFactory().type);
+        await dataObjectGrid.trySetAlias(dataObjectGridId);
     }
 
     /**

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -38,9 +38,13 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
+    "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
+    "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "css-loader": "^1.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/apps/view-framework-sampler/src/app.ts
+++ b/examples/apps/view-framework-sampler/src/app.ts
@@ -13,7 +13,7 @@ import { renderSampler } from "./view";
  *
  * @remarks We wrap this in an async function so we can await Fluid's async calls.
  */
- async function start() {
+async function start() {
     const tinyliciousModelLoader = new TinyliciousModelLoader<IDiceRollerAppModel>(
         new StaticCodeLoader(new DiceRollerContainerRuntimeFactory()),
     );

--- a/examples/apps/view-framework-sampler/src/app.ts
+++ b/examples/apps/view-framework-sampler/src/app.ts
@@ -3,54 +3,42 @@
  * Licensed under the MIT License.
  */
 
-import { getTinyliciousContainer } from "@fluid-experimental/get-container";
+import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
 
-import { DiceRollerContainerRuntimeFactory } from "./containerCode";
-import { IDiceRoller } from "./dataObject";
+import { DiceRollerContainerRuntimeFactory, IDiceRollerAppModel } from "./containerCode";
 import { renderSampler } from "./view";
 
-// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
-// an existing one.  We also need to provide the unique ID for the document we are loading from.
-
-// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.
-// We'll also choose to interpret the URL hash as an existing document's
-// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
-// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
-async function start(): Promise<void> {
-    // when the document ID is not provided, create a new one.
-    const shouldCreateNew = location.hash.length === 0;
-    const documentId = !shouldCreateNew ? window.location.hash.substring(1) : "";
-
-    // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
-    // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
-    // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
-    // function takes the ID of the document we're creating or loading, the container code to load into it, and a
-    // flag to specify whether we're creating a new document or loading an existing one.
-    const [container, containerId] = await getTinyliciousContainer(
-        documentId, DiceRollerContainerRuntimeFactory, shouldCreateNew,
+/**
+ * Start the app and render.
+ *
+ * @remarks We wrap this in an async function so we can await Fluid's async calls.
+ */
+ async function start() {
+    const tinyliciousModelLoader = new TinyliciousModelLoader<IDiceRollerAppModel>(
+        new StaticCodeLoader(new DiceRollerContainerRuntimeFactory()),
     );
 
-    // update the browser URL and the window title with the actual container ID
-    location.hash = containerId;
-    document.title = containerId;
+    let id: string;
+    let model: IDiceRollerAppModel;
 
-    // Since we're using a ContainerRuntimeFactoryWithDefaultDataStore, our dice roller is available at the URL "/".
-    const url = "/";
-    const response = await container.request({ url });
-
-    // Verify the response to make sure we got what we expected.
-    if (response.status !== 200 || response.mimeType !== "fluid/object") {
-        throw new Error(`Unable to retrieve data object at URL: "${url}"`);
-    } else if (response.value === undefined) {
-        throw new Error(`Empty response from URL: "${url}"`);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await tinyliciousModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await tinyliciousModelLoader.loadExisting(id);
     }
 
-    // In this app, we know our container code provides a default data object that is an IDiceRoller.
-    const diceRoller: IDiceRoller = response.value;
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
 
-    // Given an IDiceRoller, we can render the value and provide controls for users to roll it.
-    const div = document.getElementById("content") as HTMLDivElement;
-    renderSampler(diceRoller, div);
+    const contentDiv = document.getElementById("content") as HTMLDivElement;
+    renderSampler(model.diceRoller, contentDiv);
 }
 
 start().catch((error) => console.error(error));

--- a/examples/apps/view-framework-sampler/src/containerCode.ts
+++ b/examples/apps/view-framework-sampler/src/containerCode.ts
@@ -3,23 +3,58 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { ModelContainerRuntimeFactory } from "@fluid-example/example-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 
-import { DiceRollerInstantiationFactory } from "./dataObject";
+import { DiceRollerInstantiationFactory, IDiceRoller } from "./dataObject";
 
 /**
- * The DiceRollerContainerRuntimeFactory is the container code for our scenario.
+ * The data model for our application.
  *
- * Since we only need to instantiate and retrieve a single dice roller for our scenario, we can use a
- * ContainerRuntimeFactoryWithDefaultDataStore. We provide it with the type of the data object we want to create
- * and retrieve by default, and the registry entry mapping the type to the factory.
- *
- * This container code will create the single default data object on our behalf and make it available on the
- * Container with a URL of "/", so it can be retrieved via container.request("/").
+ * @remarks Since this is a simple example it's just a single data object.  More advanced scenarios may have more
+ * complex models.
  */
-export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRollerInstantiationFactory,
-    new Map([
-        DiceRollerInstantiationFactory.registryEntry,
-    ]),
-);
+ export interface IDiceRollerAppModel {
+    readonly diceRoller: IDiceRoller;
+}
+
+class DiceRollerAppModel implements IDiceRollerAppModel {
+    public constructor(public readonly diceRoller: IDiceRoller) { }
+}
+
+const diceRollerId = "dice-roller";
+
+/**
+ * The runtime factory for our Fluid container.
+ */
+export class DiceRollerContainerRuntimeFactory
+    extends ModelContainerRuntimeFactory<IDiceRollerAppModel> {
+    constructor() {
+        super(
+            new Map([
+                DiceRollerInstantiationFactory.registryEntry,
+            ]), // registryEntries
+        );
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
+     */
+    protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
+        const inventoryList = await runtime.createDataStore(DiceRollerInstantiationFactory.type);
+        await inventoryList.trySetAlias(diceRollerId);
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.createModel}
+     */
+    protected async createModel(runtime: IContainerRuntime, container: IContainer) {
+        const dataObjectGrid = await requestFluidObject<IDiceRoller>(
+            await runtime.getRootDataStore(diceRollerId),
+            "",
+        );
+        return new DiceRollerAppModel(dataObjectGrid);
+    }
+}

--- a/examples/apps/view-framework-sampler/src/containerCode.ts
+++ b/examples/apps/view-framework-sampler/src/containerCode.ts
@@ -16,7 +16,7 @@ import { DiceRollerInstantiationFactory, IDiceRoller } from "./dataObject";
  * @remarks Since this is a simple example it's just a single data object.  More advanced scenarios may have more
  * complex models.
  */
- export interface IDiceRollerAppModel {
+export interface IDiceRollerAppModel {
     readonly diceRoller: IDiceRoller;
 }
 
@@ -43,18 +43,18 @@ export class DiceRollerContainerRuntimeFactory
      * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const inventoryList = await runtime.createDataStore(DiceRollerInstantiationFactory.type);
-        await inventoryList.trySetAlias(diceRollerId);
+        const diceRoller = await runtime.createDataStore(DiceRollerInstantiationFactory.type);
+        await diceRoller.trySetAlias(diceRollerId);
     }
 
     /**
      * {@inheritDoc ModelContainerRuntimeFactory.createModel}
      */
     protected async createModel(runtime: IContainerRuntime, container: IContainer) {
-        const dataObjectGrid = await requestFluidObject<IDiceRoller>(
+        const diceRoller = await requestFluidObject<IDiceRoller>(
             await runtime.getRootDataStore(diceRollerId),
             "",
         );
-        return new DiceRollerAppModel(dataObjectGrid);
+        return new DiceRollerAppModel(diceRoller);
     }
 }

--- a/examples/apps/view-framework-sampler/tests/index.ts
+++ b/examples/apps/view-framework-sampler/tests/index.ts
@@ -3,36 +3,41 @@
  * Licensed under the MIT License.
  */
 
-import { getSessionStorageContainer } from "@fluid-experimental/get-container";
-import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
+import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
 
 import { renderSampler } from "../src/view";
-import { DiceRollerContainerRuntimeFactory } from "../src/containerCode";
-import { DiceRoller } from "../src/dataObject";
-
-// Since this is a single page Fluid application we are generating a new document id
-// if one was not provided
-let createNew = false;
-if (window.location.hash.length === 0) {
-    createNew = true;
-    window.location.hash = Date.now().toString();
-}
-const documentId = window.location.hash.substring(1);
+import { DiceRollerContainerRuntimeFactory, IDiceRollerAppModel } from "../src/containerCode";
 
 /**
  * This is a helper function for loading the page. It's required because getting the Fluid Container
  * requires making async calls.
  */
-export async function createContainerAndRenderInElement(element: HTMLDivElement, createNewFlag: boolean) {
-    // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
-    // to store ops.
-    const container = await getSessionStorageContainer(documentId, DiceRollerContainerRuntimeFactory, createNewFlag);
+ async function createContainerAndRenderInElement(element: HTMLDivElement) {
+    const sessionStorageModelLoader = new SessionStorageModelLoader<IDiceRollerAppModel>(
+        new StaticCodeLoader(new DiceRollerContainerRuntimeFactory()),
+    );
 
-    // Get the Default Object from the Container
-    const defaultObject = await getDefaultObjectFromContainer<DiceRoller>(container);
+    let id: string;
+    let model: IDiceRollerAppModel;
 
-    // Given an IDiceRoller, we can render its data using the view we've created in our app.
-    renderSampler(defaultObject, element);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await sessionStorageModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await sessionStorageModelLoader.loadExisting(id);
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
+
+    // Render it
+    renderSampler(model.diceRoller, element);
 
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -47,13 +52,13 @@ async function setup() {
     if (leftElement === null) {
         throw new Error("sbs-left does not exist");
     }
-    await createContainerAndRenderInElement(leftElement, createNew);
+    await createContainerAndRenderInElement(leftElement);
     const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
     if (rightElement === null) {
         throw new Error("sbs-right does not exist");
     }
     // The second time we don't need to createNew because we know a Container exists.
-    await createContainerAndRenderInElement(rightElement, false);
+    await createContainerAndRenderInElement(rightElement);
 }
 
 setup().catch((e)=> {

--- a/examples/apps/view-framework-sampler/tests/index.ts
+++ b/examples/apps/view-framework-sampler/tests/index.ts
@@ -12,7 +12,7 @@ import { DiceRollerContainerRuntimeFactory, IDiceRollerAppModel } from "../src/c
  * This is a helper function for loading the page. It's required because getting the Fluid Container
  * requires making async calls.
  */
- async function createContainerAndRenderInElement(element: HTMLDivElement) {
+async function createContainerAndRenderInElement(element: HTMLDivElement) {
     const sessionStorageModelLoader = new SessionStorageModelLoader<IDiceRollerAppModel>(
         new StaticCodeLoader(new DiceRollerContainerRuntimeFactory()),
     );

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/oldest-client-observer": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/task-manager": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -38,6 +38,7 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
+    "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/oldest-client-observer": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/task-manager": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/data-objects/task-selection/src/app.ts
+++ b/examples/data-objects/task-selection/src/app.ts
@@ -3,39 +3,39 @@
  * Licensed under the MIT License.
  */
 
-import { getTinyliciousContainer } from "@fluid-experimental/get-container";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
 
-import { oldestClientDiceId, taskManagerDiceId, TaskSelectionFactory } from "./containerCode";
-import { IDiceRoller } from "./interface";
+import { TaskSelectionContainerRuntimeFactory, ITaskSelectionAppModel } from "./containerCode";
 import { renderDiceRoller } from "./view";
 
-// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
-// an existing one.  We also need to provide the unique ID for the document we are loading from.
+/**
+ * Start the app and render.
+ *
+ * @remarks We wrap this in an async function so we can await Fluid's async calls.
+ */
+ async function start() {
+    const tinyliciousModelLoader = new TinyliciousModelLoader<ITaskSelectionAppModel>(
+        new StaticCodeLoader(new TaskSelectionContainerRuntimeFactory()),
+    );
 
-// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.
-// We'll also choose to interpret the URL hash as an existing document's
-// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
-// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
-async function start(): Promise<void> {
-    // when the document ID is not provided, create a new one.
-    const shouldCreateNew = location.hash.length === 0;
-    const documentId = !shouldCreateNew ? window.location.hash.substring(1) : "";
+    let id: string;
+    let model: ITaskSelectionAppModel;
 
-    // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
-    // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
-    // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
-    // function takes the ID of the document we're creating or loading, the container code to load into it, and a
-    // flag to specify whether we're creating a new document or loading an existing one.
-    const [container, containerId] = await getTinyliciousContainer(documentId, TaskSelectionFactory, shouldCreateNew);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await tinyliciousModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await tinyliciousModelLoader.loadExisting(id);
+    }
 
     // update the browser URL and the window title with the actual container ID
-    location.hash = containerId;
-    document.title = containerId;
-
-    // We'll use a separate dice roller for each methodology.
-    const taskManagerDiceRoller = await requestFluidObject<IDiceRoller>(container, taskManagerDiceId);
-    const oldestClientDiceRoller = await requestFluidObject<IDiceRoller>(container, oldestClientDiceId);
+    location.hash = id;
+    document.title = id;
 
     // Demo 1: Using TaskManager
     const taskManagerDiv = document.createElement("div");
@@ -44,7 +44,7 @@ async function start(): Promise<void> {
     taskManagerHeaderDiv.style.fontSize = "50px";
     taskManagerHeaderDiv.textContent = "TaskManager";
     const taskManagerViewDiv = document.createElement("div");
-    renderDiceRoller(taskManagerDiceRoller, taskManagerViewDiv);
+    renderDiceRoller(model.taskManagerDiceRoller, taskManagerViewDiv);
     taskManagerDiv.append(taskManagerHeaderDiv, taskManagerViewDiv);
 
     const divider = document.createElement("hr");
@@ -56,7 +56,7 @@ async function start(): Promise<void> {
     oldestClientHeaderDiv.style.fontSize = "50px";
     oldestClientHeaderDiv.textContent = "OldestClientObserver";
     const oldestClientViewDiv = document.createElement("div");
-    renderDiceRoller(oldestClientDiceRoller, oldestClientViewDiv);
+    renderDiceRoller(model.oldestClientDiceRoller, oldestClientViewDiv);
     oldestClientDiv.append(oldestClientHeaderDiv, oldestClientViewDiv);
 
     const div = document.getElementById("content") as HTMLDivElement;

--- a/examples/data-objects/task-selection/tests/index.ts
+++ b/examples/data-objects/task-selection/tests/index.ts
@@ -3,35 +3,40 @@
  * Licensed under the MIT License.
  */
 
-import { getSessionStorageContainer } from "@fluid-experimental/get-container";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
 
-import { oldestClientDiceId, taskManagerDiceId, TaskSelectionFactory } from "../src/containerCode";
-import { IDiceRoller } from "../src/interface";
+import { TaskSelectionContainerRuntimeFactory, ITaskSelectionAppModel } from "../src/containerCode";
 import { renderDiceRoller } from "../src/view";
-
-// Since this is a single page Fluid application we are generating a new document id
-// if one was not provided
-let createNew = false;
-if (window.location.hash.length === 0) {
-    createNew = true;
-    window.location.hash = Date.now().toString();
-}
-const documentId = window.location.hash.substring(1);
 
 /**
  * This is a helper function for loading the page. It's required because getting the Fluid Container
  * requires making async calls.
  */
-export async function createContainerAndRenderInElement(element: HTMLDivElement, createNewFlag: boolean) {
-    // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
-    // to store ops.
-    const container = await getSessionStorageContainer(documentId, TaskSelectionFactory, createNewFlag);
+async function createContainerAndRenderInElement(element: HTMLDivElement) {
+    const sessionStorageModelLoader = new SessionStorageModelLoader<ITaskSelectionAppModel>(
+        new StaticCodeLoader(new TaskSelectionContainerRuntimeFactory()),
+    );
 
-    // We'll use a separate dice roller for each methodology.
-    const taskManagerDiceRoller = await requestFluidObject<IDiceRoller>(container, taskManagerDiceId);
-    const oldestClientDiceRoller = await requestFluidObject<IDiceRoller>(container, oldestClientDiceId);
+    let id: string;
+    let model: ITaskSelectionAppModel;
 
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await sessionStorageModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await sessionStorageModelLoader.loadExisting(id);
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
+
+    
     // Demo 1: Using TaskManager
     const taskManagerDiv = document.createElement("div");
     const taskManagerHeaderDiv = document.createElement("div");
@@ -39,7 +44,7 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement,
     taskManagerHeaderDiv.style.fontSize = "50px";
     taskManagerHeaderDiv.textContent = "TaskManager";
     const taskManagerViewDiv = document.createElement("div");
-    renderDiceRoller(taskManagerDiceRoller, taskManagerViewDiv);
+    renderDiceRoller(model.taskManagerDiceRoller, taskManagerViewDiv);
     taskManagerDiv.append(taskManagerHeaderDiv, taskManagerViewDiv);
 
     const divider = document.createElement("hr");
@@ -51,7 +56,7 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement,
     oldestClientHeaderDiv.style.fontSize = "50px";
     oldestClientHeaderDiv.textContent = "OldestClientObserver";
     const oldestClientViewDiv = document.createElement("div");
-    renderDiceRoller(oldestClientDiceRoller, oldestClientViewDiv);
+    renderDiceRoller(model.oldestClientDiceRoller, oldestClientViewDiv);
     oldestClientDiv.append(oldestClientHeaderDiv, oldestClientViewDiv);
 
     element.append(taskManagerDiv, divider, oldestClientDiv);
@@ -69,13 +74,13 @@ async function setup() {
     if (leftElement === null) {
         throw new Error("sbs-left does not exist");
     }
-    await createContainerAndRenderInElement(leftElement, createNew);
+    await createContainerAndRenderInElement(leftElement);
     const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
     if (rightElement === null) {
         throw new Error("sbs-right does not exist");
     }
     // The second time we don't need to createNew because we know a Container exists.
-    await createContainerAndRenderInElement(rightElement, false);
+    await createContainerAndRenderInElement(rightElement);
 }
 
 setup().catch((e)=> {

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -37,6 +37,7 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
+    "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",

--- a/examples/hosts/app-integration/container-views/src/app.ts
+++ b/examples/hosts/app-integration/container-views/src/app.ts
@@ -3,83 +3,43 @@
  * Licensed under the MIT License.
  */
 
-import { getTinyliciousContainer } from "@fluid-experimental/get-container";
-import { FluidObject } from "@fluidframework/core-interfaces";
-import { IContainer } from "@fluidframework/container-definitions";
-import { ReactViewAdapter } from "@fluidframework/view-adapters";
-import { IFluidMountableView } from "@fluidframework/view-interfaces";
-import React from "react";
-import ReactDOM from "react-dom";
-import { DiceRollerContainerRuntimeFactory } from "./containerCode";
+import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
+import { DiceRollerContainerRuntimeFactory, IMountableViewAppModel } from "./containerCode";
 
-// I'm choosing to put the docId in the hash just for my own convenience, so the URL will end up looking something
-// like http://localhost:8080/#1596520748752.  This is not crucial to the scenario -- there should be no requirements
-// on the page's URL format deeper in the system, so you're free to change this however you'd like.
-// Additionally, I'm choosing to create a new document when navigating directly to http://localhost:8080 -- this is
-// also open for customization.
-
-// In this app, we are assuming our container code is capable of providing a default mountable view.  This is up to
-// how the container code is authored though (e.g. if the container code is data-only and does not bundle views).
-async function mountDefaultFluidObjectFromContainer(container: IContainer): Promise<void> {
-    const div = document.getElementById("content") as HTMLDivElement;
-    // For this basic scenario, I'm just requesting the default view.  Nothing stopping me from issuing alternate
-    // requests (e.g. for other Fluid objects or views) if I wished.
-    const url = "/";
-    const response = await container.request({
-        // We request with a mountableView since we intend to get this view from across the bundle boundary.
-        headers: {
-            mountableView: true,
-        },
-        url,
-    });
-
-    // Verify the response
-    if (response.status !== 200 || response.mimeType !== "fluid/object") {
-        throw new Error(`Unable to retrieve Fluid object at URL: "${url}"`);
-    } else if (response.value === undefined) {
-        throw new Error(`Empty response from URL: "${url}"`);
-    }
-
-    // Now we know we got the Fluid Object back, time to start mounting it.
-    const fluidObject: FluidObject<IFluidMountableView> = response.value;
-
-    // In a production app, we should probably be retaining a reference to mountableView long-term so we can call
-    // unmount() on it to correctly remove it from the DOM if needed.
-    const mountableView: IFluidMountableView | undefined = fluidObject.IFluidMountableView;
-    if (mountableView !== undefined) {
-        mountableView.mount(div);
-        return;
-    }
-
-    // If we don't get a mountable view back, we can still try to use a view adapter.  This won't always work (e.g.
-    // if the response is a React-based component using hooks) and is not the preferred path, but sometimes it
-    // can work.
-    if (ReactViewAdapter.canAdapt(fluidObject)) {
-        console.warn(`Container returned a non-IFluidMountableView.  This can cause errors when mounting React `
-            + `components with hooks across bundle boundaries.  URL: ${url}`);
-        ReactDOM.render(React.createElement(ReactViewAdapter, { view: fluidObject }), div);
-        return;
-    }
-
-    throw new Error("Could not retrieve a view");
-}
-
-// Just a helper function to kick things off.  Making it async allows us to use await.
-async function start(): Promise<void> {
-    // when the document ID is not provided, create a new one.
-    const shouldCreateNew = location.hash.length === 0;
-    const documentId = !shouldCreateNew ? window.location.hash.substring(1) : "";
-
-    // Get the container to use.  Associate the data with the provided documentId, and run the provided code within.
-    const [container, containerId] = await getTinyliciousContainer(
-        documentId, new DiceRollerContainerRuntimeFactory(), shouldCreateNew,
+/**
+ * Start the app and render.
+ *
+ * @remarks We wrap this in an async function so we can await Fluid's async calls.
+ */
+ async function start() {
+    const tinyliciousModelLoader = new TinyliciousModelLoader<IMountableViewAppModel>(
+        new StaticCodeLoader(new DiceRollerContainerRuntimeFactory()),
     );
 
-    // update the browser URL and the window title with the actual container ID
-    location.hash = containerId;
-    document.title = containerId;
+    let id: string;
+    let model: IMountableViewAppModel;
 
-    await mountDefaultFluidObjectFromContainer(container);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await tinyliciousModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await tinyliciousModelLoader.loadExisting(id);
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
+
+    const contentDiv = document.getElementById("content") as HTMLDivElement;
+    // In a production app, we should probably be retaining a reference to mountableView long-term so we can call
+    // unmount() on it to correctly remove it from the DOM if needed.
+    model.mountableView.mount(contentDiv);
+
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line @typescript-eslint/dot-notation
     window["fluidStarted"] = true;

--- a/examples/hosts/app-integration/container-views/webpack.config.js
+++ b/examples/hosts/app-integration/container-views/webpack.config.js
@@ -6,6 +6,7 @@
 const path = require("path");
 const { merge } = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const webpack = require("webpack");
 // const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 
 module.exports = env => {
@@ -34,6 +35,9 @@ module.exports = env => {
             libraryTarget: "umd"
         },
         plugins: [
+            new webpack.ProvidePlugin({
+                process: 'process/browser'
+            }),
             new HtmlWebpackPlugin({
                 template: "./src/index.html",
             }),

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -38,9 +38,13 @@
     "webpack:dev": "webpack --env development"
   },
   "dependencies": {
+    "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
+    "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "css-loader": "^1.0.0",
     "style-loader": "^1.0.0"
   },

--- a/examples/hosts/app-integration/external-views/src/app.ts
+++ b/examples/hosts/app-integration/external-views/src/app.ts
@@ -3,54 +3,42 @@
  * Licensed under the MIT License.
  */
 
-import { getTinyliciousContainer } from "@fluid-experimental/get-container";
+import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
 
-import { DiceRollerContainerRuntimeFactory } from "./containerCode";
-import { IDiceRoller } from "./dataObject";
+import { DiceRollerContainerRuntimeFactory, IDiceRollerAppModel } from "./containerCode";
 import { renderDiceRoller } from "./view";
 
-// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
-// an existing one.  We also need to provide the unique ID for the document we are loading from.
-
-// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.
-// We'll also choose to interpret the URL hash as an existing document's
-// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
-// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
-async function start(): Promise<void> {
-    // when the document ID is not provided, create a new one.
-    const shouldCreateNew = location.hash.length === 0;
-    const documentId = !shouldCreateNew ? window.location.hash.substring(1) : "";
-
-    // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
-    // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
-    // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
-    // function takes the ID of the document we're creating or loading, the container code to load into it, and a
-    // flag to specify whether we're creating a new document or loading an existing one.
-    const [container, containerId] = await getTinyliciousContainer(
-        documentId, DiceRollerContainerRuntimeFactory, shouldCreateNew,
+/**
+ * Start the app and render.
+ *
+ * @remarks We wrap this in an async function so we can await Fluid's async calls.
+ */
+ async function start() {
+    const tinyliciousModelLoader = new TinyliciousModelLoader<IDiceRollerAppModel>(
+        new StaticCodeLoader(new DiceRollerContainerRuntimeFactory()),
     );
 
-    // update the browser URL and the window title with the actual container ID
-    location.hash = containerId;
-    document.title = containerId;
+    let id: string;
+    let model: IDiceRollerAppModel;
 
-    // Since we're using a ContainerRuntimeFactoryWithDefaultDataStore, our dice roller is available at the URL "/".
-    const url = "/";
-    const response = await container.request({ url });
-
-    // Verify the response to make sure we got what we expected.
-    if (response.status !== 200 || response.mimeType !== "fluid/object") {
-        throw new Error(`Unable to retrieve data object at URL: "${url}"`);
-    } else if (response.value === undefined) {
-        throw new Error(`Empty response from URL: "${url}"`);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await tinyliciousModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await tinyliciousModelLoader.loadExisting(id);
     }
 
-    // In this app, we know our container code provides a default data object that is an IDiceRoller.
-    const diceRoller: IDiceRoller = response.value;
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
 
-    // Given an IDiceRoller, we can render the value and provide controls for users to roll it.
-    const div = document.getElementById("content") as HTMLDivElement;
-    renderDiceRoller(diceRoller, div);
+    const contentDiv = document.getElementById("content") as HTMLDivElement;
+    renderDiceRoller(model.diceRoller, contentDiv);
 }
 
 start().catch((error) => console.error(error));

--- a/examples/hosts/app-integration/external-views/src/containerCode.ts
+++ b/examples/hosts/app-integration/external-views/src/containerCode.ts
@@ -16,7 +16,7 @@ import { DiceRollerInstantiationFactory, IDiceRoller } from "./dataObject";
  * @remarks Since this is a simple example it's just a single data object.  More advanced scenarios may have more
  * complex models.
  */
- export interface IDiceRollerAppModel {
+export interface IDiceRollerAppModel {
     readonly diceRoller: IDiceRoller;
 }
 

--- a/examples/hosts/app-integration/external-views/src/containerCode.ts
+++ b/examples/hosts/app-integration/external-views/src/containerCode.ts
@@ -3,23 +3,59 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { ModelContainerRuntimeFactory } from "@fluid-example/example-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 
-import { DiceRollerInstantiationFactory } from "./dataObject";
+import { DiceRollerInstantiationFactory, IDiceRoller } from "./dataObject";
 
 /**
- * The DiceRollerContainerRuntimeFactory is the container code for our scenario.
+ * The data model for our application.
  *
- * Since we only need to instantiate and retrieve a single dice roller for our scenario, we can use a
- * ContainerRuntimeFactoryWithDefaultDataStore. We provide it with the type of the data object we want to create
- * and retrieve by default, and the registry entry mapping the type to the factory.
- *
- * This container code will create the single default data object on our behalf and make it available on the
- * Container with a URL of "/", so it can be retrieved via container.request("/").
+ * @remarks Since this is a simple example it's just a single data object.  More advanced scenarios may have more
+ * complex models.
  */
-export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRollerInstantiationFactory,
-    new Map([
-        DiceRollerInstantiationFactory.registryEntry,
-    ]),
-);
+ export interface IDiceRollerAppModel {
+    readonly diceRoller: IDiceRoller;
+}
+
+class DiceRollerAppModel implements IDiceRollerAppModel {
+    public constructor(public readonly diceRoller: IDiceRoller) { }
+}
+
+const diceRollerId = "dice-roller";
+
+/**
+ * The runtime factory for our Fluid container.
+ */
+export class DiceRollerContainerRuntimeFactory
+    extends ModelContainerRuntimeFactory<IDiceRollerAppModel> {
+    constructor() {
+        super(
+            new Map([
+                DiceRollerInstantiationFactory.registryEntry,
+            ]), // registryEntries
+        );
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
+     */
+    protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
+        const diceRoller = await runtime.createDataStore(DiceRollerInstantiationFactory.type);
+        await diceRoller.trySetAlias(diceRollerId);
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.createModel}
+     */
+    protected async createModel(runtime: IContainerRuntime, container: IContainer) {
+        const diceRoller = await requestFluidObject<IDiceRoller>(
+            await runtime.getRootDataStore(diceRollerId),
+            "",
+        );
+        return new DiceRollerAppModel(diceRoller);
+    }
+}
+

--- a/examples/hosts/app-integration/external-views/tests/index.ts
+++ b/examples/hosts/app-integration/external-views/tests/index.ts
@@ -3,36 +3,41 @@
  * Licensed under the MIT License.
  */
 
-import { getSessionStorageContainer } from "@fluid-experimental/get-container";
-import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
+import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
 
 import { renderDiceRoller } from "../src/view";
-import { DiceRollerContainerRuntimeFactory } from "../src/containerCode";
-import { DiceRoller } from "../src/dataObject";
-
-// Since this is a single page Fluid application we are generating a new document id
-// if one was not provided
-let createNew = false;
-if (window.location.hash.length === 0) {
-    createNew = true;
-    window.location.hash = Date.now().toString();
-}
-const documentId = window.location.hash.substring(1);
+import { DiceRollerContainerRuntimeFactory, IDiceRollerAppModel } from "../src/containerCode";
 
 /**
  * This is a helper function for loading the page. It's required because getting the Fluid Container
  * requires making async calls.
  */
-export async function createContainerAndRenderInElement(element: HTMLDivElement, createNewFlag: boolean) {
-    // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
-    // to store ops.
-    const container = await getSessionStorageContainer(documentId, DiceRollerContainerRuntimeFactory, createNewFlag);
+ async function createContainerAndRenderInElement(element: HTMLDivElement) {
+    const sessionStorageModelLoader = new SessionStorageModelLoader<IDiceRollerAppModel>(
+        new StaticCodeLoader(new DiceRollerContainerRuntimeFactory()),
+    );
 
-    // Get the Default Object from the Container
-    const defaultObject = await getDefaultObjectFromContainer<DiceRoller>(container);
+    let id: string;
+    let model: IDiceRollerAppModel;
 
-    // Given an IDiceRoller, we can render its data using the view we've created in our app.
-    renderDiceRoller(defaultObject, element);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await sessionStorageModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await sessionStorageModelLoader.loadExisting(id);
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
+
+    // Render it
+    renderDiceRoller(model.diceRoller, element);
 
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -47,13 +52,13 @@ async function setup() {
     if (leftElement === null) {
         throw new Error("sbs-left does not exist");
     }
-    await createContainerAndRenderInElement(leftElement, createNew);
+    await createContainerAndRenderInElement(leftElement);
     const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
     if (rightElement === null) {
         throw new Error("sbs-right does not exist");
     }
     // The second time we don't need to createNew because we know a Container exists.
-    await createContainerAndRenderInElement(rightElement, false);
+    await createContainerAndRenderInElement(rightElement);
 }
 
 setup().catch((e)=> {

--- a/examples/utils/example-utils/src/modelLoader/interfaces.ts
+++ b/examples/utils/example-utils/src/modelLoader/interfaces.ts
@@ -49,4 +49,4 @@ export interface IModelLoader<ModelType> {
 /**
  * The callback signature that the container author will provide.  It must return a promise for the container's model.
  */
- export type ModelMakerCallback<ModelType> = (runtime: IContainerRuntime, container: IContainer) => Promise<ModelType>;
+export type ModelMakerCallback<ModelType> = (runtime: IContainerRuntime, container: IContainer) => Promise<ModelType>;

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -35,6 +35,7 @@
     "webpack": "webpack --color --no-stats"
   },
   "dependencies": {
+    "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-binder": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
@@ -49,6 +50,7 @@
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/data-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
@@ -61,6 +63,7 @@
     "@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-binder": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-common": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/src/app.tsx
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/app.tsx
@@ -3,57 +3,47 @@
  * Licensed under the MIT License.
  */
 
-import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
-import { getTinyliciousContainer } from "@fluid-experimental/get-container";
+import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
 
-import { PropertyTreeContainerRuntimeFactory as ContainerFactory } from "./containerCode";
-
-// import { renderCheckoutView } from "./checkout_view";
+import { PropertyTreeContainerRuntimeFactory, IPropertyTreeAppModel } from "./containerCode";
 import { renderApp, renderInspector } from "./view";
-import { IPropertyTree } from "./dataObject";
 
-// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
-// an existing one.  We also need to provide the unique ID for the document we are loading from.
-
-// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.
-// We'll also choose to interpret the URL hash as an existing document's
-// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
-// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
-async function start(): Promise<void> {
-    const content = document.getElementById("content") as HTMLDivElement;
-    // const paths = await renderCheckoutView(content)
-
-    // when the document ID is not provided, create a new one.
-    const shouldCreateNew = location.hash.length === 0;
-    const documentId = !shouldCreateNew ? window.location.hash.substring(1) : "";
-
-    // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
-    // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
-    // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
-    // function takes the ID of the document we're creating or loading, the container code to load into it, and a
-    // flag to specify whether we're creating a new document or loading an existing one.
-    const [container, containerId] = await getTinyliciousContainer(documentId, ContainerFactory, shouldCreateNew);
-
-    // update the browser URL and the window title with the actual container ID
-    location.hash = containerId;
-    document.title = containerId;
-
-    /* const options = {
-        paths,
-        clientFiltering: true
-    }; */
-
-    // TODO: options currently not supported
-    const propertyTree: IPropertyTree = await getDefaultObjectFromContainer<IPropertyTree>(
-        container,
-        /* { options } */
+/**
+ * Start the app and render.
+ *
+ * @remarks We wrap this in an async function so we can await Fluid's async calls.
+ */
+async function start() {
+    const tinyliciousModelLoader = new TinyliciousModelLoader<IPropertyTreeAppModel>(
+        new StaticCodeLoader(new PropertyTreeContainerRuntimeFactory()),
     );
 
+    let id: string;
+    let model: IPropertyTreeAppModel;
+
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await tinyliciousModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await tinyliciousModelLoader.loadExisting(id);
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
+
+    const contentDiv = document.getElementById("content") as HTMLDivElement;
+
     // Render the actual sample
-    const dataBinder = renderApp(propertyTree, content);
+    const dataBinder = renderApp(model.propertyTree, contentDiv);
 
     // Render property inspector
-    renderInspector(dataBinder, propertyTree);
+    renderInspector(dataBinder, model.propertyTree);
 }
 
 start().catch((error) => console.error(error));

--- a/experimental/PropertyDDS/examples/partial-checkout/src/containerCode.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/containerCode.ts
@@ -3,13 +3,58 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { ModelContainerRuntimeFactory } from "@fluid-example/example-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 
-import { PropertyTreeInstantiationFactory } from "./dataObject";
+import { IPropertyTree, PropertyTreeInstantiationFactory } from "./dataObject";
 
-export const PropertyTreeContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    PropertyTreeInstantiationFactory,
-    new Map([
-        ["property-tree", Promise.resolve(PropertyTreeInstantiationFactory)],
-    ]),
-);
+/**
+ * The data model for our application.
+ *
+ * @remarks Since this is a simple example it's just a single data object.  More advanced scenarios may have more
+ * complex models.
+ */
+export interface IPropertyTreeAppModel {
+    readonly propertyTree: IPropertyTree;
+}
+
+class PropertyTreeAppModel implements IPropertyTreeAppModel {
+    public constructor(public readonly propertyTree: IPropertyTree) { }
+}
+
+const propertyTreeId = "property-tree";
+
+/**
+ * The runtime factory for our Fluid container.
+ */
+export class PropertyTreeContainerRuntimeFactory
+    extends ModelContainerRuntimeFactory<IPropertyTreeAppModel> {
+    constructor() {
+        super(
+            new Map([
+                ["property-tree", Promise.resolve(PropertyTreeInstantiationFactory)],
+            ]), // registryEntries
+        );
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
+     */
+    protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
+        const diceRoller = await runtime.createDataStore(PropertyTreeInstantiationFactory.type);
+        await diceRoller.trySetAlias(propertyTreeId);
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.createModel}
+     */
+    protected async createModel(runtime: IContainerRuntime, container: IContainer) {
+        const diceRoller = await requestFluidObject<IPropertyTree>(
+            await runtime.getRootDataStore(propertyTreeId),
+            "",
+        );
+        return new PropertyTreeAppModel(diceRoller);
+    }
+}

--- a/experimental/PropertyDDS/examples/partial-checkout/src/containerCode.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/containerCode.ts
@@ -43,18 +43,18 @@ export class PropertyTreeContainerRuntimeFactory
      * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const diceRoller = await runtime.createDataStore(PropertyTreeInstantiationFactory.type);
-        await diceRoller.trySetAlias(propertyTreeId);
+        const propertyTree = await runtime.createDataStore(PropertyTreeInstantiationFactory.type);
+        await propertyTree.trySetAlias(propertyTreeId);
     }
 
     /**
      * {@inheritDoc ModelContainerRuntimeFactory.createModel}
      */
     protected async createModel(runtime: IContainerRuntime, container: IContainer) {
-        const diceRoller = await requestFluidObject<IPropertyTree>(
+        const propertyTree = await requestFluidObject<IPropertyTree>(
             await runtime.getRootDataStore(propertyTreeId),
             "",
         );
-        return new PropertyTreeAppModel(diceRoller);
+        return new PropertyTreeAppModel(propertyTree);
     }
 }

--- a/experimental/PropertyDDS/examples/partial-checkout/tests/index.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/tests/index.ts
@@ -3,36 +3,41 @@
  * Licensed under the MIT License.
  */
 
-import { getSessionStorageContainer } from "@fluid-experimental/get-container";
-import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
+import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
 
+import { PropertyTreeContainerRuntimeFactory, IPropertyTreeAppModel } from "../src/containerCode";
 import { renderApp } from "../src/view";
-import { PropertyTree } from "../src/dataObject";
-import { PropertyTreeContainerRuntimeFactory as ContainerFactory } from "../src/containerCode";
-
-// Since this is a single page Fluid application we are generating a new document id
-// if one was not provided
-let createNew = false;
-if (window.location.hash.length === 0) {
-    createNew = true;
-    window.location.hash = Date.now().toString();
-}
-const documentId = window.location.hash.substring(1);
 
 /**
  * This is a helper function for loading the page. It's required because getting the Fluid Container
  * requires making async calls.
  */
-export async function createContainerAndRenderInElement(element: HTMLDivElement, createNewFlag: boolean) {
-    // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
-    // to store ops.
-    const container = await getSessionStorageContainer(documentId, ContainerFactory, createNewFlag);
+async function createContainerAndRenderInElement(element: HTMLDivElement) {
+    const sessionStorageModelLoader = new SessionStorageModelLoader<IPropertyTreeAppModel>(
+        new StaticCodeLoader(new PropertyTreeContainerRuntimeFactory()),
+    );
 
-    // Get the Default Object from the Container
-    const defaultObject = await getDefaultObjectFromContainer<PropertyTree>(container);
+    let id: string;
+    let model: IPropertyTreeAppModel;
 
-    // Given an IDiceRoller, we can render its data using the view we've created in our app.
-    renderApp(defaultObject, element);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await sessionStorageModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await sessionStorageModelLoader.loadExisting(id);
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
+
+    // Render it
+    renderApp(model.propertyTree, element);
 
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -47,13 +52,13 @@ async function setup() {
     if (leftElement === null) {
         throw new Error("sbs-left does not exist");
     }
-    await createContainerAndRenderInElement(leftElement, createNew);
+    await createContainerAndRenderInElement(leftElement);
     const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
     if (rightElement === null) {
         throw new Error("sbs-right does not exist");
     }
     // The second time we don't need to createNew because we know a Container exists.
-    await createContainerAndRenderInElement(rightElement, false);
+    await createContainerAndRenderInElement(rightElement);
 }
 
 setup().catch((e)=> {

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -35,6 +35,7 @@
     "webpack": "webpack --color --no-stats"
   },
   "dependencies": {
+    "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-binder": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
@@ -49,6 +50,7 @@
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/data-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
@@ -59,6 +61,7 @@
     "@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@fluid-example/example-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-    "@fluid-experimental/get-container": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-binder": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-common": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",

--- a/experimental/PropertyDDS/examples/property-inspector/src/app.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/app.tsx
@@ -3,46 +3,48 @@
  * Licensed under the MIT License.
  */
 
-import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
-import { getTinyliciousContainer } from "@fluid-experimental/get-container";
+import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
 import { PropertyFactory } from "@fluid-experimental/property-properties";
 import { registerSchemas } from "@fluid-experimental/schemas";
 
-import { IPropertyTree } from "./dataObject";
-import { PropertyTreeContainerRuntimeFactory as ContainerFactory } from "./containerCode";
+import { PropertyTreeContainerRuntimeFactory, IPropertyTreeAppModel } from "./containerCode";
 import { renderApp } from "./inspector";
 
-// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
-// an existing one.  We also need to provide the unique ID for the document we are loading from.
-
-// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.
-// We'll also choose to interpret the URL hash as an existing document's
-// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
-// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
-async function start(): Promise<void> {
+/**
+ * Start the app and render.
+ *
+ * @remarks We wrap this in an async function so we can await Fluid's async calls.
+ */
+async function start() {
     // Register all schemas.
     // It's important to register schemas before loading an existing document
     // in order to process the changeset.
     registerSchemas(PropertyFactory);
 
-    // when the document ID is not provided, create a new one.
-    const shouldCreateNew = location.hash.length === 0;
-    const documentId = !shouldCreateNew ? window.location.hash.substring(1) : "";
+    const tinyliciousModelLoader = new TinyliciousModelLoader<IPropertyTreeAppModel>(
+        new StaticCodeLoader(new PropertyTreeContainerRuntimeFactory()),
+    );
 
-    // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
-    // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
-    // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
-    // function takes the ID of the document we're creating or loading, the container code to load into it, and a
-    // flag to specify whether we're creating a new document or loading an existing one.
-    const [container, containerId] = await getTinyliciousContainer(documentId, ContainerFactory, shouldCreateNew);
+    let id: string;
+    let model: IPropertyTreeAppModel;
+
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await tinyliciousModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await tinyliciousModelLoader.loadExisting(id);
+    }
 
     // update the browser URL and the window title with the actual container ID
-    location.hash = containerId;
-    document.title = containerId;
+    location.hash = id;
+    document.title = id;
 
-    const propertyTree: IPropertyTree = await getDefaultObjectFromContainer<IPropertyTree>(container);
-
-    renderApp(propertyTree.tree, document.getElementById("root")!);
+    renderApp(model.propertyTree.tree, document.getElementById("root")!);
 }
 
 start().catch((error) => console.error(error));

--- a/experimental/PropertyDDS/examples/property-inspector/src/containerCode.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/src/containerCode.ts
@@ -3,13 +3,58 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { ModelContainerRuntimeFactory } from "@fluid-example/example-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 
-import { PropertyTreeInstantiationFactory } from "./dataObject";
+import { PropertyTreeInstantiationFactory, IPropertyTree } from "./dataObject";
 
-export const PropertyTreeContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    PropertyTreeInstantiationFactory,
-    new Map([
-        ["property-tree", Promise.resolve(PropertyTreeInstantiationFactory)],
-    ]),
-);
+/**
+ * The data model for our application.
+ *
+ * @remarks Since this is a simple example it's just a single data object.  More advanced scenarios may have more
+ * complex models.
+ */
+export interface IPropertyTreeAppModel {
+    readonly propertyTree: IPropertyTree;
+}
+
+class PropertyTreeAppModel implements IPropertyTreeAppModel {
+    public constructor(public readonly propertyTree: IPropertyTree) { }
+}
+
+const propertyTreeId = "property-tree";
+
+/**
+ * The runtime factory for our Fluid container.
+ */
+export class PropertyTreeContainerRuntimeFactory
+    extends ModelContainerRuntimeFactory<IPropertyTreeAppModel> {
+    constructor() {
+        super(
+            new Map([
+                ["property-tree", Promise.resolve(PropertyTreeInstantiationFactory)],
+            ]), // registryEntries
+        );
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
+     */
+    protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
+        const propertyTree = await runtime.createDataStore(PropertyTreeInstantiationFactory.type);
+        await propertyTree.trySetAlias(propertyTreeId);
+    }
+
+    /**
+     * {@inheritDoc ModelContainerRuntimeFactory.createModel}
+     */
+    protected async createModel(runtime: IContainerRuntime, container: IContainer) {
+        const propertyTree = await requestFluidObject<IPropertyTree>(
+            await runtime.getRootDataStore(propertyTreeId),
+            "",
+        );
+        return new PropertyTreeAppModel(propertyTree);
+    }
+}

--- a/experimental/PropertyDDS/examples/property-inspector/tests/index.html
+++ b/experimental/PropertyDDS/examples/property-inspector/tests/index.html
@@ -6,20 +6,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>💧</text></svg>">
     <title>Property Inspector</title>
 </head>
 <body style="margin: 0; height: 100%;">
-    <div style="flex-direction: row; display: flex;">
-        <div id="content" style="min-height: 100%; display: flex;">
-            <div id="sbs-left" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position: relative;">
-                <div style="height: 100%" id="root1"></div>
-            </div>
-            <div id="sbs-right" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position: relative;">
-                <div style="height: 100%" id="root2"></div>
-            </div>
-        </div>
-        <div id="root"></div>
+    <div id="content" style="min-height: 100%; display: flex;">
+        <div id="sbs-left" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position: relative;"></div>
+        <div id="sbs-right" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position: relative;"></div>
     </div>
 </body>
 </html>

--- a/experimental/PropertyDDS/examples/property-inspector/tests/index.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/tests/index.ts
@@ -3,36 +3,41 @@
  * Licensed under the MIT License.
  */
 
-import { getSessionStorageContainer } from "@fluid-experimental/get-container";
-import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
+import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
 
 import { renderApp } from "../src/inspector";
-import { PropertyTree } from "../src/dataObject";
-import { PropertyTreeContainerRuntimeFactory as ContainerFactory } from "../src/containerCode";
-
-// Since this is a single page Fluid application we are generating a new document id
-// if one was not provided
-let createNew = false;
-if (window.location.hash.length === 0) {
-    createNew = true;
-    window.location.hash = Date.now().toString();
-}
-const documentId = window.location.hash.substring(1);
+import { PropertyTreeContainerRuntimeFactory, IPropertyTreeAppModel } from "../src/containerCode";
 
 /**
  * This is a helper function for loading the page. It's required because getting the Fluid Container
  * requires making async calls.
  */
-export async function createContainerAndRenderInElement(element: HTMLDivElement, createNewFlag: boolean, elementId: string) {
-    // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
-    // to store ops.
-    const container = await getSessionStorageContainer(documentId, ContainerFactory, createNewFlag);
+async function createContainerAndRenderInElement(element: HTMLDivElement) {
+    const sessionStorageModelLoader = new SessionStorageModelLoader<IPropertyTreeAppModel>(
+        new StaticCodeLoader(new PropertyTreeContainerRuntimeFactory()),
+    );
 
-    // Get the Default Object from the Container
-    const defaultObject = await getDefaultObjectFromContainer<PropertyTree>(container);
+    let id: string;
+    let model: IPropertyTreeAppModel;
 
-    // Given an IDiceRoller, we can render its data using the view we've created in our app.
-    renderApp(defaultObject.tree, document.getElementById(elementId)!);
+    if (location.hash.length === 0) {
+        // Normally our code loader is expected to match up with the version passed here.
+        // But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
+        // the version doesn't actually matter.
+        const createResponse = await sessionStorageModelLoader.createDetached("1.0");
+        model = createResponse.model;
+        id = await createResponse.attach();
+    } else {
+        id = location.hash.substring(1);
+        model = await sessionStorageModelLoader.loadExisting(id);
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = id;
+    document.title = id;
+
+    // Render it
+    renderApp(model.propertyTree.tree, element);
 
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -43,17 +48,16 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement,
  * For local testing we have two div's that we are rendering into independently.
  */
 async function setup() {
-    const leftElement = document.getElementById("sbs-left") as HTMLDivElement;
+    const leftElement = document.getElementById("root1") as HTMLDivElement;
     if (leftElement === null) {
-        throw new Error("sbs-left does not exist");
+        throw new Error("root1 does not exist");
     }
-    await createContainerAndRenderInElement(leftElement, createNew, 'root1');
-    const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
+    await createContainerAndRenderInElement(leftElement);
+    const rightElement = document.getElementById("root2") as HTMLDivElement;
     if (rightElement === null) {
-        throw new Error("sbs-right does not exist");
+        throw new Error("root2 does not exist");
     }
-    // The second time we don't need to createNew because we know a Container exists.
-    await createContainerAndRenderInElement(rightElement, false, 'root2');
+    await createContainerAndRenderInElement(rightElement);
 }
 
 setup().catch((e)=> {

--- a/experimental/PropertyDDS/examples/property-inspector/tests/index.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/tests/index.ts
@@ -48,14 +48,14 @@ async function createContainerAndRenderInElement(element: HTMLDivElement) {
  * For local testing we have two div's that we are rendering into independently.
  */
 async function setup() {
-    const leftElement = document.getElementById("root1") as HTMLDivElement;
+    const leftElement = document.getElementById("sbs-left") as HTMLDivElement;
     if (leftElement === null) {
-        throw new Error("root1 does not exist");
+        throw new Error("sbs-left does not exist");
     }
     await createContainerAndRenderInElement(leftElement);
-    const rightElement = document.getElementById("root2") as HTMLDivElement;
+    const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
     if (rightElement === null) {
-        throw new Error("root2 does not exist");
+        throw new Error("sbs-right does not exist");
     }
     await createContainerAndRenderInElement(rightElement);
 }

--- a/experimental/PropertyDDS/examples/property-inspector/tests/property_inspector.test.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/tests/property_inspector.test.ts
@@ -18,10 +18,10 @@ describe("Property Inspector", () => {
     });
 
     it("Inspector at root1 is rendered", async () => {
-        await page.waitForSelector("#root1 > :first-child");
+        await page.waitForSelector("#sbs-left > :first-child");
     });
 
     it("Inspector at root2 is rendered", async () => {
-        await page.waitForSelector("#root2 > :first-child");
+        await page.waitForSelector("#sbs-right > :first-child");
     });
 });


### PR DESCRIPTION
Also most of getSessionStorageContainer barring what's in the Azure build pipeline.

This converts the remaining demos that were using getTinyliciousContainer -- a few highlights beyond the usual benefits:

- container-views gets a big win in simplicity, since it no longer has to mess with request handling for a mountable view
- task-selection gets a clean way to expose two specific objects without exposing all root data objects
- container-views was broken due to the webpack process thing, fixed now
- property-inspector's test mode had broken layout, fixed now