### PR TITLE
Tree: add node index to EditableTree

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -221,6 +221,7 @@ export interface EditableField extends ArrayLike<UnwrappedEditableTree> {
 export interface EditableTree extends Iterable<EditableField> {
     [createField](fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): EditableField | undefined;
     [getField](fieldKey: FieldKey): EditableField;
+    readonly [indexSymbol]: number;
     readonly [proxyTargetSymbol]: object;
     [Symbol.iterator](): IterableIterator<EditableField>;
     readonly [typeNameSymbol]: TreeSchemaIdentifier;
@@ -472,6 +473,9 @@ export interface IForestSubscription extends Dependee {
     tryMoveCursorToField(destination: FieldAnchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
     tryMoveCursorToNode(destination: Anchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): TreeNavigationResult;
 }
+
+// @public
+export const indexSymbol: unique symbol;
 
 // @public
 function inputLength(mark: Mark<unknown>): number;

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -114,6 +114,11 @@ export interface EditableTree extends Iterable<EditableField> {
     /**
      * Index of this node within its parent field.
      */
+    // TODO: this is a temporary solution.
+    // It should be replaced with a more general location symbol like
+    // `readonly [location]: EditableTreeUpPath`
+    // to cover all the cases, where the code may be lacking information about an origin of the node.
+    // See proposed API: https://github.com/microsoft/FluidFramework/pull/12810#issuecomment-1303949419
     readonly [indexSymbol]: number;
 
     /**

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -15,6 +15,7 @@ export {
     UnwrappedEditableTree,
     UnwrappedEditableField,
     valueSymbol,
+    indexSymbol,
     getField,
     createField,
 } from "./editableTree";

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -20,6 +20,7 @@ export {
     getEditableTreeContext,
     typeSymbol,
     typeNameSymbol,
+    indexSymbol,
     isEditableField,
     isPrimitive,
     isPrimitiveValue,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -143,6 +143,7 @@ export {
     typeSymbol,
     typeNameSymbol,
     valueSymbol,
+    indexSymbol,
     proxyTargetSymbol,
     getField,
     createField,

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -45,6 +45,7 @@ import {
     isEditableField,
     UnwrappedEditableTree,
     getField,
+    indexSymbol,
 } from "../../../feature-libraries";
 import {
     getPrimaryField,
@@ -223,6 +224,16 @@ describe("editable-tree: read-only", () => {
         }
 
         {
+            const descriptor = Object.getOwnPropertyDescriptor(nameNode, indexSymbol);
+            assert.deepEqual(descriptor, {
+                configurable: true,
+                enumerable: false,
+                value: 0,
+                writable: false,
+            });
+        }
+
+        {
             const descriptor = Object.getOwnPropertyDescriptor(nameNode, Symbol.iterator);
             assert(typeof descriptor?.value === "function");
             delete descriptor.value;
@@ -318,6 +329,7 @@ describe("editable-tree: read-only", () => {
         assert(proxyTargetSymbol in personProxy);
         assert(typeSymbol in personProxy);
         assert(typeNameSymbol in personProxy);
+        assert(indexSymbol in personProxy);
         assert(getField in personProxy);
         // Check fields show up:
         assert("age" in personProxy);

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/utils.ts
@@ -23,6 +23,7 @@ import {
     isPrimitive,
     getField,
     isUnwrappedNode,
+    indexSymbol,
 } from "../../../feature-libraries";
 import {
     getPrimaryField,
@@ -135,7 +136,9 @@ export function expectFieldEquals(
         );
     }
     for (let index = 0; index < field.length; index++) {
-        expectNodeEquals(schemaData, field.getNode(index), expected[index]);
+        const node = field.getNode(index);
+        assert.equal(node[indexSymbol], index);
+        expectNodeEquals(schemaData, node, expected[index]);
     }
 }
 


### PR DESCRIPTION
This PR introduces the `indexSymbol`, with which one can get the index of the current node.
It might be useful in situations, when there is no access to the caller iterating over the field nodes in the code.