### PR TITLE
Remove uses of any now that document message changes have propagated

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -90,8 +90,7 @@ function sanitizeMessage(message: any): IDocumentMessage {
         traces: message.traces,
         type: message.type,
         compression: message.compression,
-        // back-compat ADO #1932: Remove cast when protocol change propagates
-    } as any;
+    };
 
     return sanitizedMessage;
 }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1205,8 +1205,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
             timestamp: message.timestamp,
             traces: message.operation.traces,
             type: message.operation.type,
-            // back-compat ADO #1932: Remove cast when protocol change propagates
-            compression: (message.operation as any).compression,
+            compression: message.operation.compression,
         } as any;
         if (message.operation.type === MessageType.Summarize || message.operation.type === MessageType.NoClient) {
             const augmentedOutputMessage = outputMessage as ISequencedDocumentAugmentedMessage;

--- a/server/routerlicious/packages/test-utils/src/messageFactory.ts
+++ b/server/routerlicious/packages/test-utils/src/messageFactory.ts
@@ -77,7 +77,6 @@ export class MessageFactory {
     }
 
     public createDocumentMessage(type = MessageType.Operation, referenceSequenceNumber = 0): IDocumentMessage {
-        // back-compat ADO #1932: Remove cast when protocol change propagates
         const operation: IDocumentMessage = {
             clientSequenceNumber: ++this.clientSequenceNumber,
             contents: null,
@@ -86,7 +85,7 @@ export class MessageFactory {
             traces: [],
             type,
             compression: undefined,
-        } as any;
+        };
         return operation;
     }
 


### PR DESCRIPTION
## Description
This removes some now-unnecessary casts to any from when the compression property was added to the protocol. 