### PR TITLE
v2int/2.0: send null in no-ops instead of undefined

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1724,7 +1724,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     (type) => {
                         assert(this.activeConnection(),
                             0x241 /* "disconnect should result in stopSequenceNumberUpdate() call" */);
-                        this.submitMessage(type);
+                        // back-compat: There is a bug in 1.2 runtime where clients cannot handle
+                        // ops whose contents are undefined
+                        this.submitMessage(type, null as any);
                     },
                     this.serviceConfiguration.noopTimeFrequency,
                     this.serviceConfiguration.noopCountFrequency,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -240,7 +240,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
         assert(isClientMessage(message), 0x419 /* client sends non-client message */);
 
-        if (contents !== undefined) {
+        if (contents !== undefined && contents !== null) {
             this.opsSize += contents.length;
         }
 

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -68,7 +68,9 @@ describe("Loader", () => {
 
                 const tracker = new CollabWindowTracker(
                     (type: MessageType) => {
-                        deltaManager.submit(type);
+                        // back-compat: There is a bug in 1.2 runtime where clients cannot handle
+                        // ops whose contents are undefined
+                        deltaManager.submit(type, null as any);
                         // CollabWindowTracker expects every op submitted (including noops) to result in this call:
                         tracker.stopSequenceNumberUpdate();
                     },
@@ -147,13 +149,13 @@ describe("Loader", () => {
                 function assertOneValidNoOp(messages: IDocumentMessage[]) {
                     assert.strictEqual(1, messages.length);
                     assert.strictEqual(MessageType.NoOp, messages[0].type);
-                    assert.strictEqual(undefined, messages[0].contents);
+                    assert.strictEqual(null, messages[0].contents);
                 }
 
                 function assertOneValidAcceptOp(messages: IDocumentMessage[]) {
                     assert.strictEqual(1, messages.length);
                     assert.strictEqual(MessageType2.Accept, messages[0].type);
-                    assert.strictEqual(undefined, messages[0].contents);
+                    assert.strictEqual(null, messages[0].contents);
                 }
 
                 it("Infinite frequency parameters disables periodic noops completely", async () => {


### PR DESCRIPTION
Port #12779 to v2int/2.0, since bohemia wants to integrate it

Send `null` instead of `undefined` in no-ops

There is a bug in 1.2 runtime where clients cannot handle ops whose contents are `undefined`, since `JSON.stringify(undefined)` evaluates to `undefined`, unlike `JSON.stringify(null)`, which evaluates to `"null"`. Old clients try to access `length`, resulting in an error.