### PR TITLE
Clear the snapshot fetch timer once the snapshot is fetched/failed

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -197,9 +197,10 @@ async function fetchLatestSnapshotCore(
         assert(storageToken !== null, 0x1e5 /* "Storage token should not be null" */);
 
         let controller: AbortController | undefined;
+        let fetchTimeout: ReturnType<typeof setTimeout>;
         if (snapshotOptions?.timeout !== undefined) {
             controller = new AbortController();
-            setTimeout(
+            fetchTimeout = setTimeout(
                 () => controller!.abort(),
                 snapshotOptions.timeout,
             );
@@ -228,7 +229,10 @@ async function fetchLatestSnapshotCore(
                     storageToken,
                     snapshotOptions,
                     controller,
-                );
+                ).finally(() => {
+                    // Clear the fetchTimeout once the response is fetched.
+                    clearTimeout(fetchTimeout);
+                });
 
                 const odspResponse = response.odspResponse;
                 const contentType = odspResponse.headers.get("content-type");

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -197,7 +197,7 @@ async function fetchLatestSnapshotCore(
         assert(storageToken !== null, 0x1e5 /* "Storage token should not be null" */);
 
         let controller: AbortController | undefined;
-        let fetchTimeout: ReturnType<typeof setTimeout>;
+        let fetchTimeout: ReturnType<typeof setTimeout> | undefined;
         if (snapshotOptions?.timeout !== undefined) {
             controller = new AbortController();
             fetchTimeout = setTimeout(
@@ -231,7 +231,10 @@ async function fetchLatestSnapshotCore(
                     controller,
                 ).finally(() => {
                     // Clear the fetchTimeout once the response is fetched.
-                    clearTimeout(fetchTimeout);
+                    if (fetchTimeout !== undefined) {
+                        clearTimeout(fetchTimeout);
+                        fetchTimeout = undefined;
+                    }
                 });
 
                 const odspResponse = response.odspResponse;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -196,15 +196,6 @@ async function fetchLatestSnapshotCore(
         const storageToken = await storageTokenFetcher(tokenFetchOptions, "TreesLatest", true);
         assert(storageToken !== null, 0x1e5 /* "Storage token should not be null" */);
 
-        let controller: AbortController | undefined;
-        let fetchTimeout: ReturnType<typeof setTimeout> | undefined;
-        if (snapshotOptions?.timeout !== undefined) {
-            controller = new AbortController();
-            fetchTimeout = setTimeout(
-                () => controller!.abort(),
-                snapshotOptions.timeout,
-            );
-        }
         const perfEvent = {
             eventName: "TreesLatest",
             attempts: tokenFetchOptions.refresh ? 2 : 1,
@@ -224,6 +215,15 @@ async function fetchLatestSnapshotCore(
             logger,
             perfEvent,
             async (event) => {
+                let controller: AbortController | undefined;
+                let fetchTimeout: ReturnType<typeof setTimeout> | undefined;
+                if (snapshotOptions?.timeout !== undefined) {
+                    controller = new AbortController();
+                    fetchTimeout = setTimeout(
+                        () => controller!.abort(),
+                        snapshotOptions.timeout,
+                    );
+                }
                 const response = await snapshotDownloader(
                     odspResolvedUrl,
                     storageToken,


### PR DESCRIPTION
## Description

Clear the snapshot fetch timer once the snapshot is fetched/failed as it can cause a memory leak.