### PR TITLE
GC: Log stack for SweepReadyObject_Loaded (#12792)

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -34,6 +34,7 @@ import {
 } from "@fluidframework/runtime-utils";
 import {
     ChildLogger,
+    generateStack,
     loggerToMonitoringContext,
     MonitoringContext,
     PerformanceEvent,
@@ -1420,6 +1421,7 @@ export class GarbageCollector implements IGarbageCollector {
                     ...propsToLog,
                     eventName: `${state}Object_${usageType}`,
                     pkg: packagePath ? { value: packagePath.join("/"), tag: TelemetryDataTag.CodeArtifact } : undefined,
+                    stack: generateStack(),
                 });
             }
 


### PR DESCRIPTION
Cherry pick https://github.com/microsoft/FluidFramework/pull/12792

Adds gc log stack for inactive and sweepready loaded objects