### PR TITLE
Include container load in error handling

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -169,7 +169,7 @@ async function runnerProcess(
                 console.error("Error during logging unhandled promise rejection: ", e);
             }
         });
-        
+
         // Cycle between creating new factory vs. reusing factory.
         // Certain behavior (like driver caches) are per factory instance, and by reusing it we hit those code paths
         // At the same time we want to test newly created factory.

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -386,7 +386,7 @@ function scheduleOffline(
             }
 
             const injectionTime = random.integer(offlineDelayMinMs, offlineDelayMaxMs)(runConfig.randEng);
-            await new Promise<void>((res) => setTimeout(res, injectionTime));
+            await new Promise<void>((resolve) => setTimeout(resolve, injectionTime));
 
             assert(container.resolvedUrl !== undefined, "no url");
             const ds = dsf.documentServices.get(container.resolvedUrl);
@@ -395,7 +395,7 @@ function scheduleOffline(
             printStatus(runConfig, `going offline for ${offlineTime / 1000} seconds!`);
             ds.goOffline();
 
-            await new Promise<void>((res) => setTimeout(res, offlineTime));
+            await new Promise<void>((resolve) => setTimeout(resolve, offlineTime));
             if (!container.closed) {
                 ds.goOnline();
                 printStatus(runConfig, "going online!");


### PR DESCRIPTION
We were missing some unhandled error around container load. This change expands the try catch to cover them