### PR TITLE
setLongTimeout should not call setTimeout with negative numbers

### DIFF
--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -86,6 +86,32 @@ describe("Timers", () => {
             testExactTimeout(overrideTimeout);
         });
 
+        it("Should immediately execute if the handler is late even accounting for the restart", () => {
+            const initialRunCount = runCount;
+            timer.start(defaultTimeout);
+
+            // Restart right before we execute the handler.
+            clock.tick(defaultTimeout - 1);
+            timer.restart();
+
+            // Advance the clock by a lot, that way, we ensure that the
+            // first time our timer executes its handler, it is late by design.
+            clock.tick(defaultTimeout * 2);
+
+            // flushPromises().then(
+            //     () => {},
+            //     () => {
+            //         assert.fail("Promise flushing failed");
+            //     },
+            // );
+
+            assert.strictEqual(
+                runCount,
+                initialRunCount + 1,
+                "Should have executed immediately because the handler was late",
+            );
+        });
+
         it("Should be reusable multiple times", () => {
             timer.start();
             testExactTimeout(defaultTimeout);

--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -112,7 +112,7 @@ describe("Timers", () => {
             for (const call of calls) {
                 assert(
                     call.args[1] >= 0,
-                    "SetLongTimeout should have never been called with a negative number!",
+                    "setTimeout should have never been called with a negative number!",
                 );
             }
         });

--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -86,7 +86,7 @@ describe("Timers", () => {
             testExactTimeout(overrideTimeout);
         });
 
-        it("Should immediately execute if the handler is late even accounting for the restart", () => {
+        it("Should immediately execute with negative numbers if setTimeout is called", () => {
             const setTimeoutSpy = spy(global, "setTimeout");
             const initialRunCount = runCount;
             timer.start(-10);

--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -102,8 +102,11 @@ describe("Timers", () => {
             );
 
             const calls = setTimeoutSpy.getCalls();
-            for(const call of calls) {
-                assert(call.args[1] >= 0, "SetLongTimeout should have never been called with a negative number!");
+            for (const call of calls) {
+                assert(
+                    call.args[1] >= 0,
+                    "SetLongTimeout should have never been called with a negative number!",
+                );
             }
             setTimeoutSpy.restore();
         });
@@ -135,8 +138,11 @@ describe("Timers", () => {
             );
 
             const calls = setTimeoutSpy.getCalls();
-            for(const call of calls) {
-                assert(call.args[1] >= 0, "SetLongTimeout should have never been called with a negative number!");
+            for (const call of calls) {
+                assert(
+                    call.args[1] >= 0,
+                    "SetLongTimeout should have never been called with a negative number!",
+                );
             }
             setTimeoutSpy.restore();
         });

--- a/common/lib/common-utils/src/timer.ts
+++ b/common/lib/common-utils/src/timer.ts
@@ -83,7 +83,7 @@ export function setLongTimeout(
             maxSetTimeoutMs,
         );
     } else {
-        timeoutId = setTimeout(() => timeoutFn(), timeoutMs);
+        timeoutId = setTimeout(() => timeoutFn(), Math.max(timeoutMs, 0));
     }
 
     setTimeoutIdFn?.(timeoutId);


### PR DESCRIPTION
In light of this PR: https://github.com/microsoft/FluidFramework/pull/12804/files

Background:
- It was discovered that some setTimeout implementations did not follow the MDN standards with negative timeouts
  - Negative timeouts should execute immediately
  - This PR makes setLongTimeout avoid executing setTimeout with negative timeouts.