### PR TITLE
Draft: DIsplay Failed Test Results in Console

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -301,6 +301,19 @@ stages:
               mergeTestResults: false
             condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
+          # Display Failed Tests
+          - task: PythonScript@0
+            inputs:
+              scriptSource: 'inline'
+              script: |
+                import xml.etree.ElementTree as ET
+                tree = ET.parse('mocha-junit-report.xml')
+                root = tree.getroot()
+
+                for failure in root.iter('failure'):
+                    print (failure.text)
+            displayName: 'Display Failed Tests'
+
         # Pack
         - ${{ if ne(parameters.taskPack, false) }}:
           - task: Bash@3


### PR DESCRIPTION
Currently 'mocha-junit-report.xml' is a placeholder for the junit report path. (Unsure of where the test report is actually stored).

For the parsing script, I opted to use Python instead of Bash since Bash doesn't seem to have a robust built-in parsing tool. (Many of the online examples seem to rely on Regex) and I'm not sure if importing external Bash libraries is appropriate in the pipeline.