### PR TITLE
Cherry picked Force write mode by default for TinyliciousClient from main to LTS branch [main->Lts] (#12603) 

### DIFF
--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -53,6 +53,7 @@ import { ITreeEntry } from '@fluidframework/protocol-definitions';
 import { IUser } from '@fluidframework/protocol-definitions';
 import { MessageType } from '@fluidframework/protocol-definitions';
 import { ReadOnlyInfo } from '@fluidframework/container-definitions';
+import { ScopeType } from '@fluidframework/protocol-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public (undocumented)
@@ -69,7 +70,8 @@ export interface IMockContainerRuntimePendingMessage {
 export class InsecureTokenProvider implements ITokenProvider {
     constructor(
     tenantKey: string,
-    user: IUser);
+    user: IUser,
+    scopes?: ScopeType[] | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/api-report/tinylicious-client.api.md
+++ b/api-report/tinylicious-client.api.md
@@ -11,6 +11,7 @@ import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
+import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/protocol-definitions';
 import { ServiceAudience } from '@fluidframework/fluid-static';
 
@@ -52,6 +53,7 @@ export interface TinyliciousClientProps {
 export interface TinyliciousConnectionConfig {
     domain?: string;
     port?: number;
+    tokenProvider?: ITokenProvider;
 }
 
 // @public

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
@@ -4,7 +4,10 @@
  */
 
 import { ScopeType, ITokenClaims } from "@fluidframework/protocol-definitions";
-import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+import {
+    ITokenProvider,
+    ITokenResponse,
+} from "@fluidframework/routerlicious-driver";
 import { getRandomName } from "@fluidframework/server-services-client";
 import { KJUR as jsrsasign } from "jsrsasign";
 import { v4 as uuid } from "uuid";
@@ -14,14 +17,32 @@ import { v4 as uuid } from "uuid";
  * to get up and running.
  */
 export class InsecureTinyliciousTokenProvider implements ITokenProvider {
-    public async fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
+    constructor(
+        /**
+         * Optional. Override of scopes. If a param is not provided, InsecureTinyliciousTokenProvider
+         * will use the default scopes which are document read, write and summarizer write.
+         *
+         * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
+         *
+         * @defaultValue - [ ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite ]
+         */
+        private readonly scopes?: ScopeType[],
+    ) {}
+
+    public async fetchOrdererToken(
+        tenantId: string,
+        documentId?: string,
+    ): Promise<ITokenResponse> {
         return {
             fromCache: true,
             jwt: this.getSignedToken(tenantId, documentId),
         };
     }
 
-    public async fetchStorageToken(tenantId: string, documentId: string): Promise<ITokenResponse> {
+    public async fetchStorageToken(
+        tenantId: string,
+        documentId: string,
+    ): Promise<ITokenResponse> {
         return {
             fromCache: true,
             jwt: this.getSignedToken(tenantId, documentId),
@@ -32,14 +53,19 @@ export class InsecureTinyliciousTokenProvider implements ITokenProvider {
         tenantId: string,
         documentId: string | undefined,
         lifetime: number = 60 * 60,
-        ver: string = "1.0"): string {
+        ver: string = "1.0"
+    ): string {
         // Current time in seconds
-        const now = Math.round((new Date()).getTime() / 1000);
+        const now = Math.round(new Date().getTime() / 1000);
         const user = { id: uuid(), name: getRandomName() };
 
         const claims: ITokenClaims = {
             documentId: documentId ?? "",
-            scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+            scopes: this.scopes ?? [
+                ScopeType.DocRead,
+                ScopeType.DocWrite,
+                ScopeType.SummaryWrite,
+            ],
             tenantId,
             user,
             iat: now,
@@ -48,6 +74,11 @@ export class InsecureTinyliciousTokenProvider implements ITokenProvider {
         };
 
         const utf8Key = { utf8: "12345" };
-        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg: "HS256", typ: "JWT" }), claims, utf8Key);
+        return jsrsasign.jws.JWS.sign(
+            null,
+            JSON.stringify({ alg: "HS256", typ: "JWT" }),
+            claims,
+            utf8Key,
+        );
     }
 }

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
@@ -53,7 +53,7 @@ export class InsecureTinyliciousTokenProvider implements ITokenProvider {
         tenantId: string,
         documentId: string | undefined,
         lifetime: number = 60 * 60,
-        ver: string = "1.0"
+        ver: string = "1.0",
     ): string {
         // Current time in seconds
         const now = Math.round(new Date().getTime() / 1000);

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -59,6 +59,7 @@
     "@fluidframework/container-runtime": "^1.4.0",
     "@fluidframework/container-runtime-definitions": "^1.4.0",
     "@fluidframework/eslint-config-fluid": "^0.28.2000",
+    "@fluidframework/test-utils": "^1.3.0",
     "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -51,10 +51,10 @@ export class TinyliciousClient {
         const tokenProvider = new InsecureTinyliciousTokenProvider();
         this.urlResolver = new InsecureTinyliciousUrlResolver(
             this.props?.connection?.port,
-            this.props?.connection?.domain
+            this.props?.connection?.domain,
         );
         this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
-            this.props?.connection?.tokenProvider ?? tokenProvider
+            this.props?.connection?.tokenProvider ?? tokenProvider,
         );
     }
 
@@ -64,7 +64,7 @@ export class TinyliciousClient {
      * @returns New detached container instance along with associated services.
      */
     public async createContainer(
-        containerSchema: ContainerSchema
+        containerSchema: ContainerSchema,
     ): Promise<{
         container: IFluidContainer;
         services: TinyliciousContainerServices;
@@ -106,7 +106,7 @@ export class TinyliciousClient {
      */
     public async getContainer(
         id: string,
-        containerSchema: ContainerSchema
+        containerSchema: ContainerSchema,
     ): Promise<{
         container: IFluidContainer;
         services: TinyliciousContainerServices;
@@ -121,7 +121,7 @@ export class TinyliciousClient {
 
     // #region private
     private getContainerServices(
-        container: IContainer
+        container: IContainer,
     ): TinyliciousContainerServices {
         return {
             audience: new TinyliciousAudience(container),
@@ -130,7 +130,7 @@ export class TinyliciousClient {
 
     private createLoader(containerSchema: ContainerSchema) {
         const containerRuntimeFactory = new DOProviderContainerRuntimeFactory(
-            containerSchema
+            containerSchema,
         );
         const load = async (): Promise<IFluidModuleWithDetails> => {
             return {

--- a/packages/framework/tinylicious-client/src/interfaces.ts
+++ b/packages/framework/tinylicious-client/src/interfaces.ts
@@ -5,7 +5,7 @@
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { IMember, IServiceAudience } from "@fluidframework/fluid-static";
 import { IUser } from "@fluidframework/protocol-definitions";
-
+import { ITokenProvider } from "@fluidframework/routerlicious-driver";
 // Re-export so developers can build loggers without pulling in common-definitions
 export {
     ITelemetryBaseEvent,
@@ -42,6 +42,15 @@ export interface TinyliciousConnectionConfig {
      * @defaultValue - {@link @fluidframework/tinylicious-driver#defaultTinyliciousEndpoint}
      */
     domain?: string;
+
+    /**
+     * Optional. Override of tokenProvider. If a param is not provided, TinyliciousConnectionConfig
+     * will use the default tokenProvider which is InsecureTinyliciousTokenProvider with default scopes,
+     * which are document read, write and summarizer write.
+     *
+     * @defaultValue {@link @fluidframework/tinylicious-driver#InsecureTinyliciousTokenProvider}
+     */
+    tokenProvider?: ITokenProvider;
 }
 
 /**

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -25,6 +25,16 @@ export class InsecureTokenProvider implements ITokenProvider {
          * User with whom generated tokens will be associated.
          */
         private readonly user: IUser,
+
+        /**
+         * Optional. Override of scopes. If a param is not provided, InsecureTokenProvider
+         * will use the default scopes which are document read, write and summarizer write.
+         *
+         * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
+         *
+         * @defaultValue - [ ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite ]
+         */
+        private readonly scopes?: ScopeType[],
     ) {
 
     }
@@ -38,7 +48,7 @@ export class InsecureTokenProvider implements ITokenProvider {
             jwt: generateToken(
                 tenantId,
                 this.tenantKey,
-                [
+                this.scopes ?? [
                     ScopeType.DocRead,
                     ScopeType.DocWrite,
                     ScopeType.SummaryWrite,
@@ -58,7 +68,7 @@ export class InsecureTokenProvider implements ITokenProvider {
             jwt: generateToken(
                 tenantId,
                 this.tenantKey,
-                [
+                this.scopes ?? [
                     ScopeType.DocRead,
                     ScopeType.DocWrite,
                     ScopeType.SummaryWrite,


### PR DESCRIPTION
> Force TinyliciousClient to create all connected containers in `write` mode on the LTS branch.
> Cherry picked merge commit from the following PR; https://github.com/microsoft/FluidFramework/pull/12603

> TinyliciousClient tests are included in this PR

> - [AB#2151](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2151)
> - [AB#2152](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2152)
