### PR TITLE
Azure client tests config

### DIFF
--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -26,7 +26,7 @@ export function createAzureClient(userID?: string, userName?: string): AzureClie
         id: userID ?? uuid(),
         name: userName ?? uuid(),
     };
-    const endPoint = (process.env.azure__fluid__relay__service__endpoint as string)
+    const endPoint = process.env.azure__fluid__relay__service__endpoint as string;
 
     // use AzureClient remote mode will run against live Azure Fluid Relay.
     // Default to running Tinylicious for PR validation

--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -34,7 +34,7 @@ export function createAzureClient(userID?: string, userName?: string): AzureClie
     const connectionProps: AzureRemoteConnectionConfig | AzureLocalConnectionConfig = useAzure
         ? {
               tenantId,
-              tokenProvider: createAzureTokenProvider(userID, userName),
+              tokenProvider: createAzureTokenProvider(userID ?? "foo", userName ?? "bar"),
               endpoint: endPoint ?? "https://alfred.westus2.fluidrelay.azure.com",
               type: "remote",
           }

--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -26,6 +26,7 @@ export function createAzureClient(userID?: string, userName?: string): AzureClie
         id: userID ?? uuid(),
         name: userName ?? uuid(),
     };
+    const endPoint = (process.env.azure__fluid__relay__service__endpoint as string)
 
     // use AzureClient remote mode will run against live Azure Fluid Relay.
     // Default to running Tinylicious for PR validation
@@ -34,7 +35,7 @@ export function createAzureClient(userID?: string, userName?: string): AzureClie
         ? {
               tenantId,
               tokenProvider: createAzureTokenProvider(userID, userName),
-              endpoint: "https://alfred.westus2.fluidrelay.azure.com",
+              endpoint: endPoint ?? "https://alfred.westus2.fluidrelay.azure.com",
               type: "remote",
           }
         : {

--- a/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
@@ -2,18 +2,26 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { AzureFunctionTokenProvider, ITokenProvider } from "@fluidframework/azure-client";
+import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
 
-import {
-    AzureFunctionTokenProvider
-} from "@fluidframework/azure-client";
-
-export function createAzureTokenProvider(
-    userID?: string,
-    userName?: string,
-): AzureFunctionTokenProvider {
+export function createAzureTokenProvider(userID?: string, userName?: string): ITokenProvider {
     const fnUrl = process.env.azure__fluid__relay__service__function__url as string;
-    return new AzureFunctionTokenProvider(`${fnUrl}/api/GetFrsToken`, {
-        userId: userID ?? "foo",
-        userName: userName ?? "bar",
-    });
+    const key = process.env.azure__fluid__relay__service__key as string;
+
+    const userConfig = {
+        id: userID ?? "foo",
+        name: userName ?? "bar",
+    };
+
+    if (fnUrl) {
+        return new AzureFunctionTokenProvider(`${fnUrl}/api/GetFrsToken`, {
+            userId: userID ?? "foo",
+            userName: userName ?? "bar",
+        });
+    } else if (key) {
+        return new InsecureTokenProvider(key, userConfig);
+    } else {
+        throw new Error("Cannot create token provider.");
+    }
 }

--- a/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
@@ -5,21 +5,20 @@
 import { AzureFunctionTokenProvider, ITokenProvider } from "@fluidframework/azure-client";
 import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
 
-export function createAzureTokenProvider(userID?: string, userName?: string): ITokenProvider {
+export function createAzureTokenProvider(userId: string, userName: string): ITokenProvider {
     const fnUrl = process.env.azure__fluid__relay__service__function__url as string;
     const key = process.env.azure__fluid__relay__service__key as string;
 
-    const userConfig = {
-        id: userID ?? "foo",
-        name: userName ?? "bar",
-    };
-
     if (fnUrl) {
         return new AzureFunctionTokenProvider(`${fnUrl}/api/GetFrsToken`, {
-            userId: userID ?? "foo",
-            userName: userName ?? "bar",
+            userId,
+            userName,
         });
     } else if (key) {
+        const userConfig = {
+            id: userId,
+            name: userName,
+        };
         return new InsecureTokenProvider(key, userConfig);
     } else {
         throw new Error("Cannot create token provider.");


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Our azure client e2e tests now have configurable endpoint and auth options so the pipeline configs can decide which service endpoints to target. Our existing FRS test pipelines should not be broken as we still offer AzureFunctionTokenProvider as a token provider.

## Breaking Changes

None

